### PR TITLE
fix: azure table storage escape odata single quotes

### DIFF
--- a/internal/impl/azure/output_table_storage.go
+++ b/internal/impl/azure/output_table_storage.go
@@ -261,6 +261,8 @@ func (a *azureTableStorageWriter) execBatch(ctx context.Context, writeReqs map[s
 				var batch []aztables.TransactionAction
 				ne := len(entities)
 				for i, entity := range entities {
+					entity.PartitionKey = escapeODataString(entity.PartitionKey)
+					entity.RowKey = escapeODataString(entity.RowKey)
 					batch, err = a.addToBatch(batch, tt, entity)
 					if err != nil {
 						return err
@@ -297,6 +299,10 @@ func isLastEntity(i, ne int) bool {
 func reachedBatchLimit(i int) bool {
 	const batchSizeLimit = 100
 	return (i+1)%batchSizeLimit == 0
+}
+
+func escapeODataString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 func (a *azureTableStorageWriter) addToBatch(batch []aztables.TransactionAction, transactionType string, entity *aztables.EDMEntity) ([]aztables.TransactionAction, error) {


### PR DESCRIPTION
With the current output we can't send single quote values to either PK/RK or it will fail.
We need to escape the single quote with another double quotes.
It's sad that we need to do this, one would think that the Azure SDK would do this for us. But right now it doesn't.

For example, something like this will fail:
```yaml
output:
  azure_table_storage:
    partition_key: "pk"
    row_key: "r'k"
```
```
HTTP/1.1 400 Bad Request
X-Content-Type-Options: nosniff
DataServiceVersion: 3.0;
Content-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8

{"odata.error":{"code":"InvalidInput","message":{"lang":"en-US","value":"0:There is an unterminated string literal at position 30 in 'PartitionKey='pk',RowKey='r'k''.\nRequestId:01801433-1002-0089-55d3-a52db3000000\nTime:2023-06-23T13:06:34.0128916Z"}}}
```

And we need to do this instead:
```yaml
output:
  azure_table_storage:
    partition_key: "pk"
    row_key: "r''k"
```

This PR will only support the first approach, which is the one that I think makes more sense.

Let me know if this make sense. I will happily add a PR to the Azure SDK, but I'm not too confident that it will be merged soon.