### PR TITLE
Add free and enterprise import bundles

### DIFF
--- a/public/bundle/enterprise/LICENSE
+++ b/public/bundle/enterprise/LICENSE
@@ -1,0 +1,408 @@
+**Redpanda Community License Agreement**
+
+Please read this Redpanda Community License Agreement (the “Agreement”)
+carefully before using Redpanda (as defined below), which is offered by
+Redpanda Data, Inc. or its affiliated Legal Entities (“Redpanda Data”).
+
+By downloading Redpanda or using it in any manner, You agree that You
+have read and agree to be bound by the terms of this Agreement. If You
+are accessing Redpanda on behalf of a Legal Entity, You represent and
+warrant that You have the authority to agree to these terms on its
+behalf and the right to bind that Legal Entity to this Agreement. Use of
+Redpanda is expressly conditioned upon Your assent to all the terms of
+this Agreement, to the exclusion of all other terms.
+
+1.  **<span class="smallcaps">Definitions</span>.** In addition to other
+    terms defined elsewhere in this Agreement, the terms below have the
+    following meanings.
+
+(a) “Redpanda” shall mean the event streaming platform provided by Redpanda Data, including both Redpanda Core and Redpanda Enterprise Edition, as defined below.
+
+(b) “Redpanda Core” shall mean the version of Redpanda, available free of charge at https://github.com/redpanda-data/redpanda.
+
+(c) “Redpanda Enterprise Edition” shall mean the additional features made available by Redpanda Data, the use of which is subject to additional terms set out below.
+
+(d) “Contribution” shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted Redpanda Data for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, “submitted” means any form of electronic, verbal, or written communication sent to Redpanda Data or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Redpanda Data for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as “Not a Contribution.”
+
+(e) “Contributor” shall mean any copyright owner or individual or Legal Entity authorized by the copyright owner, other than Redpanda Data, from whom Redpanda Data receives a Contribution that Redpanda Data subsequently incorporates within the Work.
+
+(f) “Derivative Works” shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work, such as a translation, abridgement, condensation, or any other recasting, transformation, or adaptation for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+(g) “Legal Entity” shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, “control” means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+(h) “License” shall mean the terms and conditions for use, reproduction, and distribution of a Work as defined by this Agreement.
+
+(i) “Licensor” shall mean Redpanda Data or a Contributor, as applicable.
+
+(j) “Object” form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+(k) “Source” form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+(l) “Third Party Works” shall mean Works, including Contributions, and other technology owned by a person or Legal Entity other than Redpanda Data, as indicated by a copyright notice that is included in or attached to such Works or technology.
+
+(m) “Work” shall mean the work of authorship, whether in Source or Object form, made available under a License, as indicated by a copyright notice that is included in or attached to the work.
+
+(n) “You” (or “Your”) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+2.  **<span class="smallcaps">Licenses</span>**.
+
+    1.  **License to Redpanda Core.** The License for Redpanda Core is
+        the Business Source License v.1.1 ("BSL License"). Please see
+        the text of the Redpanda [BSL License](bsl.md) for full terms.
+        Redpanda Core is a no-cost, entry-level license and as such,
+        contains the following disclaimers: TO THE EXTENT PERMITTED BY
+        APPLICABLE LAW, REDPANDA CORE IS PROVIDED ON AN “AS IS” BASIS.
+        LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+        OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+        NON-INFRINGEMENT, AND TITLE. For clarity, the terms of this
+        Agreement, other than the relevant definitions in Section 1 and
+        this Section 2(a) do not apply to Redpanda Core.
+
+    2.  **License to Redpanda Enterprise Edition.**
+
+        1.  ***Grant of Copyright License:*** Subject to the terms of
+            this Agreement, Licensor hereby grants to You a worldwide,
+            non-exclusive, non-transferable limited license to
+            reproduce, prepare Enterprise Derivative Works (as defined
+            below) of, publicly display, publicly perform, sublicense,
+            and distribute Redpanda Enterprise Edition for Your business
+            purposes, for so long as You are not in violation of this
+            Section 2(b) and are current on all payments required by
+            Section 4 below.
+
+        2.  ***Grant of Patent License:*** Subject to the terms of this
+            Agreement, Licensor hereby grants to You a worldwide,
+            non-exclusive, non-transferable limited patent license to
+            make, have made, use, offer to sell, sell, import, and
+            otherwise transfer Redpanda Enterprise Edition, where such
+            license applies only to those patent claims licensable by
+            Licensor that are necessarily infringed by their
+            Contribution(s) alone or by combination of their
+            Contribution(s) with the Work to which such Contribution(s)
+            was submitted. If You institute patent litigation against
+            any entity (including a cross-claim or counterclaim in a
+            lawsuit) alleging that the Work or a Contribution
+            incorporated within the Work constitutes direct or
+            contributory patent infringement, then any patent licenses
+            granted to You under this License for that Work shall
+            terminate as of the date such litigation is filed.
+
+        3.  ***License to Third Party Works:*** From time to time
+            Redpanda Data may use, or provide You access to, Third Party
+            Works in connection Redpanda Enterprise Edition. You
+            acknowledge and agree that in addition to this Agreement,
+            Your use of Third Party Works is subject to all other terms
+            and conditions set forth in the License provided with or
+            contained in such Third Party Works. Some Third Party Works
+            may be licensed to You solely for use with Redpanda
+            Enterprise Edition under the terms of a third party License,
+            or as otherwise notified by Redpanda Data, and not under the
+            terms of this Agreement. You agree that the owners and third
+            party licensors of Third Party Works are intended third
+            party beneficiaries to this Agreement.
+
+        4.  ***Use Restriction:*** You may make use of Redpanda
+            Enterprise Edition, provided that you may not use Redpanda
+            Enterprise Edition for a Streaming or Queuing Service. A
+            “Streaming or Queueing Service” is a commercial offering
+            that allows third parties (other than your employees and
+            individual contractors) to access the functionality of
+            Redpanda Enterprise Edition by performing an action directly
+            or indirectly that causes the creation of a topic in the
+            Work. For clarity, a Streaming or Queuing Service would
+            include providers of infrastructure services, such as cloud
+            services, hosting services, data center services and
+            similarly situated third parties (including affiliates of
+            such entities) that would offer Redpanda Enterprise Edition
+            in connection with a broader service offering to customers
+            or subscribers of such of such third party’s core services.
+
+3.  **<span class="smallcaps">Support</span>.** From time to time, in
+    its sole discretion, Redpanda Data may offer professional services or
+    support for Redpanda, which may now or in the future be subject to
+    additional fees.
+
+4.  **<span class="smallcaps">Fees for Redpanda Enterprise Edition or
+    Redpanda Support.</span>**
+
+    1.  **Fees.** The License to Redpanda Enterprise Edition is
+        conditioned upon Your payment of the fees specified on
+        [pricing](https://redpanda.com/contact) which You agree to pay to Redpanda Data in accordance
+        with the payment terms set out on that page. Any professional
+        services or support for Redpanda may also be subject to Your
+        payment of fees, which will be specified by Redpanda Data when you
+        sign up to receive such professional services or support.
+        Redpanda Data reserves the right to change the fees at any time
+        with prior written notice; for recurring fees, any such
+        adjustments will take effect as of the next payment period.
+
+    2.  **Overdue Payments and Taxes.** Overdue payments are subject to
+        a service charge equal to the lesser of 1.5% per month or the
+        maximum legal interest rate allowed by law, and You shall pay
+        all Redpanda Data’s reasonable costs of collection, including court
+        costs and attorneys’ fees. Fees are stated and payable in U.S.
+        dollars and are exclusive of all sales, use, value added and
+        similar taxes, duties, withholdings and other governmental
+        assessments (but excluding taxes based on Redpanda Data’s income)
+        that may be levied on the transactions contemplated by this
+        Agreement in any jurisdiction, all of which are Your
+        responsibility unless you have provided Redpanda Data with a valid
+        tax-exempt certificate.
+
+    3.  **Record-keeping and Audit.** If fees for Redpanda Enterprise
+        Edition are based on the number of cores or servers running on
+        Redpanda Enterprise Edition or another use-based unit of
+        measurement, You must maintain complete and accurate records
+        with respect Your use of Redpanda Enterprise Edition and will
+        provide such records to Redpanda Data for inspection or audit upon
+        Redpanda Data’s reasonable request. If an inspection or audit
+        uncovers additional usage by You for which fees are owed under
+        this Agreement, then You shall pay for such additional usage at
+        Redpanda Data’s then-current rates.
+
+5.  **<span class="smallcaps">Trial License.</span>** If You have signed
+    up for a trial or evaluation of Redpanda Enterprise Edition, Your
+    License to Redpanda Enterprise Edition is granted without charge for
+    the trial or evaluation period specified when You signed up, or if
+    no term was specified, for thirty (30) calendar days, provided that
+    Your License is granted solely for purposes of Your internal
+    evaluation of Redpanda Enterprise Edition during the trial or
+    evaluation period (a “Trial License”). You may not use Redpanda
+    Enterprise Edition under a Trial License more than once in any
+    twelve (12) month period. Redpanda Data may revoke a Trial License at
+    any time and for any reason. Sections 3, 4, 9 and 11 of this
+    Agreement do not apply to Trial Licenses.
+
+6.  **<span class="smallcaps">Redistribution.</span>** You may reproduce
+    and distribute copies of the Work or Derivative Works thereof in any
+    medium, with or without modifications, and in Source or Object form,
+    provided that You meet the following conditions:
+
+    1.  You must give any other recipients of the Work or Derivative
+        Works a copy of this License; and
+
+    2.  You must cause any modified files to carry prominent notices
+        stating that You changed the files; and
+
+    3.  You must retain, in the Source form of any Derivative Works that
+        You distribute, all copyright, patent, trademark, and
+        attribution notices from the Source form of the Work, excluding
+        those notices that do not pertain to any part of the Derivative
+        Works; and
+
+    4.  If the Work includes a “NOTICE” text file as part of its
+        distribution, then any Derivative Works that You distribute must
+        include a readable copy of the attribution notices contained
+        within such NOTICE file, excluding those notices that do not
+        pertain to any part of the Derivative Works, in at least one of
+        the following places: within a NOTICE text file distributed as
+        part of the Derivative Works; within the Source form or
+        documentation, if provided along with the Derivative Works; or,
+        within a display generated by the Derivative Works, if and
+        wherever such third-party notices normally appear. The contents
+        of the NOTICE file are for informational purposes only and do
+        not modify the License. You may add Your own attribution notices
+        within Derivative Works that You distribute, alongside or as an
+        addendum to the NOTICE text from the Work, provided that such
+        additional attribution notices cannot be construed as modifying
+        the License.
+
+    5.  You may add Your own copyright statement to Your modifications
+        and may provide additional or different license terms and
+        conditions for use, reproduction, or distribution of Your
+        modifications, or for any such Derivative Works as a whole,
+        provided Your use, reproduction, and distribution of the Work
+        otherwise complies with the conditions stated in this License.
+
+    6.  **Enterprise Derivative Works.** Derivative Works of Redpanda
+        Enterprise Edition (“Enterprise Derivative Works”) may be made,
+        reproduced and distributed in any medium, with or without
+        modifications, in Source or Object form, provided that each
+        Enterprise Derivative Work will be considered to include a
+        License to Redpanda Enterprise Edition and thus will be subject
+        to the payment of fees to Redpanda Data by any user of the
+        Enterprise Derivative Work.
+
+7.  **<span class="smallcaps">Submission of Contributions.</span>**
+    Unless You explicitly state otherwise, any Contribution
+    intentionally submitted for inclusion in Redpanda by You to
+    Redpanda Data shall be under the terms and conditions of
+    [https://cla-assistant.io/redpanda-data/redpanda] (which is based off of the
+    Apache License), without any additional terms or conditions,
+    payments of royalties or otherwise to Your benefit. Notwithstanding
+    the above, nothing herein shall supersede or modify the terms of any
+    separate license agreement You may have executed with Redpanda Data
+    regarding such Contributions.
+
+8.  **<span class="smallcaps">Trademarks.</span>** This License does not
+    grant permission to use the trade names, trademarks, service marks,
+    or product names of Licensor, except as required for reasonable and
+    customary use in describing the origin of the Work and reproducing
+    the content of the NOTICE file.
+
+9.  **<span class="smallcaps">Limited Warranty.</span>**
+
+    1.  **Warranties.** Redpanda Data warrants to You that: (i) Redpanda
+        Enterprise Edition will materially perform in accordance with
+        the applicable documentation for ninety (90) days after initial
+        delivery to You; and (ii) any professional services performed by
+        Redpanda Data under this Agreement will be performed in a
+        workmanlike manner, in accordance with general industry
+        standards.
+
+    2.  **Exclusions.** Redpanda Data’s warranties in this Section 9 do not
+        extend to problems that result from: (i) Your failure to
+        implement updates issued by Redpanda Data during the warranty
+        period; (ii) any alterations or additions (including Enterprise
+        Derivative Works and Contributions) to Redpanda not performed by
+        or at the direction of Redpanda Data; (iii) failures that are not
+        reproducible by Redpanda Data; (iv) operation of Redpanda
+        Enterprise Edition in violation of this Agreement or not in
+        accordance with its documentation; (v) failures caused by
+        software, hardware or products not licensed or provided by
+        Redpanda Data hereunder; or (vi) Third Party Works.
+
+    3.  **Remedies.** In the event of a breach of a warranty under this
+        Section 9, Redpanda Data will, at its discretion and cost, either
+        repair, replace or re-perform the applicable Works or services
+        or refund a portion of fees previously paid to Redpanda Data that
+        are associated with the defective Works or services. This is
+        Your exclusive remedy, and Redpanda Data’s sole liability, arising
+        in connection with the limited warranties herein.
+
+10.  **<span class="smallcaps">Disclaimer of Warranty.</span>** EXCEPT AS
+    SET OUT IN SECTION 9, UNLESS REQUIRED BY APPLICABLE LAW, LICENSOR
+    PROVIDES THE WORK (AND EACH CONTRIBUTOR PROVIDES ITS CONTRIBUTIONS)
+    ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    EITHER EXPRESS OR IMPLIED, ARISING OUT OF COURSE OF DEALING, COURSE
+    OF PERFORMANCE, OR USAGE IN TRADE, INCLUDING, WITHOUT LIMITATION,
+    ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+    MERCHANTABILITY, CORRECTNESS, RELIABILITY, OR FITNESS FOR A
+    PARTICULAR PURPOSE, ALL OF WHICH ARE HEREBY DISCLAIMED. YOU ARE
+    SOLELY RESPONSIBLE FOR DETERMINING THE APPROPRIATENESS OF USING OR
+    REDISTRIBUTING WORKS AND ASSUME ANY RISKS ASSOCIATED WITH YOUR
+    EXERCISE OF PERMISSIONS UNDER THE APPLICABLE LICENSE FOR SUCH WORKS.
+
+11. **<span class="smallcaps">Limited Indemnity.</span>**
+
+    1.  **Indemnity.** Redpanda Data will defend, indemnify and hold You
+        harmless against any third party claims, liabilities or expenses
+        incurred (including reasonable attorneys’ fees), as well as
+        amounts finally awarded in a settlement or a non-appealable
+        judgement by a court (“Losses”), to the extent arising from any
+        claim or allegation by a third party that Redpanda Enterprise
+        Edition infringes or misappropriates a valid United States
+        patent, copyright or trade secret right of a third party;
+        provided that You give Redpanda Data: (i) prompt written notice of
+        any such claim or allegation; (ii) sole control of the defense
+        and settlement thereof; and (iii) reasonable cooperation and
+        assistance in such defense or settlement. If any Work within
+        Redpanda Enterprise Edition becomes or, in Redpanda Data’s opinion,
+        is likely to become, the subject of an injunction, Redpanda Data
+        may, at its option, (A) procure for You the right to continue
+        using such Work, (B) replace or modify such Work so that it
+        becomes non-infringing without substantially compromising its
+        functionality, or, if (A) and (B) are not commercially
+        practicable, then (C) terminate Your license to the allegedly
+        infringing Work and refund to You a prorated portion of the
+        prepaid and unearned fees for such infringing Work. The
+        foregoing states the entire liability of Redpanda Data with respect
+        to infringement of patents, copyrights, trade secrets or other
+        intellectual property rights.
+
+    2.  **Exclusions.** The foregoing obligations shall not apply
+        to: (i) Works modified by any party other than Redpanda Data
+        (including Enterprise Derivative Works and Contributions), if
+        the alleged infringement relates to such modification, (ii)
+        Works combined or bundled with any products, processes or
+        materials not provided by Redpanda Data where the alleged
+        infringement relates to such combination, (iii) use of a version
+        of Redpanda Enterprise Edition other than the version that was
+        current at the time of such use, as long as a non-infringing
+        version had been released, (iv) any Works created to Your
+        specifications, (v) infringement or misappropriation of any
+        proprietary right in which You have an interest, or (vi) Third
+        Party Works. You will defend, indemnify and hold Redpanda Data
+        harmless against any Losses arising from any such claim or
+        allegation, subject to conditions reciprocal to those in Section
+        11(a).
+
+12. **<span class="smallcaps">Limitation of Liability.</span>** In no
+    event and under no legal or equitable theory, whether in tort
+    (including negligence), contract, or otherwise, unless required by
+    applicable law (such as deliberate and grossly negligent acts), and
+    notwithstanding anything in this Agreement to the contrary, shall
+    Licensor or any Contributor be liable to You for (i) any amounts in
+    excess, in the aggregate, of the fees paid by You to Redpanda Data
+    under this Agreement in the twelve (12) months preceding the date
+    the first cause of liability arose), or (ii) any indirect, special,
+    incidental, punitive, exemplary, reliance, or consequential damages
+    of any character arising as a result of this Agreement or out of the
+    use or inability to use the Work (including but not limited to
+    damages for loss of goodwill, profits, data or data use, work
+    stoppage, computer failure or malfunction, cost of procurement of
+    substitute goods, technology or services, or any and all other
+    commercial damages or losses), even if such Licensor or Contributor
+    has been advised of the possibility of such damages. THESE
+    LIMITATIONS SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL
+    PURPOSE OF ANY LIMITED REMEDY.
+
+13. **<span class="smallcaps">Accepting Warranty or Additional
+    Liability.</span>** While redistributing Works or Derivative Works
+    thereof, and without limiting your obligations under Section 6, You
+    may choose to offer, and charge a fee for, acceptance of support,
+    warranty, indemnity, or other liability obligations and/or rights
+    consistent with this License. However, in accepting such
+    obligations, You may act only on Your own behalf and on Your sole
+    responsibility, not on behalf of any other Contributor, and only if
+    You agree to indemnify, defend, and hold Redpanda Data and each other
+    Contributor harmless for any liability incurred by, or claims
+    asserted against, such Contributor by reason of your accepting any
+    such warranty or additional liability.
+
+14. **<span class="smallcaps">General.</span>**
+
+    1.  **Relationship of Parties.** You and Redpanda Data are independent
+        contractors, and nothing herein shall be deemed to constitute
+        either party as the agent or representative of the other or both
+        parties as joint venturers or partners for any purpose.
+
+    2.  **Export Control.** You shall comply with the U.S. Foreign
+        Corrupt Practices Act and all applicable export laws,
+        restrictions and regulations of the U.S. Department of Commerce,
+        and any other applicable U.S. and foreign authority.
+
+    3.  **Assignment.** This Agreement and the rights and obligations
+        herein may not be assigned or transferred, in whole or in part,
+        by You without the prior written consent of Redpanda Data. Any
+        assignment in violation of this provision is void. This
+        Agreement shall be binding upon, and inure to the benefit of,
+        the successors and permitted assigns of the parties.
+
+    4.  **Governing Law.** This Agreement shall be governed by and
+        construed under the laws of the State of California and the
+        United States without regard to conflicts of laws provisions
+        thereof, and without regard to the Uniform Computer Information
+        Transactions Act.
+
+    5.  **Attorneys’ Fees.** In any action or proceeding to enforce
+        rights under this Agreement, the prevailing party shall be
+        entitled to recover its costs, expenses and attorneys’ fees.
+
+    6.  **Severability.** If any provision of this Agreement is held to
+        be invalid, illegal or unenforceable in any respect, that
+        provision shall be limited or eliminated to the minimum extent
+        necessary so that this Agreement otherwise remains in full force
+        and effect and enforceable.
+
+    7.  **Entire Agreement; Waivers; Modification.** This Agreement
+        constitutes the entire agreement between the parties relating to
+        the subject matter hereof and supersedes all proposals,
+        understandings, or discussions, whether written or oral,
+        relating to the subject matter of this Agreement and all past
+        dealing or industry custom. The failure of either party to
+        enforce its rights under this Agreement at any time for any
+        period shall not be construed as a waiver of such rights. No
+        changes, modifications or waivers to this Agreement will be
+        effective unless in writing and signed by both parties.

--- a/public/bundle/enterprise/package.go
+++ b/public/bundle/enterprise/package.go
@@ -1,7 +1,8 @@
-// Package all imports all component implementations that ship with the open
-// source Benthos repo. This is a convenient way of importing every single
-// connector at the cost of a larger dependency tree for your application.
-package all
+// Package enterprise imports all enterprise licensed plugin implementations
+// that ship with Redpanda Connect, along with all free plugin implementations.
+// This is a convenient way of importing every single connector at the cost of a
+// larger dependency tree for your application.
+package enterprise
 
 import (
 	// Import all public sub-categories.

--- a/public/bundle/free/LICENSE
+++ b/public/bundle/free/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/public/bundle/free/package.go
+++ b/public/bundle/free/package.go
@@ -1,7 +1,7 @@
-// Package all imports all component implementations that ship with the open
-// source Benthos repo. This is a convenient way of importing every single
-// connector at the cost of a larger dependency tree for your application.
-package all
+// Package free imports all free, open source plugin implementations that ship
+// with Redpanda Connect. This is a convenient way of importing every single
+// free connector at the cost of a larger dependency tree for your application.
+package free
 
 import (
 	// Import all public sub-categories.
@@ -45,8 +45,6 @@ import (
 	_ "github.com/redpanda-data/connect/v4/public/components/redis"
 	_ "github.com/redpanda-data/connect/v4/public/components/sentry"
 	_ "github.com/redpanda-data/connect/v4/public/components/sftp"
-	_ "github.com/redpanda-data/connect/v4/public/components/snowflake"
-	_ "github.com/redpanda-data/connect/v4/public/components/splunk"
 	_ "github.com/redpanda-data/connect/v4/public/components/sql"
 	_ "github.com/redpanda-data/connect/v4/public/components/statsd"
 	_ "github.com/redpanda-data/connect/v4/public/components/twitter"

--- a/public/components/all/x_benthos_extra.go
+++ b/public/components/all/x_benthos_extra.go
@@ -1,9 +1,0 @@
-//go:build x_benthos_extra
-
-package all
-
-import (
-	// Import extra packages, these are packages only imported with the tag
-	// x_benthos_extra, which is normally reserved for -cgo suffixed builds
-	_ "github.com/redpanda-data/connect/v4/internal/impl/zeromq"
-)

--- a/public/components/zeromq/package.go
+++ b/public/components/zeromq/package.go
@@ -1,0 +1,1 @@
+package zeromq

--- a/public/components/zeromq/x_benthos_extra.go
+++ b/public/components/zeromq/x_benthos_extra.go
@@ -1,0 +1,8 @@
+//go:build x_benthos_extra
+
+package zeromq
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/redpanda-data/connect/v4/internal/impl/zeromq"
+)


### PR DESCRIPTION
This PR adds two new packages to `public/bundle`:

- `free`, which imports all component plugins that are licensed as Apache v2
- `enterprise`, which imports everything that is in `free` as well as all enterprise licensed component plugins

The intention here is to give users that are creating custom builds a clearer entrypoint with explicit licensing. There's more work to be done regarding licensing, where ideally we need clarity for every single public package, but this at least unblocks the largest use case which is people generally wanting everything in their build.

I believe we'll need to perform a follow up task once this is merged to tag and release and make both of these packages into explicit modules, at which point they should appear with clear licensing within gopkg.