### PR TITLE
input/nats - provide boolean switch for sending ACK packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `content_md5` added to the `aws_s3` output. (@dom-lee-naimuri)
+- Field `send_ack` added to the `nats` input. (@plejd-sebman)
 
 ## 4.32.1 - 2024-07-24
 

--- a/docs/modules/components/pages/inputs/nats.adoc
+++ b/docs/modules/components/pages/inputs/nats.adoc
@@ -41,6 +41,7 @@ input:
     subject: foo.bar.baz # No default (required)
     queue: "" # No default (optional)
     auto_replay_nacks: true
+    send_ack: true
 ```
 
 --
@@ -57,6 +58,7 @@ input:
     subject: foo.bar.baz # No default (required)
     queue: "" # No default (optional)
     auto_replay_nacks: true
+    send_ack: true
     nak_delay: 1m # No default (optional)
     prefetch_count: 524288
     tls:
@@ -180,6 +182,15 @@ An optional queue group to consume as.
 === `auto_replay_nacks`
 
 Whether messages that are rejected (nacked) at the output level should be automatically replayed indefinitely, eventually resulting in back pressure if the cause of the rejections is persistent. If set to `false` these messages will instead be deleted. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data can be discarded immediately upon consumption and mutation.
+
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `send_ack`
+
+Control whether ACKS are sent as a reply to each message. When enabled, these replies are sent only once the data has been delivered to all outputs.
 
 
 *Type*: `bool`

--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -53,7 +53,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 			Optional()).
 		Field(service.NewAutoRetryNacksToggleField()).
 		Field(service.NewBoolField("send_ack").
-			Description("Control whether ACKS are sent").
+			Description("Control whether ACKS are sent as a reply to each message. When enabled, these replies are sent only once the data has been delivered to all outputs.").
 			Default(true)).
 		Field(service.NewDurationField("nak_delay").
 			Description("An optional delay duration on redelivering a message when negatively acknowledged.").

--- a/internal/impl/openai/embeddings_processor.go
+++ b/internal/impl/openai/embeddings_processor.go
@@ -37,7 +37,7 @@ func embeddingProcessorConfig() *service.ConfigSpec {
 		Categories("AI").
 		Summary("Generates vector embeddings to represent input text, using the OpenAI API.").
 		Description(`
-This processor sends text strings to the OpenAI API, which generates vector embeddings. By default, the processor submits the entire payload of each message as a string, unless you use the `+"`"+oepFieldTextMapping+"`"+` configuration field to customize it.
+This processor sends text strings to the OpenAI API, which generates vector embeddings. By default, the processor submits the entire payload of each message as a string, unless you use the ` + "`" + oepFieldTextMapping + "`" + ` configuration field to customize it.
 
 To learn more about vector embeddings, see the https://platform.openai.com/docs/guides/embeddings[OpenAI API documentation^].`).
 		Version("4.32.0").


### PR DESCRIPTION
- default value is TRUE
- when set to FALSE, the ACK package isn't sent
- this would comply with Nats protocol specification
- closes #2739 