### PR TITLE
Add cloud images to docker artefacts

### DIFF
--- a/.github/workflows/docker_edge.yml
+++ b/.github/workflows/docker_edge.yml
@@ -61,6 +61,16 @@ jobs:
         push: true
         tags: redpandadata/connect:edge
 
+    - name: Build and push cloud
+      uses: docker/build-push-action@v6
+      with:
+        context: ./
+        file: ./resources/docker/Dockerfile.cloud
+        builder: ${{ steps.buildx.outputs.name }}
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: redpandadata/connect:edge-cloud
+
     - name: Build and push CGO
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,30 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}
+
+    - name: Docker meta cloud
+      id: docker_meta_cloud
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          redpandadata/connect
+        flavor: |
+          latest=auto
+          suffix=-cloud
+        tags: |
+          type=semver,suffix=-cloud,pattern={{version}}
+          type=semver,suffix=-cloud,pattern={{major}}.{{minor}}
+          type=semver,suffix=-cloud,pattern={{major}}
+
+    - name: Build and push cloud
+      uses: docker/build-push-action@v6
+      with:
+        context: ./
+        file: ./resources/docker/Dockerfile.cloud
+        builder: ${{ steps.buildx.outputs.name }}
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        tags: ${{ steps.docker_meta_cloud.outputs.tags }}
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Field `send_ack` added to the `nats` input. (@plejd-sebman)
 - New Bloblang method `vector`. (@rockwotj)
 - New experimental `ockam_kafka` input and output. (@mrinalwadhwa, @davide-baldo)
+- Field `credentials_json` added to all GCP components. (@tomasz-sadura)
+- (Benthos) The `list` subcommand now supports the format `jsonschema`. (@Jeffail)
 
 ## 4.32.1 - 2024-07-24
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INSTALL_DIR        ?= $(GOPATH)/bin
 WEBSITE_DIR        ?= ./docs/modules
 DEST_DIR           ?= ./target
 PATHINSTBIN        = $(DEST_DIR)/bin
-DOCKER_IMAGE       ?= redpandadata/connect
+DOCKER_IMAGE       ?= docker.redpanda.com/redpandadata/connect
 
 VERSION   := $(shell git describe --tags 2> /dev/null || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
@@ -23,7 +23,7 @@ LD_FLAGS   ?= -w -s
 GO_FLAGS   ?=
 DOCS_FLAGS ?=
 
-APPS = redpanda-connect
+APPS = redpanda-connect redpanda-connect-cloud redpanda-connect-community
 all: $(APPS)
 
 install: $(APPS)
@@ -54,6 +54,10 @@ docker-cgo-tags:
 docker:
 	@docker build -f ./resources/docker/Dockerfile . -t $(DOCKER_IMAGE):$(VER_CUT)
 	@docker tag $(DOCKER_IMAGE):$(VER_CUT) $(DOCKER_IMAGE):latest
+
+docker-cloud:
+	@docker build -f ./resources/docker/Dockerfile.cloud . -t $(DOCKER_IMAGE):$(VER_CUT)-cloud
+	@docker tag $(DOCKER_IMAGE):$(VER_CUT)-cloud $(DOCKER_IMAGE):latest-cloud
 
 docker-cgo:
 	@docker build -f ./resources/docker/Dockerfile.cgo . -t $(DOCKER_IMAGE):$(VER_CUT)-cgo

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ docker run --rm \
 	-v /path/to/your/benthos.yaml:/config.yaml \
 	-v /tmp/data:/data \
 	-p 4195:4195 \
-	redpandadata/connect -c /config.yaml
+	docker.redpanda.com/redpandadata/connect run /config.yaml
 ```
 
 ## Contributing

--- a/cmd/redpanda-connect-cloud/main.go
+++ b/cmd/redpanda-connect-cloud/main.go
@@ -73,21 +73,15 @@ func main() {
 		allowSlice = append(allowSlice, s)
 	}
 
-	env := service.GlobalEnvironment()
-
 	// Observability and scanner plugins aren't necessarily present in our
 	// internal lists and so we allow everything that's imported
-	env.WalkScanners(func(name string, config *service.ConfigView) {
-		allowSlice = append(allowSlice, name)
-	})
-	env.WalkMetrics(func(name string, config *service.ConfigView) {
-		allowSlice = append(allowSlice, name)
-	})
-	env.WalkTracers(func(name string, config *service.ConfigView) {
-		allowSlice = append(allowSlice, name)
-	})
-
-	env = env.With(allowSlice...)
+	env := service.GlobalEnvironment().
+		WithBuffers(allowSlice...).
+		WithCaches(allowSlice...).
+		WithInputs(allowSlice...).
+		WithOutputs(allowSlice...).
+		WithProcessors(allowSlice...).
+		WithRateLimits(allowSlice...)
 
 	// Allow only pure methods and functions within Bloblang.
 	benv := bloblang.GlobalEnvironment()

--- a/docs/modules/components/pages/processors/log.adoc
+++ b/docs/modules/components/pages/processors/log.adoc
@@ -70,8 +70,7 @@ The log level to use.
 *Default*: `"INFO"`
 
 Options:
-`FATAL`
-, `ERROR`
+`ERROR`
 , `WARN`
 , `INFO`
 , `DEBUG`

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/redis/go-redis/v9 v9.5.3
-	github.com/redpanda-data/benthos/v4 v4.33.0
+	github.com/redpanda-data/benthos/v4 v4.34.0
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.29.0
 	github.com/rs/xid v1.2.1
 	github.com/sijms/go-ora/v2 v2.8.19

--- a/go.sum
+++ b/go.sum
@@ -1001,8 +1001,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.5.3 h1:fOAp1/uJG+ZtcITgZOfYFmTKPE7n4Vclj1wZFgRciUU=
 github.com/redis/go-redis/v9 v9.5.3/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
-github.com/redpanda-data/benthos/v4 v4.33.0 h1:CrgAjbzgn6G4xKA7Y5Byf3ikpwSkqProNgqKLFKrJBQ=
-github.com/redpanda-data/benthos/v4 v4.33.0/go.mod h1:E3ivVEVcwCC/wsvDJ8uDK84FnNXObuAIAdwzyljE6/s=
+github.com/redpanda-data/benthos/v4 v4.34.0 h1:scaQPmTfy23A8QQunYOBATPupZxmlyOYv37gueWgTl0=
+github.com/redpanda-data/benthos/v4 v4.34.0/go.mod h1:E3ivVEVcwCC/wsvDJ8uDK84FnNXObuAIAdwzyljE6/s=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.29.0 h1:Z6cF6q86b6bw0uRohX2tnUBe0EgRtak7JjQlaXBnAVs=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.29.0/go.mod h1:AU2ujaShckZ9Zn3N58MGy6QYw500v8bvWgBgdnxCqaE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -34,4 +34,4 @@ EXPOSE 4195
 
 ENTRYPOINT ["/redpanda-connect"]
 
-CMD ["-c", "/connect.yaml"]
+CMD ["run", "/connect.yaml"]

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . /go/src/github.com/redpanda-data/connect/
 # Tag timetzdata required for busybox base image:
 # https://github.com/benthosdev/benthos/issues/897
-RUN make TAGS="timetzdata"
+RUN make TAGS="timetzdata" redpanda-connect
 
 # Pack
 FROM busybox AS package

--- a/resources/docker/Dockerfile.cgo
+++ b/resources/docker/Dockerfile.cgo
@@ -33,4 +33,4 @@ EXPOSE 4195
 
 ENTRYPOINT ["./redpanda-connect"]
 
-CMD ["-c", "/connect.yaml"]
+CMD ["run", "/connect.yaml"]

--- a/resources/docker/Dockerfile.cloud
+++ b/resources/docker/Dockerfile.cloud
@@ -34,5 +34,4 @@ EXPOSE 4195
 
 ENTRYPOINT ["/redpanda-connect"]
 
-CMD ["-c", "/connect.yaml"]
-
+CMD ["run", "/connect.yaml"]

--- a/resources/docker/Dockerfile.cloud
+++ b/resources/docker/Dockerfile.cloud
@@ -1,36 +1,38 @@
 FROM golang:1.22 AS build
 
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 ENV GOOS=linux
+RUN useradd -u 10001 connect
 
 WORKDIR /go/src/github.com/redpanda-data/connect/
 # Update dependencies: On unchanged dependencies, cached layer will be reused
 COPY go.* /go/src/github.com/redpanda-data/connect/
 RUN go mod download
 
-RUN apt-get update && apt-get install -y --no-install-recommends libzmq3-dev
-
 # Build
 COPY . /go/src/github.com/redpanda-data/connect/
-
-RUN make TAGS=x_benthos_extra redpanda-connect
+# Tag timetzdata required for busybox base image:
+# https://github.com/benthosdev/benthos/issues/897
+RUN make TAGS="timetzdata" redpanda-connect-cloud
 
 # Pack
-FROM debian:latest
+FROM busybox AS package
 
 LABEL maintainer="Ashley Jeffs <ash.jeffs@redpanda.com>"
 LABEL org.opencontainers.image.source="https://github.com/redpanda-data/connect"
 
-WORKDIR /root/
-
-RUN apt-get update && apt-get install -y --no-install-recommends libzmq3-dev
+WORKDIR /
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /go/src/github.com/redpanda-data/connect/target/bin/redpanda-connect .
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /go/src/github.com/redpanda-data/connect/target/bin/redpanda-connect-cloud ./redpanda-connect
 COPY ./config/docker.yaml /connect.yaml
+
+USER connect
 
 EXPOSE 4195
 
-ENTRYPOINT ["./redpanda-connect"]
+ENTRYPOINT ["/redpanda-connect"]
 
 CMD ["-c", "/connect.yaml"]
+


### PR DESCRIPTION
This PR adds cloud build artefacts to our published docker images. Also fixes an issue where the allowlist for components was too broad and so we couldn't have a `csv` scanner without allowing a `csv` input. The new system executes the allowlist per-component type.