### PR TITLE
Topic written logs and status events to set pipeline id as key

### DIFF
--- a/internal/impl/kafka/enterprise/status_updates.go
+++ b/internal/impl/kafka/enterprise/status_updates.go
@@ -73,6 +73,7 @@ func (l *TopicLogger) sendStatusEvent(e *protoconnect.StatusEvent) {
 	msg := service.NewMessage(nil)
 	msg.SetBytes(data)
 	msg.MetaSetMut(topicMetaKey, l.statusTopic)
+	msg.MetaSetMut(keyMetaKey, l.pipelineID)
 
 	tmpO := l.o.Load()
 	if tmpO == nil {


### PR DESCRIPTION
Sets the key for topic written logs and status events to the configured pipeline identifier.