### PR TITLE
Add GCP Cloud Storage cache

### DIFF
--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -2,7 +2,7 @@ package gcp
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -65,7 +65,7 @@ func (c *gcpCloudStorageCache) Get(ctx context.Context, key string) ([]byte, err
 
 	defer reader.Close()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi,

this is something we currently use as a custom benthos plugin, but would be great as a core feature.
Especially since AWS S3 is already available as a cache.

I could match the fields available in https://www.benthos.dev/docs/components/outputs/gcp_cloud_storage (thinking about `content_type`, `chunk_size`, `content_encoding`) but wanted to get a feel for what you think about it first.


Best
Kai
