### PR TITLE
Fix wasm processor docs

### DIFF
--- a/docs/modules/components/pages/processors/wasm.adoc
+++ b/docs/modules/components/pages/processors/wasm.adoc
@@ -35,7 +35,7 @@ wasm:
 
 This processor uses https://github.com/tetratelabs/wazero[Wazero^] to execute a WASM module (with support for WASI), calling a specific function for each message being processed. From within the WASM module it is possible to query and mutate the message being processed via a suite of functions exported to the module.
 
-This ecosystem is delicate as WASM doesn't have a single clearly defined way to pass strings back and forth between the host and the module. In order to remedy this we're gradually working on introducing libraries and examples for multiple languages which can be found in https://github.com/{project-github}/tree/main/public/wasm/README.md[the codebase^].
+This ecosystem is delicate as WASM doesn't have a single clearly defined way to pass strings back and forth between the host and the module. In order to remedy this we're gradually working on introducing libraries and examples for multiple languages which can be found in https://github.com/redpanda-data/benthos/tree/main/public/wasm/README.md[the codebase^].
 
 These examples, as well as the processor itself, is a work in progress.
 

--- a/internal/impl/wasm/processor_wazero.go
+++ b/internal/impl/wasm/processor_wazero.go
@@ -36,7 +36,7 @@ func wazeroAllocProcessorConfig() *service.ConfigSpec {
 		Description(`
 This processor uses https://github.com/tetratelabs/wazero[Wazero^] to execute a WASM module (with support for WASI), calling a specific function for each message being processed. From within the WASM module it is possible to query and mutate the message being processed via a suite of functions exported to the module.
 
-This ecosystem is delicate as WASM doesn't have a single clearly defined way to pass strings back and forth between the host and the module. In order to remedy this we're gradually working on introducing libraries and examples for multiple languages which can be found in https://github.com/{project-github}/tree/main/public/wasm/README.md[the codebase^].
+This ecosystem is delicate as WASM doesn't have a single clearly defined way to pass strings back and forth between the host and the module. In order to remedy this we're gradually working on introducing libraries and examples for multiple languages which can be found in https://github.com/redpanda-data/benthos/tree/main/public/wasm/README.md[the codebase^].
 
 These examples, as well as the processor itself, is a work in progress.
 


### PR DESCRIPTION
Should this be templated out somehow similar to [`project-github`](https://github.com/redpanda-data/rp-connect-docs/blob/78fa9ddaa59e57250217e37e54d9db36141c95c3/antora.yml#L9)?