### PR TITLE
Handle hash commands such as HGETALL in redis processor

### DIFF
--- a/internal/impl/redis/processor.go
+++ b/internal/impl/redis/processor.go
@@ -351,6 +351,19 @@ func (r *redisProc) execRaw(ctx context.Context, index int, inBatch service.Mess
 		return err
 	}
 
+	if structured, ok := res.(map[any]any); ok {
+		m2 := make(map[string]any, len(structured))
+
+		for key, value := range structured {
+			typeCast, ok := key.(string)
+			if !ok {
+				return fmt.Errorf("expected a string, got: %T", key)
+			}
+			m2[typeCast] = value
+		}
+		res = m2
+	}
+
 	msg.SetStructuredMut(res)
 	return nil
 }


### PR DESCRIPTION
The crux of the reported issue was that https://github.com/benthosdev/benthos/blob/main/public/service/message.go#L262 requires an array of `[string]any` but the redis library returns `[any]any` which does not get processed right.

Once all the types are cast to string, it behaves as expected.

Added unit tests for HSet HGet and HGetAll.

All existing Redis unit tests pass.

Fixes #2282