### PR TITLE
Enable exported rule for the revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters-settings:
     enable-all-rules: false
     rules:
       - name: superfluous-else
+      - name: exported
   errcheck:
     exclude-functions:
       - (*github.com/redpanda-data/benthos/v4/internal/batch.Error).Failed

--- a/cmd/redpanda-connect/main.go
+++ b/cmd/redpanda-connect/main.go
@@ -11,8 +11,11 @@ import (
 )
 
 var (
-	Version    string
-	DateBuilt  string
+	// Version version set at compile time.
+	Version string
+	// DateBuilt date built set at compile time.
+	DateBuilt string
+	// BinaryName binary name.
 	BinaryName string = "redpanda-connect"
 )
 

--- a/internal/impl/aws/session.go
+++ b/internal/impl/aws/session.go
@@ -21,6 +21,7 @@ func int64Field(conf *service.ParsedConfig, path ...string) (int64, error) {
 	return int64(i), nil
 }
 
+// GetSession constructs an AWS session from a parsed config and provided options.
 func GetSession(ctx context.Context, parsedConf *service.ParsedConfig, opts ...func(*config.LoadOptions) error) (aws.Config, error) {
 	if region, _ := parsedConf.FieldString("region"); region != "" {
 		opts = append(opts, config.WithRegion(region))

--- a/internal/impl/azure/cosmosdb/docs.go
+++ b/internal/impl/azure/cosmosdb/docs.go
@@ -16,7 +16,8 @@ const (
 	fieldConnectionString = "connection_string"
 	fieldDatabase         = "database"
 	fieldContainer        = "container"
-	FieldPartitionKeys    = "partition_keys_map"
+	// FieldPartitionKeysMap partition_keys_map field.
+	FieldPartitionKeysMap = "partition_keys_map"
 	fieldOperation        = "operation"
 	fieldPatchOperations  = "patch_operations"
 	fieldPatchCondition   = "patch_condition"
@@ -182,7 +183,7 @@ func PartitionKeysField(isInputField bool) *service.ConfigField {
 	// TODO: Add examples for hierarchical / empty Partition Keys this when the following issues are addressed:
 	// - https://github.com/Azure/azure-sdk-for-go/issues/18578
 	// - https://github.com/Azure/azure-sdk-for-go/issues/21063
-	field := service.NewBloblangField(FieldPartitionKeys).Description("A xref:guides:bloblang/about.adoc[Bloblang mapping] which should evaluate to a single partition key value or an array of partition key values of type string, integer or boolean. Currently, hierarchical partition keys are not supported so only one value may be provided.").Example(`root = "blobfish"`).Example(`root = 41`).Example(`root = true`).Example(`root = null`)
+	field := service.NewBloblangField(FieldPartitionKeysMap).Description("A xref:guides:bloblang/about.adoc[Bloblang mapping] which should evaluate to a single partition key value or an array of partition key values of type string, integer or boolean. Currently, hierarchical partition keys are not supported so only one value may be provided.").Example(`root = "blobfish"`).Example(`root = 41`).Example(`root = true`).Example(`root = null`)
 
 	// Add dynamic examples
 	if !isInputField {
@@ -223,7 +224,7 @@ func CRUDFields(hasReadOperation bool) []*service.ConfigField {
 	}
 }
 
-// ContainerClientFromParsed creates the container client from a parsed config
+// ContainerClientFromParsed creates the container client from a parsed config.
 func ContainerClientFromParsed(conf *service.ParsedConfig) (*azcosmos.ContainerClient, error) {
 	var endpoint string
 	var err error
@@ -293,12 +294,12 @@ func ContainerClientFromParsed(conf *service.ParsedConfig) (*azcosmos.ContainerC
 	return containerClient, nil
 }
 
-// CRUDConfigFromParsed extracts the CRUD config from the parsed config
+// CRUDConfigFromParsed extracts the CRUD config from a parsed config.
 func CRUDConfigFromParsed(conf *service.ParsedConfig) (CRUDConfig, error) {
 	var c CRUDConfig
 	var err error
 
-	if c.PartitionKeys, err = conf.FieldBloblang(FieldPartitionKeys); err != nil {
+	if c.PartitionKeys, err = conf.FieldBloblang(FieldPartitionKeysMap); err != nil {
 		return CRUDConfig{}, err
 	}
 

--- a/internal/impl/azure/input_cosmosdb.go
+++ b/internal/impl/azure/input_cosmosdb.go
@@ -83,13 +83,13 @@ type cosmosDBReader struct {
 	pager *runtime.Pager[azcosmos.QueryItemsResponse]
 }
 
-func newCosmosDBReaderFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (*cosmosDBReader, error) {
+func newCosmosDBReaderFromParsed(conf *service.ParsedConfig, _ *service.Resources) (*cosmosDBReader, error) {
 	containerClient, err := cosmosdb.ContainerClientFromParsed(conf)
 	if err != nil {
 		return nil, err
 	}
 
-	partitionKeysMapping, err := conf.FieldBloblang(cosmosdb.FieldPartitionKeys)
+	partitionKeysMapping, err := conf.FieldBloblang(cosmosdb.FieldPartitionKeysMap)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/confluent/client.go
+++ b/internal/impl/confluent/client.go
@@ -55,22 +55,22 @@ func newSchemaRegistryClient(
 	}, nil
 }
 
-type SchemaInfo struct {
+type schemaInfo struct {
 	ID         int               `json:"id"`
 	Type       string            `json:"schemaType"`
 	Schema     string            `json:"schema"`
-	References []SchemaReference `json:"references"`
+	References []schemaReference `json:"references"`
 }
 
 // TODO: Further reading:
 // https://www.confluent.io/blog/multiple-event-types-in-the-same-kafka-topic/
-type SchemaReference struct {
+type schemaReference struct {
 	Name    string `json:"name"`
 	Subject string `json:"subject"`
 	Version int    `json:"version"`
 }
 
-func (c *schemaRegistryClient) GetSchemaByID(ctx context.Context, id int) (resPayload SchemaInfo, err error) {
+func (c *schemaRegistryClient) GetSchemaByID(ctx context.Context, id int) (resPayload schemaInfo, err error) {
 	var resCode int
 	var resBody []byte
 	if resCode, resBody, err = c.doRequest(ctx, "GET", fmt.Sprintf("/schemas/ids/%v", id)); err != nil {
@@ -98,7 +98,7 @@ func (c *schemaRegistryClient) GetSchemaByID(ctx context.Context, id int) (resPa
 	return
 }
 
-func (c *schemaRegistryClient) GetSchemaBySubjectAndVersion(ctx context.Context, subject string, version *int) (resPayload SchemaInfo, err error) {
+func (c *schemaRegistryClient) GetSchemaBySubjectAndVersion(ctx context.Context, subject string, version *int) (resPayload schemaInfo, err error) {
 	var path string
 	if version != nil {
 		path = fmt.Sprintf("/subjects/%s/versions/%v", url.PathEscape(subject), *version)
@@ -133,7 +133,7 @@ func (c *schemaRegistryClient) GetSchemaBySubjectAndVersion(ctx context.Context,
 	return
 }
 
-type RefWalkFn func(ctx context.Context, name string, info SchemaInfo) error
+type refWalkFn func(ctx context.Context, name string, info schemaInfo) error
 
 // For each reference provided the schema info is obtained and the provided
 // closure is called recursively, which means each reference obtained will also
@@ -141,11 +141,11 @@ type RefWalkFn func(ctx context.Context, name string, info SchemaInfo) error
 //
 // If a reference of a given subject but differing version is detected an error
 // is returned as this would put us in an invalid state.
-func (c *schemaRegistryClient) WalkReferences(ctx context.Context, refs []SchemaReference, fn RefWalkFn) error {
+func (c *schemaRegistryClient) WalkReferences(ctx context.Context, refs []schemaReference, fn refWalkFn) error {
 	return c.walkReferencesTracked(ctx, map[string]int{}, refs, fn)
 }
 
-func (c *schemaRegistryClient) walkReferencesTracked(ctx context.Context, seen map[string]int, refs []SchemaReference, fn RefWalkFn) error {
+func (c *schemaRegistryClient) walkReferencesTracked(ctx context.Context, seen map[string]int, refs []schemaReference, fn refWalkFn) error {
 	for _, ref := range refs {
 		if i, exists := seen[ref.Name]; exists {
 			if i != ref.Version {

--- a/internal/impl/confluent/serde_avro.go
+++ b/internal/impl/confluent/serde_avro.go
@@ -10,13 +10,13 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func resolveAvroReferences(ctx context.Context, client *schemaRegistryClient, info SchemaInfo) (string, error) {
+func resolveAvroReferences(ctx context.Context, client *schemaRegistryClient, info schemaInfo) (string, error) {
 	if len(info.References) == 0 {
 		return info.Schema, nil
 	}
 
 	refsMap := map[string]string{}
-	if err := client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, info SchemaInfo) error {
+	if err := client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, info schemaInfo) error {
 		refsMap[name] = info.Schema
 		return nil
 	}); err != nil {
@@ -45,7 +45,7 @@ func resolveAvroReferences(ctx context.Context, client *schemaRegistryClient, in
 	return string(schemaHydratedBytes), nil
 }
 
-func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, info SchemaInfo) (schemaEncoder, error) {
+func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, info schemaInfo) (schemaEncoder, error) {
 	schema, err := resolveAvroReferences(ctx, s.client, info)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, info SchemaI
 	}, nil
 }
 
-func (s *schemaRegistryDecoder) getAvroDecoder(ctx context.Context, info SchemaInfo) (schemaDecoder, error) {
+func (s *schemaRegistryDecoder) getAvroDecoder(ctx context.Context, info schemaInfo) (schemaDecoder, error) {
 	schema, err := resolveAvroReferences(ctx, s.client, info)
 	if err != nil {
 		return nil, err

--- a/internal/impl/confluent/serde_json.go
+++ b/internal/impl/confluent/serde_json.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info SchemaInfo) (*gojsonschema.Schema, error) {
+func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info schemaInfo) (*gojsonschema.Schema, error) {
 	sl := gojsonschema.NewSchemaLoader()
 
 	if len(info.References) == 0 {
@@ -20,7 +20,7 @@ func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info S
 		return sl.Compile(gojsonschema.NewStringLoader(info.Schema))
 	}
 
-	if err := client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, info SchemaInfo) error {
+	if err := client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, info schemaInfo) error {
 		return sl.AddSchemas(gojsonschema.NewStringLoader(info.Schema))
 	}); err != nil {
 		return nil, err
@@ -29,15 +29,15 @@ func resolveJSONSchema(ctx context.Context, client *schemaRegistryClient, info S
 	return sl.Compile(gojsonschema.NewStringLoader(info.Schema))
 }
 
-func (s *schemaRegistryEncoder) getJSONEncoder(ctx context.Context, info SchemaInfo) (schemaEncoder, error) {
+func (s *schemaRegistryEncoder) getJSONEncoder(ctx context.Context, info schemaInfo) (schemaEncoder, error) {
 	return getJSONTranscoder(ctx, s.client, info)
 }
 
-func (s *schemaRegistryDecoder) getJSONDecoder(ctx context.Context, info SchemaInfo) (schemaDecoder, error) {
+func (s *schemaRegistryDecoder) getJSONDecoder(ctx context.Context, info schemaInfo) (schemaDecoder, error) {
 	return getJSONTranscoder(ctx, s.client, info)
 }
 
-func getJSONTranscoder(ctx context.Context, cl *schemaRegistryClient, info SchemaInfo) (func(m *service.Message) error, error) {
+func getJSONTranscoder(ctx context.Context, cl *schemaRegistryClient, info schemaInfo) (func(m *service.Message) error, error) {
 	sch, err := resolveJSONSchema(ctx, cl, info)
 	if err != nil {
 		return nil, err

--- a/internal/impl/confluent/serde_protobuf.go
+++ b/internal/impl/confluent/serde_protobuf.go
@@ -18,11 +18,11 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/protobuf"
 )
 
-func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, info SchemaInfo) (schemaDecoder, error) {
+func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, info schemaInfo) (schemaDecoder, error) {
 	regMap := map[string]string{
 		".": info.Schema,
 	}
-	if err := s.client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, si SchemaInfo) error {
+	if err := s.client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, si schemaInfo) error {
 		regMap[name] = si.Schema
 		return nil
 	}); err != nil {
@@ -82,11 +82,11 @@ func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, info Sch
 	}, nil
 }
 
-func (s *schemaRegistryEncoder) getProtobufEncoder(ctx context.Context, info SchemaInfo) (schemaEncoder, error) {
+func (s *schemaRegistryEncoder) getProtobufEncoder(ctx context.Context, info schemaInfo) (schemaEncoder, error) {
 	regMap := map[string]string{
 		".": info.Schema,
 	}
-	if err := s.client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, si SchemaInfo) error {
+	if err := s.client.WalkReferences(ctx, info.References, func(ctx context.Context, name string, si schemaInfo) error {
 		regMap[name] = si.Schema
 		return nil
 	}); err != nil {

--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -19,22 +19,23 @@ import (
 )
 
 const (
-	esoFieldURLs            = "urls"
-	esoFieldSniff           = "sniff"
-	esoFieldHealthcheck     = "healthcheck"
-	esoFieldID              = "id"
-	esoFieldAction          = "action"
-	esoFieldIndex           = "index"
-	esoFieldPipeline        = "pipeline"
-	esoFieldRouting         = "routing"
-	esoFieldType            = "type"
-	esoFieldTimeout         = "timeout"
-	esoFieldTLS             = "tls"
-	esoFieldAuth            = "basic_auth"
-	esoFieldAuthEnabled     = "enabled"
-	esoFieldAuthUsername    = "username"
-	esoFieldAuthPassword    = "password"
-	esoFieldAWS             = "aws"
+	esoFieldURLs         = "urls"
+	esoFieldSniff        = "sniff"
+	esoFieldHealthcheck  = "healthcheck"
+	esoFieldID           = "id"
+	esoFieldAction       = "action"
+	esoFieldIndex        = "index"
+	esoFieldPipeline     = "pipeline"
+	esoFieldRouting      = "routing"
+	esoFieldType         = "type"
+	esoFieldTimeout      = "timeout"
+	esoFieldTLS          = "tls"
+	esoFieldAuth         = "basic_auth"
+	esoFieldAuthEnabled  = "enabled"
+	esoFieldAuthUsername = "username"
+	esoFieldAuthPassword = "password"
+	esoFieldAWS          = "aws"
+	// ESOFieldAWSEnabled enabled field.
 	ESOFieldAWSEnabled      = "enabled"
 	esoFieldGzipCompression = "gzip_compression"
 	esoFieldBatching        = "batching"
@@ -296,6 +297,7 @@ func OutputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*Out
 
 //------------------------------------------------------------------------------
 
+// Connect attempts to connect to the server.
 func (e *Output) Connect(ctx context.Context) error {
 	if e.client != nil {
 		return nil
@@ -327,6 +329,7 @@ type pendingBulkIndex struct {
 	ID       string
 }
 
+// WriteBatch writes a message batch to the output.
 func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error {
 	if e.client == nil {
 		return service.ErrNotConnected
@@ -430,6 +433,7 @@ func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error
 	return nil
 }
 
+// Close closes the output.
 func (e *Output) Close(context.Context) error {
 	return nil
 }

--- a/internal/impl/influxdb/metrics_influxdb.go
+++ b/internal/impl/influxdb/metrics_influxdb.go
@@ -32,7 +32,7 @@ const (
 	imFieldTags             = "tags"
 )
 
-func ConfigSpec() *service.ConfigSpec {
+func configSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Version("3.36.0").
@@ -102,7 +102,7 @@ func ConfigSpec() *service.ConfigSpec {
 
 func init() {
 	err := service.RegisterMetricsExporter(
-		"influxdb", ConfigSpec(),
+		"influxdb", configSpec(),
 		func(conf *service.ParsedConfig, log *service.Logger) (service.MetricsExporter, error) {
 			return fromParsed(conf, log)
 		})

--- a/internal/impl/influxdb/metrics_influxdb_integration_test.go
+++ b/internal/impl/influxdb/metrics_influxdb_integration_test.go
@@ -72,7 +72,7 @@ func TestInfluxIntegration(t *testing.T) {
 		t.Fatalf("Could not connect to influxdb docker container: %s", err)
 	}
 
-	pConf, err := ConfigSpec().ParseYAML(fmt.Sprintf(`
+	pConf, err := configSpec().ParseYAML(fmt.Sprintf(`
 url: %v
 db: db0
 interval: 1s

--- a/internal/impl/influxdb/metrics_influxdb_test.go
+++ b/internal/impl/influxdb/metrics_influxdb_test.go
@@ -10,7 +10,7 @@ import (
 func fromYAML(t testing.TB, conf string, args ...any) *influxDBMetrics {
 	t.Helper()
 
-	pConf, err := ConfigSpec().ParseYAML(fmt.Sprintf(conf, args...), nil)
+	pConf, err := configSpec().ParseYAML(fmt.Sprintf(conf, args...), nil)
 	require.NoError(t, err)
 
 	i, err := fromParsed(pConf, nil)

--- a/internal/impl/kafka/enterprise/topic_logger.go
+++ b/internal/impl/kafka/enterprise/topic_logger.go
@@ -26,6 +26,7 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
 )
 
+// TopicLoggerFields returns the topic logger config fields.
 func TopicLoggerFields() []*service.ConfigField {
 	return []*service.ConfigField{
 		service.NewStringListField("seed_brokers").
@@ -57,7 +58,7 @@ func TopicLoggerFields() []*service.ConfigField {
 			Example("100MB").
 			Example("50mib"),
 		service.NewTLSToggledField("tls"),
-		kafka.SASLField(),
+		kafka.SASLFields(),
 	}
 }
 
@@ -71,6 +72,7 @@ type TopicLogger struct {
 	attrs          []slog.Attr
 }
 
+// NewTopicLogger constructs a new topic logger.
 func NewTopicLogger() *TopicLogger {
 	return &TopicLogger{
 		fallbackLogger: &atomic.Pointer[service.Logger]{},
@@ -79,10 +81,12 @@ func NewTopicLogger() *TopicLogger {
 	}
 }
 
+// SetFallbackLogger configures a fallback logger.
 func (l *TopicLogger) SetFallbackLogger(fLogger *service.Logger) {
 	l.fallbackLogger.Store(fLogger)
 }
 
+// InitOutputFromParsed initialises the underlying output from the input config.
 func (l *TopicLogger) InitOutputFromParsed(pConf *service.ParsedConfig) error {
 	w, err := newTopicLoggerWriterFromConfig(pConf, l.fallbackLogger.Load())
 	if err != nil {
@@ -135,6 +139,7 @@ func (l *TopicLogger) InitOutputFromParsed(pConf *service.ParsedConfig) error {
 	return nil
 }
 
+// Enabled returns true if the logger is enabled and false otherwise.
 func (l *TopicLogger) Enabled(ctx context.Context, atLevel slog.Level) bool {
 	lvl := l.level.Load()
 	if lvl == nil {
@@ -143,6 +148,7 @@ func (l *TopicLogger) Enabled(ctx context.Context, atLevel slog.Level) bool {
 	return atLevel >= *lvl
 }
 
+// Handle invokes the logger for the input record.
 func (l *TopicLogger) Handle(ctx context.Context, r slog.Record) error {
 	tmpO := l.o.Load()
 	if tmpO == nil {
@@ -175,6 +181,7 @@ func (l *TopicLogger) Handle(ctx context.Context, r slog.Record) error {
 	return nil
 }
 
+// WithAttrs returns a new handle with the input attributes.
 func (l *TopicLogger) WithAttrs(attrs []slog.Attr) slog.Handler {
 	newL := *l
 	newAttributes := make([]slog.Attr, 0, len(attrs)+len(l.attrs))
@@ -184,6 +191,7 @@ func (l *TopicLogger) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &newL
 }
 
+// WithGroup TODO
 func (l *TopicLogger) WithGroup(name string) slog.Handler {
 	return l // TODO
 }

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -90,7 +90,7 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Default(true).
 			Advanced()).
 		Field(service.NewTLSToggledField("tls")).
-		Field(SASLField()).
+		Field(SASLFields()).
 		Field(service.NewBoolField("multi_header").Description("Decode headers into lists to allow handling of multiple values with the same key").Default(false).Advanced()).
 		Field(service.NewBatchPolicyField("batching").
 			Description("Allows you to configure a xref:configuration:batching.adoc[batching policy] that applies to individual topic partitions in order to batch messages together before flushing them for processing. Batching can be beneficial for performance as well as useful for windowed processing, and doing so this way preserves the ordering of topic partitions.").

--- a/internal/impl/kafka/logger.go
+++ b/internal/impl/kafka/logger.go
@@ -12,10 +12,12 @@ type KGoLogger struct {
 	L *service.Logger
 }
 
+// Level returns the logger level.
 func (k *KGoLogger) Level() kgo.LogLevel {
 	return kgo.LogLevelDebug
 }
 
+// Log calls the underlying logger implementation using the appropriate log level.
 func (k *KGoLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	tmpL := k.L
 	if len(keyvals) > 0 {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -82,7 +82,7 @@ This output often out-performs the traditional ` + "`kafka`" + ` output as well 
 			Optional().
 			Advanced()).
 		Field(service.NewTLSToggledField("tls")).
-		Field(SASLField()).
+		Field(SASLFields()).
 		LintRule(`
 root = if this.partitioner == "manual" {
   if this.partition.or("") == "" {

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -24,7 +24,8 @@ func notImportedAWSFn(c *service.ParsedConfig) (sasl.Mechanism, error) {
 // AWSSASLFromConfigFn is populated with the child `aws` package when imported.
 var AWSSASLFromConfigFn = notImportedAWSFn
 
-func SASLField() *service.ConfigField {
+// SASLFields returns the SASL config fields.
+func SASLFields() *service.ConfigField {
 	return service.NewObjectListField("sasl",
 		service.NewStringAnnotatedEnumField("mechanism", map[string]string{
 			"none":          "Disable sasl authentication",
@@ -64,6 +65,7 @@ func SASLField() *service.ConfigField {
 		)
 }
 
+// SASLMechanismsFromConfig constructs a sasl.Mechanism slice from a parsed config.
 func SASLMechanismsFromConfig(c *service.ParsedConfig) ([]sasl.Mechanism, error) {
 	if !c.Contains("sasl") {
 		return nil, nil

--- a/internal/impl/mqtt/client.go
+++ b/internal/impl/mqtt/client.go
@@ -30,7 +30,7 @@ const (
 	msFieldClientTLS               = "tls"
 )
 
-func ClientFields() []*service.ConfigField {
+func clientFields() []*service.ConfigField {
 	return []*service.ConfigField{
 		service.NewURLListField(msFieldClientURLs).
 			Description("A list of URLs to connect to. If an item of the list contains commas it will be expanded into multiple URLs.").

--- a/internal/impl/mqtt/input.go
+++ b/internal/impl/mqtt/input.go
@@ -35,7 +35,7 @@ This input adds the following metadata fields to each message:
 `+"```"+`
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].`).
-		Fields(ClientFields()...).
+		Fields(clientFields()...).
 		Fields(
 			service.NewStringListField(miFieldTopics).
 				Description("A list of topics to consume from."),

--- a/internal/impl/mqtt/output.go
+++ b/internal/impl/mqtt/output.go
@@ -27,7 +27,7 @@ func outputConfigSpec() *service.ConfigSpec {
 		Summary("Pushes messages to an MQTT broker.").
 		Description(`
 The `+"`topic`"+` field can be dynamically set using function interpolations described xref:configuration:interpolation.adoc#bloblang-queries[here]. When sending batched messages these interpolations are performed per message part.`+service.OutputPerformanceDocs(true, false)).
-		Fields(ClientFields()...).
+		Fields(clientFields()...).
 		Fields(
 			service.NewInterpolatedStringField(moFieldTopic).
 				Description("The topic to publish messages to."),

--- a/internal/impl/opensearch/output.go
+++ b/internal/impl/opensearch/output.go
@@ -33,7 +33,8 @@ const (
 	esoFieldAuthPassword = "password"
 	esoFieldBatching     = "batching"
 	esoFieldAWS          = "aws"
-	ESOFieldAWSEnabled   = "enabled"
+	// ESOFieldAWSEnabled enabled field.
+	ESOFieldAWSEnabled = "enabled"
 )
 
 func notImportedAWSOptFn(conf *service.ParsedConfig, osconf *opensearchapi.Config) error {
@@ -230,6 +231,7 @@ func OutputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*Out
 
 //------------------------------------------------------------------------------
 
+// Connect attempts to connect to the server.
 func (e *Output) Connect(ctx context.Context) error {
 	if e.client != nil {
 		return nil
@@ -253,6 +255,7 @@ type pendingBulkIndex struct {
 	ID       string
 }
 
+// WriteBatch writes a message batch to the output.
 func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error {
 	if e.client == nil {
 		return service.ErrNotConnected
@@ -333,6 +336,7 @@ func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error
 	return nil
 }
 
+// Close closes the output.
 func (e *Output) Close(context.Context) error {
 	return nil
 }

--- a/internal/impl/prometheus/metrics_prometheus_test.go
+++ b/internal/impl/prometheus/metrics_prometheus_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func promFromYAML(t testing.TB, conf string, args ...any) *Metrics {
+func promFromYAML(t testing.TB, conf string, args ...any) *metrics {
 	t.Helper()
 
-	pConf, err := ConfigSpec().ParseYAML(fmt.Sprintf(conf, args...), nil)
+	pConf, err := configSpec().ParseYAML(fmt.Sprintf(conf, args...), nil)
 	require.NoError(t, err)
 
-	p, err := FromParsed(pConf, nil)
+	p, err := fromParsed(pConf, nil)
 	require.NoError(t, err)
 
 	return p
@@ -90,7 +90,7 @@ push_interval: %v
 	}
 }
 
-func getTestProm(t *testing.T) (*Metrics, http.HandlerFunc) {
+func getTestProm(t *testing.T) (*metrics, http.HandlerFunc) {
 	t.Helper()
 
 	prom := promFromYAML(t, ``)
@@ -199,7 +199,7 @@ file_output_path: %v
 	assertContainsTestMetrics(t, string(file))
 }
 
-func applyTestMetrics(nm *Metrics) {
+func applyTestMetrics(nm *metrics) {
 	ctr := nm.NewCounterCtor("counterone")()
 	ctr.Incr(10)
 	ctr.Incr(11)

--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -100,7 +100,7 @@ type sftpReader struct {
 	// Config
 	address        string
 	paths          []string
-	creds          Credentials
+	creds          credentials
 	scannerCtor    codec.DeprecatedFallbackCodec
 	deleteOnFinish bool
 

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -44,7 +44,7 @@ func TestIntegration(t *testing.T) {
 
 	_ = resource.Expire(900)
 
-	creds := Credentials{
+	creds := credentials{
 		Username: sftpUsername,
 		Password: sftpPassword,
 	}

--- a/internal/impl/sftp/output.go
+++ b/internal/impl/sftp/output.go
@@ -70,7 +70,7 @@ type sftpWriter struct {
 	mgr *service.Resources
 
 	address    string
-	creds      Credentials
+	creds      credentials
 	path       *service.InterpolatedString
 	suffixFn   codecSuffixFn
 	appendMode bool

--- a/internal/impl/sftp/shared.go
+++ b/internal/impl/sftp/shared.go
@@ -27,7 +27,7 @@ func credentialsFields() []*service.ConfigField {
 	}
 }
 
-func credentialsFromParsed(pConf *service.ParsedConfig) (creds Credentials, err error) {
+func credentialsFromParsed(pConf *service.ParsedConfig) (creds credentials, err error) {
 	if creds.Username, err = pConf.FieldString(scFieldCredentialsUsername); err != nil {
 		return
 	}
@@ -43,14 +43,14 @@ func credentialsFromParsed(pConf *service.ParsedConfig) (creds Credentials, err 
 	return
 }
 
-type Credentials struct {
+type credentials struct {
 	Username       string
 	Password       string
 	PrivateKeyFile string
 	PrivateKeyPass string
 }
 
-func (c Credentials) GetClient(fs fs.FS, address string) (*sftp.Client, error) {
+func (c credentials) GetClient(fs fs.FS, address string) (*sftp.Client, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse address: %v", err)

--- a/internal/retries/retries.go
+++ b/internal/retries/retries.go
@@ -16,6 +16,7 @@ const (
 	crboFieldMaxElapsedTime = "max_elapsed_time"
 )
 
+// CommonRetryBackOffFields returns the common retry with backoff fields.
 func CommonRetryBackOffFields(
 	defaultMaxRetries int,
 	defaultInitInterval string,
@@ -50,6 +51,7 @@ func fieldDurationOrEmptyStr(pConf *service.ParsedConfig, path ...string) (time.
 	return pConf.FieldDuration(path...)
 }
 
+// CommonRetryBackOffCtorFromParsed extracts the common retry with backoff fields from a parsed config.
 func CommonRetryBackOffCtorFromParsed(pConf *service.ParsedConfig) (ctor func() backoff.BackOff, err error) {
 	var maxRetries int
 	if maxRetries, err = pConf.FieldInt(crboFieldMaxRetries); err != nil {


### PR DESCRIPTION
Would be nice to also enable [`unused-parameter`](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter) and probably some others as well. It will take a bit of work though...