### PR TITLE
fix: use float32 on cassandra float column

### DIFF
--- a/internal/bloblang/query/type_helpers.go
+++ b/internal/bloblang/query/type_helpers.go
@@ -104,6 +104,27 @@ func IGetNumber(v interface{}) (float64, error) {
 	return 0, NewTypeError(v, ValueNumber)
 }
 
+// IGetFloat32 takes a boxed value and attempts to extract a number (float32)
+// from it.
+func IGetFloat32(v interface{}) (float32, error) {
+	switch t := v.(type) {
+	case int:
+		return float32(t), nil
+	case int64:
+		return float32(t), nil
+	case uint64:
+		return float32(t), nil
+	case float32:
+		return t, nil
+	case float64:
+		return float32(t), nil
+	case json.Number:
+		v, e := t.Float64()
+		return float32(v), e
+	}
+	return 0, NewTypeError(v, ValueNumber)
+}
+
 // IGetInt takes a boxed value and attempts to extract an integer (int64) from
 // it.
 func IGetInt(v interface{}) (int64, error) {

--- a/lib/output/cassandra.go
+++ b/lib/output/cassandra.go
@@ -538,8 +538,14 @@ func (g genericValue) MarshalCQL(info gocql.TypeInfo) ([]byte, error) {
 			return nil, err
 		}
 		return gocql.Marshal(info, t)
-	case gocql.TypeFloat, gocql.TypeDouble:
+	case gocql.TypeDouble:
 		f, err := query.IGetNumber(g.v)
+		if err != nil {
+			return nil, err
+		}
+		return gocql.Marshal(info, f)
+	case gocql.TypeFloat:
+		f, err := query.IGetFloat32(g.v)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I have a table with a column `foo` of type `float`.

```
CREATE TABLE IF NOT EXISTS data.my_table
(
    id        text,
    foo       float,
    timestamp timestamp,
    PRIMARY key (id, timestamp)
) 
```

Using the “previous”  args parameter on cassandra output, it works fine:

```
    args:
      - ${! json("id") }
      - ${! json("foo") }
      - ${! json("timestamp") 
```

but with args_mapping:

```
    args_mapping: |
      root = [
        id,
        foo,
        timestamp
      ]
```

it fails with "Failed to send message to cassandra: can not marshal float64 into float"

Changing the table column to double instead of float, both args parameters work well.

As in https://github.com/gocql/gocql/issues/474, if we’d want to keep using float64 we’d need to change the column type to double or change our parameter to `float32`.

This PR sets the var as `float32` if the Cassandra column is `float`, and keeps `float64` if the column is `double`.

Signed-off-by: Marco Amador <marco.amador@anova.com>