### PR TITLE
Move TopicLogger out into separate enterprise package

### DIFF
--- a/cmd/redpanda-connect/main.go
+++ b/cmd/redpanda-connect/main.go
@@ -5,8 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
-
-	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
+	"github.com/redpanda-data/connect/v4/internal/impl/kafka/enterprise"
 
 	_ "github.com/redpanda-data/connect/v4/public/components/all"
 )
@@ -18,11 +17,11 @@ var (
 )
 
 func redpandaTopLevelConfigField() *service.ConfigField {
-	return service.NewObjectField("redpanda", kafka.TopicLoggerFields()...)
+	return service.NewObjectField("redpanda", enterprise.TopicLoggerFields()...)
 }
 
 func main() {
-	rpLogger := kafka.NewTopicLogger()
+	rpLogger := enterprise.NewTopicLogger()
 
 	service.RunCLI(
 		context.Background(),

--- a/internal/impl/kafka/enterprise/topic_logger.go
+++ b/internal/impl/kafka/enterprise/topic_logger.go
@@ -6,7 +6,7 @@
 //
 // https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
-package kafka
+package enterprise
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
 )
 
 func TopicLoggerFields() []*service.ConfigField {
@@ -56,7 +57,7 @@ func TopicLoggerFields() []*service.ConfigField {
 			Example("100MB").
 			Example("50mib"),
 		service.NewTLSToggledField("tls"),
-		saslField(),
+		kafka.SASLField(),
 	}
 }
 
@@ -310,7 +311,7 @@ func newTopicLoggerWriterFromConfig(conf *service.ParsedConfig, log *service.Log
 	if tlsEnabled {
 		f.tlsConf = tlsConf
 	}
-	if f.saslConfs, err = saslMechanismsFromConfig(conf); err != nil {
+	if f.saslConfs, err = kafka.SASLMechanismsFromConfig(conf); err != nil {
 		return nil, err
 	}
 
@@ -332,7 +333,7 @@ func (f *franzTopicLoggerWriter) Connect(ctx context.Context) error {
 		kgo.ProduceRequestTimeout(f.timeout),
 		kgo.ClientID(f.clientID),
 		kgo.Rack(f.rackID),
-		kgo.WithLogger(&kgoLogger{f.log}),
+		kgo.WithLogger(&kafka.KGoLogger{L: f.log}),
 	}
 	if f.tlsConf != nil {
 		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.tlsConf))

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -90,7 +90,7 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Default(true).
 			Advanced()).
 		Field(service.NewTLSToggledField("tls")).
-		Field(saslField()).
+		Field(SASLField()).
 		Field(service.NewBoolField("multi_header").Description("Decode headers into lists to allow handling of multiple values with the same key").Default(false).Advanced()).
 		Field(service.NewBatchPolicyField("batching").
 			Description("Allows you to configure a xref:configuration:batching.adoc[batching policy] that applies to individual topic partitions in order to batch messages together before flushing them for processing. Batching can be beneficial for performance as well as useful for windowed processing, and doing so this way preserves the ordering of topic partitions.").
@@ -241,7 +241,7 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	if f.multiHeader, err = conf.FieldBool("multi_header"); err != nil {
 		return nil, err
 	}
-	if f.saslConfs, err = saslMechanismsFromConfig(conf); err != nil {
+	if f.saslConfs, err = SASLMechanismsFromConfig(conf); err != nil {
 		return nil, err
 	}
 
@@ -632,7 +632,7 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 			}),
 			kgo.AutoCommitMarks(),
 			kgo.AutoCommitInterval(f.commitPeriod),
-			kgo.WithLogger(&kgoLogger{f.log}),
+			kgo.WithLogger(&KGoLogger{f.log}),
 		)
 	}
 

--- a/internal/impl/kafka/logger.go
+++ b/internal/impl/kafka/logger.go
@@ -6,18 +6,20 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-type kgoLogger struct {
-	l *service.Logger
+// KGoLogger wraps a service.Logger with an implementation that works within
+// the kgo library.
+type KGoLogger struct {
+	L *service.Logger
 }
 
-func (k *kgoLogger) Level() kgo.LogLevel {
+func (k *KGoLogger) Level() kgo.LogLevel {
 	return kgo.LogLevelDebug
 }
 
-func (k *kgoLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
-	tmpL := k.l
+func (k *KGoLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
+	tmpL := k.L
 	if len(keyvals) > 0 {
-		tmpL = k.l.With(keyvals...)
+		tmpL = k.L.With(keyvals...)
 	}
 
 	switch level {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -82,7 +82,7 @@ This output often out-performs the traditional ` + "`kafka`" + ` output as well 
 			Optional().
 			Advanced()).
 		Field(service.NewTLSToggledField("tls")).
-		Field(saslField()).
+		Field(SASLField()).
 		LintRule(`
 root = if this.partitioner == "manual" {
   if this.partition.or("") == "" {
@@ -257,7 +257,7 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 	if tlsEnabled {
 		f.tlsConf = tlsConf
 	}
-	if f.saslConfs, err = saslMechanismsFromConfig(conf); err != nil {
+	if f.saslConfs, err = SASLMechanismsFromConfig(conf); err != nil {
 		return nil, err
 	}
 
@@ -279,7 +279,7 @@ func (f *franzKafkaWriter) Connect(ctx context.Context) error {
 		kgo.ProduceRequestTimeout(f.timeout),
 		kgo.ClientID(f.clientID),
 		kgo.Rack(f.rackID),
-		kgo.WithLogger(&kgoLogger{f.log}),
+		kgo.WithLogger(&KGoLogger{f.log}),
 	}
 	if f.tlsConf != nil {
 		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.tlsConf))

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -24,7 +24,7 @@ func notImportedAWSFn(c *service.ParsedConfig) (sasl.Mechanism, error) {
 // AWSSASLFromConfigFn is populated with the child `aws` package when imported.
 var AWSSASLFromConfigFn = notImportedAWSFn
 
-func saslField() *service.ConfigField {
+func SASLField() *service.ConfigField {
 	return service.NewObjectListField("sasl",
 		service.NewStringAnnotatedEnumField("mechanism", map[string]string{
 			"none":          "Disable sasl authentication",
@@ -64,7 +64,7 @@ func saslField() *service.ConfigField {
 		)
 }
 
-func saslMechanismsFromConfig(c *service.ParsedConfig) ([]sasl.Mechanism, error) {
+func SASLMechanismsFromConfig(c *service.ParsedConfig) ([]sasl.Mechanism, error) {
 	if !c.Contains("sasl") {
 		return nil, nil
 	}


### PR DESCRIPTION
The TopicLogger is a mechanism for forwarding Redpanda Connect logs directly into a kafka topic. It was initially implemented within the kafka package since it reused some of the libraries within there for configuration and so on.

This means that an import of the kafka components was importing an enterprise licensed feature. In practice this is not a concern for FOSS users as it's impossible to activate this code simply by importing the package. However, for clarity it's better for this feature to exist in a separate package altogether.