### PR TITLE
Support multiple ollama processors with processes

### DIFF
--- a/internal/impl/ollama/chat_processor_test.go
+++ b/internal/impl/ollama/chat_processor_test.go
@@ -31,9 +31,7 @@ func createCompletionProcessorForTest(t *testing.T, addr string) *ollamaCompleti
 		baseOllamaProcessor: &baseOllamaProcessor{
 			// use smallest model possible to make it cheaper
 			model:  "tinyllama",
-			cmd:    nil,
 			client: api.NewClient(url, http.DefaultClient),
-			logger: nil,
 		},
 		userPrompt:   nil,
 		systemPrompt: nil,

--- a/internal/impl/ollama/embeddings_processor_test.go
+++ b/internal/impl/ollama/embeddings_processor_test.go
@@ -30,9 +30,7 @@ func createEmbeddingsProcessorForTest(t *testing.T, addr string) *ollamaEmbeddin
 		baseOllamaProcessor: &baseOllamaProcessor{
 			// use smallest model possible to make it cheaper
 			model:  "all-minilm",
-			cmd:    nil,
 			client: api.NewClient(url, http.DefaultClient),
-			logger: nil,
 		},
 		text: nil,
 	}

--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package singleton
+
+import (
+	"context"
+	"sync"
+)
+
+// Singleton is a thread-safe type that holds one `T` per process.
+//
+// Example usage:
+//
+//	var globalFoo = singleton.New(singleton.Config[*Foo]{
+//		Constructor: func (ctx context.Context) (*Foo, error) {
+//			return NewFoo(ctx)
+//		},
+//		Destructor: func (ctx context.Context, foo *Foo) error {
+//			return foo.Close(ctx)
+//		})
+//
+// In your setup code:
+//
+//	foo, ticket, err := globalFoo.Acquire(ctx)
+//
+// In your teardown code:
+//
+//	err := globalFoo.Close(ctx, ticket)
+type Singleton[T any] struct {
+	mu         sync.Mutex
+	tickets    map[Ticket]struct{}
+	nextTicket Ticket
+	cfg        Config[T]
+	value      T
+}
+
+// Ticket is an opaque type signifying that a singleton's resource is acquired.
+type Ticket int
+
+// Config holds the required methods to setup/teardown a `Singleton`.
+type Config[T any] struct {
+	Constructor func(context.Context) (T, error)
+	Destructor  func(context.Context, T) error
+}
+
+// New creates a new singleton using the given constructor and destructor to setup and teardown the object.
+func New[T any](cfg Config[T]) *Singleton[T] {
+	// Don't use 0 as the initial ticket so default values don't mess up the reference counting
+	return &Singleton[T]{
+		cfg:        cfg,
+		tickets:    map[Ticket]struct{}{},
+		nextTicket: Ticket(1),
+	}
+}
+
+// Acquire returns the singleton value, creating it if needed and returning the ticket for close.
+//
+// If there is no error, any result from `Acquire` should be cached.
+//
+// There must be a corresponding call to `Close` for each successful call to `Acquire` with the
+// returned ticket.
+func (s *Singleton[T]) Acquire(ctx context.Context) (val T, t Ticket, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.tickets) == 0 {
+		val, err = s.cfg.Constructor(ctx)
+		if err != nil {
+			return
+		}
+		s.value = val
+	} else {
+		val = s.value
+	}
+	t = s.nextTicket
+	s.nextTicket++
+	s.tickets[t] = struct{}{}
+	return
+}
+
+// Close the item behind the singleton using the ticket, and if needed calling the destructor.
+//
+// This function must be called once for every successful `Acquire` call on the singleton.
+//
+// This function is safe to call (even concurrently) with the same ticket - subsequent calls will noop.
+func (s *Singleton[T]) Close(ctx context.Context, ticket Ticket) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Prevent multiple destructor calls and only call the destructor if the ref count goes to 0.
+	if len(s.tickets) == 0 {
+		return nil
+	}
+	delete(s.tickets, ticket)
+	if len(s.tickets) == 0 {
+		return s.cfg.Destructor(ctx, s.value)
+	}
+	return nil
+}

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package singleton
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type Foo struct{}
+
+func TestSingleGoroutine(t *testing.T) {
+	open := false
+	s := New(Config[*Foo]{
+		Constructor: func(ctx context.Context) (*Foo, error) {
+			if open {
+				t.Error("constructor called multiple times")
+			}
+			open = true
+			return &Foo{}, nil
+		},
+		Destructor: func(ctx context.Context, foo *Foo) error {
+			if !open {
+				t.Error("destructor called multiple times")
+			}
+			open = false
+			return nil
+		},
+	})
+	require.False(t, open)
+	f1, ticket1, err := s.Acquire(context.Background())
+	require.NoError(t, err)
+	require.True(t, open)
+	f2, ticket2, err := s.Acquire(context.Background())
+	require.NoError(t, err)
+	require.True(t, open)
+	require.Same(t, f1, f2)
+	require.NoError(t, s.Close(context.Background(), ticket1))
+	require.True(t, open)
+	require.NoError(t, s.Close(context.Background(), ticket1))
+	require.True(t, open)
+	require.NoError(t, s.Close(context.Background(), ticket2))
+	require.False(t, open)
+	require.NoError(t, s.Close(context.Background(), ticket2))
+	require.False(t, open)
+}
+
+func TestMultipleGoroutines(t *testing.T) {
+	open := atomic.Bool{}
+	s := New(Config[*Foo]{
+		Constructor: func(ctx context.Context) (*Foo, error) {
+			if open.Swap(true) {
+				t.Error("constructor called multiple times")
+			}
+			return &Foo{}, nil
+		},
+		Destructor: func(ctx context.Context, foo *Foo) error {
+			if !open.Swap(false) {
+				t.Error("destructor called multiple times")
+			}
+			return nil
+		},
+	})
+	require.False(t, open.Load())
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			f1, ticket1, err := s.Acquire(context.Background())
+			require.NoError(t, err)
+			require.True(t, open.Load())
+			f2, ticket2, err := s.Acquire(context.Background())
+			require.NoError(t, err)
+			require.True(t, open.Load())
+			require.Same(t, f1, f2)
+			require.NoError(t, s.Close(context.Background(), ticket1))
+			require.True(t, open.Load())
+			require.NoError(t, s.Close(context.Background(), ticket1))
+			require.True(t, open.Load())
+			require.NoError(t, s.Close(context.Background(), ticket2))
+			// Nothing to assert, could race with other goroutines
+			require.NoError(t, s.Close(context.Background(), ticket2))
+		}(i)
+	}
+	wg.Wait()
+	require.False(t, open.Load())
+}


### PR DESCRIPTION
Currently if one tries to spin up multiple ollama processors in the same
processor you get errors about port conflicts on the second processor
that starts. Fix this by using a singleton pattern with the ollama
servers we start up automatically.

Tested manually.
