### PR TITLE
Update docs to use the new `metadata()` bloblang function

### DIFF
--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -158,7 +158,7 @@ func catchMethod(fn Function, args *ParsedParams) (Function, error) {
 var _ = registerMethod(
 	NewMethodSpec(
 		"from",
-		"Modifies a target query such that certain functions are executed from the perspective of another message in the batch. This allows you to mutate events based on the contents of other messages. Functions that support this behaviour are `content`, `json` and `meta`.",
+		"Modifies a target query such that certain functions are executed from the perspective of another message in the batch. This allows you to mutate events based on the contents of other messages. Functions that support this behaviour are `content()`, `json()`, `metadata()` and `meta()`. It cannot be used with the `@` operator.",
 		NewExampleSpec("For example, the following map extracts the contents of the JSON field `foo` specifically from message index `1` of a batch, effectively overriding the field `foo` for all messages of a batch to that of message 1:",
 			`root = this
 root.foo = json("foo").from(1)`,
@@ -200,8 +200,8 @@ func (f *fromMethod) QueryTargets(ctx TargetsContext) (TargetsContext, []TargetP
 var _ = registerMethod(
 	NewMethodSpec(
 		"from_all",
-		"Modifies a target query such that certain functions are executed from the perspective of each message in the batch, and returns the set of results as an array. Functions that support this behaviour are `content`, `json` and `meta`.",
-		NewExampleSpec("",
+		"Modifies a target query such that certain functions are executed from the perspective of each message in the batch, and returns the set of results as an array. Functions that support this behaviour are `content()`, `json()`, `metadata()` and `meta()`. It cannot be used with the `@` operator.",
+		NewExampleSpec("Sum all the message `foo`s from the current batch:",
 			`root = this
 root.foo_summed = json("foo").from_all().sum()`,
 		),

--- a/internal/impl/amqp09/output.go
+++ b/internal/impl/amqp09/output.go
@@ -95,7 +95,7 @@ The fields 'key', 'exchange' and 'type' can be dynamically set using function in
 				Description("Set the priority of each message with a dynamic interpolated expression.").
 				Advanced().
 				Example("0").
-				Example(`${! meta("amqp_priority") }`).
+				Example(`${! metadata("amqp_priority") }`).
 				Example(`${! json("doc.priority") }`).
 				Default(""),
 			service.NewOutputMaxInFlightField(),

--- a/internal/impl/aws/input_s3.go
+++ b/internal/impl/aws/input_s3.go
@@ -154,7 +154,7 @@ This input adds the following metadata fields to each message:
 - All user defined metadata
 `+"```"+`
 
-You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries). Note that user defined metadata is case insensitive within AWS, and it is likely that the keys will be received in a capitalized form, if you wish to make them consistent you can map all metadata keys to lower or uppercase using a Bloblang mapping such as `+"`meta = meta().map_each_key(key -> key.lowercase())`"+`.`).
+You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries). Note that user defined metadata is case insensitive within AWS, and it is likely that the keys will be received in a capitalized form, if you wish to make them consistent you can map all metadata keys to lower or uppercase using a Bloblang mapping such as `+"`meta = metadata().map_each_key(key -> key.string().lowercase())`"+`.`).
 		Fields(
 			service.NewStringField(s3iFieldBucket).
 				Description("The bucket to consume from. If the field `sqs.url` is specified this field is optional.").

--- a/internal/impl/aws/output_dynamodb.go
+++ b/internal/impl/aws/output_dynamodb.go
@@ -80,7 +80,7 @@ The field `+"`string_columns`"+` is a map of column names to string values, wher
 string_columns:
   id: ${!json("id")}
   title: ${!json("body.title")}
-  topic: ${!meta("kafka_topic")}
+  topic: ${!metadata("kafka_topic")}
   full_content: ${!content()}
 `+"```"+`
 
@@ -120,7 +120,7 @@ This output benefits from sending messages as a batch for improved performance. 
 				Example(map[string]any{
 					"id":           "${!json(\"id\")}",
 					"title":        "${!json(\"body.title\")}",
-					"topic":        "${!meta(\"kafka_topic\")}",
+					"topic":        "${!metadata(\"kafka_topic\")}",
 					"full_content": "${!content()}",
 				}),
 			service.NewStringMapField(ddboFieldJSONMapColumns).

--- a/internal/impl/aws/output_s3.go
+++ b/internal/impl/aws/output_s3.go
@@ -154,7 +154,7 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
-      Timestamp: ${!meta("Timestamp")}
+      Timestamp: ${!metadata("Timestamp")}
 `+"```"+`
 
 ### Credentials
@@ -202,14 +202,14 @@ output:
 				Description("The path of each message to upload.").
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`),
 			service.NewInterpolatedStringMapField(s3oFieldTags).
 				Description("Key/value pairs to store with the object as tags.").
 				Default(map[string]any{}).
 				Example(map[string]any{
 					"Key1":      "Value1",
-					"Timestamp": `${!meta("Timestamp")}`,
+					"Timestamp": `${!metadata("Timestamp")}`,
 				}),
 			service.NewInterpolatedStringField(s3oFieldContentType).
 				Description("The content type to set for each object.").

--- a/internal/impl/aws/processor_dynamodb_partiql.go
+++ b/internal/impl/aws/processor_dynamodb_partiql.go
@@ -34,7 +34,7 @@ pipeline:
         args_mapping: |
           root = [
             { "S": this.foo },
-            { "S": meta("kafka_topic") },
+            { "S": metadata("kafka_topic") },
             { "S": this.document.content },
           ]
 `,

--- a/internal/impl/aws/processor_lambda.go
+++ b/internal/impl/aws/processor_lambda.go
@@ -36,7 +36,7 @@ pipeline:
           - aws_lambda:
               function: foo
         result_map: |
-          root = if meta().exists("lambda_function_error") {
+          root = if metadata().exists("lambda_function_error") {
             throw("Invocation failed due to %v: %v".format(this.errorType, this.errorMessage))
           } else {
             this

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -85,7 +85,7 @@ If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+
 			service.NewInterpolatedStringField(bsoFieldPath).
 				Description("The path of each message to upload.").
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.json`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringEnumField(bsoFieldBlobType, "BLOCK", "APPEND").

--- a/internal/impl/azure/output_table_storage.go
+++ b/internal/impl/azure/output_table_storage.go
@@ -110,7 +110,7 @@ properties:
 		Fields(
 			service.NewInterpolatedStringField(tsoFieldTableName).
 				Description("The table to store messages into.").
-				Example(`${! meta("kafka_topic") }`).Example(`${! json("table") }`),
+				Example(`${! metadata("kafka_topic") }`).Example(`${! json("table") }`),
 			service.NewInterpolatedStringField(tsoFieldPartitionKey).
 				Description("The partition key.").
 				Example(`${! json("date") }`).
@@ -124,12 +124,12 @@ properties:
 				Default(map[string]any{}),
 			service.NewInterpolatedStringEnumField(tsoFieldInsertType, `INSERT`, `INSERT_MERGE`, `INSERT_REPLACE`).
 				Description("Type of insert operation. Valid options are `INSERT`, `INSERT_MERGE` and `INSERT_REPLACE`").
-				Example(`${! json("operation") }`).Example(`${! meta("operation") }`).Example(`INSERT`).
+				Example(`${! json("operation") }`).Example(`${! metadata("operation") }`).Example(`INSERT`).
 				Advanced().Deprecated().
 				Default(""),
 			service.NewInterpolatedStringEnumField(tsoFieldTransactionType, `INSERT`, `INSERT_MERGE`, `INSERT_REPLACE`, `UPDATE_MERGE`, `UPDATE_REPLACE`, `DELETE`).
 				Description("Type of transaction operation.").
-				Example(`${! json("operation") }`).Example(`${! meta("operation") }`).Example(`INSERT`).
+				Example(`${! json("operation") }`).Example(`${! metadata("operation") }`).Example(`INSERT`).
 				Advanced().
 				Default("INSERT"),
 			service.NewOutputMaxInFlightField().

--- a/internal/impl/azure/processor_cosmosdb.go
+++ b/internal/impl/azure/processor_cosmosdb.go
@@ -52,7 +52,7 @@ input:
         database: testdb
         container: blobfish
         partition_keys_map: root = json("habitat")
-        item_id: ${! meta("id") }
+        item_id: ${! metadata("id") }
         operation: Patch
         patch_operations:
           # Add a new /diet field

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -61,7 +61,7 @@ We will be considering alternative approaches in future so please [get in touch]
 		Field(service.NewURLField("url").Description("The base URL of the schema registry service.")).
 		Field(service.NewInterpolatedStringField("subject").Description("The schema subject to derive schemas from.").
 			Example("foo").
-			Example(`${! meta("kafka_topic") }`)).
+			Example(`${! metadata("kafka_topic") }`)).
 		Field(service.NewStringField("refresh_period").
 			Description("The period after which a schema is refreshed for each subject, this is done by polling the schema registry service.").
 			Default("10m").

--- a/internal/impl/gcp/output_cloud_storage.go
+++ b/internal/impl/gcp/output_cloud_storage.go
@@ -132,7 +132,7 @@ output:
 			service.NewInterpolatedStringField(csoFieldPath).
 				Description("The path of each message to upload.").
 				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
-				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!metadata("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringField(csoFieldContentType).

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -255,7 +255,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			service.NewObjectField(hsiFieldResponse,
 				service.NewInterpolatedStringField(hsiFieldResponseStatus).
 					Description("Specify the status code to return with synchronous responses. This is a string value, which allows you to customize it based on resulting payloads and their metadata.").
-					Examples(`${! json("status") }`, `${! meta("status") }`).
+					Examples(`${! json("status") }`, `${! metadata("status") }`).
 					Default("200"),
 				service.NewInterpolatedStringMapField(hsiFieldResponseHeaders).
 					Description("Specify headers to return with synchronous responses.").

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -46,7 +46,7 @@ This output often out-performs the traditional ` + "`kafka`" + ` output as well 
 			Advanced().Optional()).
 		Field(service.NewInterpolatedStringField("partition").
 			Description("An optional explicit partition to set for each message. This field is only relevant when the `partitioner` is set to `manual`. The provided interpolation string must be a valid integer.").
-			Example(`${! meta("partition") }`).
+			Example(`${! metadata("partition") }`).
 			Optional()).
 		Field(service.NewStringField("client_id").
 			Description("An identifier for the client connection.").

--- a/internal/impl/nats/output.go
+++ b/internal/impl/nats/output.go
@@ -28,7 +28,7 @@ func natsOutputConfig() *service.ConfigSpec {
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp")}`,
 			})).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/nats/output_jetstream.go
+++ b/internal/impl/nats/output_jetstream.go
@@ -23,14 +23,14 @@ func natsJetStreamOutputConfig() *service.ConfigSpec {
 		Field(service.NewInterpolatedStringField("subject").
 			Description("A subject to write to.").
 			Example("foo.bar.baz").
-			Example(`${! meta("kafka_topic") }`).
+			Example(`${! metadata("kafka_topic") }`).
 			Example(`foo.${! json("meta.type") }`)).
 		Field(service.NewInterpolatedStringMapField("headers").
 			Description("Explicit message headers to add to messages.").
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp")}`,
 			}).Version("4.1.0")).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/nats/processor_request_reply.go
+++ b/internal/impl/nats/processor_request_reply.go
@@ -38,7 +38,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 		Field(service.NewInterpolatedStringField("subject").
 			Description("A subject to write to.").
 			Example("foo.bar.baz").
-			Example(`${! meta("kafka_topic") }`).
+			Example(`${! metadata("kafka_topic") }`).
 			Example(`foo.${! json("meta.type") }`)).
 		Field(service.NewStringField("inbox_prefix").
 			Description("Set an explicit inbox prefix for the response subject").
@@ -50,7 +50,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			Default(map[string]any{}).
 			Example(map[string]any{
 				"Content-Type": "application/json",
-				"Timestamp":    `${!meta("Timestamp")}`,
+				"Timestamp":    `${!metadata("Timestamp")}`,
 			})).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").

--- a/internal/impl/parquet/processor_decode.go
+++ b/internal/impl/parquet/processor_decode.go
@@ -40,7 +40,7 @@ input:
 output:
   file:
     codec: lines
-    path: './foos/${! meta("s3_key") }.jsonl'
+    path: './foos/${! metadata("s3_key") }.jsonl'
 `)
 }
 

--- a/internal/impl/pure/buffer_system_window.go
+++ b/internal/impl/pure/buffer_system_window.go
@@ -53,7 +53,7 @@ A [Bloblang mapping](/docs/guides/bloblang/about) applied to each message during
 The timestamp value assigned to `+"`root`"+` must either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in ISO 8601 format. If the mapping fails or provides an invalid result the message will be dropped (with logging to describe the problem).
 `).
 			Default("root = now()").
-			Example("root = this.created_at").Example(`root = meta("kafka_timestamp_unix").number()`)).
+			Example("root = this.created_at").Example(`root = metadata("kafka_timestamp_unix")`)).
 		Field(service.NewStringField("size").
 			Description("A duration string describing the size of each window. By default windows are aligned to the zeroth minute and zeroth hour on the UTC clock, meaning windows of 1 hour duration will match the turn of each hour in the day, this can be adjusted with the `offset` field.").
 			Example("30s").Example("10m")).
@@ -110,7 +110,7 @@ pipeline:
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,
-            "created_at": meta("window_end_timestamp"),
+            "created_at": metadata("window_end_timestamp"),
             "total_cars": json("registration_plate").from_all().unique().length(),
             "passengers": json("passengers").from_all().sum(),
           }

--- a/internal/impl/pure/output_cache.go
+++ b/internal/impl/pure/output_cache.go
@@ -53,7 +53,7 @@ In order to create a unique `+"`key`"+` value per item you should use function i
 				Examples(
 					`${!count("items")}-${!timestamp_unix_nano()}`,
 					`${!json("doc.id")}`,
-					`${!meta("kafka_key")}`,
+					`${!metadata("kafka_key")}`,
 				).
 				Default(`${!count("items")}-${!timestamp_unix_nano()}`),
 			service.NewInterpolatedStringField(coFieldTTL).

--- a/internal/impl/pure/processor_archive.go
+++ b/internal/impl/pure/processor_archive.go
@@ -36,7 +36,7 @@ The functionality of this processor depends on being applied across messages tha
 		Field(service.NewInterpolatedStringField("path").
 			Description("The path to set for each message in the archive (when applicable).").
 			Example("${!count(\"files\")}-${!timestamp_unix_nano()}.txt").
-			Example("${!meta(\"kafka_key\")}-${!json(\"id\")}.json").
+			Example("${!metadata(\"kafka_key\")}-${!json(\"id\")}.json").
 			Default("")).
 		Example("Tar Archive", `
 If we had JSON messages in a batch each of the form:

--- a/internal/impl/pure/processor_cached.go
+++ b/internal/impl/pure/processor_cached.go
@@ -29,8 +29,8 @@ func newCachedProcessorConfigSpec() *service.ConfigSpec {
 			Description("A key to be resolved for each message, if the key already exists in the cache then the cached result is used, otherwise the processors are applied and the result is cached under this key. The key could be static and therefore apply generally to all messages or it could be an interpolated expression that is potentially unique for each message.").
 			Example("my_foo_result").
 			Example(`${! this.document.id }`).
-			Example(`${! meta("kafka_key") }`).
-			Example(`${! meta("kafka_topic") }`)).
+			Example(`${! metadata("kafka_key") }`).
+			Example(`${! metadata("kafka_topic") }`)).
 		Field(service.NewInterpolatedStringField("ttl").
 			Description("An optional expiry period to set for each cache entry. Some caches only have a general TTL and will therefore ignore this setting.").
 			Optional()).
@@ -44,12 +44,12 @@ pipeline:
     - branch:
         processors:
           - cached:
-              key: '${! meta("kafka_topic") }-${! meta("kafka_partition") }'
+              key: '${! metadata("kafka_topic") }-${! metadata("kafka_partition") }'
               cache: foo_cache
               processors:
                 - mapping: 'root = ""'
                 - http:
-                    url: http://example.com/enrichment/${! meta("kafka_topic") }/${! meta("kafka_partition") }
+                    url: http://example.com/enrichment/${! metadata("kafka_topic") }/${! metadata("kafka_partition") }
                     verb: GET
         result_map: 'root.enrichment = this'
 

--- a/internal/impl/pure/processor_dedupe.go
+++ b/internal/impl/pure/processor_dedupe.go
@@ -49,7 +49,7 @@ pipeline:
   processors:
     - dedupe:
         cache: keycache
-        key: ${! meta("kafka_key") }
+        key: ${! metadata("kafka_key") }
 
 cache_resources:
   - label: keycache
@@ -62,7 +62,7 @@ cache_resources:
 				Description("The [`cache` resource](/docs/components/caches/about) to target with this processor."),
 			service.NewInterpolatedStringField(dedupFieldKey).
 				Description("An interpolated string yielding the key to deduplicate by for each message.").
-				Examples(`${! meta("kafka_key") }`, `${! content().hash("xxhash64") }`),
+				Examples(`${! metadata("kafka_key") }`, `${! content().hash("xxhash64") }`),
 			service.NewBoolField(dedupFieldDropOnCacheErr).
 				Description("Whether messages should be dropped when the cache returns a general error such as a network issue.").
 				Default(true),

--- a/internal/impl/pure/processor_group_by.go
+++ b/internal/impl/pure/processor_group_by.go
@@ -46,7 +46,7 @@ pipeline:
 output:
   switch:
     cases:
-      - check: meta("grouping") == "foo"
+      - check: metadata("grouping") == "foo"
         output:
           gcp_pubsub:
             project: foo_prod

--- a/internal/impl/pure/processor_group_by_value.go
+++ b/internal/impl/pure/processor_group_by_value.go
@@ -36,7 +36,7 @@ If we were consuming Kafka messages and needed to group them by their key, archi
 pipeline:
   processors:
     - group_by_value:
-        value: ${! meta("kafka_key") }
+        value: ${! metadata("kafka_key") }
     - archive:
         format: tar
     - compress:
@@ -44,11 +44,11 @@ pipeline:
 output:
   aws_s3:
     bucket: TODO
-    path: docs/${! meta("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
+    path: docs/${! metadata("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
 `+"```"+``).
 			Field(service.NewInterpolatedStringField(gbvpFieldValue).
 				Description("The interpolated string to group based on.").
-				Examples("${! meta(\"kafka_key\") }", "${! json(\"foo.bar\") }-${! meta(\"baz\") }")),
+				Examples("${! metadata(\"kafka_key\") }", "${! json(\"foo.bar\") }-${! memetadataa(\"baz\") }")),
 		func(conf *service.ParsedConfig, res *service.Resources) (service.BatchProcessor, error) {
 			valueStr, err := conf.FieldString(gbvpFieldValue)
 			if err != nil {

--- a/internal/impl/pure/processor_log.go
+++ b/internal/impl/pure/processor_log.go
@@ -45,7 +45,7 @@ pipeline:
           root.reason = "cus I wana"
           root.id = this.id
           root.age = this.user.age
-          root.kafka_topic = meta("kafka_topic")
+          root.kafka_topic = metadata("kafka_topic")
 `+"```"+`
 `).
 		Fields(
@@ -59,7 +59,7 @@ pipeline:
 					`root.reason = "cus I wana"
 root.id = this.id
 root.age = this.user.age.number()
-root.kafka_topic = meta("kafka_topic")`,
+root.kafka_topic = metadata("kafka_topic")`,
 				).
 				Optional(),
 			service.NewInterpolatedStringField(logPFieldMessage).

--- a/internal/impl/pure/processor_metric.go
+++ b/internal/impl/pure/processor_metric.go
@@ -89,8 +89,8 @@ pipeline:
         name: Foos
         type: counter
         labels:
-          topic: ${! meta("kafka_topic") }
-          partition: ${! meta("kafka_partition") }
+          topic: ${! metadata("kafka_topic") }
+          partition: ${! metadata("kafka_partition") }
           type: ${! json("document.type").or("unknown") }
 
 metrics:
@@ -114,7 +114,7 @@ pipeline:
         name: FooSize
         type: gauge
         labels:
-          topic: ${! meta("kafka_topic") }
+          topic: ${! metadata("kafka_topic") }
         value: ${! json("foo.size") }
 
 metrics:
@@ -131,7 +131,7 @@ metrics:
 				Description("A map of label names and values that can be used to enrich metrics. Labels are not supported by some metric destinations, in which case the metrics series are combined.").
 				Example(map[string]any{
 					"type":  "${! json(\"doc.type\") }",
-					"topic": "${! meta(\"kafka_topic\") }",
+					"topic": "${! metadata(\"kafka_topic\") }",
 				}).
 				Optional(),
 			service.NewInterpolatedStringField(metProcFieldValue).

--- a/internal/impl/redis/output_hash.go
+++ b/internal/impl/redis/output_hash.go
@@ -33,8 +33,8 @@ output:
     url: tcp://localhost:6379
     key: ${!json("id")}
     fields:
-      topic: ${!meta("kafka_topic")}
-      partition: ${!meta("kafka_partition")}
+      topic: ${!metadata("kafka_topic")}
+      partition: ${!metadata("kafka_partition")}
       content: ${!json("document.text")}
 `+"```"+`
 

--- a/internal/impl/redis/processor.go
+++ b/internal/impl/redis/processor.go
@@ -31,14 +31,14 @@ performed for each message and the message contents are replaced with the result
 			Version("4.3.0").
 			Example("scard").
 			Example("incrby").
-			Example(`${! meta("command") }`).
+			Example(`${! metadata("command") }`).
 			Optional()).
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of arguments required for the specified Redis command.").
 			Version("4.3.0").
 			Optional().
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), this.count ]`)).
+			Example(`root = [ metadata("kafka_key"), this.count ]`)).
 		Field(service.NewStringAnnotatedEnumField("operator", map[string]string{
 			"keys":   `Returns an array of strings containing all the keys that match the pattern specified by the ` + "`key` field" + `.`,
 			"scard":  `Returns the cardinality of a set, or ` + "`0`" + ` if the key does not exist.`,
@@ -74,7 +74,7 @@ pipeline:
           - redis:
               url: TODO
               command: scard
-              args_mapping: 'root = [ meta("set_key") ]'
+              args_mapping: 'root = [ metadata("set_key") ]'
         result_map: 'root.cardinality = this'
 `).
 		Example("Running Total",

--- a/internal/impl/redis/script_processor.go
+++ b/internal/impl/redis/script_processor.go
@@ -32,11 +32,11 @@ In order to merge the result into the original message compose this processor wi
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of arguments required for the specified Redis script.").
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), "hardcoded_value" ]`)).
+			Example(`root = [ metadata("kafka_key"), "hardcoded_value" ]`)).
 		Field(service.NewBloblangField("keys_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of keys matching in size to the number of arguments required for the specified Redis script.").
 			Example("root = [ this.key ]").
-			Example(`root = [ meta("kafka_key"), this.count ]`)).
+			Example(`root = [ metadata("kafka_key"), this.count ]`)).
 		Field(service.NewIntField("retries").
 			Description("The maximum number of retries before abandoning a request.").
 			Default(3).
@@ -62,7 +62,7 @@ pipeline:
           redis.call("ZADD", "XX", KEYS[1], ARGV[1], value)
 
           return value
-        keys_mapping: 'root = [ meta("key") ]'
+        keys_mapping: 'root = [ metadata("key") ]'
         args_mapping: 'root = [ timestamp_unix_nano() ]'
 `)
 }

--- a/internal/impl/snowflake/output_snowflake_put.go
+++ b/internal/impl/snowflake/output_snowflake_put.go
@@ -241,11 +241,11 @@ input:
       period: 3s
       processors:
         - mapping: |
-            meta kafka_start_offset = meta("kafka_offset").from(0)
-            meta kafka_end_offset = meta("kafka_offset").from(-1)
+            meta kafka_start_offset = metadata("kafka_offset").from(0)
+            meta kafka_end_offset = metadata("kafka_offset").from(-1)
             meta batch_timestamp = if batch_index() == 0 { now() }
         - mapping: |
-            meta batch_timestamp = if batch_index() != 0 { meta("batch_timestamp").from(0) }
+            meta batch_timestamp = if batch_index() != 0 { metadata("batch_timestamp").from(0) }
 
 output:
   snowflake_put:
@@ -258,7 +258,7 @@ output:
     schema: PUBLIC
     stage: "@%BENTHOS_TBL"
     path: benthos/BENTHOS_TBL/${! @kafka_partition }
-    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! meta("batch_timestamp") }
+    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! @batch_timestamp }
     upload_parallel_threads: 4
     compression: NONE
     snowpipe: BENTHOS_PIPE

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -25,7 +25,7 @@ func sqlRawInputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewAutoRetryNacksToggleField())
 	for _, f := range connFields() {

--- a/internal/impl/sql/output_sql_deprecated.go
+++ b/internal/impl/sql/output_sql_deprecated.go
@@ -21,7 +21,7 @@ For basic inserts use the ` + "[`sql_insert`](/docs/components/outputs/sql)" + `
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -31,7 +31,7 @@ func sqlInsertOutputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`)).
+			Example(`root = [ metadata("user.id") ]`)).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the insert query (before INSERT).").
 			Optional().
@@ -65,7 +65,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 `,
 		)

--- a/internal/impl/sql/output_sql_raw.go
+++ b/internal/impl/sql/output_sql_raw.go
@@ -29,7 +29,7 @@ func sqlRawOutputConfig() *service.ConfigSpec {
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").
@@ -54,7 +54,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 `,
 		)

--- a/internal/impl/sql/processor_sql_deprecated.go
+++ b/internal/impl/sql/processor_sql_deprecated.go
@@ -28,7 +28,7 @@ For basic inserts or select queries use either the ` + "[`sql_insert`](/docs/com
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewStringField("result_codec").
 			Description("Result codec.").

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -33,7 +33,7 @@ If the insert fails to execute then the message will still remain unchanged and 
 		Field(service.NewBloblangField("args_mapping").
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of columns specified.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`)).
+			Example(`root = [ metadata("user.id") ]`)).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the insert query (before INSERT).").
 			Optional().
@@ -64,7 +64,7 @@ pipeline:
           root = [
             this.user.id,
             this.user.name,
-            meta("kafka_topic"),
+            metadata("kafka_topic"),
           ]
 `,
 		)

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -32,7 +32,7 @@ If the query fails to execute then the message will remain unchanged and the err
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `query`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewBoolField("exec_only").
 			Description("Whether the query result should be discarded. When set to `true` the message contents will remain unchanged, which is useful in cases where you are executing inserts, updates, etc.").
@@ -53,7 +53,7 @@ pipeline:
         driver: mysql
         dsn: foouser:foopassword@tcp(localhost:3306)/foodb
         query: "INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?);"
-        args_mapping: '[ document.foo, document.bar, meta("kafka_topic") ]'
+        args_mapping: '[ document.foo, document.bar, metadata("kafka_topic") ]'
         exec_only: true
 `,
 		).

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -39,7 +39,7 @@ If the query fails to execute then the message will remain unchanged and the err
 		Field(service.NewBloblangField("args_mapping").
 			Description("An optional [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an array of values matching in size to the number of placeholder arguments in the field `where`.").
 			Example("root = [ this.cat.meow, this.doc.woofs[0] ]").
-			Example(`root = [ meta("user.id") ]`).
+			Example(`root = [ metadata("user.id") ]`).
 			Optional()).
 		Field(service.NewStringField("prefix").
 			Description("An optional prefix to prepend to the query (before SELECT).").

--- a/website/docs/components/buffers/system_window.md
+++ b/website/docs/components/buffers/system_window.md
@@ -110,7 +110,7 @@ pipeline:
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,
-            "created_at": meta("window_end_timestamp"),
+            "created_at": metadata("window_end_timestamp"),
             "total_cars": json("registration_plate").from_all().unique().length(),
             "passengers": json("passengers").from_all().sum(),
           }
@@ -137,7 +137,7 @@ Default: `"root = now()"`
 
 timestamp_mapping: root = this.created_at
 
-timestamp_mapping: root = meta("kafka_timestamp_unix").number()
+timestamp_mapping: root = metadata("kafka_timestamp_unix")
 ```
 
 ### `size`

--- a/website/docs/components/inputs/aws_s3.md
+++ b/website/docs/components/inputs/aws_s3.md
@@ -112,7 +112,7 @@ This input adds the following metadata fields to each message:
 - All user defined metadata
 ```
 
-You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries). Note that user defined metadata is case insensitive within AWS, and it is likely that the keys will be received in a capitalized form, if you wish to make them consistent you can map all metadata keys to lower or uppercase using a Bloblang mapping such as `meta = meta().map_each_key(key -> key.lowercase())`.
+You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries). Note that user defined metadata is case insensitive within AWS, and it is likely that the keys will be received in a capitalized form, if you wish to make them consistent you can map all metadata keys to lower or uppercase using a Bloblang mapping such as `meta = metadata().map_each_key(key -> key.string().lowercase())`.
 
 ## Fields
 

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -332,7 +332,7 @@ Default: `"200"`
 
 status: ${! json("status") }
 
-status: ${! meta("status") }
+status: ${! metadata("status") }
 ```
 
 ### `sync_response.headers`

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -188,7 +188,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `auto_replay_nacks`

--- a/website/docs/components/outputs/amqp_0_9.md
+++ b/website/docs/components/outputs/amqp_0_9.md
@@ -274,7 +274,7 @@ Default: `""`
 
 priority: "0"
 
-priority: ${! meta("amqp_priority") }
+priority: ${! metadata("amqp_priority") }
 
 priority: ${! json("doc.priority") }
 ```

--- a/website/docs/components/outputs/aws_dynamodb.md
+++ b/website/docs/components/outputs/aws_dynamodb.md
@@ -89,7 +89,7 @@ The field `string_columns` is a map of column names to string values, where the 
 string_columns:
   id: ${!json("id")}
   title: ${!json("body.title")}
-  topic: ${!meta("kafka_topic")}
+  topic: ${!metadata("kafka_topic")}
   full_content: ${!content()}
 ```
 
@@ -146,7 +146,7 @@ string_columns:
   full_content: ${!content()}
   id: ${!json("id")}
   title: ${!json("body.title")}
-  topic: ${!meta("kafka_topic")}
+  topic: ${!metadata("kafka_topic")}
 ```
 
 ### `json_map_columns`

--- a/website/docs/components/outputs/aws_s3.md
+++ b/website/docs/components/outputs/aws_s3.md
@@ -109,7 +109,7 @@ output:
     path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
-      Timestamp: ${!meta("Timestamp")}
+      Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### Credentials
@@ -178,7 +178,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.txt
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```
@@ -197,7 +197,7 @@ Default: `{}`
 
 tags:
   Key1: Value1
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### `content_type`

--- a/website/docs/components/outputs/azure_blob_storage.md
+++ b/website/docs/components/outputs/azure_blob_storage.md
@@ -147,7 +147,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.json
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```

--- a/website/docs/components/outputs/azure_table_storage.md
+++ b/website/docs/components/outputs/azure_table_storage.md
@@ -39,7 +39,7 @@ output:
     storage_access_key: ""
     storage_connection_string: ""
     storage_sas_token: ""
-    table_name: ${! meta("kafka_topic") } # No default (required)
+    table_name: ${! metadata("kafka_topic") } # No default (required)
     partition_key: ""
     row_key: ""
     properties: {}
@@ -63,7 +63,7 @@ output:
     storage_access_key: ""
     storage_connection_string: ""
     storage_sas_token: ""
-    table_name: ${! meta("kafka_topic") } # No default (required)
+    table_name: ${! metadata("kafka_topic") } # No default (required)
     partition_key: ""
     row_key: ""
     properties: {}
@@ -169,7 +169,7 @@ Type: `string`
 ```yml
 # Examples
 
-table_name: ${! meta("kafka_topic") }
+table_name: ${! metadata("kafka_topic") }
 
 table_name: ${! json("table") }
 ```
@@ -228,7 +228,7 @@ Options: `INSERT`, `INSERT_MERGE`, `INSERT_REPLACE`, `UPDATE_MERGE`, `UPDATE_REP
 
 transaction_type: ${! json("operation") }
 
-transaction_type: ${! meta("operation") }
+transaction_type: ${! metadata("operation") }
 
 transaction_type: INSERT
 ```

--- a/website/docs/components/outputs/cache.md
+++ b/website/docs/components/outputs/cache.md
@@ -101,7 +101,7 @@ key: ${!count("items")}-${!timestamp_unix_nano()}
 
 key: ${!json("doc.id")}
 
-key: ${!meta("kafka_key")}
+key: ${!metadata("kafka_key")}
 ```
 
 ### `ttl`

--- a/website/docs/components/outputs/gcp_cloud_storage.md
+++ b/website/docs/components/outputs/gcp_cloud_storage.md
@@ -149,7 +149,7 @@ Default: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.txt
 
-path: ${!meta("kafka_key")}.json
+path: ${!metadata("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -38,7 +38,7 @@ output:
     seed_brokers: [] # No default (required)
     topic: "" # No default (required)
     key: "" # No default (optional)
-    partition: ${! meta("partition") } # No default (optional)
+    partition: ${! metadata("partition") } # No default (optional)
     metadata:
       include_prefixes: []
       include_patterns: []
@@ -62,7 +62,7 @@ output:
     topic: "" # No default (required)
     key: "" # No default (optional)
     partitioner: "" # No default (optional)
-    partition: ${! meta("partition") } # No default (optional)
+    partition: ${! metadata("partition") } # No default (optional)
     client_id: benthos
     rack_id: ""
     idempotent_write: true
@@ -162,7 +162,7 @@ Type: `string`
 ```yml
 # Examples
 
-partition: ${! meta("partition") }
+partition: ${! metadata("partition") }
 ```
 
 ### `client_id`

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -159,7 +159,7 @@ Default: `{}`
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### `metadata`

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -144,7 +144,7 @@ Type: `string`
 
 subject: foo.bar.baz
 
-subject: ${! meta("kafka_topic") }
+subject: ${! metadata("kafka_topic") }
 
 subject: foo.${! json("meta.type") }
 ```
@@ -164,7 +164,7 @@ Requires version 4.1.0 or newer
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### `metadata`

--- a/website/docs/components/outputs/redis_hash.md
+++ b/website/docs/components/outputs/redis_hash.md
@@ -76,8 +76,8 @@ output:
     url: tcp://localhost:6379
     key: ${!json("id")}
     fields:
-      topic: ${!meta("kafka_topic")}
-      partition: ${!meta("kafka_partition")}
+      topic: ${!metadata("kafka_topic")}
+      partition: ${!metadata("kafka_partition")}
       content: ${!json("document.text")}
 ```
 

--- a/website/docs/components/outputs/snowflake_put.md
+++ b/website/docs/components/outputs/snowflake_put.md
@@ -259,11 +259,11 @@ input:
       period: 3s
       processors:
         - mapping: |
-            meta kafka_start_offset = meta("kafka_offset").from(0)
-            meta kafka_end_offset = meta("kafka_offset").from(-1)
+            meta kafka_start_offset = metadata("kafka_offset").from(0)
+            meta kafka_end_offset = metadata("kafka_offset").from(-1)
             meta batch_timestamp = if batch_index() == 0 { now() }
         - mapping: |
-            meta batch_timestamp = if batch_index() != 0 { meta("batch_timestamp").from(0) }
+            meta batch_timestamp = if batch_index() != 0 { metadata("batch_timestamp").from(0) }
 
 output:
   snowflake_put:
@@ -276,7 +276,7 @@ output:
     schema: PUBLIC
     stage: "@%BENTHOS_TBL"
     path: benthos/BENTHOS_TBL/${! @kafka_partition }
-    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! meta("batch_timestamp") }
+    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! @batch_timestamp }
     upload_parallel_threads: 4
     compression: NONE
     snowpipe: BENTHOS_PIPE

--- a/website/docs/components/outputs/sql.md
+++ b/website/docs/components/outputs/sql.md
@@ -129,7 +129,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `max_in_flight`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -106,7 +106,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 ```
 
@@ -205,7 +205,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `prefix`

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -102,7 +102,7 @@ output:
       root = [
         this.user.id,
         this.user.name,
-        meta("kafka_topic"),
+        metadata("kafka_topic"),
       ]
 ```
 
@@ -205,7 +205,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `max_in_flight`

--- a/website/docs/components/processors/archive.md
+++ b/website/docs/components/processors/archive.md
@@ -64,7 +64,7 @@ Default: `""`
 
 path: ${!count("files")}-${!timestamp_unix_nano()}.txt
 
-path: ${!meta("kafka_key")}-${!json("id")}.json
+path: ${!metadata("kafka_key")}-${!json("id")}.json
 ```
 
 ## Examples

--- a/website/docs/components/processors/aws_dynamodb_partiql.md
+++ b/website/docs/components/processors/aws_dynamodb_partiql.md
@@ -83,7 +83,7 @@ pipeline:
         args_mapping: |
           root = [
             { "S": this.foo },
-            { "S": meta("kafka_topic") },
+            { "S": metadata("kafka_topic") },
             { "S": this.document.content },
           ]
 ```

--- a/website/docs/components/processors/aws_lambda.md
+++ b/website/docs/components/processors/aws_lambda.md
@@ -80,7 +80,7 @@ pipeline:
           - aws_lambda:
               function: foo
         result_map: |
-          root = if meta().exists("lambda_function_error") {
+          root = if metadata().exists("lambda_function_error") {
             throw("Invocation failed due to %v: %v".format(this.errorType, this.errorMessage))
           } else {
             this

--- a/website/docs/components/processors/azure_cosmosdb.md
+++ b/website/docs/components/processors/azure_cosmosdb.md
@@ -129,7 +129,7 @@ input:
         database: testdb
         container: blobfish
         partition_keys_map: root = json("habitat")
-        item_id: ${! meta("id") }
+        item_id: ${! metadata("id") }
         operation: Patch
         patch_operations:
           # Add a new /diet field

--- a/website/docs/components/processors/cached.md
+++ b/website/docs/components/processors/cached.md
@@ -54,12 +54,12 @@ pipeline:
     - branch:
         processors:
           - cached:
-              key: '${! meta("kafka_topic") }-${! meta("kafka_partition") }'
+              key: '${! metadata("kafka_topic") }-${! metadata("kafka_partition") }'
               cache: foo_cache
               processors:
                 - mapping: 'root = ""'
                 - http:
-                    url: http://example.com/enrichment/${! meta("kafka_topic") }/${! meta("kafka_partition") }
+                    url: http://example.com/enrichment/${! metadata("kafka_topic") }/${! metadata("kafka_partition") }
                     verb: GET
         result_map: 'root.enrichment = this'
 
@@ -136,9 +136,9 @@ key: my_foo_result
 
 key: ${! this.document.id }
 
-key: ${! meta("kafka_key") }
+key: ${! metadata("kafka_key") }
 
-key: ${! meta("kafka_topic") }
+key: ${! metadata("kafka_topic") }
 ```
 
 ### `ttl`

--- a/website/docs/components/processors/dedupe.md
+++ b/website/docs/components/processors/dedupe.md
@@ -22,7 +22,7 @@ Deduplicates messages by storing a key value in a cache using the `add` operator
 label: ""
 dedupe:
   cache: "" # No default (required)
-  key: ${! meta("kafka_key") } # No default (required)
+  key: ${! metadata("kafka_key") } # No default (required)
   drop_on_err: true
 ```
 
@@ -60,7 +60,7 @@ Type: `string`
 ```yml
 # Examples
 
-key: ${! meta("kafka_key") }
+key: ${! metadata("kafka_key") }
 
 key: ${! content().hash("xxhash64") }
 ```
@@ -88,7 +88,7 @@ pipeline:
   processors:
     - dedupe:
         cache: keycache
-        key: ${! meta("kafka_key") }
+        key: ${! metadata("kafka_key") }
 
 cache_resources:
   - label: keycache

--- a/website/docs/components/processors/group_by.md
+++ b/website/docs/components/processors/group_by.md
@@ -79,7 +79,7 @@ pipeline:
 output:
   switch:
     cases:
-      - check: meta("grouping") == "foo"
+      - check: metadata("grouping") == "foo"
         output:
           gcp_pubsub:
             project: foo_prod

--- a/website/docs/components/processors/group_by_value.md
+++ b/website/docs/components/processors/group_by_value.md
@@ -21,7 +21,7 @@ Splits a batch of messages into N batches, where each resulting batch contains a
 # Config fields, showing default values
 label: ""
 group_by_value:
-  value: ${! meta("kafka_key") } # No default (required)
+  value: ${! metadata("kafka_key") } # No default (required)
 ```
 
 This allows you to group messages using arbitrary fields within their content or metadata, process them individually, and send them to unique locations as per their group.
@@ -41,9 +41,9 @@ Type: `string`
 ```yml
 # Examples
 
-value: ${! meta("kafka_key") }
+value: ${! metadata("kafka_key") }
 
-value: ${! json("foo.bar") }-${! meta("baz") }
+value: ${! json("foo.bar") }-${! memetadataa("baz") }
 ```
 
 ## Examples
@@ -54,7 +54,7 @@ If we were consuming Kafka messages and needed to group them by their key, archi
 pipeline:
   processors:
     - group_by_value:
-        value: ${! meta("kafka_key") }
+        value: ${! metadata("kafka_key") }
     - archive:
         format: tar
     - compress:
@@ -62,6 +62,6 @@ pipeline:
 output:
   aws_s3:
     bucket: TODO
-    path: docs/${! meta("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
+    path: docs/${! metadata("kafka_key") }/${! count("files") }-${! timestamp_unix_nano() }.tar.gz
 ```
 

--- a/website/docs/components/processors/log.md
+++ b/website/docs/components/processors/log.md
@@ -26,7 +26,7 @@ log:
     root.reason = "cus I wana"
     root.id = this.id
     root.age = this.user.age.number()
-    root.kafka_topic = meta("kafka_topic")
+    root.kafka_topic = metadata("kafka_topic")
   message: ""
 ```
 
@@ -46,7 +46,7 @@ pipeline:
           root.reason = "cus I wana"
           root.id = this.id
           root.age = this.user.age
-          root.kafka_topic = meta("kafka_topic")
+          root.kafka_topic = metadata("kafka_topic")
 ```
 
 
@@ -75,7 +75,7 @@ fields_mapping: |-
   root.reason = "cus I wana"
   root.id = this.id
   root.age = this.user.age.number()
-  root.kafka_topic = meta("kafka_topic")
+  root.kafka_topic = metadata("kafka_topic")
 ```
 
 ### `message`

--- a/website/docs/components/processors/metric.md
+++ b/website/docs/components/processors/metric.md
@@ -60,7 +60,7 @@ Type: `object`
 # Examples
 
 labels:
-  topic: ${! meta("kafka_topic") }
+  topic: ${! metadata("kafka_topic") }
   type: ${! json("doc.type") }
 ```
 
@@ -91,8 +91,8 @@ pipeline:
         name: Foos
         type: counter
         labels:
-          topic: ${! meta("kafka_topic") }
-          partition: ${! meta("kafka_partition") }
+          topic: ${! metadata("kafka_topic") }
+          partition: ${! metadata("kafka_partition") }
           type: ${! json("document.type").or("unknown") }
 
 metrics:
@@ -118,7 +118,7 @@ pipeline:
         name: FooSize
         type: gauge
         labels:
-          topic: ${! meta("kafka_topic") }
+          topic: ${! metadata("kafka_topic") }
         value: ${! json("foo.size") }
 
 metrics:

--- a/website/docs/components/processors/nats_request_reply.md
+++ b/website/docs/components/processors/nats_request_reply.md
@@ -161,7 +161,7 @@ Type: `string`
 
 subject: foo.bar.baz
 
-subject: ${! meta("kafka_topic") }
+subject: ${! metadata("kafka_topic") }
 
 subject: foo.${! json("meta.type") }
 ```
@@ -193,7 +193,7 @@ Default: `{}`
 
 headers:
   Content-Type: application/json
-  Timestamp: ${!meta("Timestamp")}
+  Timestamp: ${!metadata("Timestamp")}
 ```
 
 ### `metadata`

--- a/website/docs/components/processors/parquet_decode.md
+++ b/website/docs/components/processors/parquet_decode.md
@@ -55,7 +55,7 @@ input:
 output:
   file:
     codec: lines
-    path: './foos/${! meta("s3_key") }.jsonl'
+    path: './foos/${! metadata("s3_key") }.jsonl'
 ```
 
 </TabItem>

--- a/website/docs/components/processors/redis.md
+++ b/website/docs/components/processors/redis.md
@@ -80,7 +80,7 @@ pipeline:
           - redis:
               url: TODO
               command: scard
-              args_mapping: 'root = [ meta("set_key") ]'
+              args_mapping: 'root = [ metadata("set_key") ]'
         result_map: 'root.cardinality = this'
 ```
 
@@ -330,7 +330,7 @@ command: scard
 
 command: incrby
 
-command: ${! meta("command") }
+command: ${! metadata("command") }
 ```
 
 ### `args_mapping`
@@ -346,7 +346,7 @@ Requires version 4.3.0 or newer
 
 args_mapping: root = [ this.key ]
 
-args_mapping: root = [ meta("kafka_key"), this.count ]
+args_mapping: root = [ metadata("kafka_key"), this.count ]
 ```
 
 ### `retries`

--- a/website/docs/components/processors/redis_script.md
+++ b/website/docs/components/processors/redis_script.md
@@ -96,7 +96,7 @@ pipeline:
           redis.call("ZADD", "XX", KEYS[1], ARGV[1], value)
 
           return value
-        keys_mapping: 'root = [ meta("key") ]'
+        keys_mapping: 'root = [ metadata("key") ]'
         args_mapping: 'root = [ timestamp_unix_nano() ]'
 ```
 
@@ -320,7 +320,7 @@ Type: `string`
 
 args_mapping: root = [ this.key ]
 
-args_mapping: root = [ meta("kafka_key"), "hardcoded_value" ]
+args_mapping: root = [ metadata("kafka_key"), "hardcoded_value" ]
 ```
 
 ### `keys_mapping`
@@ -335,7 +335,7 @@ Type: `string`
 
 keys_mapping: root = [ this.key ]
 
-keys_mapping: root = [ meta("kafka_key"), this.count ]
+keys_mapping: root = [ metadata("kafka_key"), this.count ]
 ```
 
 ### `retries`

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -135,7 +135,7 @@ Type: `string`
 
 subject: foo
 
-subject: ${! meta("kafka_topic") }
+subject: ${! metadata("kafka_topic") }
 ```
 
 ### `refresh_period`

--- a/website/docs/components/processors/sql.md
+++ b/website/docs/components/processors/sql.md
@@ -127,7 +127,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `result_codec`

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -94,7 +94,7 @@ pipeline:
           root = [
             this.user.id,
             this.user.name,
-            meta("kafka_topic"),
+            metadata("kafka_topic"),
           ]
 ```
 
@@ -193,7 +193,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `prefix`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -88,7 +88,7 @@ pipeline:
         driver: mysql
         dsn: foouser:foopassword@tcp(localhost:3306)/foodb
         query: "INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?);"
-        args_mapping: '[ document.foo, document.bar, meta("kafka_topic") ]'
+        args_mapping: '[ document.foo, document.bar, metadata("kafka_topic") ]'
         exec_only: true
 ```
 
@@ -211,7 +211,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `exec_only`

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -215,7 +215,7 @@ Type: `string`
 
 args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ]
 
-args_mapping: root = [ meta("user.id") ]
+args_mapping: root = [ metadata("user.id") ]
 ```
 
 ### `prefix`

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -134,7 +134,7 @@ root.result = this.foo.exists("bar.baz")
 
 ### `from`
 
-Modifies a target query such that certain functions are executed from the perspective of another message in the batch. This allows you to mutate events based on the contents of other messages. Functions that support this behaviour are `content`, `json` and `meta`.
+Modifies a target query such that certain functions are executed from the perspective of another message in the batch. This allows you to mutate events based on the contents of other messages. Functions that support this behaviour are `content()`, `json()`, `metadata()` and `meta()`. It cannot be used with the `@` operator.
 
 #### Parameters
 
@@ -152,10 +152,12 @@ root.foo = json("foo").from(1)
 
 ### `from_all`
 
-Modifies a target query such that certain functions are executed from the perspective of each message in the batch, and returns the set of results as an array. Functions that support this behaviour are `content`, `json` and `meta`.
+Modifies a target query such that certain functions are executed from the perspective of each message in the batch, and returns the set of results as an array. Functions that support this behaviour are `content()`, `json()`, `metadata()` and `meta()`. It cannot be used with the `@` operator.
 
 #### Examples
 
+
+Sum all the message `foo`s from the current batch:
 
 ```coffee
 root = this


### PR DESCRIPTION
The `meta()` function is deprecated since v4.15.0, but it can still come in handy as a shortcut for `metadata("foo").string()` and `metadata().map_each(m -> m.string())` can be replaced with a call to `meta()`.