### PR TITLE
Add module for MQTTv5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,6 +192,7 @@ require (
 	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
+	github.com/eclipse/paho.golang v0.12.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4A
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/eclipse/paho.golang v0.12.0 h1:EXQFJbJklDnUqW6lyAknMWRhM2NgpHxwrrL8riUmp3Q=
+github.com/eclipse/paho.golang v0.12.0/go.mod h1:TSDCUivu9JnoR9Hl+H7sQMcHkejWH2/xKK1NJGtLbIE=
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/emicklei/proto v1.10.0 h1:pDGyFRVV5RvV+nkBK9iy3q67FBy9Xa7vwrOTE+g5aGw=

--- a/internal/component/input/config.go
+++ b/internal/component/input/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Generate     GenerateConfig     `json:"generate" yaml:"generate"`
 	Inproc       InprocConfig       `json:"inproc" yaml:"inproc"`
 	MQTT         MQTTConfig         `json:"mqtt" yaml:"mqtt"`
+	MQTTv5       MQTTConfig         `json:"mqtt5" yaml:"mqtt5"`
 	Nanomsg      NanomsgConfig      `json:"nanomsg" yaml:"nanomsg"`
 	NSQ          NSQConfig          `json:"nsq" yaml:"nsq"`
 	Plugin       any                `json:"plugin,omitempty" yaml:"plugin,omitempty"`
@@ -44,6 +45,7 @@ func NewConfig() Config {
 		Generate:     NewGenerateConfig(),
 		Inproc:       NewInprocConfig(),
 		MQTT:         NewMQTTConfig(),
+		MQTTv5:       NewMQTTConfig(),
 		Nanomsg:      NewNanomsgConfig(),
 		NSQ:          NewNSQConfig(),
 		Plugin:       nil,

--- a/internal/component/output/config.go
+++ b/internal/component/output/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Fallback     TryConfig          `json:"fallback" yaml:"fallback"`
 	Inproc       string             `json:"inproc" yaml:"inproc"`
 	MQTT         MQTTConfig         `json:"mqtt" yaml:"mqtt"`
+	MQTTv5       MQTTConfig         `json:"mqtt5" yaml:"mqtt5"`
 	Nanomsg      NanomsgConfig      `json:"nanomsg" yaml:"nanomsg"`
 	NSQ          NSQConfig          `json:"nsq" yaml:"nsq"`
 	Plugin       any                `json:"plugin,omitempty" yaml:"plugin,omitempty"`

--- a/internal/impl/mqtt5/input.go
+++ b/internal/impl/mqtt5/input.go
@@ -1,0 +1,410 @@
+package mqtt5
+
+import (
+	"context"
+	"fmt"
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/paho"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	gonanoid "github.com/matoous/go-nanoid/v2"
+
+	"github.com/benthosdev/benthos/v4/internal/bundle"
+	"github.com/benthosdev/benthos/v4/internal/component"
+	"github.com/benthosdev/benthos/v4/internal/component/input"
+	"github.com/benthosdev/benthos/v4/internal/component/input/processors"
+	"github.com/benthosdev/benthos/v4/internal/docs"
+	mqttconf "github.com/benthosdev/benthos/v4/internal/impl/mqtt/shared"
+	"github.com/benthosdev/benthos/v4/internal/log"
+	"github.com/benthosdev/benthos/v4/internal/message"
+	"github.com/benthosdev/benthos/v4/internal/tls"
+)
+
+type MqttLogger struct {
+	log log.Modular
+}
+
+func (l MqttLogger) Println(v ...interface{}) {
+	l.log.Infof("%v\n", v...)
+}
+
+func (l MqttLogger) Printf(format string, v ...interface{}) {
+	l.log.Infof(format, v...)
+}
+
+func init() {
+	err := bundle.AllInputs.Add(processors.WrapConstructor(func(conf input.Config, nm bundle.NewManagement) (input.Streamed, error) {
+		m, err := newMQTTReader(conf.MQTTv5, nm)
+		if err != nil {
+			return nil, err
+		}
+		return input.NewAsyncReader("mqtt5", input.NewAsyncPreserver(m), nm)
+	}), docs.ComponentSpec{
+		Name: "mqtt5",
+		Summary: `
+Subscribe to topics on MQTT brokers, via protocol version 5.`,
+		Description: `
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+` + "``` text" + `
+- mqtt_qos
+- mqtt_retained
+- mqtt_topic
+- mqtt_message_id
+` + "```" + `
+
+You can access these metadata fields using
+[function interpolation](/docs/configuration/interpolation#bloblang-queries).`,
+		Config: docs.FieldComponent().WithChildren(
+			docs.FieldURL("urls", "A list of URLs to connect to. If an item of the list contains commas it will be expanded into multiple URLs.").Array(),
+			docs.FieldString("topics", "A list of topics to consume from.").Array(),
+			docs.FieldString("client_id", "An identifier for the client connection."),
+			docs.FieldString("dynamic_client_id_suffix", "Append a dynamically generated suffix to the specified `client_id` on each run of the pipeline. This can be useful when clustering Benthos producers.").Optional().Advanced().HasAnnotatedOptions(
+				"nanoid", "append a nanoid of length 21 characters",
+			).LinterFunc(nil),
+			docs.FieldInt("qos", "The level of delivery guarantee to enforce.").HasOptions("0", "1", "2").Advanced().LinterFunc(nil),
+			docs.FieldBool("clean_session", "Set whether the connection is non-persistent.").Advanced(),
+			mqttconf.WillFieldSpec(),
+			docs.FieldString("connect_timeout", "The maximum amount of time to wait in order to establish a connection before the attempt is abandoned.", "1s", "500ms").HasDefault("30s").AtVersion("3.58.0"),
+			docs.FieldString("user", "A username to assume for the connection.").Advanced(),
+			docs.FieldString("password", "A password to provide for the connection.").Advanced().Secret(),
+			docs.FieldInt("keepalive", "Max seconds of inactivity before a keepalive message is sent.").Advanced(),
+			tls.FieldSpec().AtVersion("3.45.0"),
+		).ChildDefaultAndTypesFromStruct(input.NewMQTTConfig()),
+		Categories: []string{
+			"Services",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+type mqttReader struct {
+	client  *autopaho.ConnectionManager
+	msgChan chan paho.Publish
+	cMut    sync.Mutex
+
+	connectTimeout time.Duration
+	conf           input.MQTTConfig
+
+	interruptChan chan struct{}
+
+	urls []string
+
+	log log.Modular
+	mgr bundle.NewManagement
+}
+
+func newMQTTReader(conf input.MQTTConfig, mgr bundle.NewManagement) (*mqttReader, error) {
+	m := &mqttReader{
+		conf:          conf,
+		interruptChan: make(chan struct{}),
+		log:           mgr.Logger(),
+		mgr:           mgr,
+	}
+
+	var err error
+	if m.connectTimeout, err = time.ParseDuration(conf.ConnectTimeout); err != nil {
+		return nil, fmt.Errorf("unable to parse connect timeout duration string: %w", err)
+	}
+
+	switch m.conf.DynamicClientIDSuffix {
+	case "nanoid":
+		nid, err := gonanoid.New()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate nanoid: %w", err)
+		}
+		m.conf.ClientID += nid
+	case "":
+	default:
+		return nil, fmt.Errorf("unknown dynamic_client_id_suffix: %v", m.conf.DynamicClientIDSuffix)
+	}
+
+	if err := m.conf.Will.Validate(); err != nil {
+		return nil, err
+	}
+
+	// if urls is empty, panic
+	if len(conf.URLs) == 0 {
+		panic("no configured broker URLs (MQTTv5 adapter)")
+	}
+	for _, u := range conf.URLs {
+		for _, splitURL := range strings.Split(u, ",") {
+			if len(splitURL) > 0 {
+				m.urls = append(m.urls, splitURL)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *mqttReader) Connect(ctx context.Context) error {
+	// will run until canceled
+	//ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	//defer stop()
+
+	m.cMut.Lock()
+	defer m.cMut.Unlock()
+
+	if m.client != nil {
+		return nil
+	}
+
+	var msgMut sync.Mutex
+	msgChan := make(chan paho.Publish)
+
+	closeMsgChan := func() bool {
+		msgMut.Lock()
+		chanOpen := msgChan != nil
+		if chanOpen {
+			close(msgChan)
+			msgChan = nil
+		}
+		msgMut.Unlock()
+		return chanOpen
+	}
+
+	var brokers []*url.URL
+
+	// if m.urls is empty, panic
+	if len(m.urls) == 0 {
+		panic("no broker URLs (MQTTv5 adapter)")
+	}
+
+	for _, u := range m.urls {
+		parsedUrl, err := url.Parse(u)
+		if err != nil {
+			panic("invalid broker url")
+		}
+		brokers = append(brokers, parsedUrl)
+	}
+
+	var active = true
+	processMsg := func(msg *paho.Publish, topic string) {
+		msgMut.Lock()
+		if msgChan != nil {
+			select {
+			case msgChan <- *msg:
+			case <-m.interruptChan:
+			}
+		}
+		msgMut.Unlock()
+	}
+
+	router := paho.NewSingleHandlerRouter(func(msg *paho.Publish) {
+		m.log.Infof("Received MQTTv5 message via default handler")
+		processMsg(msg, "_unknown_")
+	})
+
+	for _, topic := range m.conf.Topics {
+		router.RegisterHandler(topic, func(msg *paho.Publish) {
+			m.log.Infof("Received MQTTv5 message on topic '%s'", topic)
+			processMsg(msg, topic)
+		})
+	}
+	infoLogger := MqttLogger{log: m.log}
+	errLogger := MqttLogger{log: m.log}
+
+	conf := autopaho.ClientConfig{
+		BrokerUrls: brokers,
+		Debug:      infoLogger,
+		PahoDebug:  infoLogger,
+		PahoErrors: errLogger,
+		KeepAlive:  uint16(time.Duration(m.conf.KeepAlive) * time.Second),
+		OnConnectionUp: func(mgr *autopaho.ConnectionManager, connack *paho.Connack) {
+			m.log.Infof("MQTTv5 broker connection active")
+			topics := make(map[string]byte)
+
+			// if there are no topics, there are no subscriptions to set
+			if len(m.conf.Topics) == 0 {
+				m.log.Infof("No MQTT subscription topics")
+				return
+			}
+			for _, topic := range m.conf.Topics {
+				topics[topic] = m.conf.QoS
+			}
+
+			var subscriptions []paho.SubscribeOptions
+			for topic, qos := range topics {
+				subscriptions = append(subscriptions, paho.SubscribeOptions{
+					Topic: topic,
+					QoS:   qos,
+				})
+			}
+
+			if len(topics) > 0 {
+				if ack, err := mgr.Subscribe(context.Background(), &paho.Subscribe{
+					Subscriptions: subscriptions,
+				}); err != nil {
+					m.log.Errorf("Failed to subscribe over MQTTv5 (%s, %v)", err, ack.Reasons)
+				}
+			}
+			m.log.Infof("MQTTv5 subscriptions active (%d)\n", len(topics))
+		},
+		OnConnectError: func(err error) {
+			m.log.Errorf("Failed to connect to MQTTv5 broker: %s", err)
+		},
+		ClientConfig: paho.ClientConfig{
+			ClientID: m.conf.ClientID,
+			Router:   router,
+			OnClientError: func(err error) {
+				m.log.Errorf("MQTTv5 client error: %s", err)
+			},
+			OnServerDisconnect: func(d *paho.Disconnect) {
+				active = false
+				closeMsgChan()
+
+				if d.Properties != nil {
+					m.log.Errorf("Connection lost due to: %s\n", d.Properties.ReasonString)
+				} else {
+					m.log.Errorf("Connection lost due to reason code: %d\n", d.ReasonCode)
+				}
+			},
+		},
+	}
+
+	if m.conf.Will.Enabled {
+		conf.SetWillMessage(
+			m.conf.Will.Topic,
+			[]byte(m.conf.Will.Payload),
+			m.conf.Will.QoS,
+			m.conf.Will.Retained,
+		)
+	}
+
+	if m.conf.TLS.Enabled {
+		m.log.Infof("Using MQTTv5 over TLS")
+		tlsConf, err := m.conf.TLS.Get(m.mgr.FS())
+		if err != nil {
+			return err
+		}
+		conf.TlsCfg = tlsConf
+	}
+
+	if m.conf.User != "" && m.conf.Password != "" {
+		conf.SetUsernamePassword(
+			m.conf.User,
+			[]byte(m.conf.Password),
+		)
+	}
+
+	// connect to the broker
+	conn, err := autopaho.NewConnection(ctx, conf)
+	if err != nil {
+		return err
+	}
+
+	// await established connection
+	m.log.Infof("Connecting to MQTTv5 broker")
+	connErr := conn.AwaitConnection(ctx)
+	if connErr != nil {
+		panic("Failed to connect to MQTTv5 broker")
+	}
+
+	//m.log.Infof("MQTTv5 broker connection active")
+	//topics := make(map[string]byte)
+	//for _, topic := range m.conf.Topics {
+	//	topics[topic] = m.conf.QoS
+	//}
+	//
+	//var subscriptions []paho.SubscribeOptions
+	//for topic, qos := range topics {
+	//	subscriptions = append(subscriptions, paho.SubscribeOptions{
+	//		Topic: topic,
+	//		QoS:   qos,
+	//	})
+	//}
+	//
+	//if _, err := conn.Subscribe(context.Background(), &paho.Subscribe{
+	//	Subscriptions: subscriptions,
+	//}); err != nil {
+	//	fmt.Printf("failed to subscribe (%s). This is likely to mean no messages will be received.", err)
+	//}
+
+	m.log.Infof("Receiving MQTTv5 messages from topics: %v\n", m.conf.Topics)
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Second):
+				if !active {
+					if closeMsgChan() {
+						m.log.Errorln("Connection lost for unknown reasons.")
+					}
+					return
+				}
+			case <-conn.Done():
+			case <-m.interruptChan:
+				return
+			}
+		}
+	}()
+	m.client = conn
+	m.msgChan = msgChan
+	return nil
+}
+
+func (m *mqttReader) Ack(msg *paho.Publish) {
+	// nothing at this time @TODO
+}
+
+func (m *mqttReader) ReadBatch(ctx context.Context) (message.Batch, input.AsyncAckFn, error) {
+	m.cMut.Lock()
+	msgChan := m.msgChan
+	m.cMut.Unlock()
+
+	if msgChan == nil {
+		return nil, nil, component.ErrNotConnected
+	}
+
+	select {
+	case msg, open := <-msgChan:
+		if !open {
+			m.cMut.Lock()
+			m.msgChan = nil
+			m.client = nil
+			m.cMut.Unlock()
+			return nil, nil, component.ErrNotConnected
+		}
+
+		inner := message.QuickBatch([][]byte{msg.Payload})
+
+		p := inner.Get(0)
+		p.MetaSetMut("mqtt_qos", int(msg.QoS))
+		p.MetaSetMut("mqtt_retained", msg.Retain)
+		p.MetaSetMut("mqtt_topic", msg.Topic)
+		p.MetaSetMut("mqtt_message_id", int(msg.PacketID))
+
+		return inner, func(ctx context.Context, res error) error {
+			if res == nil {
+				m.Ack(&msg)
+			}
+			return nil
+		}, nil
+	case <-ctx.Done():
+	case <-m.interruptChan:
+		return nil, nil, component.ErrTypeClosed
+	}
+	return nil, nil, component.ErrTimeout
+}
+
+func (m *mqttReader) Close(ctx context.Context) (err error) {
+	m.cMut.Lock()
+	defer m.cMut.Unlock()
+
+	if m.client != nil {
+		err := m.client.Disconnect(ctx)
+		if err != nil {
+			return err
+		}
+		m.client = nil
+		close(m.interruptChan)
+	}
+	return
+}

--- a/internal/impl/mqtt5/integration_test.go
+++ b/internal/impl/mqtt5/integration_test.go
@@ -1,0 +1,97 @@
+package mqtt5
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/benthosdev/benthos/v4/internal/integration"
+)
+
+func TestIntegrationMQTT(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Second * 30
+	resource, err := pool.Run("ncarlier/mqtt", "latest", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	_ = resource.Expire(900)
+	require.NoError(t, pool.Retry(func() error {
+		inConf := mqtt.NewClientOptions().SetClientID("UNIT_TEST")
+		inConf = inConf.AddBroker(fmt.Sprintf("tcp://localhost:%v", resource.GetPort("1883/tcp")))
+
+		mIn := mqtt.NewClient(inConf)
+		tok := mIn.Connect()
+		tok.Wait()
+		if cErr := tok.Error(); cErr != nil {
+			return cErr
+		}
+		mIn.Disconnect(0)
+		return nil
+	}))
+
+	template := `
+output:
+  mqtt:
+    urls: [ tcp://localhost:$PORT ]
+    qos: 1
+    topic: topic-$ID
+    client_id: client-output-$ID
+    dynamic_client_id_suffix: "$VAR1"
+    max_in_flight: $MAX_IN_FLIGHT
+
+input:
+  mqtt:
+    urls: [ tcp://localhost:$PORT ]
+    topics: [ topic-$ID ]
+    client_id: client-input-$ID
+    dynamic_client_id_suffix: "$VAR1"
+    clean_session: false
+`
+	suite := integration.StreamTests(
+		integration.StreamTestOpenClose(),
+		// integration.StreamTestMetadata(), TODO
+		integration.StreamTestSendBatch(10),
+		integration.StreamTestStreamParallel(1000),
+		// integration.StreamTestStreamParallelLossy(1000),
+	)
+	suite.Run(
+		t, template,
+		integration.StreamTestOptSleepAfterInput(100*time.Millisecond),
+		integration.StreamTestOptSleepAfterOutput(100*time.Millisecond),
+		integration.StreamTestOptPort(resource.GetPort("1883/tcp")),
+	)
+	t.Run("with max in flight", func(t *testing.T) {
+		t.Parallel()
+		suite.Run(
+			t, template,
+			integration.StreamTestOptSleepAfterInput(100*time.Millisecond),
+			integration.StreamTestOptSleepAfterOutput(100*time.Millisecond),
+			integration.StreamTestOptPort(resource.GetPort("1883/tcp")),
+			integration.StreamTestOptMaxInFlight(10),
+		)
+	})
+	t.Run("with generated suffix", func(t *testing.T) {
+		t.Parallel()
+		suite.Run(
+			t, template,
+			integration.StreamTestOptSleepAfterInput(100*time.Millisecond),
+			integration.StreamTestOptSleepAfterOutput(100*time.Millisecond),
+			integration.StreamTestOptPort(resource.GetPort("1883/tcp")),
+			integration.StreamTestOptMaxInFlight(10),
+			integration.StreamTestOptVarOne("nanoid"),
+		)
+	})
+}

--- a/internal/impl/mqtt5/output.go
+++ b/internal/impl/mqtt5/output.go
@@ -1,0 +1,243 @@
+package mqtt5
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	gonanoid "github.com/matoous/go-nanoid/v2"
+
+	"github.com/benthosdev/benthos/v4/internal/bloblang/field"
+	"github.com/benthosdev/benthos/v4/internal/bundle"
+	"github.com/benthosdev/benthos/v4/internal/component"
+	"github.com/benthosdev/benthos/v4/internal/component/output"
+	"github.com/benthosdev/benthos/v4/internal/component/output/processors"
+	"github.com/benthosdev/benthos/v4/internal/docs"
+	mqttconf "github.com/benthosdev/benthos/v4/internal/impl/mqtt/shared"
+	"github.com/benthosdev/benthos/v4/internal/log"
+	"github.com/benthosdev/benthos/v4/internal/message"
+	"github.com/benthosdev/benthos/v4/internal/tls"
+)
+
+func init() {
+	err := bundle.AllOutputs.Add(processors.WrapConstructor(func(conf output.Config, nm bundle.NewManagement) (output.Streamed, error) {
+		w, err := newMQTTWriter(conf.MQTTv5, nm)
+		if err != nil {
+			return nil, err
+		}
+		a, err := output.NewAsyncWriter("mqtt5", conf.MQTTv5.MaxInFlight, w, nm)
+		if err != nil {
+			return nil, err
+		}
+		return output.OnlySinglePayloads(a), nil
+	}), docs.ComponentSpec{
+		Name: "mqtt5",
+		Summary: `
+Pushes messages to an MQTT broker, using protocol version 5.`,
+		Description: output.Description(true, false, `
+The `+"`topic`"+` field can be dynamically set using function interpolations
+described [here](/docs/configuration/interpolation#bloblang-queries). When sending batched
+messages these interpolations are performed per message part.`),
+		Config: docs.FieldComponent().WithChildren(
+			docs.FieldURL("urls", "A list of URLs to connect to. If an item of the list contains commas it will be expanded into multiple URLs.", []string{"tcp://localhost:1883"}).Array(),
+			docs.FieldString("topic", "The topic to publish messages to."),
+			docs.FieldString("client_id", "An identifier for the client connection."),
+			docs.FieldString("dynamic_client_id_suffix", "Append a dynamically generated suffix to the specified `client_id` on each run of the pipeline. This can be useful when clustering Benthos producers.").Optional().Advanced().HasAnnotatedOptions(
+				"nanoid", "append a nanoid of length 21 characters",
+			).LinterFunc(nil),
+			docs.FieldInt("qos", "The QoS value to set for each message.").HasOptions("0", "1", "2").LinterFunc(nil),
+			docs.FieldString("connect_timeout", "The maximum amount of time to wait in order to establish a connection before the attempt is abandoned.", "1s", "500ms").HasDefault("30s").AtVersion("3.58.0"),
+			docs.FieldString("write_timeout", "The maximum amount of time to wait to write data before the attempt is abandoned.", "1s", "500ms").HasDefault("3s").AtVersion("3.58.0"),
+			docs.FieldBool("retained", "Set message as retained on the topic."),
+			docs.FieldString("retained_interpolated", "Override the value of `retained` with an interpolable value, this allows it to be dynamically set based on message contents. The value must resolve to either `true` or `false`.").IsInterpolated().Advanced().AtVersion("3.59.0"),
+			mqttconf.WillFieldSpec(),
+			docs.FieldString("user", "A username to connect with.").Advanced(),
+			docs.FieldString("password", "A password to connect with.").Advanced().Secret(),
+			docs.FieldInt("keepalive", "Max seconds of inactivity before a keepalive message is sent.").Advanced(),
+			tls.FieldSpec().AtVersion("3.45.0"),
+			docs.FieldInt("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
+		).ChildDefaultAndTypesFromStruct(output.NewMQTTConfig()),
+		Categories: []string{
+			"Services",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+type mqttWriter struct {
+	log log.Modular
+	mgr bundle.NewManagement
+
+	connectTimeout time.Duration
+	writeTimeout   time.Duration
+
+	urls     []string
+	conf     output.MQTTConfig
+	topic    *field.Expression
+	retained *field.Expression
+
+	client  mqtt.Client
+	connMut sync.RWMutex
+}
+
+func newMQTTWriter(conf output.MQTTConfig, mgr bundle.NewManagement) (*mqttWriter, error) {
+	m := &mqttWriter{
+		log:  mgr.Logger(),
+		mgr:  mgr,
+		conf: conf,
+	}
+
+	var err error
+	if m.connectTimeout, err = time.ParseDuration(conf.ConnectTimeout); err != nil {
+		return nil, fmt.Errorf("unable to parse connect timeout duration string: %w", err)
+	}
+	if m.writeTimeout, err = time.ParseDuration(conf.WriteTimeout); err != nil {
+		return nil, fmt.Errorf("unable to parse write timeout duration string: %w", err)
+	}
+
+	if m.topic, err = mgr.BloblEnvironment().NewField(conf.Topic); err != nil {
+		return nil, fmt.Errorf("failed to parse topic expression: %v", err)
+	}
+
+	if conf.RetainedInterpolated != "" {
+		if m.retained, err = mgr.BloblEnvironment().NewField(conf.RetainedInterpolated); err != nil {
+			return nil, fmt.Errorf("failed to parse retained expression: %v", err)
+		}
+	}
+
+	switch m.conf.DynamicClientIDSuffix {
+	case "nanoid":
+		nid, err := gonanoid.New()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate nanoid: %w", err)
+		}
+		m.conf.ClientID += nid
+	case "":
+	default:
+		return nil, fmt.Errorf("unknown dynamic_client_id_suffix: %v", m.conf.DynamicClientIDSuffix)
+	}
+
+	if err := m.conf.Will.Validate(); err != nil {
+		return nil, err
+	}
+
+	for _, u := range conf.URLs {
+		for _, splitURL := range strings.Split(u, ",") {
+			if len(splitURL) > 0 {
+				m.urls = append(m.urls, splitURL)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *mqttWriter) Connect(ctx context.Context) error {
+	m.connMut.Lock()
+	defer m.connMut.Unlock()
+
+	if m.client != nil {
+		return nil
+	}
+
+	conf := mqtt.NewClientOptions().
+		SetAutoReconnect(false).
+		SetConnectionLostHandler(func(client mqtt.Client, reason error) {
+			client.Disconnect(0)
+			m.log.Errorf("Connection lost due to: %v\n", reason)
+		}).
+		SetConnectTimeout(m.connectTimeout).
+		SetWriteTimeout(m.writeTimeout).
+		SetKeepAlive(time.Duration(m.conf.KeepAlive) * time.Second).
+		SetClientID(m.conf.ClientID)
+
+	for _, u := range m.urls {
+		conf = conf.AddBroker(u)
+	}
+
+	if m.conf.Will.Enabled {
+		conf = conf.SetWill(m.conf.Will.Topic, m.conf.Will.Payload, m.conf.Will.QoS, m.conf.Will.Retained)
+	}
+
+	if m.conf.TLS.Enabled {
+		tlsConf, err := m.conf.TLS.Get(m.mgr.FS())
+		if err != nil {
+			return err
+		}
+		conf.SetTLSConfig(tlsConf)
+	}
+
+	if m.conf.User != "" {
+		conf.SetUsername(m.conf.User)
+	}
+
+	if m.conf.Password != "" {
+		conf.SetPassword(m.conf.Password)
+	}
+
+	client := mqtt.NewClient(conf)
+
+	tok := client.Connect()
+	tok.Wait()
+	if err := tok.Error(); err != nil {
+		return err
+	}
+
+	m.client = client
+	return nil
+}
+
+func (m *mqttWriter) WriteBatch(ctx context.Context, msg message.Batch) error {
+	m.connMut.RLock()
+	client := m.client
+	m.connMut.RUnlock()
+
+	if client == nil {
+		return component.ErrNotConnected
+	}
+
+	return output.IterateBatchedSend(msg, func(i int, p *message.Part) error {
+		retained := m.conf.Retained
+		if m.retained != nil {
+			retainedStr, parseErr := m.retained.String(i, msg)
+			if parseErr != nil {
+				m.log.Errorf("Retained interpolation error: %v", parseErr)
+			} else if retained, parseErr = strconv.ParseBool(retainedStr); parseErr != nil {
+				m.log.Errorf("Error parsing boolean value from retained flag: %v \n", parseErr)
+			}
+		}
+
+		topicStr, err := m.topic.String(i, msg)
+		if err != nil {
+			return fmt.Errorf("topic interpolation error: %w", err)
+		}
+
+		mtok := client.Publish(topicStr, m.conf.QoS, retained, p.AsBytes())
+		mtok.Wait()
+		sendErr := mtok.Error()
+		if sendErr == mqtt.ErrNotConnected {
+			m.connMut.RLock()
+			m.client = nil
+			m.connMut.RUnlock()
+			sendErr = component.ErrNotConnected
+		}
+		return sendErr
+	})
+}
+
+func (m *mqttWriter) Close(context.Context) error {
+	m.connMut.Lock()
+	defer m.connMut.Unlock()
+
+	if m.client != nil {
+		m.client.Disconnect(0)
+		m.client = nil
+	}
+	return nil
+}

--- a/internal/impl/mqtt5/package.go
+++ b/internal/impl/mqtt5/package.go
@@ -1,0 +1,3 @@
+// Package mqtt will eventually contain all implementations of MQTT components
+// (that are currently within ./internal/old)
+package mqtt5

--- a/public/components/all/package.go
+++ b/public/components/all/package.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/benthosdev/benthos/v4/public/components/memcached"
 	_ "github.com/benthosdev/benthos/v4/public/components/mongodb"
 	_ "github.com/benthosdev/benthos/v4/public/components/mqtt"
+	_ "github.com/benthosdev/benthos/v4/public/components/mqtt5"
 	_ "github.com/benthosdev/benthos/v4/public/components/msgpack"
 	_ "github.com/benthosdev/benthos/v4/public/components/nanomsg"
 	_ "github.com/benthosdev/benthos/v4/public/components/nats"

--- a/public/components/mqtt5/package.go
+++ b/public/components/mqtt5/package.go
@@ -1,0 +1,6 @@
+package mqtt5
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/mqtt5"
+)


### PR DESCRIPTION
## Summary

This PR adds a new `mqtt5` module, usable as an `input` or an `output`, which implements MQTTv5 support via the newer [Paho client](https://github.com/eclipse/paho.golang).

The structure changes between Paho clients are rather large, but the core config and datastructures relevant to MQTT haven't changed; so this module pulls much of its code from the regular `mqtt` module, but re-implements the `Connect` functions as needed.

Candidly, I'm very new to Go, I'm coming at this from JVM-land, so if I'm doing anything absurd please let me know. The adapter already works as an `input` and I'm adding `output` functionality next.

This change is enabling us to use Benthos with [Cloudflare Pubsub](https://developers.cloudflare.com/pub-sub/), which, at this time, [only supports MQTTv5](https://developers.cloudflare.com/pub-sub/platform/mqtt-compatibility/).

## Changelog

- [x] Add `mqtt5` support for `input`
- [ ] Add `mqtt5` support for `output`
