### PR TITLE
Replace old vectorized.io repositories with redpanda.com

### DIFF
--- a/internal/impl/kafka/integration_sarama_test.go
+++ b/internal/impl/kafka/integration_sarama_test.go
@@ -35,7 +35,7 @@ func TestIntegrationSaramaCheckpointOneLockUp(t *testing.T) {
 	kafkaPortStr := strconv.Itoa(kafkaPort)
 
 	options := &dockertest.RunOptions{
-		Repository:   "docker.vectorized.io/vectorized/redpanda",
+		Repository:   "docker.redpanda.com/redpandadata/redpanda",
 		Tag:          "latest",
 		Hostname:     "redpanda",
 		ExposedPorts: []string{"9092"},
@@ -193,7 +193,7 @@ func TestIntegrationSaramaRedpanda(t *testing.T) {
 	kafkaPortStr := strconv.Itoa(kafkaPort)
 
 	options := &dockertest.RunOptions{
-		Repository:   "docker.vectorized.io/vectorized/redpanda",
+		Repository:   "docker.redpanda.com/redpandadata/redpanda",
 		Tag:          "latest",
 		Hostname:     "redpanda",
 		ExposedPorts: []string{"9092"},

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -60,7 +60,7 @@ func TestIntegrationKafka(t *testing.T) {
 	kafkaPortStr := strconv.Itoa(kafkaPort)
 
 	options := &dockertest.RunOptions{
-		Repository:   "docker.vectorized.io/vectorized/redpanda",
+		Repository:   "docker.redpanda.com/redpandadata/redpanda",
 		Tag:          "latest",
 		Hostname:     "redpanda",
 		ExposedPorts: []string{"9092"},
@@ -263,7 +263,7 @@ func TestIntegrationKafkaSasl(t *testing.T) {
 	kafkaPortStr := strconv.Itoa(kafkaPort)
 
 	options := &dockertest.RunOptions{
-		Repository:   "docker.vectorized.io/vectorized/redpanda",
+		Repository:   "docker.redpanda.com/redpandadata/redpanda",
 		Tag:          "latest",
 		Hostname:     "redpanda",
 		ExposedPorts: []string{"9092"},


### PR DESCRIPTION
The old `vectorized.io` repository is deprecated. While I think it still gets updated images, it will be sunset in the future.

This PR doesn't touch the blog post since it's cross-posted on Redpanda's website.
