### PR TITLE
call wg.Done() directly instead of deferring

### DIFF
--- a/lib/pipeline/processor.go
+++ b/lib/pipeline/processor.go
@@ -149,8 +149,8 @@ func (p *Processor) dispatchMessages(msgs []types.Message, ogResChan chan<- type
 
 	for _, msg := range msgs {
 		go func(m types.Message) {
-			defer wg.Done()
 			sendMsg(m)
+			wg.Done()
 		}(msg)
 	}
 


### PR DESCRIPTION
optimize the dispatchMessages loop by directly calling wg.Done()