### PR TITLE
accept version as parameter in installer script

### DIFF
--- a/website/docs/guides/getting_started.md
+++ b/website/docs/guides/getting_started.md
@@ -17,6 +17,14 @@ curl -Lsf https://sh.benthos.dev | bash
 
 Or you can grab an archive containing Benthos from the [releases page][releases].
 
+Or install a specific version with the installer script:
+
+```sh
+curl -Lsf https://sh.benthos.dev | bash -s -- <VERSION>
+Example:
+curl -Lsf https://sh.benthos.dev | bash -s -- 3.56.0
+```
+
 ### Docker
 
 If you have docker installed you can pull the latest official Benthos image with:

--- a/website/static/sh/install
+++ b/website/static/sh/install
@@ -111,9 +111,20 @@ install_benthos()
 	echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
 	benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
 
-	benthos_latest_tag=$(curl -s https://api.github.com/repos/Jeffail/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
-	benthos_latest_version=$(echo ${benthos_latest_tag} | cut -c2-)
-	benthos_url="https://github.com/Jeffail/benthos/releases/download/${benthos_latest_tag}/benthos_${benthos_latest_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
+	if [[ "$#" -eq 0 ]]; then
+		# get latest release
+		benthos_tag=$(curl -s https://api.github.com/repos/Jeffail/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
+		benthos_version=$(echo ${benthos_tag} | cut -c2-)
+	elif [[ "$#" -gt 1 ]]; then
+		echo "Too many arguments."
+		exit 1
+	elif [ -n $1  ]; then
+		# try to get passed version
+		benthos_tag="v$1"
+		benthos_version=$1
+	fi
+
+	benthos_url="https://github.com/Jeffail/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
 
 	dl="/tmp/$benthos_file"
 	rm -rf -- "$dl"
@@ -138,4 +149,4 @@ install_benthos()
 	return 0
 }
 
-install_benthos
+install_benthos $@


### PR DESCRIPTION
In some cases we need to ensure, we are using the exact same version of Benthos as before (recovery, cluster-scaling etc.).

Expanded the Bash-installer to accept a version to download and install. If no version is passed, latest will still be used. Thanks to you, the tags are nearly the version numbering, which made it quiet easy.

Changes: 

- docs on website (tested locally)
- if's to determine passed version
- renamed benthos_latest-variables 