### PR TITLE
Supress make warning present on Benthos forks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PATHINSTSERVERLESS = $(DEST_DIR)/serverless
 PATHINSTDOCKER     = $(DEST_DIR)/docker
 DOCKER_IMAGE       ?= ghcr.io/redpanda-data/connect
 
-VERSION   := $(shell git describe --tags || echo "v0.0.0")
+VERSION   := $(shell git describe --tags 2> /dev/null || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
 VER_MAJOR := $(shell echo $(VER_CUT) | cut -f1 -d.)
 VER_MINOR := $(shell echo $(VER_CUT) | cut -f2 -d.)


### PR DESCRIPTION
If you develop Benthos on a fork, you won't have any _git tags_ present by default.

The git describe throws an annoying error which shows for any `make` command
```
$ git describe --tags
fatal: No names found, cannot describe anything.
```

such as:
```
$ make
fatal: No names found, cannot describe anything.
make: Nothing to be done for `all'.
```

Supressing the error message makes the make output way more pleasant