### PR TITLE
Add "array" bloblang method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.27.0 - TBD
+## 4.27.0 - 2024-04-23
 
 ### Added
 

--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -78,6 +78,33 @@ func applyMethod(target Function, args *ParsedParams) (Function, error) {
 
 //------------------------------------------------------------------------------
 
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"array", "",
+	).InCategory(
+		MethodCategoryCoercion,
+		"Marshal a value into an array. If the value is already an array it is unchanged.",
+		NewExampleSpec("",
+			`root.my_array = this.name.array()`,
+			`{"name":"foobar bazson"}`,
+			`{"my_array":["foobar bazson"]}`,
+		),
+	),
+	func(*ParsedParams) (simpleMethod, error) {
+		return func(v any, ctx FunctionContext) (any, error) {
+			switch v.(type) {
+				case []any:
+					return v, nil
+			}
+			arr := make([]any, 1)
+			arr[0] = v
+			return arr, nil
+		}, nil
+	},
+)
+
+//------------------------------------------------------------------------------
+
 var _ = registerMethod(
 	NewMethodSpec("bool", "").InCategory(
 		MethodCategoryCoercion,

--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -93,8 +93,8 @@ var _ = registerSimpleMethod(
 	func(*ParsedParams) (simpleMethod, error) {
 		return func(v any, ctx FunctionContext) (any, error) {
 			switch v.(type) {
-				case []any:
-					return v, nil
+			case []any:
+				return v, nil
 			}
 			arr := make([]any, 1)
 			arr[0] = v

--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -492,6 +492,34 @@ func TestMethods(t *testing.T) {
 			),
 			output: false,
 		},
+		"check array": {
+			input: methods(
+				literalFn([]any{1}),
+				method("array"),
+			),
+			output: []any{1},
+		},
+		"check array 2": {
+			input: methods(
+				literalFn(1),
+				method("array"),
+			),
+			output: []any{1},
+		},
+		"check array 3": {
+			input: methods(
+				literalFn(nil),
+				method("array"),
+			),
+			output: []any{nil},
+		},
+		"check array 4": {
+			input: methods(
+				literalFn([]any{}),
+				method("array"),
+			),
+			output: []any{},
+		},
 		"check bool": {
 			input: methods(
 				literalFn("true"),

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1679,8 +1679,11 @@ root.created_at_unix = this.created_at.ts_unix_nano()
 
 Marshal a value into an array. If the value is already an array it is unchanged.
 
+#### Examples
+
+
 ```coffee
-root.my_array = this.name.arry()
+root.my_array = this.name.array()
 
 # In:  {"name":"foobar bazson"}
 # Out: {"my_array":["foobar bazson"]}

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1675,6 +1675,17 @@ root.created_at_unix = this.created_at.ts_unix_nano()
 
 ## Type Coercion
 
+### `array`
+
+Marshal a value into an array. If the value is already an array it is unchanged.
+
+```coffee
+root.my_array = this.name.arry()
+
+# In:  {"name":"foobar bazson"}
+# Out: {"my_array":["foobar bazson"]}
+```
+
 ### `bool`
 
 Attempt to parse a value into a boolean. An optional argument can be provided, in which case if the value cannot be parsed the argument will be returned instead. If the value is a number then any non-zero value will resolve to `true`, if the value is a string then any of the following values are considered valid: `1, t, T, TRUE, true, True, 0, f, F, FALSE`.


### PR DESCRIPTION
These changes add an `array` type coercion **bloblang** method similar to the `bytes` method: If the caller is already of type array the input is returned. If it is any other type the input is wrapped into a one-element array. Such a method helps to avoid constructs like `this.with("name").values().flatten()` to ensure an array returned.

- [x] added passing tests
- [x] format passing style 
- [x] added docs entry

Feedback welcome