### PR TITLE
pulsar/oauth2: fix config lookup, add "scope"

### DIFF
--- a/docs/modules/components/pages/inputs/pulsar.adoc
+++ b/docs/modules/components/pages/inputs/pulsar.adoc
@@ -62,6 +62,7 @@ input:
         enabled: false
         audience: ""
         issuer_url: ""
+        scope: ""
         private_key_file: ""
       token:
         enabled: false
@@ -220,6 +221,14 @@ OAuth2 issuer URL.
 
 *Default*: `""`
 
+=== `auth.oauth2.scope`
+
+OAuth2 scope to request.
+
+
+Type: `string`
+Default: `""`
+
 === `auth.oauth2.private_key_file`
 
 The path to a file containing a private key.
@@ -254,5 +263,3 @@ Actual base64 encoded token.
 *Type*: `string`
 
 *Default*: `""`
-
-

--- a/docs/modules/components/pages/outputs/pulsar.adoc
+++ b/docs/modules/components/pages/outputs/pulsar.adoc
@@ -62,6 +62,7 @@ output:
         enabled: false
         audience: ""
         issuer_url: ""
+        scope: ""
         private_key_file: ""
       token:
         enabled: false
@@ -195,6 +196,14 @@ OAuth2 issuer URL.
 
 *Default*: `""`
 
+=== `auth.oauth2.scope`
+
+OAuth2 scope to request.
+
+
+Type: `string`
+Default: `""`
+
 === `auth.oauth2.private_key_file`
 
 The path to a file containing a private key.
@@ -229,5 +238,3 @@ Actual base64 encoded token.
 *Type*: `string`
 
 *Default*: `""`
-
-

--- a/internal/impl/pulsar/auth_field.go
+++ b/internal/impl/pulsar/auth_field.go
@@ -18,6 +18,9 @@ func authField() *service.ConfigField {
 			service.NewURLField("issuer_url").
 				Description("OAuth2 issuer URL.").
 				Default(""),
+			service.NewURLField("scope").
+				Description("OAuth2 scope to request.").
+				Default(""),
 			service.NewStringField("private_key_file").
 				Description("The path to a file containing a private key.").
 				Default(""),
@@ -48,6 +51,7 @@ type oAuth2Config struct {
 	Audience       string
 	IssuerURL      string
 	PrivateKeyFile string
+	Scope          string
 }
 
 type tokenConfig struct {
@@ -69,6 +73,9 @@ func authFromParsed(p *service.ParsedConfig) (c authConfig, err error) {
 			return
 		}
 		if c.OAuth2.IssuerURL, err = p.FieldString("oauth2", "issuer_url"); err != nil {
+			return
+		}
+		if c.OAuth2.Scope, err = p.FieldString("oauth2", "scope"); err != nil {
 			return
 		}
 		if c.OAuth2.PrivateKeyFile, err = p.FieldString("oauth2", "private_key_file"); err != nil {
@@ -123,6 +130,7 @@ func (c *oAuth2Config) ToMap() map[string]string {
 		"issuerUrl":  c.IssuerURL,
 		"audience":   c.Audience,
 		"privateKey": c.PrivateKeyFile,
+		"scope":      c.Scope,
 	}
 }
 

--- a/internal/impl/pulsar/auth_field.go
+++ b/internal/impl/pulsar/auth_field.go
@@ -61,17 +61,17 @@ func authFromParsed(p *service.ParsedConfig) (c authConfig, err error) {
 	}
 	p = p.Namespace("auth")
 
-	if p.Contains("oauth") {
-		if c.OAuth2.Enabled, err = p.FieldBool("oauth", "enabled"); err != nil {
+	if p.Contains("oauth2") {
+		if c.OAuth2.Enabled, err = p.FieldBool("oauth2", "enabled"); err != nil {
 			return
 		}
-		if c.OAuth2.Audience, err = p.FieldString("oauth", "audience"); err != nil {
+		if c.OAuth2.Audience, err = p.FieldString("oauth2", "audience"); err != nil {
 			return
 		}
-		if c.OAuth2.IssuerURL, err = p.FieldString("oauth", "issuer_url"); err != nil {
+		if c.OAuth2.IssuerURL, err = p.FieldString("oauth2", "issuer_url"); err != nil {
 			return
 		}
-		if c.OAuth2.PrivateKeyFile, err = p.FieldString("oauth", "private_key_file"); err != nil {
+		if c.OAuth2.PrivateKeyFile, err = p.FieldString("oauth2", "private_key_file"); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
These are two things I had to adjust to be able to use Benthos with Pulsar and Keycloak.

I think the config lookup is a straight bug -- it can't work if you enable linting the config, can it? The linter should bail if you set "oauth" instead of "oauth2" and if you set "oauth2", the auth config builder will fail to pick up the values.