### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/tools/benthos_docs_gen/main.go
+++ b/cmd/tools/benthos_docs_gen/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -30,7 +30,7 @@ import (
 var verbose bool
 
 func create(t, path string, resBytes []byte) {
-	if existing, err := ioutil.ReadFile(path); err == nil {
+	if existing, err := os.ReadFile(path); err == nil {
 		if bytes.Equal(existing, resBytes) {
 			if verbose {
 				fmt.Printf("Skipping '%v' at: %v\n", t, path)
@@ -38,7 +38,7 @@ func create(t, path string, resBytes []byte) {
 			return
 		}
 	}
-	if err := ioutil.WriteFile(path, resBytes, 0644); err != nil {
+	if err := os.WriteFile(path, resBytes, 0644); err != nil {
 		panic(err)
 	}
 	fmt.Printf("Documentation for '%v' has changed, updating: %v\n", t, path)

--- a/internal/bloblang/parser/mapping_parser_test.go
+++ b/internal/bloblang/parser/mapping_parser_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestMappingErrors(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_mapping_errors")
+	dir, err := os.MkdirTemp("", "benthos_mapping_errors")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
@@ -23,9 +22,9 @@ func TestMappingErrors(t *testing.T) {
 	noMapsFile := filepath.Join(dir, "no_maps.blobl")
 	goodMapFile := filepath.Join(dir, "good_map.blobl")
 
-	require.NoError(t, ioutil.WriteFile(badMapFile, []byte(`not a map bruh`), 0777))
-	require.NoError(t, ioutil.WriteFile(noMapsFile, []byte(`foo = "this is valid but has no maps"`), 0777))
-	require.NoError(t, ioutil.WriteFile(goodMapFile, []byte(`map foo { foo = "this is valid" }`), 0777))
+	require.NoError(t, os.WriteFile(badMapFile, []byte(`not a map bruh`), 0777))
+	require.NoError(t, os.WriteFile(noMapsFile, []byte(`foo = "this is valid but has no maps"`), 0777))
+	require.NoError(t, os.WriteFile(goodMapFile, []byte(`map foo { foo = "this is valid" }`), 0777))
 
 	tests := map[string]struct {
 		mapping     string
@@ -172,20 +171,20 @@ foo = bar.apply("foo")`, goodMapFile),
 }
 
 func TestMappings(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_mapping")
+	dir, err := os.MkdirTemp("", "benthos_mapping")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
 	})
 
 	goodMapFile := filepath.Join(dir, "foo_map.blobl")
-	require.NoError(t, ioutil.WriteFile(goodMapFile, []byte(`map foo {
+	require.NoError(t, os.WriteFile(goodMapFile, []byte(`map foo {
   foo = "this is valid"
   nested = this
 }`), 0777))
 
 	directMapFile := filepath.Join(dir, "direct_map.blobl")
-	require.NoError(t, ioutil.WriteFile(directMapFile, []byte(`root.nested = this`), 0777))
+	require.NoError(t, os.WriteFile(directMapFile, []byte(`root.nested = this`), 0777))
 
 	type part struct {
 		Content string

--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sync"
@@ -336,7 +335,7 @@ func fileFunction(args *ParsedParams) (Function, error) {
 	if err != nil {
 		return nil, err
 	}
-	pathBytes, err := ioutil.ReadFile(path)
+	pathBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bloblang/query/methods_strings.go
+++ b/internal/bloblang/query/methods_strings.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -211,22 +211,22 @@ var _ = registerSimpleMethod(
 		case "base64":
 			schemeFn = func(b []byte) ([]byte, error) {
 				e := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(b))
-				return ioutil.ReadAll(e)
+				return io.ReadAll(e)
 			}
 		case "base64url":
 			schemeFn = func(b []byte) ([]byte, error) {
 				e := base64.NewDecoder(base64.URLEncoding, bytes.NewReader(b))
-				return ioutil.ReadAll(e)
+				return io.ReadAll(e)
 			}
 		case "hex":
 			schemeFn = func(b []byte) ([]byte, error) {
 				e := hex.NewDecoder(bytes.NewReader(b))
-				return ioutil.ReadAll(e)
+				return io.ReadAll(e)
 			}
 		case "ascii85":
 			schemeFn = func(b []byte) ([]byte, error) {
 				e := ascii85.NewDecoder(bytes.NewReader(b))
-				return ioutil.ReadAll(e)
+				return io.ReadAll(e)
 			}
 		case "z85":
 			schemeFn = func(b []byte) ([]byte, error) {

--- a/internal/bloblang/query/parsed_test.go
+++ b/internal/bloblang/query/parsed_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestFunctionExamples(t *testing.T) {
-	tmpJSONFile, err := ioutil.TempFile("", "benthos_bloblang_functions_test")
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_functions_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(tmpJSONFile.Name())
@@ -56,7 +55,7 @@ func TestFunctionExamples(t *testing.T) {
 }
 
 func TestMethodExamples(t *testing.T) {
-	tmpJSONFile, err := ioutil.TempFile("", "benthos_bloblang_methods_test")
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_methods_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(tmpJSONFile.Name())

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -298,7 +297,7 @@ func (a *allBytesReader) Next(ctx context.Context) ([]types.Part, ReaderAckFn, e
 		return nil, nil, io.EOF
 	}
 	a.consumed = true
-	b, err := ioutil.ReadAll(a.i)
+	b, err := io.ReadAll(a.i)
 	if err != nil {
 		_ = a.ack(ctx, err)
 		return nil, nil, err

--- a/internal/filepath/glob_test.go
+++ b/internal/filepath/glob_test.go
@@ -1,7 +1,6 @@
 package filepath
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +19,7 @@ func TestGlobPatterns(t *testing.T) {
 		`src/cats/meows/c.js.tmp`,
 	}
 
-	tmpDir, err := ioutil.TempDir("", "test_glob_patterns")
+	tmpDir, err := os.MkdirTemp("", "test_glob_patterns")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -33,7 +32,7 @@ func TestGlobPatterns(t *testing.T) {
 			require.NoError(t, os.MkdirAll(tmpPath, 0755))
 		} else {
 			require.NoError(t, os.MkdirAll(filepath.Dir(tmpPath), 0755))
-			require.NoError(t, ioutil.WriteFile(tmpPath, []byte("keep me"), 0755))
+			require.NoError(t, os.WriteFile(tmpPath, []byte("keep me"), 0755))
 		}
 	}
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -75,7 +74,7 @@ func TestHTTPClientSendBasic(t *testing.T) {
 			resultChan <- msg
 		}()
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		msg.Append(message.NewPart(b))
@@ -107,7 +106,7 @@ func TestHTTPClientSendBasic(t *testing.T) {
 
 func TestHTTPClientBadContentType(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		_, err = w.Write(bytes.ToUpper(b))
@@ -189,7 +188,7 @@ func TestHTTPClientSendInterpolate(t *testing.T) {
 			resultChan <- msg
 		}()
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		msg.Append(message.NewPart(b))
@@ -244,13 +243,13 @@ func TestHTTPClientSendMultipart(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				msgBytes, err := ioutil.ReadAll(p)
+				msgBytes, err := io.ReadAll(p)
 				require.NoError(t, err)
 
 				msg.Append(message.NewPart(msgBytes))
 			}
 		} else {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 
 			msg.Append(message.NewPart(b))

--- a/internal/impl/confluent/schema_registry_decode.go
+++ b/internal/impl/confluent/schema_registry_decode.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -255,7 +255,7 @@ func (s *schemaRegistryDecoder) getDecoder(id int) (schemaDecoder, error) {
 			continue
 		}
 
-		resBytes, err = ioutil.ReadAll(res.Body)
+		resBytes, err = io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			s.logger.Errorf("failed to read response for schema '%v': %v", id, err)

--- a/internal/impl/confluent/schema_registry_encode.go
+++ b/internal/impl/confluent/schema_registry_encode.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -269,7 +269,7 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 			continue
 		}
 
-		resBytes, err = ioutil.ReadAll(res.Body)
+		resBytes, err = io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			s.logger.Errorf("failed to read response for schema subject '%v': %v", subject, err)

--- a/internal/impl/gcp/bigquery_output_test.go
+++ b/internal/impl/gcp/bigquery_output_test.go
@@ -2,7 +2,7 @@ package gcp
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -414,7 +414,7 @@ func TestGCPBigQueryOutputWriteOk(t *testing.T) {
 			// job execution called with job.Run()
 			if r.URL.Path == "/upload/bigquery/v2/projects/project_meow/jobs" {
 				var err error
-				body, err = ioutil.ReadAll(r.Body)
+				body, err = io.ReadAll(r.Body)
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)
 					return

--- a/internal/impl/sftp/sftp.go
+++ b/internal/impl/sftp/sftp.go
@@ -2,8 +2,8 @@ package sftp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	"github.com/pkg/sftp"
@@ -65,7 +65,7 @@ func (c Credentials) GetClient(address string) (*sftp.Client, error) {
 	if c.PrivateKeyFile != "" {
 		// read private key file
 		var privateKey []byte
-		privateKey, err = ioutil.ReadFile(c.PrivateKeyFile)
+		privateKey, err = os.ReadFile(c.PrivateKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read private key: %v", err)
 		}

--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/Jeffail/benthos/v3/internal/bloblang"
 	"github.com/Jeffail/benthos/v3/internal/bloblang/parser"
@@ -183,7 +183,7 @@ func (c Config) Test() ([]string, error) {
 // ReadConfig attempts to read a template configuration file.
 func ReadConfig(path string) (conf Config, lints []string, err error) {
 	var templateBytes []byte
-	if templateBytes, err = ioutil.ReadFile(path); err != nil {
+	if templateBytes, err = os.ReadFile(path); err != nil {
 		return
 	}
 

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -1,7 +1,7 @@
 package template_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 
 func TestTemplateTesting(t *testing.T) {
 	testTemplatesDir := "../../template/test"
-	files, err := ioutil.ReadDir(testTemplatesDir)
+	files, err := os.ReadDir(testTemplatesDir)
 	require.NoError(t, err)
 
 	for _, f := range files {

--- a/lib/api/dynamic_crud.go
+++ b/lib/api/dynamic_crud.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -207,7 +207,7 @@ func (d *Dynamic) handleGETInput(w http.ResponseWriter, r *http.Request) error {
 func (d *Dynamic) handlePOSTInput(w http.ResponseWriter, r *http.Request) error {
 	id := mux.Vars(r)["id"]
 
-	reqBytes, err := ioutil.ReadAll(r.Body)
+	reqBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/lib/buffer/single/mmap_buffer_test.go
+++ b/lib/buffer/single/mmap_buffer_test.go
@@ -2,7 +2,6 @@ package single
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -20,7 +19,7 @@ func cleanUpMmapDir(dir string) {
 func TestMmapBufferBasic(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -76,7 +75,7 @@ func TestMmapBufferBasic(t *testing.T) {
 func TestMmapBufferBacklogCounter(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -142,7 +141,7 @@ func TestMmapBufferBacklogCounter(t *testing.T) {
 func TestMmapBufferLoopingRandom(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -202,7 +201,7 @@ func TestMmapBufferLoopingRandom(t *testing.T) {
 func TestMmapBufferMultiFiles(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -258,7 +257,7 @@ func TestMmapBufferMultiFiles(t *testing.T) {
 func TestMmapBufferRecoverFiles(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -326,7 +325,7 @@ func TestMmapBufferRecoverFiles(t *testing.T) {
 func TestMmapBufferRejectLargeMessage(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -354,7 +353,7 @@ func TestMmapBufferRejectLargeMessage(t *testing.T) {
 }
 
 func BenchmarkMmapBufferBasic(b *testing.B) {
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		b.Error(err)
 		return

--- a/lib/buffer/single/mmap_cache_test.go
+++ b/lib/buffer/single/mmap_cache_test.go
@@ -1,7 +1,7 @@
 package single
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -11,7 +11,7 @@ import (
 func TestMmapCacheTracker(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -101,7 +101,7 @@ func TestMmapCacheTracker(t *testing.T) {
 func TestMmapCacheIndexes(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return
@@ -201,7 +201,7 @@ func TestMmapCacheIndexes(t *testing.T) {
 func TestMmapCacheRaces(t *testing.T) {
 	t.Skip("DEPRECATED")
 
-	dir, err := ioutil.TempDir("", "benthos_test_")
+	dir, err := os.MkdirTemp("", "benthos_test_")
 	if err != nil {
 		t.Error(err)
 		return

--- a/lib/buffer/single_wrapper_test.go
+++ b/lib/buffer/single_wrapper_test.go
@@ -1,7 +1,6 @@
 package buffer
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -310,7 +309,7 @@ func BenchmarkSingleMem(b *testing.B) {
 }
 
 func BenchmarkSingleMmap(b *testing.B) {
-	dir, err := ioutil.TempDir("", "benthos_mmap_test")
+	dir, err := os.MkdirTemp("", "benthos_mmap_test")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/lib/cache/aws_s3.go
+++ b/lib/cache/aws_s3.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/internal/docs"
@@ -246,7 +246,7 @@ func (s *S3) Get(key string) ([]byte, error) {
 
 	var bytes []byte
 	if err == nil {
-		bytes, err = ioutil.ReadAll(obj.Body)
+		bytes, err = io.ReadAll(obj.Body)
 		obj.Body.Close()
 	}
 	return bytes, err

--- a/lib/cache/file.go
+++ b/lib/cache/file.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -57,7 +56,7 @@ type fileV2 struct {
 }
 
 func (f *fileV2) Get(_ context.Context, key string) ([]byte, error) {
-	b, err := ioutil.ReadFile(filepath.Join(f.dir, key))
+	b, err := os.ReadFile(filepath.Join(f.dir, key))
 	if os.IsNotExist(err) {
 		return nil, types.ErrKeyNotFound
 	}
@@ -65,7 +64,7 @@ func (f *fileV2) Get(_ context.Context, key string) ([]byte, error) {
 }
 
 func (f *fileV2) Set(_ context.Context, key string, value []byte, _ *time.Duration) error {
-	return ioutil.WriteFile(filepath.Join(f.dir, key), value, 0644)
+	return os.WriteFile(filepath.Join(f.dir, key), value, 0644)
 }
 
 func (f *fileV2) Add(_ context.Context, key string, value []byte, _ *time.Duration) error {
@@ -107,7 +106,7 @@ type File struct {
 //
 // Deprecated: This implementation is no longer used.
 func (f *File) Get(key string) ([]byte, error) {
-	b, err := ioutil.ReadFile(filepath.Join(f.dir, key))
+	b, err := os.ReadFile(filepath.Join(f.dir, key))
 	if os.IsNotExist(err) {
 		return nil, types.ErrKeyNotFound
 	}
@@ -118,7 +117,7 @@ func (f *File) Get(key string) ([]byte, error) {
 //
 // Deprecated: This implementation is no longer used.
 func (f *File) Set(key string, value []byte) error {
-	return ioutil.WriteFile(filepath.Join(f.dir, key), value, 0644)
+	return os.WriteFile(filepath.Join(f.dir, key), value, 0644)
 }
 
 // SetMulti attempts to set the value of multiple keys, returns an error if any

--- a/lib/cache/file_test.go
+++ b/lib/cache/file_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 func TestFileCache(t *testing.T) {
 	conf := NewConfig()
 	conf.Type = TypeFile
-	dir, err := ioutil.TempDir("", "benthos_file_cache_test")
+	dir, err := os.MkdirTemp("", "benthos_file_cache_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/condition/jsonschema_test.go
+++ b/lib/condition/jsonschema_test.go
@@ -2,7 +2,6 @@ package condition
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestJSONSchemaExternalSchemaCheck(t *testing.T) {
 		}
 	}`
 
-	tmpSchemaFile, err := ioutil.TempFile("", "benthos_jsonschema_test")
+	tmpSchemaFile, err := os.CreateTemp("", "benthos_jsonschema_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +197,7 @@ func TestJSONSchemaInvalidSchema(t *testing.T) {
 		"type": "any"
 	}`
 
-	tmpSchemaFile, err := ioutil.TempFile("", "benthos_jsonschema_invalid_schema_test")
+	tmpSchemaFile, err := os.CreateTemp("", "benthos_jsonschema_invalid_schema_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/config/refs.go
+++ b/lib/config/refs.go
@@ -3,8 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -31,7 +31,7 @@ func ReadWithJSONPointers(path string, replaceEnvs bool) ([]byte, error) {
 //
 // If any non-fatal errors occur lints are returned along with the result.
 func ReadWithJSONPointersLinted(path string, replaceEnvs bool) (configBytes []byte, lints []string, err error) {
-	configBytes, err = ioutil.ReadFile(path)
+	configBytes, err = os.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -164,7 +164,7 @@ func expandRefVal(path string, level int, root, v interface{}) (interface{}, err
 			rPath = filepath.Join(filepath.Dir(path), rPath)
 		}
 
-		configBytes, err := ioutil.ReadFile(rPath)
+		configBytes, err := os.ReadFile(rPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read relative $ref path '%v' in config '%v': %v", rPath, path, err)
 		}

--- a/lib/config/refs_test.go
+++ b/lib/config/refs_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,7 @@ import (
 //------------------------------------------------------------------------------
 
 func TestConfigRefs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_config_ref_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,13 +33,13 @@ func TestConfigRefs(t *testing.T) {
 	secondFile := []byte(`["foo",{"$ref":"../third.yaml"},"bar"]`)
 	thirdFile := []byte(`{"c":[9,8,7]}`)
 
-	if err = ioutil.WriteFile(rootPath, rootFile, 0777); err != nil {
+	if err = os.WriteFile(rootPath, rootFile, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(secondPath, secondFile, 0777); err != nil {
+	if err = os.WriteFile(secondPath, secondFile, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(thirdPath, thirdFile, 0777); err != nil {
+	if err = os.WriteFile(thirdPath, thirdFile, 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,7 +65,7 @@ d: bar
 }
 
 func TestConfigRefsRootExpansion(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_config_ref_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,13 +87,13 @@ func TestConfigRefsRootExpansion(t *testing.T) {
 	secondFile := []byte(`{"$ref":"../third.yaml"}`)
 	thirdFile := []byte(`{"c":[9,8,7]}`)
 
-	if err = ioutil.WriteFile(rootPath, rootFile, 0777); err != nil {
+	if err = os.WriteFile(rootPath, rootFile, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(secondPath, secondFile, 0777); err != nil {
+	if err = os.WriteFile(secondPath, secondFile, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(thirdPath, thirdFile, 0777); err != nil {
+	if err = os.WriteFile(thirdPath, thirdFile, 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -257,7 +256,7 @@ func TestJSONPointer(t *testing.T) {
 }
 
 func TestLocalRefs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_config_ref_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +269,7 @@ func TestLocalRefs(t *testing.T) {
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	rootFile := []byte(`{"a":{"bar":"baz"},"b":{"$ref":"#/a/bar"},"c":{"$ref":"#/b"}}`)
 
-	if err = ioutil.WriteFile(rootPath, rootFile, 0777); err != nil {
+	if err = os.WriteFile(rootPath, rootFile, 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -290,7 +289,7 @@ c: baz
 }
 
 func TestRecursiveRefs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_config_ref_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,10 +305,10 @@ func TestRecursiveRefs(t *testing.T) {
 	fooFile := []byte(`{"a":{"$ref":"./bar.yaml"}}`)
 	barFile := []byte(`{"b":{"$ref":"./foo.yaml"}}`)
 
-	if err = ioutil.WriteFile(fooPath, fooFile, 0777); err != nil {
+	if err = os.WriteFile(fooPath, fooFile, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(barPath, barFile, 0777); err != nil {
+	if err = os.WriteFile(barPath, barFile, 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -320,7 +319,7 @@ func TestRecursiveRefs(t *testing.T) {
 }
 
 func TestConfigNoRefs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_config_ref_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_config_ref_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +332,7 @@ func TestConfigNoRefs(t *testing.T) {
 	rootPath := filepath.Join(tmpDir, "root.yaml")
 	rootFile := []byte(`{"foo":{ "bar":"baz"}}`)
 
-	if err = ioutil.WriteFile(rootPath, rootFile, 0777); err != nil {
+	if err = os.WriteFile(rootPath, rootFile, 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/input/csv_test.go
+++ b/lib/input/csv_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,19 +73,19 @@ func TestCSVReaderHappy(t *testing.T) {
 }
 
 func TestCSVGPaths(t *testing.T) {
-	dir, err := ioutil.TempDir("", "csv_glob_test")
+	dir, err := os.MkdirTemp("", "csv_glob_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
 	})
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
 foo1,bar1,baz1
 foo2,bar2,baz2
 foo3,bar3,baz3
 `), 0777))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "b.csv"), []byte(`header4,header5,header6
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.csv"), []byte(`header4,header5,header6
 foo4,bar4,baz4
 foo5,bar5,baz5
 foo6,bar6,baz6
@@ -120,19 +119,19 @@ foo6,bar6,baz6
 }
 
 func TestCSVGlobPaths(t *testing.T) {
-	dir, err := ioutil.TempDir("", "csv_glob_test")
+	dir, err := os.MkdirTemp("", "csv_glob_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
 	})
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.csv"), []byte(`header1,header2,header3
 foo1,bar1,baz1
 foo2,bar2,baz2
 foo3,bar3,baz3
 `), 0777))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "b.csv"), []byte(`header4,header5,header6
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.csv"), []byte(`header4,header5,header6
 foo4,bar4,baz4
 foo5,bar5,baz5
 foo6,bar6,baz6

--- a/lib/input/file_test.go
+++ b/lib/input/file_test.go
@@ -3,7 +3,6 @@ package input
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -19,7 +18,7 @@ import (
 )
 
 func TestFileSinglePartDeprecated(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "benthos_file_test")
+	tmpfile, err := os.CreateTemp("", "benthos_file_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -76,7 +75,7 @@ func TestFileSinglePartDeprecated(t *testing.T) {
 }
 
 func TestFileMultiPartDeprecated(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "benthos_file_test")
+	tmpfile, err := os.CreateTemp("", "benthos_file_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -149,17 +148,17 @@ func TestFileMultiPartDeprecated(t *testing.T) {
 }
 
 func TestFileDirectory(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_file_input_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_file_input_test")
 	require.NoError(t, err)
 
-	tmpInnerDir, err := ioutil.TempDir(tmpDir, "benthos_inner")
+	tmpInnerDir, err := os.MkdirTemp(tmpDir, "benthos_inner")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 
-	tmpFile, err := ioutil.TempFile(tmpDir, "f1*.txt")
+	tmpFile, err := os.CreateTemp(tmpDir, "f1*.txt")
 	require.NoError(t, err)
 
 	_, err = tmpFile.Write([]byte("foo"))
@@ -168,7 +167,7 @@ func TestFileDirectory(t *testing.T) {
 	err = tmpFile.Close()
 	require.NoError(t, err)
 
-	tmpFileTwo, err := ioutil.TempFile(tmpInnerDir, "f2*.txt")
+	tmpFileTwo, err := os.CreateTemp(tmpInnerDir, "f2*.txt")
 	require.NoError(t, err)
 
 	_, err = tmpFileTwo.Write([]byte("bar"))

--- a/lib/input/http_client_test.go
+++ b/lib/input/http_client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -275,7 +274,7 @@ func TestHTTPClientPOST(t *testing.T) {
 		}
 		defer r.Body.Close()
 
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 		}

--- a/lib/input/http_server.go
+++ b/lib/input/http_server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -353,14 +352,14 @@ func (h *HTTPServer) extractMessageFromRequest(r *http.Request) (types.Message, 
 				return nil, err
 			}
 			var msgBytes []byte
-			if msgBytes, err = ioutil.ReadAll(p); err != nil {
+			if msgBytes, err = io.ReadAll(p); err != nil {
 				return nil, err
 			}
 			msg.Append(message.NewPart(msgBytes))
 		}
 	} else {
 		var msgBytes []byte
-		if msgBytes, err = ioutil.ReadAll(r.Body); err != nil {
+		if msgBytes, err = io.ReadAll(r.Body); err != nil {
 			return nil, err
 		}
 		msg.Append(message.NewPart(msgBytes))

--- a/lib/input/http_server_test.go
+++ b/lib/input/http_server_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net"
@@ -92,7 +91,7 @@ func TestHTTPBasic(t *testing.T) {
 			} else if res.StatusCode != 200 {
 				t.Errorf("Wrong error code returned: %v", res.StatusCode)
 			}
-			resBytes, err := ioutil.ReadAll(res.Body)
+			resBytes, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Error(err)
 			}
@@ -186,7 +185,7 @@ func TestHTTPBasic(t *testing.T) {
 			} else if res.StatusCode != 200 {
 				t.Errorf("Wrong error code returned: %v", res.StatusCode)
 			}
-			resBytes, err := ioutil.ReadAll(res.Body)
+			resBytes, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Error(err)
 			}
@@ -807,7 +806,7 @@ func TestHTTPSyncResponseHeaders(t *testing.T) {
 		} else if res.StatusCode != 200 {
 			t.Errorf("Wrong error code returned: %v", res.StatusCode)
 		}
-		resBytes, err := ioutil.ReadAll(res.Body)
+		resBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1015,7 +1014,7 @@ func TestHTTPSyncResponseHeadersStatus(t *testing.T) {
 		} else if res.StatusCode != 200 {
 			t.Errorf("Wrong error code returned: %v", res.StatusCode)
 		}
-		resBytes, err := ioutil.ReadAll(res.Body)
+		resBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1039,7 +1038,7 @@ func TestHTTPSyncResponseHeadersStatus(t *testing.T) {
 		} else if res.StatusCode != 400 {
 			t.Errorf("Wrong error code returned: %v", res.StatusCode)
 		}
-		resBytes, err = ioutil.ReadAll(res.Body)
+		resBytes, err = io.ReadAll(res.Body)
 		if err != nil {
 			t.Error(err)
 		}

--- a/lib/input/read_until_test.go
+++ b/lib/input/read_until_test.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ func TestReadUntilInput(t *testing.T) {
 bar
 baz`)
 
-	tmpfile, err := ioutil.TempFile("", "benthos_read_until_test")
+	tmpfile, err := os.CreateTemp("", "benthos_read_until_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/input/reader/amazon_s3.go
+++ b/lib/input/reader/amazon_s3.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -611,7 +611,7 @@ func (a *AmazonS3) read() (types.Part, objKey, error) {
 		return nil, objKey{}, types.ErrTimeout
 	}
 
-	bytes, err := ioutil.ReadAll(obj.Body)
+	bytes, err := io.ReadAll(obj.Body)
 	obj.Body.Close()
 	if err != nil {
 		a.popTargetKey()

--- a/lib/input/reader/files.go
+++ b/lib/input/reader/files.go
@@ -3,7 +3,7 @@ package reader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -92,7 +92,7 @@ func (f *Files) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn,
 	}
 	defer file.Close()
 
-	msgBytes, readerr := ioutil.ReadAll(file)
+	msgBytes, readerr := io.ReadAll(file)
 	if readerr != nil {
 		return nil, nil, readerr
 	}

--- a/lib/input/reader/files_test.go
+++ b/lib/input/reader/files_test.go
@@ -2,7 +2,6 @@ package reader
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -15,18 +14,18 @@ import (
 //------------------------------------------------------------------------------
 
 func TestFilesDirectory(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_file_input_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_file_input_test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	var tmpInnerDir string
-	if tmpInnerDir, err = ioutil.TempDir(tmpDir, "benthos_inner"); err != nil {
+	if tmpInnerDir, err = os.MkdirTemp(tmpDir, "benthos_inner"); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	var tmpFile *os.File
-	if tmpFile, err = ioutil.TempFile(tmpDir, "f1"); err != nil {
+	if tmpFile, err = os.CreateTemp(tmpDir, "f1"); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmpFile.Name())
@@ -37,7 +36,7 @@ func TestFilesDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if tmpFile, err = ioutil.TempFile(tmpInnerDir, "f2"); err != nil {
+	if tmpFile, err = os.CreateTemp(tmpInnerDir, "f2"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err = tmpFile.Write([]byte("bar")); err != nil {
@@ -94,7 +93,7 @@ func TestFilesDirectory(t *testing.T) {
 }
 
 func TestFilesFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "f1")
+	tmpFile, err := os.CreateTemp("", "f1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,14 +155,14 @@ func TestFilesBadPath(t *testing.T) {
 }
 
 func TestFilesDirectoryDelete(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_file_input_delete_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_file_input_delete_test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	var tmpFile *os.File
-	if tmpFile, err = ioutil.TempFile(tmpDir, "f1"); err != nil {
+	if tmpFile, err = os.CreateTemp(tmpDir, "f1"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err = tmpFile.Write([]byte("foo")); err != nil {

--- a/lib/input/reader/nsq.go
+++ b/lib/input/reader/nsq.go
@@ -3,7 +3,7 @@ package reader
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	llog "log"
 	"strings"
 	"sync"
@@ -141,7 +141,7 @@ func (n *NSQ) ConnectWithContext(ctx context.Context) (err error) {
 		return
 	}
 
-	consumer.SetLogger(llog.New(ioutil.Discard, "", llog.Flags()), nsq.LogLevelError)
+	consumer.SetLogger(llog.New(io.Discard, "", llog.Flags()), nsq.LogLevelError)
 	consumer.AddHandler(n)
 
 	if err = consumer.ConnectToNSQDs(n.addresses); err != nil {

--- a/lib/input/sequence_test.go
+++ b/lib/input/sequence_test.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,14 +20,14 @@ func writeFiles(t *testing.T, dir string, nameToContent map[string]string) {
 	t.Helper()
 
 	for k, v := range nameToContent {
-		require.NoError(t, ioutil.WriteFile(filepath.Join(dir, k), []byte(v), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, k), []byte(v), 0600))
 	}
 }
 
 func TestSequenceHappy(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "benthos_sequence_input_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_sequence_input_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })
@@ -86,7 +85,7 @@ consumeLoop:
 func TestSequenceJoins(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "benthos_sequence_joins_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })
@@ -218,7 +217,7 @@ func TestSequenceJoinsMergeStrategies(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "benthos_sequence_joins_test")
+			tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_test")
 			require.NoError(t, err)
 
 			t.Cleanup(func() { os.RemoveAll(tmpDir) })
@@ -289,7 +288,7 @@ func TestSequenceJoinsBig(t *testing.T) {
 	t.Skip()
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "benthos_sequence_joins_big_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_sequence_joins_big_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })
@@ -375,7 +374,7 @@ consumeLoop:
 func TestSequenceSad(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "benthos_sequence_input_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_sequence_input_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() { os.RemoveAll(tmpDir) })

--- a/lib/input/socket_server_test.go
+++ b/lib/input/socket_server_test.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -21,7 +20,7 @@ import (
 )
 
 func TestSocketServerBasic(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -93,7 +92,7 @@ func TestSocketServerBasic(t *testing.T) {
 }
 
 func TestSocketServerRetries(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -180,7 +179,7 @@ func TestSocketServerRetries(t *testing.T) {
 }
 
 func TestSocketServerWriteToClosed(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -212,7 +211,7 @@ func TestSocketServerWriteToClosed(t *testing.T) {
 }
 
 func TestSocketServerReconnect(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -292,7 +291,7 @@ func TestSocketServerReconnect(t *testing.T) {
 }
 
 func TestSocketServerMultipart(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -364,7 +363,7 @@ func TestSocketServerMultipart(t *testing.T) {
 }
 
 func TestSocketServerMultipartCustomDelim(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -437,7 +436,7 @@ func TestSocketServerMultipartCustomDelim(t *testing.T) {
 }
 
 func TestSocketServerMultipartShutdown(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "benthos_socket_test")
+	tmpDir, err := os.MkdirTemp("", "benthos_socket_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/lib/input/subprocess_test.go
+++ b/lib/input/subprocess_test.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -18,7 +17,7 @@ import (
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "benthos_subprocess_input_test")
+	dir, err := os.MkdirTemp("", "benthos_subprocess_input_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -26,7 +25,7 @@ func testProgram(t *testing.T, program string) string {
 	})
 
 	pathStr := path.Join(dir, "main.go")
-	require.NoError(t, ioutil.WriteFile(pathStr, []byte(program), 0666))
+	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0666))
 
 	return pathStr
 }

--- a/lib/log/modular.go
+++ b/lib/log/modular.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strconv"
 	"strings"
@@ -248,7 +247,7 @@ func NewV2(stream io.Writer, config Config) (Modular, error) {
 // Noop creates and returns a new logger object that writes nothing.
 func Noop() Modular {
 	return &Logger{
-		stream:       ioutil.Discard,
+		stream:       io.Discard,
 		prefix:       "benthos",
 		fields:       map[string]interface{}{},
 		level:        LogOff,

--- a/lib/output/broker_test.go
+++ b/lib/output/broker_test.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestFanOutBroker(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_fan_out_broker_tests")
+	dir, err := os.MkdirTemp("", "benthos_fan_out_broker_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +90,7 @@ func TestFanOutBroker(t *testing.T) {
 
 	for k, exp := range expFiles {
 		k = filepath.Join(dir, k)
-		fileBytes, err := ioutil.ReadFile(k)
+		fileBytes, err := os.ReadFile(k)
 		if err != nil {
 			t.Errorf("Expected file '%v' could not be read: %v", k, err)
 			continue
@@ -103,7 +102,7 @@ func TestFanOutBroker(t *testing.T) {
 }
 
 func TestRoundRobinBroker(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_round_robin_broker_tests")
+	dir, err := os.MkdirTemp("", "benthos_round_robin_broker_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +178,7 @@ func TestRoundRobinBroker(t *testing.T) {
 
 	for k, exp := range expFiles {
 		k = filepath.Join(dir, k)
-		fileBytes, err := ioutil.ReadFile(k)
+		fileBytes, err := os.ReadFile(k)
 		if err != nil {
 			t.Errorf("Expected file '%v' could not be read: %v", k, err)
 			continue
@@ -191,7 +190,7 @@ func TestRoundRobinBroker(t *testing.T) {
 }
 
 func TestGreedyBroker(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_broker_greedy_tests")
+	dir, err := os.MkdirTemp("", "benthos_broker_greedy_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +272,7 @@ func TestGreedyBroker(t *testing.T) {
 
 	for k, exp := range expFiles {
 		k = filepath.Join(dir, k)
-		fileBytes, err := ioutil.ReadFile(k)
+		fileBytes, err := os.ReadFile(k)
 		if err != nil {
 			t.Errorf("Expected file '%v' could not be read: %v", k, err)
 			continue
@@ -285,7 +284,7 @@ func TestGreedyBroker(t *testing.T) {
 }
 
 func TestTryBroker(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_try_broker_tests")
+	dir, err := os.MkdirTemp("", "benthos_try_broker_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +364,7 @@ func TestTryBroker(t *testing.T) {
 
 	for k, exp := range expFiles {
 		k = filepath.Join(dir, k)
-		fileBytes, err := ioutil.ReadFile(k)
+		fileBytes, err := os.ReadFile(k)
 		if err != nil {
 			t.Errorf("Expected file '%v' could not be read: %v", k, err)
 			continue

--- a/lib/output/http_client_test.go
+++ b/lib/output/http_client_test.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -34,7 +33,7 @@ func TestHTTPClientMultipartEnabled(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			msgBytes, err := ioutil.ReadAll(p)
+			msgBytes, err := io.ReadAll(p)
 			require.NoError(t, err)
 
 			resultChan <- string(msgBytes)
@@ -90,7 +89,7 @@ func TestHTTPClientMultipartEnabled(t *testing.T) {
 func TestHTTPClientMultipartDisabled(t *testing.T) {
 	resultChan := make(chan string, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resBytes, err := ioutil.ReadAll(r.Body)
+		resBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		resultChan <- string(resBytes)
 	}))

--- a/lib/output/subprocess_test.go
+++ b/lib/output/subprocess_test.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -19,7 +18,7 @@ import (
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "benthos_subprocess_output_test")
+	dir, err := os.MkdirTemp("", "benthos_subprocess_output_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -27,7 +26,7 @@ func testProgram(t *testing.T, program string) string {
 	})
 
 	pathStr := path.Join(dir, "main.go")
-	require.NoError(t, ioutil.WriteFile(pathStr, []byte(program), 0666))
+	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0666))
 
 	return pathStr
 }
@@ -60,7 +59,7 @@ func TestSubprocessBasic(t *testing.T) {
 
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "benthos_subprocess_output_happy")
+	dir, err := os.MkdirTemp("", "benthos_subprocess_output_happy")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
@@ -74,7 +73,6 @@ import (
 	"os"
 	"strings"
 	"bytes"
-	"io/ioutil"
 )
 
 func main() {
@@ -91,7 +89,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile(target, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(target, buf.Bytes(), 0644); err != nil {
 		panic(err)
 	}
 }
@@ -118,7 +116,7 @@ func main() {
 	require.NoError(t, o.WaitForClose(time.Second))
 
 	assert.Eventually(t, func() bool {
-		resBytes, err := ioutil.ReadFile(path.Join(dir, "output.txt"))
+		resBytes, err := os.ReadFile(path.Join(dir, "output.txt"))
 		if err != nil {
 			return false
 		}
@@ -131,7 +129,7 @@ func TestSubprocessEarlyExit(t *testing.T) {
 
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "benthos_subprocess_output_early_exit")
+	dir, err := os.MkdirTemp("", "benthos_subprocess_output_early_exit")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
@@ -177,7 +175,7 @@ func main() {
 	assert.Eventually(t, func() bool {
 		sendMsg(t, "bar", tranChan)
 
-		resBytes, err := ioutil.ReadFile(path.Join(dir, "bar.txt"))
+		resBytes, err := os.ReadFile(path.Join(dir, "bar.txt"))
 		if err != nil {
 			return false
 		}
@@ -187,7 +185,7 @@ func main() {
 	assert.Eventually(t, func() bool {
 		sendMsg(t, "baz", tranChan)
 
-		resBytes, err := ioutil.ReadFile(path.Join(dir, "baz.txt"))
+		resBytes, err := os.ReadFile(path.Join(dir, "baz.txt"))
 		if err != nil {
 			return false
 		}
@@ -197,15 +195,15 @@ func main() {
 	o.CloseAsync()
 	require.NoError(t, o.WaitForClose(time.Second))
 
-	resBytes, err := ioutil.ReadFile(path.Join(dir, "foo.txt"))
+	resBytes, err := os.ReadFile(path.Join(dir, "foo.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "FOO\n", string(resBytes))
 
-	resBytes, err = ioutil.ReadFile(path.Join(dir, "bar.txt"))
+	resBytes, err = os.ReadFile(path.Join(dir, "bar.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "BAR\n", string(resBytes))
 
-	resBytes, err = ioutil.ReadFile(path.Join(dir, "baz.txt"))
+	resBytes, err = os.ReadFile(path.Join(dir, "baz.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "BAZ\n", string(resBytes))
 }

--- a/lib/output/try_test.go
+++ b/lib/output/try_test.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestTryOutputBasic(t *testing.T) {
-	dir, err := ioutil.TempDir("", "benthos_try_output_tests")
+	dir, err := os.MkdirTemp("", "benthos_try_output_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +93,7 @@ func TestTryOutputBasic(t *testing.T) {
 
 	for k, exp := range expFiles {
 		k = filepath.Join(dir, k)
-		fileBytes, err := ioutil.ReadFile(k)
+		fileBytes, err := os.ReadFile(k)
 		if err != nil {
 			t.Errorf("Expected file '%v' could not be read: %v", k, err)
 			continue

--- a/lib/output/writer/files.go
+++ b/lib/output/writer/files.go
@@ -3,7 +3,6 @@ package writer
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -98,7 +97,7 @@ func (f *Files) Write(msg types.Message) error {
 			return err
 		}
 
-		return ioutil.WriteFile(path, p.Get(), os.FileMode(0666))
+		return os.WriteFile(path, p.Get(), os.FileMode(0666))
 	})
 }
 

--- a/lib/output/writer/http_client_test.go
+++ b/lib/output/writer/http_client_test.go
@@ -3,7 +3,6 @@ package writer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -66,7 +65,7 @@ func TestHTTPClientBasic(t *testing.T) {
 			resultChan <- msg
 		}()
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return
@@ -117,7 +116,7 @@ func TestHTTPClientSyncResponse(t *testing.T) {
 	nTestLoops := 1000
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return
@@ -164,7 +163,7 @@ func TestHTTPClientSyncResponseCopyHeaders(t *testing.T) {
 	nTestLoops := 1000
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return
@@ -235,7 +234,7 @@ func TestHTTPClientMultipart(t *testing.T) {
 					t.Error(err)
 					return
 				}
-				msgBytes, err := ioutil.ReadAll(p)
+				msgBytes, err := io.ReadAll(p)
 				if err != nil {
 					t.Error(err)
 					return
@@ -243,7 +242,7 @@ func TestHTTPClientMultipart(t *testing.T) {
 				msg.Append(message.NewPart(msgBytes))
 			}
 		} else {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error(err)
 				return

--- a/lib/output/writer/nsq.go
+++ b/lib/output/writer/nsq.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	llog "log"
 	"sync"
 	"time"
@@ -104,7 +104,7 @@ func (n *NSQ) Connect() error {
 		return err
 	}
 
-	producer.SetLogger(llog.New(ioutil.Discard, "", llog.Flags()), nsq.LogLevelError)
+	producer.SetLogger(llog.New(io.Discard, "", llog.Flags()), nsq.LogLevelError)
 
 	if err := producer.Ping(); err != nil {
 		return err

--- a/lib/processor/avro.go
+++ b/lib/processor/avro.go
@@ -2,11 +2,10 @@ package processor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
+	"net/http"
 	"strings"
 	"time"
-
-	"net/http"
 
 	"github.com/Jeffail/benthos/v3/internal/docs"
 	"github.com/Jeffail/benthos/v3/lib/log"
@@ -187,7 +186,7 @@ func loadSchema(schemaPath string) (string, error) {
 
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 
 	if err != nil {
 		return "", err

--- a/lib/processor/avro_test.go
+++ b/lib/processor/avro_test.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -181,7 +180,7 @@ func TestAvroSchemaPath(t *testing.T) {
 	]
 }`
 
-	tmpSchemaFile, err := ioutil.TempFile("", "benthos_avro_test")
+	tmpSchemaFile, err := os.CreateTemp("", "benthos_avro_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/processor/awk.go
+++ b/lib/processor/awk.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"sync"
 	"time"
@@ -852,7 +852,7 @@ func (a *AWK) ProcessMessage(msg types.Message) ([]types.Message, types.Response
 			return err
 		}
 
-		if errMsg, err := ioutil.ReadAll(&errBuf); err != nil {
+		if errMsg, err := io.ReadAll(&errBuf); err != nil {
 			a.log.Errorf("Read err error: %v\n", err)
 		} else if len(errMsg) > 0 {
 			a.mErr.Incr(1)
@@ -860,7 +860,7 @@ func (a *AWK) ProcessMessage(msg types.Message) ([]types.Message, types.Response
 			return errors.New(string(errMsg))
 		}
 
-		resMsg, err := ioutil.ReadAll(&outBuf)
+		resMsg, err := io.ReadAll(&outBuf)
 		if err != nil {
 			a.mErr.Incr(1)
 			a.log.Errorf("Read output error: %v\n", err)

--- a/lib/processor/decode.go
+++ b/lib/processor/decode.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/Jeffail/benthos/v3/internal/docs"
@@ -58,17 +58,17 @@ type decodeFunc func(bytes []byte) ([]byte, error)
 
 func base64Decode(b []byte) ([]byte, error) {
 	e := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(b))
-	return ioutil.ReadAll(e)
+	return io.ReadAll(e)
 }
 
 func hexDecode(b []byte) ([]byte, error) {
 	e := hex.NewDecoder(bytes.NewReader(b))
-	return ioutil.ReadAll(e)
+	return io.ReadAll(e)
 }
 
 func ascii85Decode(b []byte) ([]byte, error) {
 	e := ascii85.NewDecoder(bytes.NewReader(b))
-	return ioutil.ReadAll(e)
+	return io.ReadAll(e)
 }
 
 func z85Decode(b []byte) ([]byte, error) {

--- a/lib/processor/grok_test.go
+++ b/lib/processor/grok_test.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -126,14 +125,14 @@ func TestGrok(t *testing.T) {
 }
 
 func TestGrokFileImports(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "grok_test")
+	tmpDir, err := os.MkdirTemp("", "grok_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "foos"), []byte(`
+	err = os.WriteFile(filepath.Join(tmpDir, "foos"), []byte(`
 FOOFLAT %{WORD:first} %{WORD:second} %{WORD:third}
 FOONESTED %{INT:nested.first:int} %{WORD:nested.second} %{WORD:nested.third}
 `), 0777)

--- a/lib/processor/http_old_test.go
+++ b/lib/processor/http_old_test.go
@@ -1,7 +1,7 @@
 package processor
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -61,7 +61,7 @@ func TestHTTPOldClientBasic(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +132,7 @@ func TestHTTPOldClientEmptyResponse(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestHTTPOldClientBasicWithMetadata(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,7 +306,7 @@ func TestHTTPOldClientParallelError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wg.Done()
 		wg.Wait()
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/processor/http_test.go
+++ b/lib/processor/http_test.go
@@ -2,7 +2,7 @@ package processor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -65,7 +65,7 @@ func TestHTTPClientBasic(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +136,7 @@ func TestHTTPClientEmptyResponse(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestHTTPClientBasicWithMetadata(t *testing.T) {
 	i := 0
 	expPayloads := []string{"foo", "bar", "baz"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -310,7 +310,7 @@ func TestHTTPClientParallelError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wg.Done()
 		wg.Wait()
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/processor/jsonschema_test.go
+++ b/lib/processor/jsonschema_test.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -35,7 +34,7 @@ func TestJSONSchemaExternalSchemaCheck(t *testing.T) {
 		}
 	}`
 
-	tmpSchemaFile, err := ioutil.TempFile("", "benthos_jsonschema_test")
+	tmpSchemaFile, err := os.CreateTemp("", "benthos_jsonschema_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +330,7 @@ func TestJSONSchemaInvalidSchema(t *testing.T) {
 		"type": "any"
 	}`
 
-	tmpSchemaFile, err := ioutil.TempFile("", "benthos_jsonschema_invalid_schema_test")
+	tmpSchemaFile, err := os.CreateTemp("", "benthos_jsonschema_invalid_schema_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/processor/parallel_test.go
+++ b/lib/processor/parallel_test.go
@@ -1,7 +1,7 @@
 package processor
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -57,7 +57,7 @@ func TestParallelError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wg.Done()
 		wg.Wait()
-		reqBytes, err := ioutil.ReadAll(r.Body)
+		reqBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/processor/subprocess_test.go
+++ b/lib/processor/subprocess_test.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -171,7 +170,7 @@ func TestSubprocessWithErrors(t *testing.T) {
 func testProgram(t *testing.T, program string) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "benthos_subprocessor_test")
+	dir, err := os.MkdirTemp("", "benthos_subprocessor_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -179,7 +178,7 @@ func testProgram(t *testing.T, program string) string {
 	})
 
 	pathStr := path.Join(dir, "main.go")
-	require.NoError(t, ioutil.WriteFile(pathStr, []byte(program), 0666))
+	require.NoError(t, os.WriteFile(pathStr, []byte(program), 0666))
 
 	return pathStr
 }

--- a/lib/serverless/handler_test.go
+++ b/lib/serverless/handler_test.go
@@ -2,7 +2,7 @@ package serverless
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -24,7 +24,7 @@ func TestHandlerAsync(t *testing.T) {
 		resMut.Lock()
 		defer resMut.Unlock()
 
-		resBytes, err := ioutil.ReadAll(r.Body)
+		resBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -157,7 +157,7 @@ func TestHandlerCombined(t *testing.T) {
 		resMut.Lock()
 		defer resMut.Unlock()
 
-		resBytes, err := ioutil.ReadAll(r.Body)
+		resBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/service/blobl/cli.go
+++ b/lib/service/blobl/cli.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -220,7 +219,7 @@ func run(c *cli.Context) error {
 			fmt.Fprintln(os.Stderr, red("invalid flags, unable to execute both a file mapping and an inline mapping"))
 			os.Exit(1)
 		}
-		mappingBytes, err := ioutil.ReadFile(file)
+		mappingBytes, err := os.ReadFile(file)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, red("failed to read mapping file: %v\n"), err)
 			os.Exit(1)

--- a/lib/service/blobl/server.go
+++ b/lib/service/blobl/server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -250,7 +249,7 @@ func newFileSync(inputFile, mappingFile string, writeBack bool) *fileSync {
 	}
 
 	if inputFile != "" {
-		inputBytes, err := ioutil.ReadFile(inputFile)
+		inputBytes, err := os.ReadFile(inputFile)
 		if err != nil {
 			if !writeBack || !errors.Is(err, os.ErrNotExist) {
 				log.Fatal(err)
@@ -261,7 +260,7 @@ func newFileSync(inputFile, mappingFile string, writeBack bool) *fileSync {
 	}
 
 	if mappingFile != "" {
-		mappingBytes, err := ioutil.ReadFile(mappingFile)
+		mappingBytes, err := os.ReadFile(mappingFile)
 		if err != nil {
 			if !writeBack || !errors.Is(err, os.ErrNotExist) {
 				log.Fatal(err)
@@ -303,12 +302,12 @@ func (f *fileSync) write() {
 	}
 
 	if f.inputFile != "" {
-		if err := ioutil.WriteFile(f.inputFile, []byte(f.inputString), 0644); err != nil {
+		if err := os.WriteFile(f.inputFile, []byte(f.inputString), 0644); err != nil {
 			log.Printf("Failed to write input file: %v\n", err)
 		}
 	}
 	if f.mappingFile != "" {
-		if err := ioutil.WriteFile(f.mappingFile, []byte(f.mappingString), 0644); err != nil {
+		if err := os.WriteFile(f.mappingFile, []byte(f.mappingString), 0644); err != nil {
 			log.Printf("Failed to write mapping file: %v\n", err)
 		}
 	}

--- a/lib/service/lint.go
+++ b/lib/service/lint.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,7 +59,7 @@ func lintFile(path string) (pathLints []pathLint) {
 }
 
 func lintMDSnippets(path string) (pathLints []pathLint) {
-	rawBytes, err := ioutil.ReadFile(path)
+	rawBytes, err := os.ReadFile(path)
 	if err != nil {
 		pathLints = append(pathLints, pathLint{
 			source: path,

--- a/lib/service/test/case_test.go
+++ b/lib/service/test/case_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -223,7 +222,7 @@ func TestFileCaseInputs(t *testing.T) {
 
 	provider["/pipeline/processors"] = []types.Processor{proc}
 
-	tmpDir, err := ioutil.TempDir("", "test_file_content")
+	tmpDir, err := os.MkdirTemp("", "test_file_content")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -287,7 +286,7 @@ func TestFileCaseConditions(t *testing.T) {
 
 	provider["/pipeline/processors"] = []types.Processor{proc}
 
-	tmpDir, err := ioutil.TempDir("", "test_file_case")
+	tmpDir, err := os.MkdirTemp("", "test_file_case")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/lib/service/test/command.go
+++ b/lib/service/test/command.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -53,7 +52,7 @@ func getDefinition(targetPath, definitionPath string) (*Definition, error) {
 		definitionPath = targetPath
 	}
 	var definition Definition
-	defBytes, err := ioutil.ReadFile(definitionPath)
+	defBytes, err := os.ReadFile(definitionPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read test definition from '%v': %v", definitionPath, err)
 	}

--- a/lib/service/test/condition_test.go
+++ b/lib/service/test/condition_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -424,7 +423,7 @@ func TestJSONContainsCondition(t *testing.T) {
 func TestFileEqualsCondition(t *testing.T) {
 	color.NoColor = true
 
-	tmpDir, err := ioutil.TempDir("", "test_file_condition")
+	tmpDir, err := os.MkdirTemp("", "test_file_condition")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/lib/service/test/generate.go
+++ b/lib/service/test/generate.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -12,7 +11,7 @@ import (
 //------------------------------------------------------------------------------
 
 func isBenthosConfig(path string) (bool, error) {
-	cbytes, err := ioutil.ReadFile(path)
+	cbytes, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}
@@ -48,7 +47,7 @@ func generateDefinitions(targetPath, testSuffix string, recurse bool) error {
 		} else {
 			return fmt.Errorf("test definition file '%v' already exists", definitionPath)
 		}
-		if err = ioutil.WriteFile(definitionPath, defaultDefBytes, 0666); err != nil {
+		if err = os.WriteFile(definitionPath, defaultDefBytes, 0666); err != nil {
 			return fmt.Errorf("failed to write test definition '%v': %v", definitionPath, err)
 		}
 	}
@@ -84,7 +83,7 @@ func generateDefinitions(targetPath, testSuffix string, recurse bool) error {
 			return nil
 		}
 
-		if err = ioutil.WriteFile(definitionPath, defaultDefBytes, 0666); err != nil {
+		if err = os.WriteFile(definitionPath, defaultDefBytes, 0666); err != nil {
 			return fmt.Errorf("failed to write test definition '%v': %v", definitionPath, err)
 		}
 		return nil

--- a/lib/service/test/generate_test.go
+++ b/lib/service/test/generate_test.go
@@ -1,7 +1,6 @@
 package test_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +56,7 @@ tests:
 		t.Errorf("Expected not exist error, got %v", err)
 	}
 
-	actBytes, err := ioutil.ReadFile(filepath.Join(testDir, "foo_benthos_test.yaml"))
+	actBytes, err := os.ReadFile(filepath.Join(testDir, "foo_benthos_test.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +65,7 @@ tests:
 		t.Errorf("Definition does not match default: %v != %v", act, exp)
 	}
 
-	if actBytes, err = ioutil.ReadFile(filepath.Join(testDir, "bar_benthos_test.yaml")); err != nil {
+	if actBytes, err = os.ReadFile(filepath.Join(testDir, "bar_benthos_test.yaml")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,7 +100,7 @@ pipeline:
 		t.Fatal(err)
 	}
 
-	actBytes, err := ioutil.ReadFile(filepath.Join(testDir, "foo_benthos_test.yaml"))
+	actBytes, err := os.ReadFile(filepath.Join(testDir, "foo_benthos_test.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/service/test/processors_provider.go
+++ b/lib/service/test/processors_provider.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -94,7 +93,7 @@ func (p *ProcessorsProvider) ProvideBloblang(pathStr string) ([]types.Processor,
 		pathStr = filepath.Join(filepath.Dir(p.targetPath), pathStr)
 	}
 
-	mappingBytes, err := ioutil.ReadFile(pathStr)
+	mappingBytes, err := os.ReadFile(pathStr)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/service/test/processors_provider_test.go
+++ b/lib/service/test/processors_provider_test.go
@@ -2,7 +2,6 @@ package test_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 )
 
 func initTestFiles(files map[string]string) (string, error) {
-	testDir, err := ioutil.TempDir("", "benthos_config_test_test")
+	testDir, err := os.MkdirTemp("", "benthos_config_test_test")
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +27,7 @@ func initTestFiles(files map[string]string) (string, error) {
 		if err := os.MkdirAll(filepath.Dir(fp), 0777); err != nil {
 			return "", err
 		}
-		if err := ioutil.WriteFile(fp, []byte(v), 0777); err != nil {
+		if err := os.WriteFile(fp, []byte(v), 0777); err != nil {
 			return "", err
 		}
 	}

--- a/lib/stream/example_config_test.go
+++ b/lib/stream/example_config_test.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -34,7 +33,7 @@ func (p CustomProcessor) WaitForClose(timeout time.Duration) error {
 // ExampleYAMLConfig demonstrates running a Benthos stream with a configuration
 // parsed from a YAML file and a custom processor.
 func Example_yamlConfig() {
-	confBytes, err := ioutil.ReadFile("./foo.yaml")
+	confBytes, err := os.ReadFile("./foo.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/lib/stream/manager/api.go
+++ b/lib/stream/manager/api.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -25,7 +25,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/util/text"
 	"github.com/Jeffail/gabs/v2"
 	"github.com/gorilla/mux"
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 //------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ func (m *Type) HandleStreamsCRUD(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var setBytes []byte
-	if setBytes, requestErr = ioutil.ReadAll(r.Body); requestErr != nil {
+	if setBytes, requestErr = io.ReadAll(r.Body); requestErr != nil {
 		return
 	}
 
@@ -282,7 +282,7 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 
 	readConfig := func() (confOut stream.Config, lints []string, err error) {
 		var confBytes []byte
-		if confBytes, err = ioutil.ReadAll(r.Body); err != nil {
+		if confBytes, err = io.ReadAll(r.Body); err != nil {
 			return
 		}
 		confBytes = text.ReplaceEnvVariables(confBytes)
@@ -304,7 +304,7 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 	}
 	patchConfig := func(confIn stream.Config) (confOut stream.Config, err error) {
 		var patchBytes []byte
-		if patchBytes, err = ioutil.ReadAll(r.Body); err != nil {
+		if patchBytes, err = io.ReadAll(r.Body); err != nil {
 			return
 		}
 
@@ -512,7 +512,7 @@ func (m *Type) HandleResourceCRUD(w http.ResponseWriter, r *http.Request) {
 	var lints []string
 	{
 		var confBytes []byte
-		if confBytes, requestErr = ioutil.ReadAll(r.Body); requestErr != nil {
+		if confBytes, requestErr = io.ReadAll(r.Body); requestErr != nil {
 			return
 		}
 		confBytes = text.ReplaceEnvVariables(confBytes)

--- a/lib/stream/manager/api_test.go
+++ b/lib/stream/manager/api_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -816,7 +815,7 @@ func TestTypeAPISetResources(t *testing.T) {
 		manager.OptSetAPITimeout(time.Millisecond*100),
 	)
 
-	tmpDir, err := ioutil.TempDir("", "resources")
+	tmpDir, err := os.MkdirTemp("", "resources")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/lib/stream/manager/from_directory_test.go
+++ b/lib/stream/manager/from_directory_test.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestFromDirectory(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "streams_test")
+	testDir, err := os.MkdirTemp("", "streams_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,10 +47,10 @@ func TestFromDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(fooPath, fooBytes, 0666); err != nil {
+	if err = os.WriteFile(fooPath, fooBytes, 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(barPath, barBytes, 0666); err != nil {
+	if err = os.WriteFile(barPath, barBytes, 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/stream/manager/from_path_test.go
+++ b/lib/stream/manager/from_path_test.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestFromPathHappy(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "streams_test")
+	testDir, err := os.MkdirTemp("", "streams_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,13 +48,13 @@ func TestFromPathHappy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(fooPath, fooBytes, 0666); err != nil {
+	if err = os.WriteFile(fooPath, fooBytes, 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(barPath, barBytes, 0666); err != nil {
+	if err = os.WriteFile(barPath, barBytes, 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(ignorePath, []byte("ignore me please"), 0666); err != nil {
+	if err = os.WriteFile(ignorePath, []byte("ignore me please"), 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/test/integration/azure_test.go
+++ b/lib/test/integration/azure_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -46,12 +46,12 @@ func (t AzuriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Details here: https://github.com/Azure/Azurite/issues/663
 	if strings.Contains(reqURL, "comp=list") &&
 		strings.Contains(reqURL, "restype=container") {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return resp, fmt.Errorf("failed to read response body: %w", err)
 		}
 		newBody := strings.ReplaceAll(string(bodyBytes), "<Snapshot/>", "")
-		resp.Body = ioutil.NopCloser(strings.NewReader(newBody))
+		resp.Body = io.NopCloser(strings.NewReader(newBody))
 		resp.ContentLength = int64(len(newBody))
 	}
 

--- a/lib/util/http/auth/jwt.go
+++ b/lib/util/http/auth/jwt.go
@@ -3,8 +3,8 @@ package auth
 import (
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/golang-jwt/jwt"
@@ -80,7 +80,7 @@ func (j JWTConfig) parsePrivateKey() error {
 		return nil
 	}
 
-	privateKey, err := ioutil.ReadFile(j.PrivateKeyFile)
+	privateKey, err := os.ReadFile(j.PrivateKeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read private key: %v", err)
 	}

--- a/lib/util/http/client/type_test.go
+++ b/lib/util/http/client/type_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -77,7 +76,7 @@ func TestHTTPClientSendBasic(t *testing.T) {
 			resultChan <- msg
 		}()
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return
@@ -201,7 +200,7 @@ func TestHTTPClientSendInterpolate(t *testing.T) {
 			resultChan <- msg
 		}()
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 			return
@@ -278,7 +277,7 @@ func TestHTTPClientSendMultipart(t *testing.T) {
 					t.Error(err)
 					return
 				}
-				msgBytes, err := ioutil.ReadAll(p)
+				msgBytes, err := io.ReadAll(p)
 				if err != nil {
 					t.Error(err)
 					return
@@ -286,7 +285,7 @@ func TestHTTPClientSendMultipart(t *testing.T) {
 				msg.Append(message.NewPart(msgBytes))
 			}
 		} else {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error(err)
 				return

--- a/lib/util/tls/type.go
+++ b/lib/util/tls/type.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 )
 
 //------------------------------------------------------------------------------
@@ -80,7 +80,7 @@ func (c *Config) Get() (*tls.Config, error) {
 	}
 
 	if len(c.RootCAsFile) > 0 {
-		caCert, err := ioutil.ReadFile(c.RootCAsFile)
+		caCert, err := os.ReadFile(c.RootCAsFile)
 		if err != nil {
 			return nil, err
 		}

--- a/public/service/stream_builder_test.go
+++ b/public/service/stream_builder_test.go
@@ -3,7 +3,6 @@ package service_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func TestStreamBuilderDefault(t *testing.T) {
 }
 
 func TestStreamBuilderProducerFunc(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "stream_builder_producer_test")
+	tmpDir, err := os.MkdirTemp("", "stream_builder_producer_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
@@ -94,14 +93,14 @@ file:
 	require.NoError(t, strm.Run(context.Background()))
 	wg.Wait()
 
-	outBytes, err := ioutil.ReadFile(outFilePath)
+	outBytes, err := os.ReadFile(outFilePath)
 	require.NoError(t, err)
 
 	assert.Equal(t, "HELLO WORLD 1\nHELLO WORLD 2\nHELLO WORLD 3\n", string(outBytes))
 }
 
 func TestStreamBuilderBatchProducerFunc(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "stream_builder_batch_producer_test")
+	tmpDir, err := os.MkdirTemp("", "stream_builder_batch_producer_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
@@ -158,7 +157,7 @@ file:
 	require.NoError(t, strm.Run(context.Background()))
 	wg.Wait()
 
-	outBytes, err := ioutil.ReadFile(outFilePath)
+	outBytes, err := os.ReadFile(outFilePath)
 	require.NoError(t, err)
 
 	assert.Equal(t, "HELLO WORLD 1\nHELLO WORLD 2\n\nHELLO WORLD 3\nHELLO WORLD 4\n\nHELLO WORLD 5\nHELLO WORLD 6\n\n", string(outBytes))
@@ -207,14 +206,14 @@ logger:
 }
 
 func TestStreamBuilderConsumerFunc(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "stream_builder_consumer_test")
+	tmpDir, err := os.MkdirTemp("", "stream_builder_consumer_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 
 	inFilePath := filepath.Join(tmpDir, "in.txt")
-	require.NoError(t, ioutil.WriteFile(inFilePath, []byte(`HELLO WORLD 1
+	require.NoError(t, os.WriteFile(inFilePath, []byte(`HELLO WORLD 1
 HELLO WORLD 2
 HELLO WORLD 3`), 0755))
 
@@ -262,14 +261,14 @@ file:
 }
 
 func TestStreamBuilderBatchConsumerFunc(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "stream_builder_batch_consumer_test")
+	tmpDir, err := os.MkdirTemp("", "stream_builder_batch_consumer_test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 
 	inFilePath := filepath.Join(tmpDir, "in.txt")
-	require.NoError(t, ioutil.WriteFile(inFilePath, []byte(`HELLO WORLD 1
+	require.NoError(t, os.WriteFile(inFilePath, []byte(`HELLO WORLD 1
 HELLO WORLD 2
 
 HELLO WORLD 3


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.