### PR TITLE
Add Splunk TLS fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## v4.31.0 - TBD
+
+### Added
+
+- The `splunk` input and `splunk_hec` output now support custom `tls` configuration.
+
 ## 4.30.0 - 2024-06-13
 
 ### Added

--- a/docs/modules/components/pages/inputs/splunk.adoc
+++ b/docs/modules/components/pages/inputs/splunk.adoc
@@ -52,7 +52,13 @@ input:
     user: "" # No default (required)
     password: "" # No default (required)
     query: "" # No default (required)
-    skip_cert_verify: false
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
     auto_replay_nacks: true
 ```
 
@@ -104,7 +110,24 @@ Splunk search query.
 *Type*: `string`
 
 
-=== `skip_cert_verify`
+=== `tls`
+
+Custom TLS settings can be used to override system defaults.
+
+
+*Type*: `object`
+
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
 
 Whether to skip server side certificate verification.
 
@@ -112,6 +135,140 @@ Whether to skip server side certificate verification.
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 3.45.0 or newer
+
+=== `tls.root_cas`
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+A plain text certificate key to use.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/outputs/splunk_hec.adoc
+++ b/docs/modules/components/pages/outputs/splunk_hec.adoc
@@ -63,7 +63,13 @@ output:
     event_source: "" # No default (optional)
     event_sourcetype: "" # No default (optional)
     event_index: "" # No default (optional)
-    skip_cert_verify: false
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
     max_in_flight: 64
     batching:
       count: 0
@@ -153,7 +159,24 @@ Set the index value to assign to the event data. Overrides existing index field 
 *Type*: `string`
 
 
-=== `skip_cert_verify`
+=== `tls`
+
+Custom TLS settings can be used to override system defaults.
+
+
+*Type*: `object`
+
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
 
 Whether to skip server side certificate verification.
 
@@ -161,6 +184,140 @@ Whether to skip server side certificate verification.
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 3.45.0 or newer
+
+=== `tls.root_cas`
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+A plain text certificate key to use.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
 
 === `max_in_flight`
 


### PR DESCRIPTION
Fixes #1905.

I also cleaned some leftover typos... I was overly-excited when I finally figured out how to use that Splunk container and forgot to re-read my code :)

To test this, I couldn't figure out how to fetch the cert used by the container for those endpoints, so I ended up running https://mitmproxy.org as a local HTTP reverse proxy and I set `tls.root_cas_file: ${HOME}/.mitmproxy/mitmproxy-ca-cert.pem`.