### PR TITLE
Add an Ockam Kafka Input and an Ockam Kafka Output

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -33,7 +33,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func FranzKafkaInputConfig() *service.ConfigSpec {
+func franzKafkaInputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
@@ -58,57 +58,7 @@ This input adds the following metadata fields to each message:
 - All record headers
 ` + "```" + `
 `).
-		Field(service.NewStringListField("seed_brokers").
-			Description("A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.").
-			Example([]string{"localhost:9092"}).
-			Example([]string{"foo:9092", "bar:9092"}).
-			Example([]string{"foo:9092,bar:9092"})).
-		Field(service.NewStringListField("topics").
-			Description(`
-A list of topics to consume from. Multiple comma separated topics can be listed in a single element. When a ` + "`consumer_group`" + ` is specified partitions are automatically distributed across consumers of a topic, otherwise all partitions are consumed.
-
-Alternatively, it's possible to specify explicit partitions to consume from with a colon after the topic name, e.g. ` + "`foo:0`" + ` would consume the partition 0 of the topic foo. This syntax supports ranges, e.g. ` + "`foo:0-10`" + ` would consume partitions 0 through to 10 inclusive.
-
-Finally, it's also possible to specify an explicit offset to consume from by adding another colon after the partition, e.g. ` + "`foo:0:10`" + ` would consume the partition 0 of the topic foo starting from the offset 10. If the offset is not present (or remains unspecified) then the field ` + "`start_from_oldest`" + ` determines which offset to start from.`).
-			Example([]string{"foo", "bar"}).
-			Example([]string{"things.*"}).
-			Example([]string{"foo,bar"}).
-			Example([]string{"foo:0", "bar:1", "bar:3"}).
-			Example([]string{"foo:0,bar:1,bar:3"}).
-			Example([]string{"foo:0-5"})).
-		Field(service.NewBoolField("regexp_topics").
-			Description("Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When topics are specified with explicit partitions this field must remain set to `false`.").
-			Default(false)).
-		Field(service.NewStringField("consumer_group").
-			Description("An optional consumer group to consume as. When specified the partitions of specified topics are automatically distributed across consumers sharing a consumer group, and partition offsets are automatically committed and resumed under this name. Consumer groups are not supported when specifying explicit partitions to consume from in the `topics` field.").
-			Optional()).
-		Field(service.NewStringField("client_id").
-			Description("An identifier for the client connection.").
-			Default("benthos").
-			Advanced()).
-		Field(service.NewStringField("rack_id").
-			Description("A rack identifier for this client.").
-			Default("").
-			Advanced()).
-		Field(service.NewIntField("checkpoint_limit").
-			Description("Determines how many messages of the same partition can be processed in parallel before applying back pressure. When a message of a given offset is delivered to the output the offset is only allowed to be committed when all messages of prior offsets have also been delivered, this ensures at-least-once delivery guarantees. However, this mechanism also increases the likelihood of duplicates in the event of crashes or server faults, reducing the checkpoint limit will mitigate this.").
-			Default(1024).
-			Advanced()).
-		Field(service.NewAutoRetryNacksToggleField()).
-		Field(service.NewDurationField("commit_period").
-			Description("The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown.").
-			Default("5s").
-			Advanced()).
-		Field(service.NewBoolField("start_from_oldest").
-			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
-			Default(true).
-			Advanced()).
-		Field(service.NewTLSToggledField("tls")).
-		Field(SASLFields()).
-		Field(service.NewBoolField("multi_header").Description("Decode headers into lists to allow handling of multiple values with the same key").Default(false).Advanced()).
-		Field(service.NewBatchPolicyField("batching").
-			Description("Allows you to configure a xref:configuration:batching.adoc[batching policy] that applies to individual topic partitions in order to batch messages together before flushing them for processing. Batching can be beneficial for performance as well as useful for windowed processing, and doing so this way preserves the ordering of topic partitions.").
-			Advanced()).
+		Fields(FranzKafkaInputConfigFields()...).
 		LintRule(`
 let has_topic_partitions = this.topics.any(t -> t.contains(":"))
 root = if $has_topic_partitions {
@@ -121,8 +71,64 @@ root = if $has_topic_partitions {
 `)
 }
 
+func FranzKafkaInputConfigFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewStringListField("seed_brokers").
+			Description("A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.").
+			Example([]string{"localhost:9092"}).
+			Example([]string{"foo:9092", "bar:9092"}).
+			Example([]string{"foo:9092,bar:9092"}),
+		service.NewStringListField("topics").
+			Description(`
+A list of topics to consume from. Multiple comma separated topics can be listed in a single element. When a ` + "`consumer_group`" + ` is specified partitions are automatically distributed across consumers of a topic, otherwise all partitions are consumed.
+
+Alternatively, it's possible to specify explicit partitions to consume from with a colon after the topic name, e.g. ` + "`foo:0`" + ` would consume the partition 0 of the topic foo. This syntax supports ranges, e.g. ` + "`foo:0-10`" + ` would consume partitions 0 through to 10 inclusive.
+
+Finally, it's also possible to specify an explicit offset to consume from by adding another colon after the partition, e.g. ` + "`foo:0:10`" + ` would consume the partition 0 of the topic foo starting from the offset 10. If the offset is not present (or remains unspecified) then the field ` + "`start_from_oldest`" + ` determines which offset to start from.`).
+			Example([]string{"foo", "bar"}).
+			Example([]string{"things.*"}).
+			Example([]string{"foo,bar"}).
+			Example([]string{"foo:0", "bar:1", "bar:3"}).
+			Example([]string{"foo:0,bar:1,bar:3"}).
+			Example([]string{"foo:0-5"}),
+		service.NewBoolField("regexp_topics").
+			Description("Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When topics are specified with explicit partitions this field must remain set to `false`.").
+			Default(false),
+		service.NewStringField("consumer_group").
+			Description("An optional consumer group to consume as. When specified the partitions of specified topics are automatically distributed across consumers sharing a consumer group, and partition offsets are automatically committed and resumed under this name. Consumer groups are not supported when specifying explicit partitions to consume from in the `topics` field.").
+			Optional(),
+		service.NewStringField("client_id").
+			Description("An identifier for the client connection.").
+			Default("benthos").
+			Advanced(),
+		service.NewStringField("rack_id").
+			Description("A rack identifier for this client.").
+			Default("").
+			Advanced(),
+		service.NewIntField("checkpoint_limit").
+			Description("Determines how many messages of the same partition can be processed in parallel before applying back pressure. When a message of a given offset is delivered to the output the offset is only allowed to be committed when all messages of prior offsets have also been delivered, this ensures at-least-once delivery guarantees. However, this mechanism also increases the likelihood of duplicates in the event of crashes or server faults, reducing the checkpoint limit will mitigate this.").
+			Default(1024).
+			Advanced(),
+		service.NewAutoRetryNacksToggleField(),
+		service.NewDurationField("commit_period").
+			Description("The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown.").
+			Default("5s").
+			Advanced(),
+		service.NewBoolField("start_from_oldest").
+			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
+			Default(true).
+			Advanced(),
+		service.NewTLSToggledField("tls"),
+		SASLFields(),
+		service.NewBoolField("multi_header").Description("Decode headers into lists to allow handling of multiple values with the same key").Default(false).Advanced(),
+		service.NewBatchPolicyField("batching").
+			Description("Allows you to configure a xref:configuration:batching.adoc[batching policy] that applies to individual topic partitions in order to batch messages together before flushing them for processing. Batching can be beneficial for performance as well as useful for windowed processing, and doing so this way preserves the ordering of topic partitions.").
+			Advanced(),
+	}
+}
+
 func init() {
-	err := service.RegisterBatchInput("kafka_franz", FranzKafkaInputConfig(),
+	err := service.RegisterBatchInput("kafka_franz", franzKafkaInputConfig(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 			rdr, err := NewFranzKafkaReaderFromConfig(conf, mgr)
 			if err != nil {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -30,7 +30,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func FranzKafkaOutputConfig() *service.ConfigSpec {
+func franzKafkaOutputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
@@ -41,80 +41,86 @@ Writes a batch of messages to Kafka brokers and waits for acknowledgement before
 
 This output often out-performs the traditional ` + "`kafka`" + ` output as well as providing more useful logs and error messages.
 `).
-		Field(service.NewStringListField("seed_brokers").
+		Fields(FranzKafkaOutputConfigFields()...).
+		LintRule(`
+root = if this.partitioner == "manual" {
+if this.partition.or("") == "" {
+"a partition must be specified when the partitioner is set to manual"
+}
+} else if this.partition.or("") != "" {
+"a partition cannot be specified unless the partitioner is set to manual"
+}`)
+}
+
+func FranzKafkaOutputConfigFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewStringListField("seed_brokers").
 			Description("A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.").
 			Example([]string{"localhost:9092"}).
 			Example([]string{"foo:9092", "bar:9092"}).
-			Example([]string{"foo:9092,bar:9092"})).
-		Field(service.NewInterpolatedStringField("topic").
-			Description("A topic to write messages to.")).
-		Field(service.NewInterpolatedStringField("key").
-			Description("An optional key to populate for each message.").Optional()).
-		Field(service.NewStringAnnotatedEnumField("partitioner", map[string]string{
+			Example([]string{"foo:9092,bar:9092"}),
+		service.NewInterpolatedStringField("topic").
+			Description("A topic to write messages to."),
+		service.NewInterpolatedStringField("key").
+			Description("An optional key to populate for each message.").Optional(),
+		service.NewStringAnnotatedEnumField("partitioner", map[string]string{
 			"murmur2_hash": "Kafka's default hash algorithm that uses a 32-bit murmur2 hash of the key to compute which partition the record will be on.",
 			"round_robin":  "Round-robin's messages through all available partitions. This algorithm has lower throughput and causes higher CPU load on brokers, but can be useful if you want to ensure an even distribution of records to partitions.",
 			"least_backup": "Chooses the least backed up partition (the partition with the fewest amount of buffered records). Partitions are selected per batch.",
 			"manual":       "Manually select a partition for each message, requires the field `partition` to be specified.",
 		}).
 			Description("Override the default murmur2 hashing partitioner.").
-			Advanced().Optional()).
-		Field(service.NewInterpolatedStringField("partition").
+			Advanced().Optional(),
+		service.NewInterpolatedStringField("partition").
 			Description("An optional explicit partition to set for each message. This field is only relevant when the `partitioner` is set to `manual`. The provided interpolation string must be a valid integer.").
 			Example(`${! meta("partition") }`).
-			Optional()).
-		Field(service.NewStringField("client_id").
+			Optional(),
+		service.NewStringField("client_id").
 			Description("An identifier for the client connection.").
 			Default("benthos").
-			Advanced()).
-		Field(service.NewStringField("rack_id").
+			Advanced(),
+		service.NewStringField("rack_id").
 			Description("A rack identifier for this client.").
 			Default("").
-			Advanced()).
-		Field(service.NewBoolField("idempotent_write").
+			Advanced(),
+		service.NewBoolField("idempotent_write").
 			Description("Enable the idempotent write producer option. This requires the `IDEMPOTENT_WRITE` permission on `CLUSTER` and can be disabled if this permission is not available.").
 			Default(true).
-			Advanced()).
-		Field(service.NewMetadataFilterField("metadata").
+			Advanced(),
+		service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").
-			Optional()).
-		Field(service.NewIntField("max_in_flight").
+			Optional(),
+		service.NewIntField("max_in_flight").
 			Description("The maximum number of batches to be sending in parallel at any given time.").
-			Default(10)).
-		Field(service.NewDurationField("timeout").
+			Default(10),
+		service.NewDurationField("timeout").
 			Description("The maximum period of time to wait for message sends before abandoning the request and retrying").
 			Default("10s").
-			Advanced()).
-		Field(service.NewBatchPolicyField("batching")).
-		Field(service.NewStringField("max_message_bytes").
+			Advanced(),
+		service.NewBatchPolicyField("batching"),
+		service.NewStringField("max_message_bytes").
 			Description("The maximum space in bytes than an individual message may take, messages larger than this value will be rejected. This field corresponds to Kafka's `max.message.bytes`.").
 			Advanced().
 			Default("1MB").
 			Example("100MB").
-			Example("50mib")).
-		Field(service.NewStringEnumField("compression", "lz4", "snappy", "gzip", "none", "zstd").
+			Example("50mib"),
+		service.NewStringEnumField("compression", "lz4", "snappy", "gzip", "none", "zstd").
 			Description("Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.").
 			Optional().
-			Advanced()).
-		Field(service.NewTLSToggledField("tls")).
-		Field(SASLFields()).
-		Field(service.NewInterpolatedStringField("timestamp").
+			Advanced(),
+		service.NewTLSToggledField("tls"),
+		SASLFields(),
+		service.NewInterpolatedStringField("timestamp").
 			Description("An optional timestamp to set for each message. When left empty, the current timestamp is used.").
 			Example(`${! timestamp_unix() }`).
 			Example(`${! metadata("kafka_timestamp_unix") }`).
 			Optional().
-			Advanced()).
-		LintRule(`
-root = if this.partitioner == "manual" {
-  if this.partition.or("") == "" {
-    "a partition must be specified when the partitioner is set to manual"
-  }
-} else if this.partition.or("") != "" {
-  "a partition cannot be specified unless the partitioner is set to manual"
-}`)
+			Advanced(),
+	}
 }
 
 func init() {
-	err := service.RegisterBatchOutput("kafka_franz", FranzKafkaOutputConfig(),
+	err := service.RegisterBatchOutput("kafka_franz", franzKafkaOutputConfig(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (
 			output service.BatchOutput,
 			batchPolicy service.BatchPolicy,

--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -1,0 +1,326 @@
+package ockam
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// Run `ockam ...` commands
+func runCommand(capture bool, arg ...string) (string, string, error) {
+	bin, err := findCommandBinary()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to find Ockam Command binary: %v", err)
+	}
+
+	cmd := exec.Command(bin, arg...)
+	cmd.Env = append(os.Environ(),
+		"OCKAM_HOME="+ockamHome(),
+		"NO_INPUT=true",
+		"NO_COLOR=true",
+		"OCKAM_DISABLE_UPGRADE_CHECK=true",
+		"OCKAM_OPENTELEMETRY_EXPORT=false",
+	)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if capture {
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+	} else {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to open %s: %v", os.DevNull, err)
+		}
+		defer devNull.Close()
+
+		cmd.Stdout = devNull
+		cmd.Stderr = devNull
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	err = cmd.Run()
+	stdout := stdoutBuf.String()
+	stderr := stderrBuf.String()
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to run the command: %s, error: %v\nstdout:\n%s\nstderr:\n%s",
+			cmd.String(), err, stdout, stderr)
+		return stdout, stderr, errors.New(errMsg)
+	}
+
+	return stdout, stderr, nil
+}
+
+// Returns the path to the Ockam Command binary.
+// If it's not found, it will be downloaded and installed.
+func setupCommand() (string, error) {
+	bin, err := findCommandBinary()
+	if err == nil {
+		return bin, nil
+	}
+
+	err = installCommand()
+	if err != nil {
+		return "", fmt.Errorf("failed to install Ockam Command: %v", err)
+	}
+
+	return findCommandBinary()
+}
+
+// Returns the path to the Ockam Command binary or an error if it can't find the binary.
+func findCommandBinary() (string, error) {
+	// If the OCKAM environment variable is set, assume that as the path of the Ockam Command binary.
+	command := os.Getenv("OCKAM")
+	if command != "" {
+		return command, nil
+	}
+
+	// If ockam is in path, assume that as the Ockam Command binary.
+	_, err := exec.LookPath("ockam")
+	if err == nil {
+		return "ockam", nil
+	}
+
+	// Try to find the path of Ockam Command by running `command -v ockam`
+	shell, err := shell()
+	if err == nil {
+		cmdToFindBinary := "command -v ockam"
+
+		// If ockamHome()/env file is present and readable, source it before running `command -v ockam`
+		// This may be helpful when Ockam Command was installed using the Ockam Command install script.
+		envFile, err := envFile()
+		if err == nil {
+			cmdToFindBinary = "source " + envFile + " && " + cmdToFindBinary
+		}
+
+		cmd := exec.Command(shell, "-c", cmdToFindBinary)
+		output, err := cmd.Output()
+		if err == nil {
+			path := strings.TrimSpace(string(output))
+			if path != "" {
+				return path, nil
+			}
+		}
+	}
+
+	// If ockamHome() + "/bin/ockam" exists, return its path
+	path := filepath.Join(ockamHome(), "bin", "ockam")
+	_, err = os.Stat(path)
+	if err == nil {
+		return path, nil
+	}
+
+	return "", errors.New("failed to find Ockam Command binary")
+}
+
+// Installs Ockam Command.
+//
+// If bash is not available, directly download and install the binary.
+// If bash is available, install using the install script.
+func installCommand() error {
+	_, err := exec.LookPath("bash")
+	if err != nil {
+		return downloadAndInstall()
+	} else {
+		return downloadAndInstallWithInstallScript()
+	}
+}
+
+func downloadAndInstall() error {
+	binaryType, err := pickBinaryType()
+	if err != nil {
+		return err
+	}
+	url := "https://github.com/build-trust/ockam/releases/latest/download/ockam." + binaryType
+
+	version := os.Getenv("OCKAM_VERSION")
+	if version != "" {
+		url = "https://github.com/build-trust/ockam/releases/download/ockam_" + version + "/ockam." + binaryType
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download the binary %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got HTTP response with status code != 200, while downloading %s: %v", url, resp.StatusCode)
+	}
+
+	binaryDirPath := filepath.Join(ockamHome(), "/bin")
+	err = os.MkdirAll(binaryDirPath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create directories in this path %s: %v", binaryDirPath, err)
+	}
+
+	binary := filepath.Join(binaryDirPath, "/ockam")
+	out, err := os.Create(binary)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", binary, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy downloaded contents to file %s: %v", binary, err)
+	}
+
+	err = os.Chmod(binary, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to change permissions of the file %s: %v", binary, err)
+	}
+	return nil
+}
+
+func pickBinaryType() (string, error) {
+	binaries := map[string]string{
+		"darwin/arm64": "aarch64-apple-darwin",
+		"darwin/amd64": "x86_64-apple-darwin",
+		"linux/arm64":  "aarch64-unknown-linux-musl",
+		"linux/armv7":  "armv7-unknown-linux-musleabihf",
+		"linux/amd64":  "x86_64-unknown-linux-gnu",
+	}
+
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	binary, exists := binaries[fmt.Sprintf("%s/%s", os, arch)]
+	if !exists {
+		return "", fmt.Errorf("no available binary for: %s/%s", os, arch)
+	}
+
+	return binary, nil
+}
+
+func downloadAndInstallWithInstallScript() error {
+	// Download the install script.
+	resp, err := http.Get("https://install.command.ockam.io")
+	if err != nil {
+		return fmt.Errorf("failed to download the install script: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got HTTP response with status code != 200, while downloading the install script: %v", resp.StatusCode)
+	}
+
+	// Save the install script to a temporary file.
+	tmpFile, err := os.CreateTemp("", "install-ockam-*.sh")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file for the install script: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	_, err = io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy install script to a temporary file: %v", err)
+	}
+	err = os.Chmod(tmpFile.Name(), 0700)
+	if err != nil {
+		return fmt.Errorf("failed to change permissions on the install script to 0700: %v", err)
+	}
+
+	// Prepare the install script invocation command
+	c := []string{tmpFile.Name()}
+	version := os.Getenv("OCKAM_VERSION")
+	if version != "" {
+		c = append(c, "--version", version)
+	}
+
+	// Run the install script
+	cmd := exec.Command("bash", c...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to execute the install script: %v", err)
+	}
+
+	return nil
+}
+
+// Returns the name of a shell executable, "bash" or "sh".
+//
+// It returns the name of a shell only if an executable with that name is found in $PATH.
+// Returns an error of neither bash or sh are found in $PATH. Which may happen in environments like a docker container.
+func shell() (string, error) {
+	shells := []string{"bash", "sh"}
+	for _, s := range shells {
+		_, err := exec.LookPath(s)
+		if err == nil {
+			return s, nil
+		}
+	}
+	return "", errors.New("failed to find bash or sh in path")
+}
+
+// Returns the path to the environment file that is used to add Ockam Command to $PATH, in a shell.
+//
+// This file may be found at ockamHome()/env. This function first tries to open the file at that path in read-only mode.
+// If opening the env file succeeds, this function returns its path, otherwise it returns an error.
+func envFile() (string, error) {
+	envFile := filepath.Join(ockamHome(), "/env")
+
+	// Check if the env file can be opened for reading
+	file, err := os.Open(envFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open env file %s: %v", envFile, err)
+	}
+	defer file.Close()
+
+	return envFile, nil
+}
+
+// Returns the path to Ockam Command's home directory.
+func ockamHome() string {
+	o := os.Getenv("OCKAM_HOME")
+	if o != "" {
+		return o
+	}
+
+	fallBackHomeDir := filepath.Join("/tmp", ".ockam")
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fallBackHomeDir
+	}
+
+	_, err = os.Stat(homeDir)
+	if os.IsNotExist(err) {
+		return fallBackHomeDir
+	}
+
+	err = os.MkdirAll(filepath.Join(homeDir, ".ockam"), os.ModePerm)
+	if os.IsPermission(err) {
+		return fallBackHomeDir
+
+	}
+
+	return filepath.Join(homeDir, ".ockam")
+}
+
+func findAvailableLocalTCPAddress() (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	address := listener.Addr().String()
+	_ = listener.Close()
+
+	return address, nil
+}
+
+func localTCPAddressIsTaken(address string) bool {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return true
+	}
+	_ = listener.Close()
+	return false
+}

--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ockam
 
 import (

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -1,0 +1,173 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
+)
+
+// this function is, almost, an exact copy of the init() function in ../kafka/input_kafka_franz.go
+func init() {
+	err := service.RegisterBatchInput("ockam_kafka", ockamKafkaInputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			i, err := newOckamKafkaInput(conf, mgr)
+			if err != nil {
+				return nil, err
+			}
+			return service.AutoRetryNacksBatchedToggled(conf, i)
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ockamKafkaInputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaInputConfig().
+		Summary(`Ockam`).
+		Field(service.NewStringListField("seed_brokers").Optional().
+			Description("A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.").
+			Example([]string{"localhost:9092"}).
+			Example([]string{"foo:9092", "bar:9092"}).
+			Example([]string{"foo:9092,bar:9092"})).
+		Field(service.NewStringField("ockam_identity_name").Optional()).
+		Field(service.NewStringField("ockam_node_address").Default("127.0.0.1:6262").Optional()).
+		Field(service.NewStringField("ockam_allow_producer").Default("self").Optional()).
+		Field(service.NewStringField("ockam_enrollment_ticket").Optional()).
+		Field(service.NewStringField("ockam_relay").Optional()).
+		Field(service.NewStringField("ockam_allow").Default("self").Optional()).
+		Field(service.NewStringField("ockam_route_to_kafka_outlet").Default("self").Optional())
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaInput struct {
+	node        node
+	kafkaReader *kafka.FranzKafkaReader
+}
+
+func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*ockamKafkaInput, error) {
+	_, err := setupCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Node ----
+
+	var ticket string
+	if conf.Contains("ockam_enrollment_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollment_ticket")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var relay string
+	if conf.Contains("ockam_relay") {
+		relay, err = conf.FieldString("ockam_relay")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var identityName string
+	if conf.Contains("ockam_identity_name") {
+		identityName, err = conf.FieldString("ockam_identity_name")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	address, err := conf.FieldString("ockam_node_address")
+	if err != nil {
+		return nil, err
+	}
+	if localTCPAddressIsTaken(address) {
+		return nil, errors.New("ockam_node_address '" + address + "' is already in use")
+	}
+
+	n, err := newNode(identityName, address, ticket, relay)
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Kafka Inlet ----
+
+	allowProducer, err := conf.FieldString("ockam_allow_producer")
+	if err != nil {
+		return nil, err
+	}
+
+	kafkaInletAddress, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	var routeToKafkaOutlet string
+	routeToKafkaOutlet, err = conf.FieldString("ockam_route_to_kafka_outlet")
+	if err != nil {
+		return nil, err
+	}
+
+	var allowOutlet string
+	allowOutlet, err = conf.FieldString("ockam_allow")
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, "self", allowOutlet, allowProducer, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Create Ockam Kafka Outlet if necessary ----
+	kafkaReader, err := kafka.NewFranzKafkaReaderFromConfig(conf, mgr)
+	if err != nil {
+		return nil, err
+	}
+
+	if routeToKafkaOutlet == "self" {
+		// TODO: Handle other tls fields in kafka franz
+		_, tls, err := conf.FieldTLSToggled("tls")
+		if err != nil {
+			tls = false
+		}
+		// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+		seedBrokers, err := conf.FieldStringList("seed_brokers")
+		if err != nil {
+			return nil, err
+		}
+		if len(seedBrokers) > 1 {
+			mgr.Logger().Warn("ockam_kafka input only supports one seed broker")
+		}
+		bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+		// TODO: Handle more that one seed brokers
+
+		kafkaOutletName := "redpanda-connect-kafka-outlet"
+		err = n.createKafkaOutlet(kafkaOutletName, bootstrapServer, tls, "self")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
+	kafkaReader.SeedBrokers = []string{kafkaInletAddress}
+	// Disable TLS, kafka_franz writer will communicate in plaintext with the Ockam kafka inlet
+	kafkaReader.TLSConf = nil
+
+	return &ockamKafkaInput{*n, kafkaReader}, nil
+}
+
+func (o *ockamKafkaInput) Connect(ctx context.Context) error {
+	return o.kafkaReader.Connect(ctx)
+}
+
+func (o *ockamKafkaInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return o.kafkaReader.ReadBatch(ctx)
+}
+
+func (o *ockamKafkaInput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaReader.Close(ctx), o.node.delete())
+}

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -32,6 +32,7 @@ func ockamKafkaInputConfig() *service.ConfigSpec {
 			Example([]string{"localhost:9092"}).
 			Example([]string{"foo:9092", "bar:9092"}).
 			Example([]string{"foo:9092,bar:9092"})).
+		Field(service.NewBoolField("disable_content_encryption").Default(false).Optional()).
 		Field(service.NewStringField("ockam_identity_name").Optional()).
 		Field(service.NewStringField("ockam_node_address").Default("127.0.0.1:6262").Optional()).
 		Field(service.NewStringField("ockam_allow_producer").Default("self").Optional()).
@@ -117,7 +118,13 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 		return nil, err
 	}
 
-	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, "self", allowOutlet, allowProducer, "")
+	var disableContentEncryption bool
+	disableContentEncryption, err = conf.FieldBool("disable_content_encryption")
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, "self", allowOutlet, allowProducer, "", disableContentEncryption)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -63,7 +63,7 @@ func (n *node) delete() error {
 }
 
 // TODO: improve this function's interface
-func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string) error {
+func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string, disableContentEncryption bool) error {
 	args := []string{"kafka-inlet", "create", "--addr", name, "--at", n.name, "--from", from, "--to", to}
 	if routeToConsumer != "" {
 		args = append(args, "--consumer", routeToConsumer)
@@ -71,6 +71,10 @@ func (n *node) createKafkaInlet(name string, from string, to string, avoidPublis
 
 	if avoidPublishing {
 		args = append(args, "--avoid-publishing")
+	}
+
+	if disableContentEncryption {
+		args = append(args, "--disable-content-encryption")
 	}
 
 	args = appendAllowArgs(args, "--allow", allowOutlet, n.identifier)

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -1,0 +1,207 @@
+package ockam
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+type node struct {
+	name       string
+	address    string
+	identity   string
+	identifier string
+	config     string
+}
+
+func newNode(identityName string, address string, ticket string, relay string) (*node, error) {
+	name := "redpanda-connect-" + generateName()
+
+	identity, identifier, err := getIdentity(identityName)
+	if err != nil {
+		return nil, err
+	}
+
+	configuration := map[string]interface{}{
+		"name":                 name,
+		"identity":             identity,
+		"tcp-listener-address": address,
+	}
+
+	if ticket != "" {
+		configuration["ticket"] = ticket
+		if relay != "" {
+			configuration["relay"] = relay
+		}
+	}
+
+	j, err := json.Marshal(configuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal node config to json string: %v", err)
+	}
+
+	node := &node{name: name, address: address, identity: identity, identifier: identifier, config: string(j)}
+
+	err = node.create()
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func (n *node) create() error {
+	_, _, err := runCommand(false, "node", "create", "--node-config", n.config)
+	return err
+}
+
+func (n *node) delete() error {
+	_, _, err := runCommand(false, "node", "delete", n.name, "--yes")
+	return err
+}
+
+// TODO: improve this function's interface
+func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string) error {
+	args := []string{"kafka-inlet", "create", "--addr", name, "--at", n.name, "--from", from, "--to", to}
+	if routeToConsumer != "" {
+		args = append(args, "--consumer", routeToConsumer)
+	}
+
+	if avoidPublishing {
+		args = append(args, "--avoid-publishing")
+	}
+
+	args = appendAllowArgs(args, "--allow", allowOutlet, n.identifier)
+	args = appendAllowArgs(args, "--allow-producer", allowProducer, n.identifier)
+	args = appendAllowArgs(args, "--allow-consumer", allowConsumer, n.identifier)
+
+	_, _, err := runCommand(true, args...)
+	return err
+}
+
+func (n *node) createKafkaOutlet(name string, bootstrapServer string, tls bool, allowInlet string) error {
+	args := []string{"kafka-outlet", "create", "--addr", name, "--at", n.name, "--bootstrap-server", bootstrapServer}
+
+	if tls {
+		args = append(args, "--tls")
+	}
+
+	if allowInlet != "" {
+		if allowInlet == "self" {
+			args = append(args, "--allow", "(= subject.identifier \""+n.identifier+"\")")
+		} else if rune(allowInlet[0]) == 'I' {
+			args = append(args, "--allow", "(= subject.identifier \""+allowInlet+"\")")
+		} else {
+			args = append(args, "--allow", allowInlet)
+		}
+	}
+
+	_, _, err := runCommand(false, args...)
+	return err
+}
+
+func generateName() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomNumber := r.Intn(1 << 32)
+	return fmt.Sprintf("%08x", randomNumber)
+}
+
+func appendAllowArgs(args []string, flag string, value string, identifier string) []string {
+	if value != "" {
+		if value == "self" {
+			args = append(args, flag, "(= subject.identifier \""+identifier+"\")")
+		} else if rune(value[0]) == 'I' {
+			args = append(args, flag, "(= subject.identifier \""+value+"\")")
+		} else {
+			args = append(args, flag, value)
+		}
+	}
+
+	return args
+}
+
+func listIdentities() ([]map[string]interface{}, error) {
+	stdout, _, err := runCommand(true, "identity", "list", "--output", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var identities []map[string]interface{}
+	err = json.Unmarshal([]byte(stdout), &identities)
+	if err != nil {
+		return nil, err
+	}
+
+	return identities, nil
+}
+
+func findOrCreateDefaultIdentity() (string, string, error) {
+	identities, err := listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["is_default"].(bool) {
+			return identity["name"].(string), identity["identifier"].(string), nil
+		}
+	}
+
+	_, _, err = runCommand(false, "identity", "create")
+	if err != nil {
+		return "", "", err
+	}
+
+	identities, err = listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["is_default"].(bool) {
+			return identity["name"].(string), identity["identifier"].(string), nil
+		}
+	}
+
+	return "", "", errors.New("default identity not found")
+}
+
+func findOrCreateIdentityByName(identityName string) (string, string, error) {
+	identities, err := listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["name"] == identityName {
+			return identityName, identity["identifier"].(string), nil
+		}
+	}
+
+	_, _, err = runCommand(false, "identity", "create", identityName)
+	if err != nil {
+		return "", "", err
+	}
+
+	identities, err = listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["name"] == identityName {
+			return identityName, identity["identifier"].(string), nil
+		}
+	}
+
+	return "", "", errors.New("failed to create identity")
+}
+
+func getIdentity(identityName string) (string, string, error) {
+	if identityName != "" {
+		return findOrCreateIdentityByName(identityName)
+	}
+	return findOrCreateDefaultIdentity()
+}

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ockam
 
 import (

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -1,0 +1,175 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
+)
+
+// this function is, almost, an exact copy of the init() function in ../kafka/output_kafka_franz.go
+func init() {
+	err := service.RegisterBatchOutput("ockam_kafka", ockamKafkaOutputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (
+			output service.BatchOutput,
+			batchPolicy service.BatchPolicy,
+			maxInFlight int,
+			err error,
+		) {
+			if maxInFlight, err = conf.FieldInt("max_in_flight"); err != nil {
+				return
+			}
+			if batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
+				return
+			}
+			output, err = newOckamKafkaOutput(conf, mgr.Logger())
+			return
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ockamKafkaOutputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaOutputConfig().
+		Summary("Ockam").
+		Field(service.NewStringListField("seed_brokers").Optional().
+			Description("A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.").
+			Example([]string{"localhost:9092"}).
+			Example([]string{"foo:9092", "bar:9092"}).
+			Example([]string{"foo:9092,bar:9092"})).
+		Field(service.NewStringField("ockam_enrollment_ticket").Optional()).
+		Field(service.NewStringField("ockam_identity_name").Optional()).
+		Field(service.NewStringField("ockam_allow_consumer").Default("self").Optional()).
+		Field(service.NewStringField("ockam_route_to_consumer").Default("/ip4/127.0.0.1/tcp/6262")).
+		Field(service.NewStringField("ockam_allow").Default("self").Optional()).
+		Field(service.NewStringField("ockam_route_to_kafka_outlet").Default("self").Optional())
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaOutput struct {
+	kafkaWriter *kafka.FranzKafkaWriter
+	node        node
+}
+
+func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ockamKafkaOutput, error) {
+	_, err := setupCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Node ----
+
+	var ticket string
+	if conf.Contains("ockam_enrollment_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollment_ticket")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var identityName string
+	if conf.Contains("ockam_identity_name") {
+		identityName, err = conf.FieldString("ockam_identity_name")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	address, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := newNode(identityName, address, ticket, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Kafka Inlet ----
+
+	routeToConsumer, err := conf.FieldString("ockam_route_to_consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	allowConsumer, err := conf.FieldString("ockam_allow_consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	kafkaInletAddress, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	var routeToKafkaOutlet string
+	routeToKafkaOutlet, err = conf.FieldString("ockam_route_to_kafka_outlet")
+	if err != nil {
+		return nil, err
+	}
+
+	var allowOutlet string
+	allowOutlet, err = conf.FieldString("ockam_allow")
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, routeToConsumer, allowOutlet, "", allowConsumer)
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Create Ockam Kafka Outlet ----
+
+	kafkaWriter, err := kafka.NewFranzKafkaWriterFromConfig(conf, log)
+	if err != nil {
+		return nil, err
+	}
+
+	if routeToKafkaOutlet == "self" {
+		// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+		seedBrokers, err := conf.FieldStringList("seed_brokers")
+		if err != nil {
+			return nil, err
+		}
+		if len(seedBrokers) > 1 {
+			log.Warn("ockam_kafka output only supports one seed broker")
+		}
+		bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+		// TODO: Handle more that one seed brokers
+
+		_, tls, err := conf.FieldTLSToggled("tls")
+		if err != nil {
+			tls = false
+		}
+
+		kafkaOutletName := "redpanda-connect-kafka-outlet"
+		err = n.createKafkaOutlet(kafkaOutletName, bootstrapServer, tls, "self")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
+	kafkaWriter.SeedBrokers = []string{kafkaInletAddress}
+	// Disable TLS, kafka_franz writer will communicate in plaintext with the ockam kafka inlet
+	kafkaWriter.TLSConf = nil
+
+	return &ockamKafkaOutput{kafkaWriter, *n}, nil
+}
+
+func (o *ockamKafkaOutput) Connect(ctx context.Context) error {
+	return o.kafkaWriter.Connect(ctx)
+}
+
+func (o *ockamKafkaOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	return o.kafkaWriter.WriteBatch(ctx, batch)
+}
+
+func (o *ockamKafkaOutput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaWriter.Close(ctx), o.node.delete())
+}

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -40,6 +40,7 @@ func ockamKafkaOutputConfig() *service.ConfigSpec {
 			Example([]string{"localhost:9092"}).
 			Example([]string{"foo:9092", "bar:9092"}).
 			Example([]string{"foo:9092,bar:9092"})).
+		Field(service.NewBoolField("disable_content_encryption").Default(false).Optional()).
 		Field(service.NewStringField("ockam_enrollment_ticket").Optional()).
 		Field(service.NewStringField("ockam_identity_name").Optional()).
 		Field(service.NewStringField("ockam_allow_consumer").Default("self").Optional()).
@@ -118,7 +119,13 @@ func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ocka
 		return nil, err
 	}
 
-	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, routeToConsumer, allowOutlet, "", allowConsumer)
+	var disableContentEncryption bool
+	disableContentEncryption, err = conf.FieldBool("disable_content_encryption")
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, routeToConsumer, allowOutlet, "", allowConsumer, disableContentEncryption)
 	if err != nil {
 		return nil, err
 	}

--- a/public/components/community/package.go
+++ b/public/components/community/package.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/redpanda-data/connect/v4/public/components/nanomsg"
 	_ "github.com/redpanda-data/connect/v4/public/components/nats"
 	_ "github.com/redpanda-data/connect/v4/public/components/nsq"
+	_ "github.com/redpanda-data/connect/v4/public/components/ockam"
 	_ "github.com/redpanda-data/connect/v4/public/components/opensearch"
 	_ "github.com/redpanda-data/connect/v4/public/components/otlp"
 	_ "github.com/redpanda-data/connect/v4/public/components/pinecone"

--- a/public/components/ockam/package.go
+++ b/public/components/ockam/package.go
@@ -1,0 +1,6 @@
+package ockam
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/redpanda-data/connect/v4/internal/impl/ockam"
+)


### PR DESCRIPTION
Everyone on the [Ockam](https://github.com/build-trust/ockam) team is thrilled to contribute two new Ockam Kafka plugins - an input and an output.

Ockam Kafka plugins for Redpanda Connect create Ockam Portals to send end-to-end encrypted messages through Kafka. These plugins combine Ockam and the Franz Kafka plugins to setup encrypted portals.

Messages from a producer are encrypted to a specific Consumer. Only that specific Consumer can decrypt these messages. This guarantees that your data cannot be observed or tampered as it passes through Kafka. Operators of the Kafka cluster only see end-to-end encrypted data. Any compromise of an operator's infrastructure cannot compromise your business data. Kafka brokers cannot see the data.

# Examples

## On one machine

Let's begin with a very simple local example that runs all the parts on one machine.

### Consumer

The consumer uses `ockam_kafka` input to decrypt and read messages from Kafka. It then transforms messages using a processor and writes the transformed message to stdout.

```yaml
# consumer.yaml

input:
  ockam_kafka:
    seed_brokers: [localhost:9092]
    topics: [topic_A]
    consumer_group: example_group

pipeline:
  processors:
    - bloblang: |
        root.doc = this | content().string()
        root.length = content().length()
        root.topic = meta("kafka_topic")

output:
  stdout: {}
```

### Producer

The producer reads messages from stdin. It then uses `ockam_kafka` output to encrypt and write messages to Kafka.

```yaml
# producer.yaml

input:
  stdin: {}

output:
  ockam_kafka:
    seed_brokers: [localhost:9092]
    topic: topic_A
```

### Run

With a `redpanda-connect` binary compiled using this pull request:

```shell
# Setup Redpanda
brew install redpanda-data/tap/redpanda
rpk container start

# Start a Consumer
redpanda-connect -c ./consumer.yaml

# Start Producers in separate terminals and type some messages.
redpanda-connect -c ./producer.yaml --set "http.address=127.0.0.1:4196"
redpanda-connect -c ./producer.yaml --set "http.address=127.0.0.1:4197"
redpanda-connect -c ./producer.yaml --set "http.address=127.0.0.1:4198"

# See encrypted messages in Redpanda at http://localhost:8080
```

## Between two machines

### Consumer

```yaml
# consumer.yaml

input:
  ockam_kafka:
    seed_brokers: [${IP_OF_REDPANDA_MACHINE}:9092]
    topics: [topic_A]
    consumer_group: example_group
    ockam_node_address: 0.0.0.0:6262
    ockam_allow_producer: ${OCKAM_ALLOW_PRODUCER}

pipeline:
  processors:
    - bloblang: |
        root.doc = this | content().string()
        root.length = content().length()
        root.topic = meta("kafka_topic")

output:
  stdout: {}

```

### Producer

```yaml
# producer.yaml

input:
  stdin: {}

output:
  ockam_kafka:
    seed_brokers: [${IP_OF_REDPANDA_MACHINE}:9092]
    topic: topic_A
    ockam_route_to_consumer: /ip4/${IP_OF_CONSUMER_MACHINE}/tcp/6262
    ockam_allow_consumer: ${OCKAM_ALLOW_CONSUMER}
```

### Run

With a `redpanda-connect` binary compiled using this pull request:

```shell
# Redpanda
brew install redpanda-data/tap/redpanda
rpk container start

# Machine 1 - Producer
curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash && source "$HOME/.ockam/env"
ockam identity create
# copy the generated Identity's identifier to Machine 2 - I5fc86d2...

# Machine 2 - Consumer
curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash && source "$HOME/.ockam/env"
ockam identity create
IP_OF_REDPANDA_MACHINE=... OCKAM_ALLOW_PRODUCER=I5fc86d2... redpanda-connect -c ./consumer.yaml
# copy the generated Identity's identifier to Machine 1 - I94d64b91...

# Machine 1 - Producer
IP_OF_REDPANDA_MACHINE=... IP_OF_CONSUMER_MACHINE=... \
  OCKAM_ALLOW_CONSUMER=I94d64b91... redpanda-connect -c ./producer.yaml

```

## Across several machines

### Consumer

```yaml
# consumer.yaml

input:
  ockam_kafka:
    seed_brokers: [rp-node-0:9092]
    topics: [topic_A]
    consumer_group: example_group
    ockam_allow_producer: producer
    ockam_relay: consumer_relay
    ockam_enrollment_ticket: ${OCKAM_ENROLLMENT_TICKET}

pipeline:
  processors:
    - bloblang: |
        root = this
        root.data.message = this.data.message.uppercase()

output:
  stdout: {}

```

### Producer

```yaml
# producer.yaml

input:
  generate:
    count: 1000
    interval: "@every 1s"
    mapping: |
      root = {
        "_producer": hostname(),
        "data": { "email": fake("email"), "message": fake("sentence") }
      }

output:
  ockam_kafka:
    seed_brokers: [rp-node-0:9092]
    topic: topic_A
    ockam_route_to_consumer: /project/default/service/forward_to_consumer_relay/secure/api
    ockam_allow_consumer: consumer
    ockam_enrollment_ticket: ${OCKAM_ENROLLMENT_TICKET}

```

### Run

As a temporary step, until this pull request is merged, we compiled this PR's branch and pushed a docker image to `ghcr.io/build-trust/redpanda-connect`

```shell
# Setup Redpanda
brew install redpanda-data/tap/redpanda
rpk container start

# Setup Ockam
brew install build-trust/ockam/ockam
ockam enroll

# Setup Consumer
ockam project ticket --usage-count 1 --expires-in 10m --attribute consumer --relay consumer_relay > ticket
docker run --rm --network redpanda --name consumer -v "$(pwd)/consumer.yaml:/connect.yaml" \
  -e OCKAM_ENROLLMENT_TICKET="$(cat ticket)" ghcr.io/build-trust/redpanda-connect

# Setup Producers (in a new terminal window)
for i in $(seq 1 3); do
    ockam project ticket --usage-count 1 --expires-in 10m --attribute producer > ticket
    docker run --rm -d --network redpanda --name "producer$i" -v "$(pwd)/producer.yaml:/connect.yaml" \
        -e OCKAM_ENROLLMENT_TICKET="$(cat ./ticket)" ghcr.io/build-trust/redpanda-connect
done

# It can take a minute or so for the messages to start flowing.
# Observe that the above consumer can decrypt and transform messages.

# However, if you look at the messages inside redpanda console at localhost:8080
# or using the below rpk command, you'll notice that the messages are encrypted.
rpk topic consume topic_A

# Cleanup
docker stop $(docker ps -q --filter "name=producer" --filter "name=consumer")
rpk container purge

```


## Across several machines - using Redpanda Serverless

## Consumer

```yaml
#consumer.yaml

input:
  ockam_kafka:
    seed_brokers: ["${REDPANDA_BOOTSTRAP_SERVER}"]
    topics: [topic_A]
    consumer_group: example_group
    tls:
      enabled: true
    sasl:
      - mechanism: "SCRAM-SHA-256"
        username: "${REDPANDA_USERNAME}"
        password: "${REDPANDA_PASSWORD}"
    ockam_allow_producer: producer
    ockam_relay: consumer_relay
    ockam_enrollment_ticket: "${OCKAM_ENROLLMENT_TICKET}"

pipeline:
  processors:
    - bloblang: |
        root = this
        root.data.message = this.data.message.uppercase()

output:
  stdout: {}

```

## Producers

```yaml
# producer.yaml

input:
  generate:
    count: 1000
    interval: "@every 1s"
    mapping: |
      root = {
        "_producer": hostname(),
        "data": { "email": fake("email"), "message": fake("sentence") }
      }

output:
  ockam_kafka:
    seed_brokers: ["${REDPANDA_BOOTSTRAP_SERVER}"]
    topic: topic_A
    sasl:
      - mechanism: "SCRAM-SHA-256"
        username: "${REDPANDA_USERNAME}"
        password: "${REDPANDA_PASSWORD}"
    tls:
      enabled: true
    ockam_route_to_consumer: /project/default/service/forward_to_consumer_relay/secure/api
    ockam_allow_consumer: consumer
    ockam_enrollment_ticket: ${OCKAM_ENROLLMENT_TICKET}
```

## Run

```shell

# Setup Redpanda
#   1. Create a Redpanda serverless cluster - https://cloud.redpanda.com/
#   2. Create a new topic with name topic_A with default settings.
#   3. Create a new user with name tester.
#       - Select SCRAM-SHA-256 as SASL Mechanism and copy the password to use as environment variable below.
#       - Navigate to Security->ACLs, select tester, select "Allow all operations"
#   4. Copy the following values to your shell's and set them as environment variables:
export REDPANDA_BOOTSTRAP_SERVER="TODO:9092"
export REDPANDA_USERNAME="tester"
export REDPANDA_PASSWORD="TODO"

# Setup Ockam
#   1. Signup for Ockam https://ockam.io/signup
#   2. Setup Ockam Command on your development machine
brew install build-trust/ockam/ockam
ockam enroll

# Setup Consumer
ockam project ticket --usage-count 1 --expires-in 10m --attribute consumer --relay consumer_relay > ticket
docker run --rm --name consumer \
  -v "$(pwd)/consumer.yaml:/connect.yaml" \
  -e OCKAM_ENROLLMENT_TICKET="$(cat ticket)" \
  -e REDPANDA_BOOTSTRAP_SERVER="$REDPANDA_BOOTSTRAP_SERVER" \
  -e REDPANDA_USERNAME="$REDPANDA_USERNAME" \
  -e REDPANDA_PASSWORD="$REDPANDA_PASSWORD" \
  ghcr.io/build-trust/redpanda-connect

# Setup Producers (in a new terminal window)
for i in $(seq 1 3); do
    ockam project ticket --usage-count 1 --expires-in 10m --attribute producer > ticket
    docker run --rm -d --name "producer$i" \
        -v "$(pwd)/producer.yaml:/connect.yaml" \
        -e OCKAM_ENROLLMENT_TICKET="$(cat ./ticket)" \
        -e REDPANDA_BOOTSTRAP_SERVER="$REDPANDA_BOOTSTRAP_SERVER" \
        -e REDPANDA_USERNAME="$REDPANDA_USERNAME" \
        -e REDPANDA_PASSWORD="$REDPANDA_PASSWORD" \
        ghcr.io/build-trust/redpanda-connect
done

# It can take a minute or so for the messages to start flowing.
# Observe that the above consumer can decrypt and transform messages.

# However, if you look at the messages inside redpanda console or using
# the below rpk command, you'll notice that the messages are encrypted.
rpk cloud login
rpk topic consume topic_A

# Cleanup
docker stop $(docker ps -q --filter "name=producer" --filter "name=consumer")

```