### PR TITLE
Additional `kafka_franz` input kafka consumer configuration

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -85,6 +85,22 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Description("The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown.").
 			Default("5s").
 			Advanced()).
+		Field(service.NewIntField("fetch_min_bytes").
+			Description("Determines the minimum amount of data that to receive from the broker when fetching records").
+			Default(1).
+			Advanced()).
+		Field(service.NewIntField("fetch_max_wait_ms").
+			Description("Determines how long in milliseconds for the broker to wait until it has enough data to send before responding").
+			Default(500).
+			Advanced()).
+		Field(service.NewIntField("max_partition_fetch_bytes").
+			Description("Determines the maximum amount of data to receive from a single partition in a single fetch request").
+			Default(1000000).
+			Advanced()).
+		Field(service.NewIntField("max_poll_records").
+			Description("Determines the maximum number of records to return in a single poll").
+			Default(500).
+			Advanced()).
 		Field(service.NewBoolField("start_from_oldest").
 			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
 			Default(true).

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -97,10 +97,6 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Description("Determines the maximum amount of data to receive from a single partition in a single fetch request").
 			Default(1000000).
 			Advanced()).
-		Field(service.NewIntField("max_poll_records").
-			Description("Determines the maximum number of records to return in a single poll").
-			Default(500).
-			Advanced()).
 		Field(service.NewBoolField("start_from_oldest").
 			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
 			Default(true).
@@ -256,10 +252,6 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 
 	if f.maxPartitionFetchBytes, err = conf.FieldInt("max_partition_fetch_bytes"); err != nil {
-		return nil, err
-	}
-
-	if f.maxPollRecords, err = conf.FieldInt("max_poll_records"); err != nil {
 		return nil, err
 	}
 
@@ -652,6 +644,9 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		kgo.ConsumerGroup(f.consumerGroup),
 		kgo.ClientID(f.clientID),
 		kgo.Rack(f.rackID),
+		kgo.FetchMinBytes(int32(f.fetchMinBytes)),
+		kgo.FetchMaxWait(f.fetchMaxWaitDuration),
+		kgo.FetchMaxPartitionBytes(int32(f.maxPartitionFetchBytes)),
 	}
 
 	if f.consumerGroup != "" {

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -145,20 +145,24 @@ type batchWithAckFn struct {
 }
 
 type franzKafkaReader struct {
-	seedBrokers     []string
-	topics          []string
-	topicPartitions map[string]map[int32]kgo.Offset
-	clientID        string
-	rackID          string
-	consumerGroup   string
-	tlsConf         *tls.Config
-	saslConfs       []sasl.Mechanism
-	checkpointLimit int
-	startFromOldest bool
-	commitPeriod    time.Duration
-	regexPattern    bool
-	multiHeader     bool
-	batchPolicy     service.BatchPolicy
+	seedBrokers            []string
+	topics                 []string
+	topicPartitions        map[string]map[int32]kgo.Offset
+	clientID               string
+	rackID                 string
+	consumerGroup          string
+	tlsConf                *tls.Config
+	saslConfs              []sasl.Mechanism
+	checkpointLimit        int
+	startFromOldest        bool
+	commitPeriod           time.Duration
+	fetchMinBytes          int
+	fetchMaxWaitDuration   time.Duration
+	maxPartitionFetchBytes int
+	maxPollRecords         int
+	regexPattern           bool
+	multiHeader            bool
+	batchPolicy            service.BatchPolicy
 
 	batchChan atomic.Value
 	res       *service.Resources
@@ -240,6 +244,22 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 
 	if f.commitPeriod, err = conf.FieldDuration("commit_period"); err != nil {
+		return nil, err
+	}
+
+	if f.fetchMinBytes, err = conf.FieldInt("fetch_min_bytes"); err != nil {
+		return nil, err
+	}
+
+	if f.fetchMaxWaitDuration, err = conf.FieldDuration("fetch_max_wait_duration"); err != nil {
+		return nil, err
+	}
+
+	if f.maxPartitionFetchBytes, err = conf.FieldInt("max_partition_fetch_bytes"); err != nil {
+		return nil, err
+	}
+
+	if f.maxPollRecords, err = conf.FieldInt("max_poll_records"); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -89,9 +89,9 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Description("Determines the minimum amount of data that to receive from the broker when fetching records").
 			Default(1).
 			Advanced()).
-		Field(service.NewIntField("fetch_max_wait_ms").
-			Description("Determines how long in milliseconds for the broker to wait until it has enough data to send before responding").
-			Default(500).
+		Field(service.NewDurationField("fetch_max_wait_duration").
+			Description("Determines how long in for the broker to wait until it has enough data to send before responding").
+			Default(time.Duration.Milliseconds(500)).
 			Advanced()).
 		Field(service.NewIntField("max_partition_fetch_bytes").
 			Description("Determines the maximum amount of data to receive from a single partition in a single fetch request").

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -91,7 +91,7 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Advanced()).
 		Field(service.NewDurationField("fetch_max_wait_duration").
 			Description("Determines how long in for the broker to wait until it has enough data to send before responding").
-			Default(time.Duration.Milliseconds(500)).
+			Default(time.Duration.Seconds(5)).
 			Advanced()).
 		Field(service.NewIntField("max_partition_fetch_bytes").
 			Description("Determines the maximum amount of data to receive from a single partition in a single fetch request").

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -155,7 +155,6 @@ type franzKafkaReader struct {
 	fetchMinBytes          int
 	fetchMaxWaitDuration   time.Duration
 	maxPartitionFetchBytes int
-	maxPollRecords         int
 	regexPattern           bool
 	multiHeader            bool
 	batchPolicy            service.BatchPolicy

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -59,6 +59,9 @@ input:
     checkpoint_limit: 1024
     auto_replay_nacks: true
     commit_period: 5s
+    fetch_min_bytes: 1
+    fetch_max_wait_duration: 5e-09
+    max_partition_fetch_bytes: 1000000
     start_from_oldest: true
     tls:
       enabled: false
@@ -212,6 +215,30 @@ The period of time between each commit of the current partition offsets. Offsets
 
 Type: `string`  
 Default: `"5s"`  
+
+### `fetch_min_bytes`
+
+Determines the minimum amount of data that to receive from the broker when fetching records
+
+
+Type: `int`  
+Default: `1`  
+
+### `fetch_max_wait_duration`
+
+Determines how long in for the broker to wait until it has enough data to send before responding
+
+
+Type: `string`  
+Default: `5e-9`  
+
+### `max_partition_fetch_bytes`
+
+Determines the maximum amount of data to receive from a single partition in a single fetch request
+
+
+Type: `int`  
+Default: `1000000`  
 
 ### `start_from_oldest`
 


### PR DESCRIPTION
# What

Adding addition kafka configuration parameters that can be passed from `kafka_franz` input to the underlying franz client opts.

the configurations added are:

```go
		kgo.FetchMinBytes(int32(f.fetchMinBytes)),
		kgo.FetchMaxWait(f.fetchMaxWaitDuration),
		kgo.FetchMaxPartitionBytes(int32(f.maxPartitionFetchBytes)),
```

# Why

- This allows greater flexibility for configuring consumerthroughput of benthos apps using `kafka_franz`
- The configs I've added are commonly tuned parameters (across all kafka client implementations) for improving consumer throughput (at the cost of latency)

# Notes

for `Default()` I've used the defaults from `franz-go` client opts as to not introduce new behaviour