### PR TITLE
Pin public bundles to 4.29.0

### DIFF
--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -2,7 +2,7 @@ module github.com/redpanda-data/connect/public/bundle/enterprise/v4
 
 go 1.22.3
 
-require github.com/redpanda-data/connect/v4 v4.28.1-0.20240603161855-9f6190c6325c
+require github.com/redpanda-data/connect/v4 v4.29.0
 
 require (
 	cloud.google.com/go v0.112.0 // indirect

--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/enterprise/v4
 
-go 1.22.3
+go 1.21
 
 require github.com/redpanda-data/connect/v4 v4.29.0
 

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -2,7 +2,7 @@ module github.com/redpanda-data/connect/public/bundle/free/v4
 
 go 1.22.3
 
-require github.com/redpanda-data/connect/v4 v4.28.1-0.20240603161855-9f6190c6325c
+require github.com/redpanda-data/connect/v4 v4.29.0
 
 require (
 	cloud.google.com/go v0.112.0 // indirect

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/free/v4
 
-go 1.22.3
+go 1.21
 
 require github.com/redpanda-data/connect/v4 v4.29.0
 


### PR DESCRIPTION
I've seen packages doing something similar to this, where there are nested modules that reference the higher level modules, they tag a new release of "proper X" and then follow it by pinning that version in the nested modules, they will then tag that follow up commit with something akin to `bundle/v4.29.0` and so on.

I'm not 100% sure how this works as Go module versioning documentation isn't particularly helpful here. Ideally we need to fix the fact that gopkg isn't showing proper versions: https://pkg.go.dev/github.com/redpanda-data/connect/public/bundle/free/v4 (right now we're showing `v4.0.0-20240605133803-6df2b5d48e49`)

Reference example: https://github.com/hashicorp/golang-lru