### PR TITLE
Add `proxy_url` field to the websocket components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ All notable changes to this project will be documented in this file.
 - Field `auto_replay_nacks` added to all inputs that traditionally automatically retry nacked messages as a toggle for this behaviour.
 - New `retry` processor.
 - New `noop` cache.
+- Field `proxy_url` added to the `websocket` input and output.
 
 ### Fixed
 
 - The `unarchive` processor no longer yields linting errors when the format `csv:x` is specified. This is a regression introduced in v4.25.0.
 - The `sftp` input will no longer consume files when the watcher cache returns an error. Instead, it will reattempt the file upon the next poll.
 - The `aws_sqs` input no longer logs error level logs for visibility timeout refreshing errors.
+- The `websocket` input and output now obey the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.
 
 ### Changed
 

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -40,6 +40,9 @@ func websocketInputSpec() *service.ConfigSpec {
 			service.NewURLField("url").
 				Description("The URL to connect to.").
 				Example("ws://localhost:4195/get/ws"),
+			service.NewURLField("proxy_url").
+				Description("An optional HTTP proxy URL.").
+				Advanced().Optional(),
 			service.NewStringField("open_message").
 				Description("An optional message to send to the server upon connection.").
 				Advanced().Optional(),
@@ -92,12 +95,13 @@ type websocketReader struct {
 
 	lock *sync.Mutex
 
-	client     *websocket.Conn
-	urlParsed  *url.URL
-	urlStr     string
-	tlsEnabled bool
-	tlsConf    *tls.Config
-	reqSigner  httpclient.RequestSigner
+	client         *websocket.Conn
+	urlParsed      *url.URL
+	urlStr         string
+	proxyURLParsed *url.URL
+	tlsEnabled     bool
+	tlsConf        *tls.Config
+	reqSigner      httpclient.RequestSigner
 
 	openMsgType wsOpenMsgType
 	openMsg     []byte
@@ -115,6 +119,11 @@ func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 	}
 	if ws.urlStr, err = conf.FieldString("url"); err != nil {
 		return nil, err
+	}
+	if conf.Contains("proxy_url") {
+		if ws.proxyURLParsed, err = conf.FieldURL("proxy_url"); err != nil {
+			return nil, err
+		}
 	}
 	if ws.tlsConf, ws.tlsEnabled, err = conf.FieldTLSToggled("tls"); err != nil {
 		return nil, err
@@ -169,14 +178,17 @@ func (w *websocketReader) Connect(ctx context.Context) error {
 		}
 	}()
 
+	dialer := *websocket.DefaultDialer
+	if w.proxyURLParsed != nil {
+		dialer.Proxy = http.ProxyURL(w.proxyURLParsed)
+	}
+
 	if w.tlsEnabled {
-		dialer := websocket.Dialer{
-			TLSClientConfig: w.tlsConf,
-		}
+		dialer.TLSClientConfig = w.tlsConf
 		if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 			return err
 		}
-	} else if client, res, err = websocket.DefaultDialer.Dial(w.urlStr, headers); err != nil {
+	} else if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 		return err
 	}
 

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -43,6 +43,7 @@ input:
   label: ""
   websocket:
     url: ws://localhost:4195/get/ws # No default (required)
+    proxy_url: "" # No default (optional)
     open_message: "" # No default (optional)
     open_message_type: binary
     auto_replay_nacks: true
@@ -92,6 +93,13 @@ Type: `string`
 
 url: ws://localhost:4195/get/ws
 ```
+
+### `proxy_url`
+
+An optional HTTP proxy URL.
+
+
+Type: `string`  
 
 ### `open_message`
 

--- a/website/docs/components/outputs/websocket.md
+++ b/website/docs/components/outputs/websocket.md
@@ -42,6 +42,7 @@ output:
   label: ""
   websocket:
     url: "" # No default (required)
+    proxy_url: "" # No default (optional)
     tls:
       enabled: false
       skip_cert_verify: false
@@ -75,6 +76,13 @@ output:
 ### `url`
 
 The URL to connect to.
+
+
+Type: `string`  
+
+### `proxy_url`
+
+An optional HTTP proxy URL.
 
 
 Type: `string`  


### PR DESCRIPTION
Fixes #2278.

Note: The `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables can be used as fallback when this field isn't set. Details here: <https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment>.

I tested this using an echo NodeJS server:
```node
const WebSocket = require('ws');

const wss = new WebSocket.Server({ port: 8080 });

wss.on('connection', function connection(ws) {
  ws.on('message', function incoming(message) {
    console.log('received: %s', message);
  });

  ws.send('hello from the server!');
});
```

that I ran on a remote GitPod box like so:

```shell
> pip install ws
> node test.js
```

It exposes the server via a https endpoint, so then I am able to interact with it using this config:

```yaml
input:
  websocket:
    url: wss://8080-mihaitodor-benthos-4exudlgyttk.ws-eu106.gitpod.io
  processors:
    - log:
        message: ${! content() }

output:
  websocket:
    url: wss://8080-mihaitodor-benthos-4exudlgyttk.ws-eu106.gitpod.io
```

Then I ran [`mitmweb`](https://mitmproxy.org/) locally and I configured the new `proxy_url` field like so:

```yaml
input:
  websocket:
    url: wss://8080-mihaitodor-benthos-4exudlgyttk.ws-eu106.gitpod.io
    proxy_url: http://localhost:8080
    tls:
      enabled: true
      skip_cert_verify: true
  processors:
    - log:
        message: ${! content() }

output:
  websocket:
    url: wss://8080-mihaitodor-benthos-4exudlgyttk.ws-eu106.gitpod.io
    proxy_url: http://localhost:8080
    tls:
      enabled: true
      skip_cert_verify: true
```

I also had to set `skip_cert_verify: true` because Benthos can't validate the cert from `8080-mihaitodor-benthos-4exudlgyttk.ws-eu106.gitpod.io` when mitmproxy acts as a man-in-the-middle proxy.