### PR TITLE
pulsar/input: add subscription_initial_position

### DIFF
--- a/docs/modules/components/pages/inputs/pulsar.adoc
+++ b/docs/modules/components/pages/inputs/pulsar.adoc
@@ -36,6 +36,7 @@ input:
     topics_pattern: "" # No default (optional)
     subscription_name: "" # No default (required)
     subscription_type: shared
+    subscription_initial_position: latest
     tls:
       root_cas_file: ""
 ```
@@ -55,6 +56,7 @@ input:
     topics_pattern: "" # No default (optional)
     subscription_name: "" # No default (required)
     subscription_type: shared
+    subscription_initial_position: latest
     tls:
       root_cas_file: ""
     auth:
@@ -152,6 +154,17 @@ Options:
 , `failover`
 , `exclusive`
 .
+
+
+=== `subscription_initial_position`
+
+Specify the subscription initial position for this consumer.
+
+
+Type: `string`
+Default: `"latest"`
+Options: `latest`, `earliest`.
+
 
 === `tls`
 
@@ -254,5 +267,3 @@ Actual base64 encoded token.
 *Type*: `string`
 
 *Default*: `""`
-
-


### PR DESCRIPTION
For #917.

I wasn't sure how the integration tests worked... so I've not touched those. Tested with my local app, FWIW. 🤞 