### PR TITLE
couchbase: add CAS support

### DIFF
--- a/docs/modules/components/pages/processors/couchbase.adoc
+++ b/docs/modules/components/pages/processors/couchbase.adoc
@@ -69,7 +69,7 @@ couchbase:
 --
 ======
 
-When inserting, replacing or upserting documents, each must have the `content` property set.
+When inserting, replacing or upserting documents, each must have the `content` property set. CAS value is stored in meta `couchbase_cas`. It prevent read/write conflict by only allowing write if not modified by other. You can clear the value with `meta couchbase_cas = deleted()` to disable this check.
 
 == Fields
 

--- a/internal/impl/couchbase/couchbase.go
+++ b/internal/impl/couchbase/couchbase.go
@@ -20,56 +20,72 @@ import (
 	"github.com/couchbase/gocb/v2"
 )
 
-func valueFromOp(op gocb.BulkOp) (out any, err error) {
+func valueFromOp(op gocb.BulkOp) (out any, cas gocb.Cas, err error) {
 	switch o := op.(type) {
 	case *gocb.GetOp:
 		if o.Err != nil {
-			return nil, o.Err
+			return nil, gocb.Cas(0), o.Err
 		}
 		err := o.Result.Content(&out)
-		return out, err
+
+		return out, o.Result.Cas(), err
 	case *gocb.InsertOp:
-		return nil, o.Err
+		if o.Result != nil {
+			return nil, o.Result.Cas(), o.Err
+		}
+		return nil, gocb.Cas(0), o.Err
 	case *gocb.RemoveOp:
-		return nil, o.Err
+		if o.Result != nil {
+			return nil, o.Result.Cas(), o.Err
+		}
+		return nil, gocb.Cas(0), o.Err
 	case *gocb.ReplaceOp:
-		return nil, o.Err
+		if o.Result != nil {
+			return nil, o.Result.Cas(), o.Err
+		}
+		return nil, gocb.Cas(0), o.Err
 	case *gocb.UpsertOp:
-		return nil, o.Err
+		if o.Result != nil {
+			return nil, o.Result.Cas(), o.Err
+		}
+		return nil, gocb.Cas(0), o.Err
 	}
 
-	return nil, errors.New("type not supported")
+	return nil, gocb.Cas(0), errors.New("type not supported")
 }
 
-func get(key string, _ []byte) gocb.BulkOp {
+func get(key string, _ []byte, _ gocb.Cas) gocb.BulkOp {
 	return &gocb.GetOp{
 		ID: key,
 	}
 }
 
-func insert(key string, data []byte) gocb.BulkOp {
+func insert(key string, data []byte, _ gocb.Cas) gocb.BulkOp {
 	return &gocb.InsertOp{
 		ID:    key,
 		Value: data,
 	}
 }
 
-func remove(key string, _ []byte) gocb.BulkOp {
+func remove(key string, _ []byte, cas gocb.Cas) gocb.BulkOp {
 	return &gocb.RemoveOp{
-		ID: key,
+		ID:  key,
+		Cas: cas,
 	}
 }
 
-func replace(key string, data []byte) gocb.BulkOp {
+func replace(key string, data []byte, cas gocb.Cas) gocb.BulkOp {
 	return &gocb.ReplaceOp{
 		ID:    key,
 		Value: data,
+		Cas:   cas,
 	}
 }
 
-func upsert(key string, data []byte) gocb.BulkOp {
+func upsert(key string, data []byte, cas gocb.Cas) gocb.BulkOp {
 	return &gocb.UpsertOp{
 		ID:    key,
 		Value: data,
+		Cas:   cas,
 	}
 }

--- a/internal/impl/couchbase/processor_test.go
+++ b/internal/impl/couchbase/processor_test.go
@@ -196,6 +196,11 @@ operation: 'insert'
 	assert.Len(t, msgOut, 1)
 	assert.Len(t, msgOut[0], 1)
 
+	// check CAS
+	cas, ok := msgOut[0][0].MetaGetMut(couchbase.MetaCASKey)
+	assert.True(t, ok)
+	assert.NotEmpty(t, cas)
+
 	// message content should stay the same.
 	dataOut, err := msgOut[0][0].AsBytes()
 	assert.NoError(t, err)
@@ -221,6 +226,11 @@ operation: 'upsert'
 	assert.NoError(t, err)
 	assert.Len(t, msgOut, 1)
 	assert.Len(t, msgOut[0], 1)
+
+	// check CAS
+	cas, ok := msgOut[0][0].MetaGetMut(couchbase.MetaCASKey)
+	assert.True(t, ok)
+	assert.NotEmpty(t, cas)
 
 	// message content should stay the same.
 	dataOut, err := msgOut[0][0].AsBytes()
@@ -248,6 +258,11 @@ operation: 'replace'
 	assert.Len(t, msgOut, 1)
 	assert.Len(t, msgOut[0], 1)
 
+	// check CAS
+	cas, ok := msgOut[0][0].MetaGetMut(couchbase.MetaCASKey)
+	assert.True(t, ok)
+	assert.NotEmpty(t, cas)
+
 	// message content should stay the same.
 	dataOut, err := msgOut[0][0].AsBytes()
 	assert.NoError(t, err)
@@ -273,6 +288,11 @@ operation: 'get'
 	assert.Len(t, msgOut, 1)
 	assert.Len(t, msgOut[0], 1)
 
+	// check CAS
+	cas, ok := msgOut[0][0].MetaGetMut(couchbase.MetaCASKey)
+	assert.True(t, ok)
+	assert.NotEmpty(t, cas)
+
 	// message should contain expected payload.
 	dataOut, err := msgOut[0][0].AsBytes()
 	assert.NoError(t, err)
@@ -297,6 +317,11 @@ operation: 'remove'
 	assert.NoError(t, err)
 	assert.Len(t, msgOut, 1)
 	assert.Len(t, msgOut[0], 1)
+
+	// check CAS
+	cas, ok := msgOut[0][0].MetaGetMut(couchbase.MetaCASKey)
+	assert.True(t, ok)
+	assert.NotEmpty(t, cas)
 
 	// message content should stay the same.
 	dataOut, err := msgOut[0][0].AsBytes()

--- a/internal/impl/couchbase/processor_test.go
+++ b/internal/impl/couchbase/processor_test.go
@@ -17,6 +17,7 @@ package couchbase_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service/integration"
 
 	"github.com/redpanda-data/connect/v4/internal/impl/couchbase"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
 )
 
 func TestProcessorConfigLinting(t *testing.T) {
@@ -349,10 +352,116 @@ operation: 'get'
 	assert.Len(t, msgOut[0], 1)
 
 	// message should contain an error.
-	assert.Error(t, msgOut[0][0].GetError(), "TODO")
+	assert.Error(t, msgOut[0][0].GetError())
 
 	// message content should stay the same.
 	dataOut, err := msgOut[0][0].AsBytes()
 	assert.NoError(t, err)
 	assert.Equal(t, uid, string(dataOut))
+}
+
+func TestIntegrationCouchbaseStream(t *testing.T) {
+	ctx := context.Background()
+
+	integration.CheckSkip(t)
+
+	servicePort := requireCouchbase(t)
+	bucket := fmt.Sprintf("testing-stream-%d", time.Now().Unix())
+	require.NoError(t, createBucket(context.Background(), t, servicePort, bucket))
+	t.Cleanup(func() {
+		require.NoError(t, removeBucket(context.Background(), t, servicePort, bucket))
+	})
+
+	for _, clearCAS := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%t", clearCAS), func(t *testing.T) {
+			streamOutBuilder := service.NewStreamBuilder()
+			require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: OFF`))
+
+			inFn, err := streamOutBuilder.AddBatchProducerFunc()
+			require.NoError(t, err)
+
+			var outBatches []service.MessageBatch
+			var outBatchMut sync.Mutex
+			require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(c context.Context, mb service.MessageBatch) error {
+				outBatchMut.Lock()
+				outBatches = append(outBatches, mb)
+				outBatchMut.Unlock()
+				return nil
+			}))
+
+			// insert
+			require.NoError(t, streamOutBuilder.AddProcessorYAML(fmt.Sprintf(`
+couchbase:
+  url: 'couchbase://localhost:%s'
+  bucket: %s
+  username: %s
+  password: %s
+  id: '${! json("key") }'
+  content: 'root = this'
+  operation: 'insert'
+`, servicePort, bucket, username, password)))
+
+			if clearCAS { // ignore cas check
+				require.NoError(t, streamOutBuilder.AddProcessorYAML(`
+mapping: |
+  meta couchbase_cas = deleted()
+`))
+			}
+
+			// upsert
+			require.NoError(t, streamOutBuilder.AddProcessorYAML(fmt.Sprintf(`
+couchbase:
+  url: 'couchbase://localhost:%s'
+  bucket: %s
+  username: %s
+  password: %s
+  id: '${! json("key") }'
+  content: 'root = this'
+  operation: 'upsert'
+`, servicePort, bucket, username, password)))
+
+			if clearCAS { // ignore cas check
+				require.NoError(t, streamOutBuilder.AddProcessorYAML(`
+mapping: |
+  meta couchbase_cas = deleted()
+`))
+			}
+			// remove
+			require.NoError(t, streamOutBuilder.AddProcessorYAML(fmt.Sprintf(`
+couchbase:
+  url: 'couchbase://localhost:%s'
+  bucket: %s
+  username: %s
+  password: %s
+  id: '${! json("key") }'
+  operation: 'remove'
+`, servicePort, bucket, username, password)))
+
+			streamOut, err := streamOutBuilder.Build()
+			require.NoError(t, err)
+			go func() {
+				err = streamOut.Run(context.Background())
+				require.NoError(t, err)
+			}()
+
+			require.NoError(t, inFn(ctx, service.MessageBatch{
+				service.NewMessage([]byte(`{"key":"hello","value":"word"}`)),
+			}))
+			require.NoError(t, streamOut.StopWithin(time.Second*15))
+
+			assert.Eventually(t, func() bool {
+				outBatchMut.Lock()
+				defer outBatchMut.Unlock()
+				return len(outBatches) == 1
+			}, time.Second*5, time.Millisecond*100)
+
+			// batch processing should be fine and contain one message.
+			assert.NoError(t, err)
+			assert.Len(t, outBatches, 1)
+			assert.Len(t, outBatches[0], 1)
+
+			// message should contain an error.
+			assert.NoError(t, outBatches[0][0].GetError())
+		})
+	}
 }


### PR DESCRIPTION
Set and use [Couchbase CAS](https://docs.couchbase.com/java-sdk/current/howtos/concurrent-document-mutations.html) in metadata `couchbase_cas` to prevent write conflict. 
If an entry is modified by an other process between read and write it will return an error if CAS is mismatched.

This change should be transparent and prevent data loss by default. 
This check can be disabled by clearing the CAS value if needed.