### PR TITLE
Makefile: create INSTALL_DIR if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ APPS = benthos
 all: $(APPS)
 
 install: $(APPS)
+	@install -d $(INSTALL_DIR)
 	@rm -f $(INSTALL_DIR)/benthos
 	@cp $(PATHINSTBIN)/* $(INSTALL_DIR)/
 


### PR DESCRIPTION
When building benthos within a "pristine" `GOPATH` the `bin` subdirectory might not necessarily exist yet, thus create `INSTALL_DIR` if needed.

I have run into this issue when building (internal) Debian packages for Benthos, in such environment I'm setting `GOPATH` to a temporary directory and then post-install copying out `benthos` to its final location.

Let me know what you think, thank you!