### PR TITLE
qdrant: doc formatting fix

### DIFF
--- a/docs/modules/components/pages/outputs/qdrant.adoc
+++ b/docs/modules/components/pages/outputs/qdrant.adoc
@@ -23,7 +23,7 @@
 component_type_dropdown::[]
 
 
-Adds items to a [Qdrant](https://qdrant.tech/) collection
+Adds items to a https://qdrant.tech/[Qdrant^] collection
 
 Introduced in version 4.33.0.
 

--- a/docs/modules/components/pages/outputs/qdrant.adoc
+++ b/docs/modules/components/pages/outputs/qdrant.adoc
@@ -49,7 +49,7 @@ output:
     api_token: ""
     collection_name: "" # No default (required)
     id: root = "dc88c126-679f-49f5-ab85-04b77e8c2791" # No default (required)
-    vector_mapping: root = [1.2, 0.5, 0.76] # No default (required)
+    vector_mapping: 'root = {"dense_vector": [0.352,0.532,0.754],"sparse_vector": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}, "multi_vector": [[0.352,0.532],[0.352,0.532]]}' # No default (required)
     payload_mapping: root = {}
 ```
 
@@ -81,7 +81,7 @@ output:
       client_certs: []
     collection_name: "" # No default (required)
     id: root = "dc88c126-679f-49f5-ab85-04b77e8c2791" # No default (required)
-    vector_mapping: root = [1.2, 0.5, 0.76] # No default (required)
+    vector_mapping: 'root = {"dense_vector": [0.352,0.532,0.754],"sparse_vector": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}, "multi_vector": [[0.352,0.532],[0.352,0.532]]}' # No default (required)
     payload_mapping: root = {}
 ```
 
@@ -434,6 +434,8 @@ The mapping to extract the vector from the document.
 ```yml
 # Examples
 
+vector_mapping: 'root = {"dense_vector": [0.352,0.532,0.754],"sparse_vector": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}, "multi_vector": [[0.352,0.532],[0.352,0.532]]}'
+
 vector_mapping: root = [1.2, 0.5, 0.76]
 
 vector_mapping: root = this.vector
@@ -444,7 +446,7 @@ vector_mapping: 'root = {"some_sparse": {"indices":[23,325,532],"values":[0.352,
 
 vector_mapping: 'root = {"some_multi": [[0.352,0.532,0.532,0.234],[0.352,0.532,0.532,0.234]]}'
 
-vector_mapping: 'root = {"some_dense": [0.352,0.532,0.532,0.234],"some_sparse": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}}'
+vector_mapping: 'root = {"some_dense": [0.352,0.532,0.532,0.234]}'
 ```
 
 === `payload_mapping`

--- a/internal/impl/qdrant/output.go
+++ b/internal/impl/qdrant/output.go
@@ -38,7 +38,7 @@ func outputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Version("4.33.0").
 		Categories("AI").
-		Summary("Adds items to a [Qdrant](https://qdrant.tech/) collection").
+		Summary("Adds items to a https://qdrant.tech/[Qdrant^] collection").
 		Description(service.OutputPerformanceDocs(true, true)).
 		Fields(
 			service.NewOutputMaxInFlightField(),

--- a/internal/impl/qdrant/output.go
+++ b/internal/impl/qdrant/output.go
@@ -59,12 +59,13 @@ func outputSpec() *service.ConfigSpec {
 				Example(`root = 832`),
 			service.NewBloblangField(qoFieldVectorMapping).
 				Description("The mapping to extract the vector from the document.").
+				Example(`root = {"dense_vector": [0.352,0.532,0.754],"sparse_vector": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}, "multi_vector": [[0.352,0.532],[0.352,0.532]]}`).
 				Example(`root = [1.2, 0.5, 0.76]`).
 				Example(`root = this.vector`).
 				Example(`root = [[0.352,0.532,0.532,0.234],[0.352,0.532,0.532,0.234]]`).
 				Example(`root = {"some_sparse": {"indices":[23,325,532],"values":[0.352,0.532,0.532]}}`).
 				Example(`root = {"some_multi": [[0.352,0.532,0.532,0.234],[0.352,0.532,0.532,0.234]]}`).
-				Example(`root = {"some_dense": [0.352,0.532,0.532,0.234],"some_sparse": {"indices": [23,325,532],"values": [0.352,0.532,0.532]}}`),
+				Example(`root = {"some_dense": [0.352,0.532,0.532,0.234]}`),
 			service.NewBloblangField(qoFieldPayloadMapping).
 				Default(`root = {}`).
 				Description("An optional mapping of message to payload associated with the point.").


### PR DESCRIPTION
- Fixes the hyperlink as per ADOC.
- Adds a more comprehensive example for vector mapping.