### PR TITLE
Fix `schema_registry` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.33.1 - TBD
+
+### Fixed
+
+- The `schema_registry` output now allows pushing schemas if the target Schema Registry instance is in `IMPORT` mode. (@mihaitodor)
+
 ## 4.33.0 - 2024-08-13
 
 ### Added

--- a/internal/impl/kafka/enterprise/integration_test.go
+++ b/internal/impl/kafka/enterprise/integration_test.go
@@ -263,6 +263,9 @@ func TestSchemaRegistryIntegration(t *testing.T) {
 		},
 	}
 
+	sourcePort := startSchemaRegistry(t, pool)
+	sinkPort := startSchemaRegistry(t, pool)
+
 	cleanupSubject := func(port, subject string, hardDelete bool) {
 		u, err := url.Parse(fmt.Sprintf("http://localhost:%s/subjects/%s", port, subject))
 		require.NoError(t, err)
@@ -285,9 +288,6 @@ func TestSchemaRegistryIntegration(t *testing.T) {
 			subject := u4.String()
 			extraSubject := "foobar"
 
-			// TODO: Move these start calls outside of the test loop once we have a way to cleanup subjects which works.
-			sourcePort := startSchemaRegistry(t, pool)
-			sinkPort := startSchemaRegistry(t, pool)
 			t.Cleanup(func() {
 				cleanupSubject(sourcePort, subject, false)
 				cleanupSubject(sourcePort, subject, true)

--- a/internal/impl/kafka/enterprise/schema_registry_output.go
+++ b/internal/impl/kafka/enterprise/schema_registry_output.go
@@ -159,8 +159,8 @@ func (o *output) Connect(ctx context.Context) error {
 		}
 	}
 
-	if payload.Mode != "READWRITE" {
-		return fmt.Errorf("schema registry instance mode must be set to READWRITE instead of %q", payload.Mode)
+	if payload.Mode != "READWRITE" && payload.Mode != "IMPORT" {
+		return fmt.Errorf("schema registry instance mode must be set to READWRITE or IMPORT instead of %q", payload.Mode)
 	}
 
 	o.connected.Store(true)


### PR DESCRIPTION
Allow pushing schemas if the target Schema Registry instance is in `IMPORT` mode.

Also speed up integration tests following some bugfixes in Redpanda which allow us to cleanup schemas properly.