### PR TITLE
Separate cloud build imports into a public package

### DIFF
--- a/cmd/redpanda-connect-cloud/main.go
+++ b/cmd/redpanda-connect-cloud/main.go
@@ -15,40 +15,13 @@
 package main
 
 import (
-	"strings"
-
-	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/cli"
+	"github.com/redpanda-data/connect/v4/public/schema"
 
 	// Only import a subset of components for execution.
-	_ "github.com/redpanda-data/connect/v4/public/components/amqp09"
-	_ "github.com/redpanda-data/connect/v4/public/components/aws"
-	_ "github.com/redpanda-data/connect/v4/public/components/changelog"
-	_ "github.com/redpanda-data/connect/v4/public/components/confluent"
-	_ "github.com/redpanda-data/connect/v4/public/components/crypto"
-	_ "github.com/redpanda-data/connect/v4/public/components/io"
-	_ "github.com/redpanda-data/connect/v4/public/components/kafka"
-	_ "github.com/redpanda-data/connect/v4/public/components/maxmind"
-	_ "github.com/redpanda-data/connect/v4/public/components/memcached"
-	_ "github.com/redpanda-data/connect/v4/public/components/msgpack"
-	_ "github.com/redpanda-data/connect/v4/public/components/nats"
-	_ "github.com/redpanda-data/connect/v4/public/components/opensearch"
-	_ "github.com/redpanda-data/connect/v4/public/components/otlp"
-	_ "github.com/redpanda-data/connect/v4/public/components/prometheus"
-	_ "github.com/redpanda-data/connect/v4/public/components/pure"
-	_ "github.com/redpanda-data/connect/v4/public/components/pure/extended"
-	_ "github.com/redpanda-data/connect/v4/public/components/redis"
-	_ "github.com/redpanda-data/connect/v4/public/components/sftp"
-	_ "github.com/redpanda-data/connect/v4/public/components/sql/base"
-
-	// Import all (supported) sql drivers.
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
-	_ "github.com/sijms/go-ora/v2"
-
-	_ "embed"
+	_ "github.com/redpanda-data/connect/v4/public/components/cloud"
 )
 
 var (
@@ -60,32 +33,7 @@ var (
 	BinaryName string = "redpanda-connect"
 )
 
-//go:embed allow_list.txt
-var allowList string
-
 func main() {
-	var allowSlice []string
-	for _, s := range strings.Split(allowList, "\n") {
-		s = strings.TrimSpace(s)
-		if s == "" || strings.HasPrefix(s, "#") {
-			continue
-		}
-		allowSlice = append(allowSlice, s)
-	}
-
-	// Observability and scanner plugins aren't necessarily present in our
-	// internal lists and so we allow everything that's imported
-	env := service.GlobalEnvironment().
-		WithBuffers(allowSlice...).
-		WithCaches(allowSlice...).
-		WithInputs(allowSlice...).
-		WithOutputs(allowSlice...).
-		WithProcessors(allowSlice...).
-		WithRateLimits(allowSlice...)
-
-	// Allow only pure methods and functions within Bloblang.
-	benv := bloblang.GlobalEnvironment()
-	env.UseBloblangEnvironment(benv.OnlyPure())
-
-	cli.InitEnterpriseCLI(BinaryName, Version, DateBuilt, true, service.CLIOptSetEnvironment(env))
+	schema := schema.Cloud(Version, DateBuilt)
+	cli.InitEnterpriseCLI(BinaryName, Version, DateBuilt, schema, service.CLIOptSetEnvironment(schema.Environment()))
 }

--- a/cmd/redpanda-connect/main.go
+++ b/cmd/redpanda-connect/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"github.com/redpanda-data/connect/v4/internal/cli"
+	"github.com/redpanda-data/connect/v4/public/schema"
 
 	_ "github.com/redpanda-data/connect/v4/public/components/all"
 )
@@ -30,5 +31,5 @@ var (
 )
 
 func main() {
-	cli.InitEnterpriseCLI(BinaryName, Version, DateBuilt, false)
+	cli.InitEnterpriseCLI(BinaryName, Version, DateBuilt, schema.Standard(Version, DateBuilt))
 }

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -20,26 +20,11 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/kafka/enterprise"
 )
 
-func redpandaTopLevelConfigField() *service.ConfigField {
-	return service.NewObjectField("redpanda", enterprise.TopicLoggerFields()...)
-}
-
-// Schema returns the config schema for Redpanda Connect.
-func Schema(removeDefaultInputOutput bool, version, dateBuilt string) *service.ConfigSchema {
-	s := service.NewEnvironment().FullConfigSchema(version, dateBuilt)
-	if removeDefaultInputOutput {
-		s.SetFieldDefault(map[string]any{}, "input")
-		s.SetFieldDefault(map[string]any{}, "output")
-	}
-	s = s.Field(redpandaTopLevelConfigField())
-	return s
-}
-
 // InitEnterpriseCLI kicks off the benthos cli with a suite of options that adds
 // all of the enterprise functionality of Redpanda Connect. This has been
 // abstracted into a separate package so that multiple distributions (classic
 // versus cloud) can reference the same code.
-func InitEnterpriseCLI(binaryName, version, dateBuilt string, removeDefaultInputOutput bool, opts ...service.CLIOptFunc) {
+func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.ConfigSchema, opts ...service.CLIOptFunc) {
 	rpLogger := enterprise.NewTopicLogger(xid.New().String())
 	var fbLogger *service.Logger
 
@@ -65,7 +50,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, removeDefaultInput
 		),
 		service.CLIOptSetDocumentationURL("https://docs.redpanda.com/redpanda-connect"),
 		service.CLIOptSetMainSchemaFrom(func() *service.ConfigSchema {
-			return Schema(removeDefaultInputOutput, version, dateBuilt)
+			return schema
 		}),
 		service.CLIOptOnLoggerInit(func(l *service.Logger) {
 			fbLogger = l

--- a/public/components/cloud/package.go
+++ b/public/components/cloud/package.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloud imports all enterprise and FOSS component implementations that
+// ship with Redpanda Connect in the cloud.
+package cloud
+
+import (
+	// Only import a subset of components for execution.
+	_ "github.com/redpanda-data/connect/v4/public/components/amqp09"
+	_ "github.com/redpanda-data/connect/v4/public/components/aws"
+	_ "github.com/redpanda-data/connect/v4/public/components/changelog"
+	_ "github.com/redpanda-data/connect/v4/public/components/confluent"
+	_ "github.com/redpanda-data/connect/v4/public/components/crypto"
+	_ "github.com/redpanda-data/connect/v4/public/components/io"
+	_ "github.com/redpanda-data/connect/v4/public/components/kafka"
+	_ "github.com/redpanda-data/connect/v4/public/components/maxmind"
+	_ "github.com/redpanda-data/connect/v4/public/components/memcached"
+	_ "github.com/redpanda-data/connect/v4/public/components/msgpack"
+	_ "github.com/redpanda-data/connect/v4/public/components/nats"
+	_ "github.com/redpanda-data/connect/v4/public/components/opensearch"
+	_ "github.com/redpanda-data/connect/v4/public/components/otlp"
+	_ "github.com/redpanda-data/connect/v4/public/components/prometheus"
+	_ "github.com/redpanda-data/connect/v4/public/components/pure"
+	_ "github.com/redpanda-data/connect/v4/public/components/pure/extended"
+	_ "github.com/redpanda-data/connect/v4/public/components/redis"
+	_ "github.com/redpanda-data/connect/v4/public/components/sftp"
+	_ "github.com/redpanda-data/connect/v4/public/components/sql/base"
+
+	// Import all (supported) sql drivers.
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	_ "github.com/sijms/go-ora/v2"
+)

--- a/public/schema/cloud_allow_list.txt
+++ b/public/schema/cloud_allow_list.txt
@@ -80,3 +80,4 @@ reject
 reject_errored
 retry
 switch
+none

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.22 AS build
 
 ENV CGO_ENABLED=0

--- a/resources/docker/Dockerfile.cgo
+++ b/resources/docker/Dockerfile.cgo
@@ -1,3 +1,17 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.22 AS build
 
 ENV CGO_ENABLED=1

--- a/resources/docker/Dockerfile.cloud
+++ b/resources/docker/Dockerfile.cloud
@@ -1,3 +1,11 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
 FROM golang:1.22 AS build
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Moves the cloud schema and component imports to public packages so that other tools can utilise them. Also adds a couple other bits:
- License headers to dockerfiles
- Changed the default service name in logs to `redpanda-connect`