### PR TITLE
Fix CLI binary name

### DIFF
--- a/cmd/redpanda-connect/main.go
+++ b/cmd/redpanda-connect/main.go
@@ -16,7 +16,7 @@ var (
 	// DateBuilt date built set at compile time.
 	DateBuilt string
 	// BinaryName binary name.
-	BinaryName string = "redpanda-connect"
+	BinaryName string = "rpk connect"
 )
 
 func redpandaTopLevelConfigField() *service.ConfigField {


### PR DESCRIPTION
I'm not entirely sure that this is the complete fix, since the binary here is under the `cmd/redpanda-connect` directory. But since `connect` is only distributed under the `rpk` binary now, it might be fine?

Fixes #2639.