### PR TITLE
Support API Keys for ElasticSearch output

### DIFF
--- a/docs/modules/components/pages/outputs/elasticsearch.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch.adoc
@@ -41,6 +41,7 @@ output:
     index: "" # No default (required)
     id: ${!count("elastic_ids")}-${!timestamp_unix()}
     type: ""
+    api_key: "" # No default (optional)
     max_in_flight: 64
     batching:
       count: 0
@@ -69,6 +70,7 @@ output:
     sniff: true
     healthcheck: true
     timeout: 5s
+    api_key: "" # No default (optional)
     tls:
       enabled: false
       skip_cert_verify: false
@@ -224,6 +226,19 @@ The maximum time to wait before abandoning a request (and trying again).
 *Type*: `string`
 
 *Default*: `"5s"`
+
+=== `api_key`
+
+The key to set in the Authorization header if using API keys for authentication.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
 
 === `tls`
 

--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -48,6 +48,7 @@ const (
 	esoFieldAuthEnabled  = "enabled"
 	esoFieldAuthUsername = "username"
 	esoFieldAuthPassword = "password"
+	esoFieldAPIKey       = "api_key"
 	esoFieldAWS          = "aws"
 	// ESOFieldAWSEnabled enabled field.
 	ESOFieldAWSEnabled      = "enabled"
@@ -107,6 +108,17 @@ func esoConfigFromParsed(pConf *service.ParsedConfig) (conf esoConfig, err error
 			}
 			conf.clientOpts = append(conf.clientOpts, elastic.SetBasicAuth(username, password))
 		}
+	}
+
+	if pConf.Contains(esoFieldAPIKey) {
+		var apiKey string
+		apiKey, err = pConf.FieldString(esoFieldAPIKey)
+		if err != nil {
+			return
+		}
+		header := http.Header{}
+		header.Set("Authorization", "ApiKey "+apiKey)
+		conf.clientOpts = append(conf.clientOpts, elastic.SetHeaders(header))
 	}
 
 	var timeout time.Duration
@@ -245,6 +257,10 @@ It's possible to enable AWS connectivity with this output using the `+"`aws`"+` 
 				Description("The maximum time to wait before abandoning a request (and trying again).").
 				Advanced().
 				Default("5s"),
+			service.NewStringField(esoFieldAPIKey).
+				Description("The key to set in the Authorization header if using API keys for authentication.").
+				Optional().
+				Secret(),
 			service.NewTLSToggledField(esoFieldTLS),
 			service.NewOutputMaxInFlightField(),
 		).


### PR DESCRIPTION
Basic auth is no longer recommended, and API keys are considered the
recommended authentication option now. API keys are also the only
supported option on ElasticSearch Cloud.
