### PR TITLE
Add SQL tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/PaesslerAG/gval v1.2.2
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/XSAM/otelsql v0.29.0
 	github.com/apache/pulsar-client-go v0.12.0
 	github.com/aws/aws-lambda-go v1.46.0
 	github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/PaesslerAG/gval v1.2.2/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbV
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
+github.com/XSAM/otelsql v0.29.0 h1:pEw9YXXs8ZrGRYfDc0cmArIz9lci5b42gmP5+tA1Huc=
+github.com/XSAM/otelsql v0.29.0/go.mod h1:d3/0xGIGC5RVEE+Ld7KotwaLy6zDeaF3fLJHOPpdN2w=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -1118,6 +1120,8 @@ go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGX
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
 go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
+go.opentelemetry.io/otel/sdk/metric v1.24.0 h1:yyMQrPzF+k88/DbH7o4FMAs80puqd+9osbiBrJrz/w8=
+go.opentelemetry.io/otel/sdk/metric v1.24.0/go.mod h1:I6Y5FjH6rvEnTTAYQz3Mmv2kl6Ek5IIrmwTLqMrrOE0=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -9,6 +9,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/shutdown"
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 	"github.com/benthosdev/benthos/v4/public/service"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func sqlRawInputConfig() *service.ConfigSpec {
@@ -82,12 +83,14 @@ type sqlRawInput struct {
 	connSettings *connSettings
 
 	logger  *service.Logger
+	tracer  trace.TracerProvider
 	shutSig *shutdown.Signaller
 }
 
 func newSQLRawInputFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (*sqlRawInput, error) {
 	s := &sqlRawInput{
 		logger:  mgr.Logger(),
+		tracer:  mgr.OtelTracer(),
 		shutSig: shutdown.NewSignaller(),
 	}
 
@@ -130,7 +133,7 @@ func (s *sqlRawInput) Connect(ctx context.Context) (err error) {
 	}
 
 	var db *sql.DB
-	if db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if db, err = sqlOpenWithReworks(s.logger, s.tracer, s.driver, s.dsn); err != nil {
 		return err
 	}
 	defer func() {

--- a/internal/impl/sql/output_sql_deprecated.go
+++ b/internal/impl/sql/output_sql_deprecated.go
@@ -77,5 +77,5 @@ func newSQLDeprecatedOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 	if err != nil {
 		return nil, err
 	}
-	return newSQLRawOutput(mgr.Logger(), driverStr, dsnStr, queryStatic, nil, argsMapping, connSettings), nil
+	return newSQLRawOutput(mgr.Logger(), mgr.OtelTracer(), driverStr, dsnStr, queryStatic, nil, argsMapping, connSettings), nil
 }

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/Masterminds/squirrel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/benthosdev/benthos/v4/internal/shutdown"
 	"github.com/benthosdev/benthos/v4/public/bloblang"
@@ -104,12 +105,14 @@ type sqlInsertOutput struct {
 	connSettings *connSettings
 
 	logger  *service.Logger
+	tracer  trace.TracerProvider
 	shutSig *shutdown.Signaller
 }
 
 func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (*sqlInsertOutput, error) {
 	s := &sqlInsertOutput{
 		logger:  mgr.Logger(),
+		tracer:  mgr.OtelTracer(),
 		shutSig: shutdown.NewSignaller(),
 	}
 
@@ -191,7 +194,7 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if s.db, err = sqlOpenWithReworks(s.logger, s.tracer, s.driver, s.dsn); err != nil {
 		return err
 	}
 

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -9,6 +9,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/shutdown"
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 	"github.com/benthosdev/benthos/v4/public/service"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func sqlRawOutputConfig() *service.ConfigSpec {
@@ -94,6 +95,7 @@ type sqlRawOutput struct {
 	connSettings *connSettings
 
 	logger  *service.Logger
+	tracer  trace.TracerProvider
 	shutSig *shutdown.Signaller
 }
 
@@ -133,11 +135,12 @@ func newSQLRawOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resource
 	if err != nil {
 		return nil, err
 	}
-	return newSQLRawOutput(mgr.Logger(), driverStr, dsnStr, queryStatic, queryDyn, argsMapping, connSettings), nil
+	return newSQLRawOutput(mgr.Logger(), mgr.OtelTracer(), driverStr, dsnStr, queryStatic, queryDyn, argsMapping, connSettings), nil
 }
 
 func newSQLRawOutput(
 	logger *service.Logger,
+	tracer trace.TracerProvider,
 	driverStr, dsnStr string,
 	queryStatic string,
 	queryDyn *service.InterpolatedString,
@@ -146,6 +149,7 @@ func newSQLRawOutput(
 ) *sqlRawOutput {
 	return &sqlRawOutput{
 		logger:       logger,
+		tracer:       tracer,
 		shutSig:      shutdown.NewSignaller(),
 		driver:       driverStr,
 		dsn:          dsnStr,
@@ -165,7 +169,7 @@ func (s *sqlRawOutput) Connect(ctx context.Context) error {
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+	if s.db, err = sqlOpenWithReworks(s.logger, s.tracer, s.driver, s.dsn); err != nil {
 		return err
 	}
 

--- a/internal/impl/sql/processor_sql_deprecated.go
+++ b/internal/impl/sql/processor_sql_deprecated.go
@@ -93,5 +93,5 @@ func NewSQLDeprecatedProcessorFromConfig(conf *service.ParsedConfig, mgr *servic
 	if err != nil {
 		return nil, err
 	}
-	return newSQLRawProcessor(mgr.Logger(), driverStr, dsnStr, queryStatic, queryDyn, onlyExec, argsMapping, connSettings)
+	return newSQLRawProcessor(mgr.Logger(), mgr.OtelTracer(), driverStr, dsnStr, queryStatic, queryDyn, onlyExec, argsMapping, connSettings)
 }

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -171,7 +171,7 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		return nil, err
 	}
 
-	if s.db, err = sqlOpenWithReworks(mgr.Logger(), driverStr, dsnStr); err != nil {
+	if s.db, err = sqlOpenWithReworks(mgr.Logger(), mgr.OtelTracer(), driverStr, dsnStr); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -229,13 +229,13 @@ func (s *sqlRawProcessor) ProcessBatch(ctx context.Context, batch service.Messag
 		}
 
 		if s.onlyExec {
-			if _, err := s.db.ExecContext(ctx, queryStr, args...); err != nil {
+			if _, err := s.db.ExecContext(msg.Context(), queryStr, args...); err != nil {
 				s.logger.Debugf("Failed to run query: %v", err)
 				msg.SetError(err)
 				continue
 			}
 		} else {
-			rows, err := s.db.QueryContext(ctx, queryStr, args...)
+			rows, err := s.db.QueryContext(msg.Context(), queryStr, args...)
 			if err != nil {
 				s.logger.Debugf("Failed to run query: %v", err)
 				msg.SetError(err)

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -171,7 +171,7 @@ func NewSQLSelectProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 		return nil, err
 	}
 
-	if s.db, err = sqlOpenWithReworks(mgr.Logger(), driverStr, dsnStr); err != nil {
+	if s.db, err = sqlOpenWithReworks(mgr.Logger(), mgr.OtelTracer(), driverStr, dsnStr); err != nil {
 		return nil, err
 	}
 	connSettings.apply(context.Background(), s.db, s.logger)


### PR DESCRIPTION
Hey Blobs!

This is mostly just conversation starter / prototype to try out sql tracing using [XSAM/otelsql](github.com/XSAM/otelsql). It currently only adds sql traces to the `sql_raw` processor since it  (and the `sql_raw` output) don't mash their messages together so there is still a 1-1 parent-child relationship between incoming and outgoing messages. Maybe this PR is actually about span linking (https://opentelemetry.io/docs/concepts/signals/traces/#span-links) in cases where we do turn batches into single sql queries.