### PR TITLE
Adds GCP credentials as JOSN

### DIFF
--- a/docs/modules/components/pages/caches/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/caches/gcp_cloud_storage.adoc
@@ -30,6 +30,7 @@ label: ""
 gcp_cloud_storage:
   bucket: "" # No default (required)
   content_type: "" # No default (optional)
+  credentials_json: ""
 ```
 
 It is not possible to atomically upload cloud storage objects exclusively when the target does not already exist, therefore this cache is not suitable for deduplication.
@@ -51,5 +52,19 @@ Optional field to explicitly set the Content-Type.
 
 *Type*: `string`
 
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 

--- a/docs/modules/components/pages/inputs/gcp_bigquery_select.adoc
+++ b/docs/modules/components/pages/inputs/gcp_bigquery_select.adoc
@@ -33,6 +33,7 @@ input:
   label: ""
   gcp_bigquery_select:
     project: "" # No default (required)
+    credentials_json: ""
     table: bigquery-public-data.samples.shakespeare # No default (required)
     columns: [] # No default (required)
     where: type = ? and created_at > ? # No default (optional)
@@ -86,6 +87,20 @@ GCP project where the query job will execute.
 
 *Type*: `string`
 
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `table`
 

--- a/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
@@ -41,6 +41,7 @@ input:
   gcp_cloud_storage:
     bucket: "" # No default (required)
     prefix: ""
+    credentials_json: ""
     scanner:
       to_the_end: {}
 ```
@@ -57,6 +58,7 @@ input:
   gcp_cloud_storage:
     bucket: "" # No default (required)
     prefix: ""
+    credentials_json: ""
     scanner:
       to_the_end: {}
     delete_objects: false
@@ -98,6 +100,20 @@ The name of the bucket from which to download objects.
 === `prefix`
 
 An optional path prefix, if set only objects with the prefix are consumed.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/inputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/inputs/gcp_pubsub.adoc
@@ -38,6 +38,7 @@ input:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: ""
     subscription: "" # No default (required)
     endpoint: ""
     sync: false
@@ -56,6 +57,7 @@ input:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: ""
     subscription: "" # No default (required)
     endpoint: ""
     sync: false
@@ -91,6 +93,20 @@ The project ID of the target subscription.
 
 *Type*: `string`
 
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `subscription`
 

--- a/docs/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -45,6 +45,7 @@ output:
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
     job_labels: {}
+    credentials_json: ""
     csv:
       header: []
       field_delimiter: ','
@@ -76,6 +77,7 @@ output:
     max_bad_records: 0
     auto_detect: false
     job_labels: {}
+    credentials_json: ""
     csv:
       header: []
       field_delimiter: ','
@@ -250,6 +252,20 @@ A list of labels to add to the load job.
 *Type*: `object`
 
 *Default*: `{}`
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `csv`
 

--- a/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
@@ -44,6 +44,7 @@ output:
     content_type: application/octet-stream
     collision_mode: overwrite
     timeout: 3s
+    credentials_json: ""
     max_in_flight: 64
     batching:
       count: 0
@@ -69,6 +70,7 @@ output:
     collision_mode: overwrite
     chunk_size: 16777216
     timeout: 3s
+    credentials_json: ""
     max_in_flight: 64
     batching:
       count: 0
@@ -231,6 +233,21 @@ timeout: 1s
 
 timeout: 500ms
 ```
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/outputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/outputs/gcp_pubsub.adoc
@@ -38,6 +38,7 @@ output:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: ""
     topic: "" # No default (required)
     endpoint: ""
     max_in_flight: 64
@@ -64,6 +65,7 @@ output:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: ""
     topic: "" # No default (required)
     endpoint: ""
     ordering_key: "" # No default (optional)
@@ -121,6 +123,20 @@ The project ID of the topic to publish to.
 
 *Type*: `string`
 
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `topic`
 

--- a/docs/modules/components/pages/processors/gcp_bigquery_select.adoc
+++ b/docs/modules/components/pages/processors/gcp_bigquery_select.adoc
@@ -32,6 +32,7 @@ Introduced in version 3.64.0.
 label: ""
 gcp_bigquery_select:
   project: "" # No default (required)
+  credentials_json: ""
   table: bigquery-public-data.samples.shakespeare # No default (required)
   columns: [] # No default (required)
   where: type = ? and created_at > ? # No default (optional)
@@ -85,6 +86,20 @@ GCP project where the query job will execute.
 
 *Type*: `string`
 
+
+=== `credentials_json`
+
+An optional field to set Google Service Account Credentials json.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `table`
 

--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -36,7 +36,7 @@ func gcpCloudStorageCacheConfig() *service.ConfigSpec {
 		Field(service.NewStringField("content_type").
 			Description("Optional field to explicitly set the Content-Type.").Optional()).
 		Field(service.NewStringField("credentials_json").
-			Description("An optional field to set Google Service Account Credentials json.").Optional().Secret().Default(""))
+			Description("An optional field to set Google Service Account Credentials json.").Secret().Default(""))
 
 	return spec
 }

--- a/internal/impl/gcp/input_bigquery_select.go
+++ b/internal/impl/gcp/input_bigquery_select.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"github.com/Jeffail/shutdown"
 
@@ -30,11 +31,12 @@ import (
 )
 
 type bigQuerySelectInputConfig struct {
-	project       string
-	queryParts    *bqQueryParts
-	argsMapping   *bloblang.Executor
-	queryPriority bigquery.QueryPriority
-	jobLabels     map[string]string
+	project         string
+	queryParts      *bqQueryParts
+	argsMapping     *bloblang.Executor
+	queryPriority   bigquery.QueryPriority
+	jobLabels       map[string]string
+	credentialsJSON string
 }
 
 func bigQuerySelectInputConfigFromParsed(inConf *service.ParsedConfig) (conf bigQuerySelectInputConfig, err error) {
@@ -87,6 +89,13 @@ func bigQuerySelectInputConfigFromParsed(inConf *service.ParsedConfig) (conf big
 		return
 	}
 
+	if inConf.Contains("credentials_json") {
+		conf.credentialsJSON, err = inConf.FieldString("credentials_json")
+		if err != nil {
+			return
+		}
+	}
+
 	return
 }
 
@@ -98,6 +107,11 @@ func newBigQuerySelectInputConfig() *service.ConfigSpec {
 		Summary("Executes a `SELECT` query against BigQuery and creates a message for each row received.").
 		Description(`Once the rows from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a xref:components:inputs/sequence.adoc[sequence] to execute).`).
 		Field(service.NewStringField("project").Description("GCP project where the query job will execute.")).
+		Field(service.NewStringField("credentials_json").
+			Description("An optional field to set Google Service Account Credentials json.").
+			Optional().
+			Secret().
+			Default("")).
 		Field(service.NewStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).
 		Field(service.NewStringListField("columns").Description("A list of columns to query.")).
 		Field(service.NewStringField("where").
@@ -172,7 +186,14 @@ func (inp *bigQuerySelectInput) Connect(ctx context.Context) error {
 	jobctx, _ := inp.shutdownSig.SoftStopCtx(context.Background())
 
 	if inp.client == nil {
-		client, err := bigquery.NewClient(jobctx, inp.config.project)
+		var err error
+		var opt []option.ClientOption
+		opt, err = getClientOptionWithCredential(inp.config.credentialsJSON, opt)
+		if err != nil {
+			return err
+		}
+
+		client, err := bigquery.NewClient(jobctx, inp.config.project, opt...)
 		if err != nil {
 			return fmt.Errorf("failed to create bigquery client: %w", err)
 		}

--- a/internal/impl/gcp/input_bigquery_select.go
+++ b/internal/impl/gcp/input_bigquery_select.go
@@ -89,11 +89,8 @@ func bigQuerySelectInputConfigFromParsed(inConf *service.ParsedConfig) (conf big
 		return
 	}
 
-	if inConf.Contains("credentials_json") {
-		conf.credentialsJSON, err = inConf.FieldString("credentials_json")
-		if err != nil {
-			return
-		}
+	if conf.credentialsJSON, err = inConf.FieldString("credentials_json"); err != nil {
+		return
 	}
 
 	return
@@ -109,7 +106,6 @@ func newBigQuerySelectInputConfig() *service.ConfigSpec {
 		Field(service.NewStringField("project").Description("GCP project where the query job will execute.")).
 		Field(service.NewStringField("credentials_json").
 			Description("An optional field to set Google Service Account Credentials json.").
-			Optional().
 			Secret().
 			Default("")).
 		Field(service.NewStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).

--- a/internal/impl/gcp/input_cloud_storage.go
+++ b/internal/impl/gcp/input_cloud_storage.go
@@ -100,7 +100,6 @@ By default Redpanda Connect will use a shared credentials file when connecting t
 			service.NewStringField(csiFieldCredentialsJSON).
 				Description("An optional field to set Google Service Account Credentials json.").
 				Default("").
-				Optional().
 				Secret(),
 		).
 		Fields(codec.DeprecatedCodecFields("to_the_end")...).

--- a/internal/impl/gcp/input_cloud_storage.go
+++ b/internal/impl/gcp/input_cloud_storage.go
@@ -24,6 +24,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/benthos/v4/public/service/codec"
@@ -31,16 +32,18 @@ import (
 
 const (
 	// Cloud Storage Input Fields
-	csiFieldBucket        = "bucket"
-	csiFieldPrefix        = "prefix"
-	csiFieldDeleteObjects = "delete_objects"
+	csiFieldBucket          = "bucket"
+	csiFieldPrefix          = "prefix"
+	csiFieldCredentialsJSON = "credentials_json"
+	csiFieldDeleteObjects   = "delete_objects"
 )
 
 type csiConfig struct {
-	Bucket        string
-	Prefix        string
-	DeleteObjects bool
-	Codec         codec.DeprecatedFallbackCodec
+	Bucket          string
+	Prefix          string
+	CredentialsJSON string
+	DeleteObjects   bool
+	Codec           codec.DeprecatedFallbackCodec
 }
 
 func csiConfigFromParsed(pConf *service.ParsedConfig) (conf csiConfig, err error) {
@@ -48,6 +51,9 @@ func csiConfigFromParsed(pConf *service.ParsedConfig) (conf csiConfig, err error
 		return
 	}
 	if conf.Prefix, err = pConf.FieldString(csiFieldPrefix); err != nil {
+		return
+	}
+	if conf.CredentialsJSON, err = pConf.FieldString(csiFieldCredentialsJSON); err != nil {
 		return
 	}
 	if conf.Codec, err = codec.DeprecatedCodecFromParsed(pConf); err != nil {
@@ -91,6 +97,11 @@ By default Redpanda Connect will use a shared credentials file when connecting t
 			service.NewStringField(csiFieldPrefix).
 				Description("An optional path prefix, if set only objects with the prefix are consumed.").
 				Default(""),
+			service.NewStringField(csiFieldCredentialsJSON).
+				Description("An optional field to set Google Service Account Credentials json.").
+				Default("").
+				Optional().
+				Secret(),
 		).
 		Fields(codec.DeprecatedCodecFields("to_the_end")...).
 		Fields(
@@ -267,7 +278,14 @@ func newGCPCloudStorageInput(conf csiConfig, res *service.Resources) (*gcpCloudS
 // Cloud Storage bucket.
 func (g *gcpCloudStorageInput) Connect(ctx context.Context) error {
 	var err error
-	g.client, err = storage.NewClient(context.Background())
+
+	var opt []option.ClientOption
+	opt, err = getClientOptionWithCredential(g.conf.CredentialsJSON, opt)
+	if err != nil {
+		return err
+	}
+
+	g.client, err = storage.NewClient(context.Background(), opt...)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -29,6 +29,7 @@ import (
 const (
 	// Pubsub Input Fields
 	pbiFieldProjectID              = "project"
+	pbiFieldCredentialsJSON        = "credentials_json"
 	pbiFieldSubscriptionID         = "subscription"
 	pbiFieldEndpoint               = "endpoint"
 	pbiFieldMaxOutstandingMessages = "max_outstanding_messages"
@@ -41,6 +42,7 @@ const (
 
 type pbiConfig struct {
 	ProjectID              string
+	CredentialsJSON        string
 	SubscriptionID         string
 	Endpoint               string
 	MaxOutstandingMessages int
@@ -52,6 +54,9 @@ type pbiConfig struct {
 
 func pbiConfigFromParsed(pConf *service.ParsedConfig) (conf pbiConfig, err error) {
 	if conf.ProjectID, err = pConf.FieldString(pbiFieldProjectID); err != nil {
+		return
+	}
+	if conf.CredentialsJSON, err = pConf.FieldString(pbiFieldCredentialsJSON); err != nil {
 		return
 	}
 	if conf.SubscriptionID, err = pConf.FieldString(pbiFieldSubscriptionID); err != nil {
@@ -102,6 +107,11 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 		Fields(
 			service.NewStringField(pbiFieldProjectID).
 				Description("The project ID of the target subscription."),
+			service.NewStringField(pbiFieldCredentialsJSON).
+				Description("An optional field to set Google Service Account Credentials json.").
+				Default("").
+				Optional().
+				Secret(),
 			service.NewStringField(pbiFieldSubscriptionID).
 				Description("The target subscription ID."),
 			service.NewStringField(pbiFieldEndpoint).
@@ -182,12 +192,19 @@ type gcpPubSubReader struct {
 }
 
 func newGCPPubSubReader(conf pbiConfig, res *service.Resources) (*gcpPubSubReader, error) {
+	var err error
 	var opt []option.ClientOption
 	if strings.TrimSpace(conf.Endpoint) != "" {
 		opt = []option.ClientOption{option.WithEndpoint(conf.Endpoint)}
 	}
 
-	client, err := pubsub.NewClient(context.Background(), conf.ProjectID, opt...)
+	opt, err = getClientOptionWithCredential(conf.CredentialsJSON, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	var client *pubsub.Client
+	client, err = pubsub.NewClient(context.Background(), conf.ProjectID, opt...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -110,7 +110,6 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 			service.NewStringField(pbiFieldCredentialsJSON).
 				Description("An optional field to set Google Service Account Credentials json.").
 				Default("").
-				Optional().
 				Secret(),
 			service.NewStringField(pbiFieldSubscriptionID).
 				Description("The target subscription ID."),

--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -209,7 +209,7 @@ For the CSV format when the field ` + "`csv.header`" + ` is specified a header r
 			Advanced().
 			Default(false)).
 		Field(service.NewStringMapField("job_labels").Description("A list of labels to add to the load job.").Default(map[string]any{})).
-		Field(service.NewStringField("credentials_json").Description("An optional field to set Google Service Account Credentials json.").Optional().Secret().Default("")).
+		Field(service.NewStringField("credentials_json").Description("An optional field to set Google Service Account Credentials json.").Secret().Default("")).
 		Field(service.NewObjectField("csv",
 			service.NewStringListField("header").
 				Description("A list of values to use as header for each batch of messages. If not specified the first line of each message will be used as header.").

--- a/internal/impl/gcp/output_cloud_storage.go
+++ b/internal/impl/gcp/output_cloud_storage.go
@@ -183,7 +183,6 @@ output:
 			service.NewInterpolatedStringField(csoFieldCredentialsJSON).
 				Description("An optional field to set Google Service Account Credentials json.").
 				Default("").
-				Optional().
 				Secret(),
 			service.NewOutputMaxInFlightField().
 				Description("The maximum number of message batches to have in flight at a given time. Increase this to improve throughput."),

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -59,6 +59,11 @@ pipeline:
 `+"```"+``).
 		Fields(
 			service.NewStringField("project").Description("The project ID of the topic to publish to."),
+			service.NewStringField("credentials_json").
+				Description("An optional field to set Google Service Account Credentials json.").
+				Default("").
+				Optional().
+				Secret(),
 			service.NewInterpolatedStringField("topic").Description("The topic to publish to."),
 			service.NewStringField("endpoint").
 				Default("").
@@ -195,6 +200,16 @@ func newPubSubOutput(conf *service.ParsedConfig) (*pubsubOutput, error) {
 	var opt []option.ClientOption
 	if endpoint != "" {
 		opt = []option.ClientOption{option.WithEndpoint(endpoint)}
+	}
+
+	var credsJSON string
+	credsJSON, err = conf.FieldString("credentials_json")
+	if err != nil {
+		return nil, err
+	}
+	opt, err = getClientOptionWithCredential(credsJSON, opt)
+	if err != nil {
+		return nil, err
 	}
 
 	return &pubsubOutput{

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -62,7 +62,6 @@ pipeline:
 			service.NewStringField("credentials_json").
 				Description("An optional field to set Google Service Account Credentials json.").
 				Default("").
-				Optional().
 				Secret(),
 			service.NewInterpolatedStringField("topic").Description("The topic to publish to."),
 			service.NewStringField("endpoint").

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -44,11 +44,9 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 	if conf.project, err = inConf.FieldString("project"); err != nil {
 		return
 	}
-	if inConf.Contains("credentials_json") {
-		conf.credentialsJSON, err = inConf.FieldString("credentials_json")
-		if err != nil {
-			return
-		}
+
+	if conf.credentialsJSON, err = inConf.FieldString("credentials_json"); err != nil {
+		return
 	}
 
 	if inConf.Contains("args_mapping") {
@@ -98,7 +96,7 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 		Categories("Integration").
 		Summary("Executes a `SELECT` query against BigQuery and replaces messages with the rows returned.").
 		Field(service.NewStringField("project").Description("GCP project where the query job will execute.")).
-		Field(service.NewStringField("credentials_json").Description("An optional field to set Google Service Account Credentials json.").Optional().Secret().Default("")).
+		Field(service.NewStringField("credentials_json").Description("An optional field to set Google Service Account Credentials json.").Secret().Default("")).
 		Field(service.NewStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).
 		Field(service.NewStringListField("columns").Description("A list of columns to query.")).
 		Field(service.NewStringField("where").

--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -29,7 +29,8 @@ import (
 )
 
 type bigQuerySelectProcessorConfig struct {
-	project string
+	project         string
+	credentialsJSON string
 
 	queryParts  *bqQueryParts
 	jobLabels   map[string]string
@@ -42,6 +43,12 @@ func bigQuerySelectProcessorConfigFromParsed(inConf *service.ParsedConfig) (conf
 
 	if conf.project, err = inConf.FieldString("project"); err != nil {
 		return
+	}
+	if inConf.Contains("credentials_json") {
+		conf.credentialsJSON, err = inConf.FieldString("credentials_json")
+		if err != nil {
+			return
+		}
 	}
 
 	if inConf.Contains("args_mapping") {
@@ -91,6 +98,7 @@ func newBigQuerySelectProcessorConfig() *service.ConfigSpec {
 		Categories("Integration").
 		Summary("Executes a `SELECT` query against BigQuery and replaces messages with the rows returned.").
 		Field(service.NewStringField("project").Description("GCP project where the query job will execute.")).
+		Field(service.NewStringField("credentials_json").Description("An optional field to set Google Service Account Credentials json.").Optional().Secret().Default("")).
 		Field(service.NewStringField("table").Description("Fully-qualified BigQuery table name to query.").Example("bigquery-public-data.samples.shakespeare")).
 		Field(service.NewStringListField("columns").Description("A list of columns to query.")).
 		Field(service.NewStringField("where").
@@ -159,6 +167,12 @@ func newBigQuerySelectProcessor(inConf *service.ParsedConfig, options *bigQueryP
 	}
 
 	closeCtx, closeF := context.WithCancel(context.Background())
+
+	options.clientOptions, err = getClientOptionWithCredential(conf.credentialsJSON, options.clientOptions)
+	if err != nil {
+		closeF()
+		return nil, err
+	}
 
 	wrapped, err := bigquery.NewClient(closeCtx, conf.project, options.clientOptions...)
 	if err != nil {


### PR DESCRIPTION
This adds a `credentials_json` field for GCP services inputs, outputs and processors:
- cache_cloud_storage
- input_bigquery_select
- input_cloud_storage
- input_pubsub
- output_bigquery
- output_cloud_storage
- output_pubsub
- processor_bigquery_select

Ref: https://github.com/redpanda-data/connect/issues/1761