### PR TITLE
Add reset_visibility param to aws_sqs input

### DIFF
--- a/lib/input/aws_sqs.go
+++ b/lib/input/aws_sqs.go
@@ -59,6 +59,7 @@ You can access these metadata fields using
 		FieldSpecs: append(docs.FieldSpecs{
 			docs.FieldCommon("url", "The SQS URL to consume from."),
 			docs.FieldAdvanced("delete_message", "Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism."),
+			docs.FieldAdvanced("reset_visibility", "Whether to set the visibility timeout of the consumed message to zero once it is nacked. Disabling honors the preset visibility timeout specified for the queue."),
 		}, sess.FieldSpecs()...),
 		Categories: []Category{
 			CategoryServices,

--- a/website/docs/components/inputs/aws_sqs.md
+++ b/website/docs/components/inputs/aws_sqs.md
@@ -45,6 +45,7 @@ input:
   aws_sqs:
     url: ""
     delete_message: true
+    reset_visibility: true
     region: eu-west-1
     endpoint: ""
     credentials:
@@ -93,6 +94,14 @@ Default: `""`
 ### `delete_message`
 
 Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism.
+
+
+Type: `bool`  
+Default: `true`  
+
+### `reset_visibility`
+
+Whether to set the visibility timeout of the consumed message to zero once it is nacked. Disabling honors the preset visibility timeout specified for the queue.
 
 
 Type: `bool`  


### PR DESCRIPTION
Closes: https://github.com/Jeffail/benthos/issues/910

Add an additional parameter of reset_visibility to the aws_sqs input. 

Determines whether to set the visibility of the timeout of a nack-ed message to 0, or to leave it unchanged. Just the way delete_message determines whether to delete an ack-ed message, or leave it unchanged.

reset_visibility defaults to true, retaining backwards compatibility.

