### PR TITLE
Add more ollama processor options

### DIFF
--- a/docs/modules/components/pages/processors/ollama_chat.adoc
+++ b/docs/modules/components/pages/processors/ollama_chat.adoc
@@ -65,7 +65,7 @@ ollama_chat:
   max_tokens: 0 # No default (optional)
   temperature: 0 # No default (optional)
   num_keep: 0 # No default (optional)
-  seed: 0 # No default (optional)
+  seed: 42 # No default (optional)
   top_k: 0 # No default (optional)
   top_p: 0 # No default (optional)
   repeat_penalty: 0 # No default (optional)
@@ -135,7 +135,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `response_format`
 
-The response format of generated type, the model must also be prompted to output the appropriate response type.
+The format of the response that the Ollama model generates. If specifying JSON output, then the `prompt` should specify that the output should be in JSON as well.
 
 
 *Type*: `string`
@@ -149,7 +149,7 @@ Options:
 
 === `max_tokens`
 
-The maximum number of tokens to predict and output.
+The maximum number of tokens to predict and output. Limiting the amount of output means that requests are processed faster and have a fixed limit on the cost.
 
 
 *Type*: `int`
@@ -157,7 +157,7 @@ The maximum number of tokens to predict and output.
 
 === `temperature`
 
-The temperature of the model. Increasing the temperature will make the model answer more creatively.
+The temperature of the model. Increasing the temperature makes the model answer more creatively.
 
 
 *Type*: `int`
@@ -165,7 +165,7 @@ The temperature of the model. Increasing the temperature will make the model ans
 
 === `num_keep`
 
-Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.
+Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to `4`. Use `-1` to retain all tokens from the initial prompt.
 
 
 *Type*: `int`
@@ -179,9 +179,15 @@ Sets the random number seed to use for generation. Setting this to a specific nu
 *Type*: `int`
 
 
+```yml
+# Examples
+
+seed: 42
+```
+
 === `top_k`
 
-Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.
+Reduces the probability of generating nonsense. A higher value, for example `100`, will give more diverse answers. A lower value, for example `10`, will be more conservative.
 
 
 *Type*: `int`
@@ -189,7 +195,7 @@ Reduces the probability of generating nonsense. A higher value (e.g. 100) will g
 
 === `top_p`
 
-Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
+Works together with `top-k`. A higher value, for example 0.95, will lead to more diverse text. A lower value, for example 0.5, will generate more focused and conservative text.
 
 
 *Type*: `float`
@@ -197,7 +203,7 @@ Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse
 
 === `repeat_penalty`
 
-Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.
+Sets how strongly to penalize repetitions. A higher value, for example 1.5, will penalize repetitions more strongly. A lower value, for example 0.9, will be more lenient.
 
 
 *Type*: `float`
@@ -205,7 +211,7 @@ Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penal
 
 === `presence_penalty`
 
-Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+Positive values penalize new tokens if they have appeared in the text so far. This increases the model's likelihood to talk about new topics.
 
 
 *Type*: `float`
@@ -213,7 +219,7 @@ Positive values penalize new tokens based on whether they appear in the text so 
 
 === `frequency_penalty`
 
-Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+Positive values penalize new tokens based on the frequency of their appearance in the text so far. This decreases the model's likelihood to repeat the same line verbatim.
 
 
 *Type*: `float`
@@ -221,7 +227,7 @@ Positive values penalize new tokens based on their existing frequency in the tex
 
 === `stop`
 
-Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.
+Sets the stop sequences to use. When this pattern is encountered the LLM stops generating text and returns the final response.
 
 
 *Type*: `array`
@@ -237,7 +243,7 @@ Options for the model runner that are used when the model is first loaded into m
 
 === `runner.context_size`
 
-Sets the size of the context window used to generate the next token.
+Sets the size of the context window used to generate the next token. Using a larger context window uses more memory and takes longer to processor.
 
 
 *Type*: `int`
@@ -253,7 +259,7 @@ The maximum number of requests to process in parallel.
 
 === `runner.gpu_layers`
 
-This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically.
+This option allows offloading some layers to the GPU for computation. This generally results in increased performance. By default, the runtime decides the number of layers dynamically.
 
 
 *Type*: `int`
@@ -261,7 +267,7 @@ This option allows offloading some layers to the GPU for computation. Generally 
 
 === `runner.threads`
 
-Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads.
+Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default, the runtime decides the optimal number of threads.
 
 
 *Type*: `int`
@@ -269,7 +275,7 @@ Set the number of threads to use during generation. For optimal performance, it 
 
 === `runner.use_mmap`
 
-If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed.
+Map the model into memory. This is only support on unix systems and allows loading only the necessary parts of the model as needed.
 
 
 *Type*: `bool`
@@ -277,7 +283,7 @@ If supported, map the model into memory. This allows the system to load only the
 
 === `runner.use_mlock`
 
-Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
+Lock the model in memory, preventing it from being swapped out when memory-mapped. This option can improve performance but reduces some of the advantages of memory-mapping because it uses more RAM to run and can slow down load times as the model loads into RAM.
 
 
 *Type*: `bool`

--- a/docs/modules/components/pages/processors/ollama_chat.adoc
+++ b/docs/modules/components/pages/processors/ollama_chat.adoc
@@ -38,9 +38,15 @@ Common::
 # Common config fields, showing default values
 label: ""
 ollama_chat:
-  server_address: http://127.0.0.1:11434 # No default (optional)
   model: llama3.1 # No default (required)
   prompt: "" # No default (optional)
+  response_format: text
+  max_tokens: 0 # No default (optional)
+  temperature: 0 # No default (optional)
+  runner:
+    context_size: 0 # No default (optional)
+    batch_size: 0 # No default (optional)
+  server_address: http://127.0.0.1:11434 # No default (optional)
 ```
 
 --
@@ -52,10 +58,28 @@ Advanced::
 # All config fields, showing default values
 label: ""
 ollama_chat:
-  server_address: http://127.0.0.1:11434 # No default (optional)
   model: llama3.1 # No default (required)
   prompt: "" # No default (optional)
   system_prompt: "" # No default (optional)
+  response_format: text
+  max_tokens: 0 # No default (optional)
+  temperature: 0 # No default (optional)
+  num_keep: 0 # No default (optional)
+  seed: 0 # No default (optional)
+  top_k: 0 # No default (optional)
+  top_p: 0 # No default (optional)
+  repeat_penalty: 0 # No default (optional)
+  presence_penalty: 0 # No default (optional)
+  frequency_penalty: 0 # No default (optional)
+  stop: [] # No default (optional)
+  runner:
+    context_size: 0 # No default (optional)
+    batch_size: 0 # No default (optional)
+    gpu_layers: 0 # No default (optional)
+    threads: 0 # No default (optional)
+    use_mmap: false # No default (optional)
+    use_mlock: false # No default (optional)
+  server_address: http://127.0.0.1:11434 # No default (optional)
   cache_directory: /opt/cache/connect/ollama # No default (optional)
   download_url: "" # No default (optional)
 ```
@@ -70,20 +94,6 @@ By default, the processor starts and runs a locally installed Ollama server. Alt
 For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ollama documentation^].
 
 == Fields
-
-=== `server_address`
-
-The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.
-
-
-*Type*: `string`
-
-
-```yml
-# Examples
-
-server_address: http://127.0.0.1:11434
-```
 
 === `model`
 
@@ -122,6 +132,170 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
+
+=== `response_format`
+
+The response format of generated type, the model must also be prompted to output the appropriate response type.
+
+
+*Type*: `string`
+
+*Default*: `"text"`
+
+Options:
+`text`
+, `json`
+.
+
+=== `max_tokens`
+
+The maximum number of tokens to predict and output.
+
+
+*Type*: `int`
+
+
+=== `temperature`
+
+The temperature of the model. Increasing the temperature will make the model answer more creatively.
+
+
+*Type*: `int`
+
+
+=== `num_keep`
+
+Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.
+
+
+*Type*: `int`
+
+
+=== `seed`
+
+Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt.
+
+
+*Type*: `int`
+
+
+=== `top_k`
+
+Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.
+
+
+*Type*: `int`
+
+
+=== `top_p`
+
+Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
+
+
+*Type*: `float`
+
+
+=== `repeat_penalty`
+
+Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.
+
+
+*Type*: `float`
+
+
+=== `presence_penalty`
+
+Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+
+*Type*: `float`
+
+
+=== `frequency_penalty`
+
+Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+
+*Type*: `float`
+
+
+=== `stop`
+
+Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.
+
+
+*Type*: `array`
+
+
+=== `runner`
+
+Options for the model runner that are used when the model is first loaded into memory.
+
+
+*Type*: `object`
+
+
+=== `runner.context_size`
+
+Sets the size of the context window used to generate the next token.
+
+
+*Type*: `int`
+
+
+=== `runner.batch_size`
+
+The maximum number of requests to process in parallel.
+
+
+*Type*: `int`
+
+
+=== `runner.gpu_layers`
+
+This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically.
+
+
+*Type*: `int`
+
+
+=== `runner.threads`
+
+Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads.
+
+
+*Type*: `int`
+
+
+=== `runner.use_mmap`
+
+If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed.
+
+
+*Type*: `bool`
+
+
+=== `runner.use_mlock`
+
+Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
+
+
+*Type*: `bool`
+
+
+=== `server_address`
+
+The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.
+
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+server_address: http://127.0.0.1:11434
+```
 
 === `cache_directory`
 

--- a/docs/modules/components/pages/processors/ollama_embeddings.adoc
+++ b/docs/modules/components/pages/processors/ollama_embeddings.adoc
@@ -40,8 +40,6 @@ label: ""
 ollama_embeddings:
   model: nomic-embed-text # No default (required)
   text: "" # No default (optional)
-  max_tokens: 0 # No default (optional)
-  temperature: 0 # No default (optional)
   runner:
     context_size: 0 # No default (optional)
     batch_size: 0 # No default (optional)
@@ -59,16 +57,6 @@ label: ""
 ollama_embeddings:
   model: nomic-embed-text # No default (required)
   text: "" # No default (optional)
-  max_tokens: 0 # No default (optional)
-  temperature: 0 # No default (optional)
-  num_keep: 0 # No default (optional)
-  seed: 0 # No default (optional)
-  top_k: 0 # No default (optional)
-  top_p: 0 # No default (optional)
-  repeat_penalty: 0 # No default (optional)
-  presence_penalty: 0 # No default (optional)
-  frequency_penalty: 0 # No default (optional)
-  stop: [] # No default (optional)
   runner:
     context_size: 0 # No default (optional)
     batch_size: 0 # No default (optional)
@@ -121,86 +109,6 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 *Type*: `string`
 
 
-=== `max_tokens`
-
-The maximum number of tokens to predict and output.
-
-
-*Type*: `int`
-
-
-=== `temperature`
-
-The temperature of the model. Increasing the temperature will make the model answer more creatively.
-
-
-*Type*: `int`
-
-
-=== `num_keep`
-
-Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.
-
-
-*Type*: `int`
-
-
-=== `seed`
-
-Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt.
-
-
-*Type*: `int`
-
-
-=== `top_k`
-
-Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.
-
-
-*Type*: `int`
-
-
-=== `top_p`
-
-Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
-
-
-*Type*: `float`
-
-
-=== `repeat_penalty`
-
-Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.
-
-
-*Type*: `float`
-
-
-=== `presence_penalty`
-
-Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
-
-
-*Type*: `float`
-
-
-=== `frequency_penalty`
-
-Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
-
-
-*Type*: `float`
-
-
-=== `stop`
-
-Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.
-
-
-*Type*: `array`
-
-
 === `runner`
 
 Options for the model runner that are used when the model is first loaded into memory.
@@ -211,7 +119,7 @@ Options for the model runner that are used when the model is first loaded into m
 
 === `runner.context_size`
 
-Sets the size of the context window used to generate the next token.
+Sets the size of the context window used to generate the next token. Using a larger context window uses more memory and takes longer to processor.
 
 
 *Type*: `int`
@@ -227,7 +135,7 @@ The maximum number of requests to process in parallel.
 
 === `runner.gpu_layers`
 
-This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically.
+This option allows offloading some layers to the GPU for computation. This generally results in increased performance. By default, the runtime decides the number of layers dynamically.
 
 
 *Type*: `int`
@@ -235,7 +143,7 @@ This option allows offloading some layers to the GPU for computation. Generally 
 
 === `runner.threads`
 
-Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads.
+Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default, the runtime decides the optimal number of threads.
 
 
 *Type*: `int`
@@ -243,7 +151,7 @@ Set the number of threads to use during generation. For optimal performance, it 
 
 === `runner.use_mmap`
 
-If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed.
+Map the model into memory. This is only support on unix systems and allows loading only the necessary parts of the model as needed.
 
 
 *Type*: `bool`
@@ -251,7 +159,7 @@ If supported, map the model into memory. This allows the system to load only the
 
 === `runner.use_mlock`
 
-Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
+Lock the model in memory, preventing it from being swapped out when memory-mapped. This option can improve performance but reduces some of the advantages of memory-mapping because it uses more RAM to run and can slow down load times as the model loads into RAM.
 
 
 *Type*: `bool`

--- a/docs/modules/components/pages/processors/ollama_embeddings.adoc
+++ b/docs/modules/components/pages/processors/ollama_embeddings.adoc
@@ -38,9 +38,14 @@ Common::
 # Common config fields, showing default values
 label: ""
 ollama_embeddings:
-  server_address: http://127.0.0.1:11434 # No default (optional)
   model: nomic-embed-text # No default (required)
   text: "" # No default (optional)
+  max_tokens: 0 # No default (optional)
+  temperature: 0 # No default (optional)
+  runner:
+    context_size: 0 # No default (optional)
+    batch_size: 0 # No default (optional)
+  server_address: http://127.0.0.1:11434 # No default (optional)
 ```
 
 --
@@ -52,9 +57,26 @@ Advanced::
 # All config fields, showing default values
 label: ""
 ollama_embeddings:
-  server_address: http://127.0.0.1:11434 # No default (optional)
   model: nomic-embed-text # No default (required)
   text: "" # No default (optional)
+  max_tokens: 0 # No default (optional)
+  temperature: 0 # No default (optional)
+  num_keep: 0 # No default (optional)
+  seed: 0 # No default (optional)
+  top_k: 0 # No default (optional)
+  top_p: 0 # No default (optional)
+  repeat_penalty: 0 # No default (optional)
+  presence_penalty: 0 # No default (optional)
+  frequency_penalty: 0 # No default (optional)
+  stop: [] # No default (optional)
+  runner:
+    context_size: 0 # No default (optional)
+    batch_size: 0 # No default (optional)
+    gpu_layers: 0 # No default (optional)
+    threads: 0 # No default (optional)
+    use_mmap: false # No default (optional)
+    use_mlock: false # No default (optional)
+  server_address: http://127.0.0.1:11434 # No default (optional)
   cache_directory: /opt/cache/connect/ollama # No default (optional)
   download_url: "" # No default (optional)
 ```
@@ -69,20 +91,6 @@ By default, the processor starts and runs a locally installed Ollama server. Alt
 For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ollama documentation^].
 
 == Fields
-
-=== `server_address`
-
-The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.
-
-
-*Type*: `string`
-
-
-```yml
-# Examples
-
-server_address: http://127.0.0.1:11434
-```
 
 === `model`
 
@@ -112,6 +120,156 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
+
+=== `max_tokens`
+
+The maximum number of tokens to predict and output.
+
+
+*Type*: `int`
+
+
+=== `temperature`
+
+The temperature of the model. Increasing the temperature will make the model answer more creatively.
+
+
+*Type*: `int`
+
+
+=== `num_keep`
+
+Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.
+
+
+*Type*: `int`
+
+
+=== `seed`
+
+Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt.
+
+
+*Type*: `int`
+
+
+=== `top_k`
+
+Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.
+
+
+*Type*: `int`
+
+
+=== `top_p`
+
+Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.
+
+
+*Type*: `float`
+
+
+=== `repeat_penalty`
+
+Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.
+
+
+*Type*: `float`
+
+
+=== `presence_penalty`
+
+Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+
+*Type*: `float`
+
+
+=== `frequency_penalty`
+
+Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+
+*Type*: `float`
+
+
+=== `stop`
+
+Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.
+
+
+*Type*: `array`
+
+
+=== `runner`
+
+Options for the model runner that are used when the model is first loaded into memory.
+
+
+*Type*: `object`
+
+
+=== `runner.context_size`
+
+Sets the size of the context window used to generate the next token.
+
+
+*Type*: `int`
+
+
+=== `runner.batch_size`
+
+The maximum number of requests to process in parallel.
+
+
+*Type*: `int`
+
+
+=== `runner.gpu_layers`
+
+This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically.
+
+
+*Type*: `int`
+
+
+=== `runner.threads`
+
+Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads.
+
+
+*Type*: `int`
+
+
+=== `runner.use_mmap`
+
+If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed.
+
+
+*Type*: `bool`
+
+
+=== `runner.use_mlock`
+
+Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
+
+
+*Type*: `bool`
+
+
+=== `server_address`
+
+The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.
+
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+server_address: http://127.0.0.1:11434
+```
 
 === `cache_directory`
 

--- a/internal/impl/ollama/base_processor.go
+++ b/internal/impl/ollama/base_processor.go
@@ -11,6 +11,7 @@ package ollama
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,10 +39,94 @@ const (
 	bopFieldModel          = "model"
 	bopFieldCacheDirectory = "cache_directory"
 	bopFieldDownloadURL    = "download_url"
+	// Prediction options
+	bopFieldMaxTokens        = "max_tokens"
+	bopFieldNumKeep          = "num_keep"
+	bopFieldSeed             = "seed"
+	bopFieldTopK             = "top_k"
+	bopFieldTopP             = "top_p"
+	bopFieldTemp             = "temperature"
+	bopFieldRepeatPenalty    = "repeat_penalty"
+	bopFieldPresencePenalty  = "presence_penalty"
+	bopFieldFrequencyPenalty = "frequency_penalty"
+	bopFieldStop             = "stop"
+
+	bopFieldRunner = "runner"
+	// Runner fields
+	bopFieldContextSize = "context_size"
+	bopFieldBatchSize   = "batch_size"
+	bopFieldGPULayers   = "gpu_layers"
+	bopFieldThreads     = "threads"
+	bopFieldLowVRAM     = "low_vram"
+	bopFieldUseMMap     = "use_mmap"
+	bopFieldUseMLock    = "use_mlock"
 )
 
 func commonFields() []*service.ConfigField {
 	return []*service.ConfigField{
+		service.NewIntField(bopFieldMaxTokens).
+			Optional().
+			Description("The maximum number of tokens to predict and output."),
+		service.NewIntField(bopFieldTemp).
+			Optional().
+			Description("The temperature of the model. Increasing the temperature will make the model answer more creatively."),
+		service.NewIntField(bopFieldNumKeep).
+			Optional().
+			Advanced().
+			Description(`Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.`),
+		service.NewIntField(bopFieldSeed).
+			Optional().
+			Advanced().
+			Description("Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt."),
+		service.NewIntField(bopFieldTopK).
+			Optional().
+			Advanced().
+			Description(`Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.`),
+		service.NewFloatField(bopFieldTopP).
+			Optional().
+			Advanced().
+			Description(`Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.`),
+		service.NewFloatField(bopFieldRepeatPenalty).
+			Optional().
+			Advanced().
+			Description(`Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.`),
+		service.NewFloatField(bopFieldPresencePenalty).
+			Optional().
+			Advanced().
+			Description(`Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.`),
+		service.NewFloatField(bopFieldFrequencyPenalty).
+			Optional().
+			Advanced().
+			Description(`Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.`),
+		service.NewStringListField(bopFieldStop).
+			Optional().
+			Advanced().
+			Description(`Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.`),
+		service.NewObjectField(
+			bopFieldRunner,
+			service.NewIntField(bopFieldContextSize).
+				Optional().
+				Description("Sets the size of the context window used to generate the next token."),
+			service.NewIntField(bopFieldBatchSize).
+				Optional().
+				Description("The maximum number of requests to process in parallel."),
+			service.NewIntField(bopFieldGPULayers).
+				Optional().
+				Advanced().
+				Description("This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically."),
+			service.NewIntField(bopFieldThreads).
+				Optional().
+				Advanced().
+				Description("Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads."),
+			service.NewBoolField(bopFieldUseMMap).
+				Optional().
+				Advanced().
+				Description("If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed."),
+			service.NewBoolField(bopFieldUseMLock).
+				Optional().
+				Advanced().
+				Description("Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM."),
+		).Optional().Description(`Options for the model runner that are used when the model is first loaded into memory.`),
 		service.NewStringField(bopFieldServerAddress).
 			Description("The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.").
 			Example("http://127.0.0.1:11434").
@@ -56,6 +141,133 @@ func commonFields() []*service.ConfigField {
 			Advanced().
 			Optional(),
 	}
+}
+
+func extractOptions(conf *service.ParsedConfig) (map[string]any, error) {
+	opts := api.Options{}
+	if conf.Contains(bopFieldMaxTokens) {
+		v, err := conf.FieldInt(bopFieldMaxTokens)
+		if err != nil {
+			return nil, err
+		}
+		opts.NumPredict = v
+	}
+	if conf.Contains(bopFieldTemp) {
+		v, err := conf.FieldFloat(bopFieldTemp)
+		if err != nil {
+			return nil, err
+		}
+		opts.Temperature = float32(v)
+	}
+	if conf.Contains(bopFieldNumKeep) {
+		v, err := conf.FieldInt(bopFieldNumKeep)
+		if err != nil {
+			return nil, err
+		}
+		opts.NumKeep = v
+	}
+	if conf.Contains(bopFieldSeed) {
+		v, err := conf.FieldInt(bopFieldSeed)
+		if err != nil {
+			return nil, err
+		}
+		opts.Seed = v
+	}
+	if conf.Contains(bopFieldTopK) {
+		v, err := conf.FieldInt(bopFieldTopK)
+		if err != nil {
+			return nil, err
+		}
+		opts.TopK = v
+	}
+	if conf.Contains(bopFieldTopP) {
+		v, err := conf.FieldFloat(bopFieldTopP)
+		if err != nil {
+			return nil, err
+		}
+		opts.TopP = float32(v)
+	}
+	if conf.Contains(bopFieldRepeatPenalty) {
+		v, err := conf.FieldFloat(bopFieldTopP)
+		if err != nil {
+			return nil, err
+		}
+		opts.RepeatPenalty = float32(v)
+	}
+	if conf.Contains(bopFieldFrequencyPenalty) {
+		v, err := conf.FieldFloat(bopFieldFrequencyPenalty)
+		if err != nil {
+			return nil, err
+		}
+		opts.FrequencyPenalty = float32(v)
+	}
+	if conf.Contains(bopFieldPresencePenalty) {
+		v, err := conf.FieldFloat(bopFieldPresencePenalty)
+		if err != nil {
+			return nil, err
+		}
+		opts.PresencePenalty = float32(v)
+	}
+	if conf.Contains(bopFieldStop) {
+		v, err := conf.FieldStringList(bopFieldStop)
+		if err != nil {
+			return nil, err
+		}
+		opts.Stop = v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldContextSize) {
+		v, err := conf.FieldInt(bopFieldStop, bopFieldContextSize)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.NumCtx = v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldBatchSize) {
+		v, err := conf.FieldInt(bopFieldStop, bopFieldBatchSize)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.NumBatch = v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldGPULayers) {
+		v, err := conf.FieldInt(bopFieldStop, bopFieldGPULayers)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.NumGPU = v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldThreads) {
+		v, err := conf.FieldInt(bopFieldStop, bopFieldThreads)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.NumThread = v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldUseMMap) {
+		v, err := conf.FieldBool(bopFieldStop, bopFieldUseMMap)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.UseMMap = &v
+	}
+	if conf.Contains(bopFieldRunner, bopFieldUseMLock) {
+		v, err := conf.FieldBool(bopFieldStop, bopFieldUseMLock)
+		if err != nil {
+			return nil, err
+		}
+		opts.Runner.UseMLock = v
+	}
+	// The API for some reason doesn't use the strongly typed option, but a generic map,
+	// so roundtrip it via JSON so we don't have to manually map the names to their JSON fields.
+	b, err := json.Marshal(&opts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to serialize model options to JSON: %w", err)
+	}
+	serializedOpts := make(map[string]any)
+	if err = json.Unmarshal(b, &serializedOpts); err != nil {
+		return nil, fmt.Errorf("unable to serialize model options to JSON: %w", err)
+	}
+	return serializedOpts, nil
 }
 
 type commandOutput struct {
@@ -211,6 +423,7 @@ var ollamaProcess = singleton.New(singleton.Config[*exec.Cmd]{
 
 type baseOllamaProcessor struct {
 	model  string
+	opts   map[string]any
 	ticket singleton.Ticket
 	client *api.Client
 	logger *service.Logger
@@ -223,6 +436,7 @@ func newBaseProcessor(conf *service.ParsedConfig, mgr *service.Resources) (p *ba
 	if err != nil {
 		return
 	}
+	p.opts, err = extractOptions(conf)
 	if conf.Contains(bopFieldServerAddress) {
 		var a string
 		a, err = conf.FieldString(bopFieldServerAddress)

--- a/internal/impl/ollama/base_processor.go
+++ b/internal/impl/ollama/base_processor.go
@@ -40,6 +40,24 @@ const (
 	bopFieldDownloadURL    = "download_url"
 )
 
+func commonFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewStringField(bopFieldServerAddress).
+			Description("The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.").
+			Example("http://127.0.0.1:11434").
+			Optional(),
+		service.NewStringField(bopFieldCacheDirectory).
+			Description("If `" + bopFieldServerAddress + "` is not set - the directory to download the ollama binary and use as a model cache.").
+			Example("/opt/cache/connect/ollama").
+			Advanced().
+			Optional(),
+		service.NewStringField(bopFieldDownloadURL).
+			Description("If `" + bopFieldServerAddress + "` is not set - the URL to download the ollama binary from. Defaults to the offical Ollama GitHub release for this platform.").
+			Advanced().
+			Optional(),
+	}
+}
+
 type commandOutput struct {
 	logger *service.Logger
 	buffer []byte

--- a/internal/impl/ollama/base_processor.go
+++ b/internal/impl/ollama/base_processor.go
@@ -39,17 +39,6 @@ const (
 	bopFieldModel          = "model"
 	bopFieldCacheDirectory = "cache_directory"
 	bopFieldDownloadURL    = "download_url"
-	// Prediction options
-	bopFieldMaxTokens        = "max_tokens"
-	bopFieldNumKeep          = "num_keep"
-	bopFieldSeed             = "seed"
-	bopFieldTopK             = "top_k"
-	bopFieldTopP             = "top_p"
-	bopFieldTemp             = "temperature"
-	bopFieldRepeatPenalty    = "repeat_penalty"
-	bopFieldPresencePenalty  = "presence_penalty"
-	bopFieldFrequencyPenalty = "frequency_penalty"
-	bopFieldStop             = "stop"
 
 	bopFieldRunner = "runner"
 	// Runner fields
@@ -64,68 +53,30 @@ const (
 
 func commonFields() []*service.ConfigField {
 	return []*service.ConfigField{
-		service.NewIntField(bopFieldMaxTokens).
-			Optional().
-			Description("The maximum number of tokens to predict and output."),
-		service.NewIntField(bopFieldTemp).
-			Optional().
-			Description("The temperature of the model. Increasing the temperature will make the model answer more creatively."),
-		service.NewIntField(bopFieldNumKeep).
-			Optional().
-			Advanced().
-			Description(`Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to 4. Use -1 to retain all tokens from the initial prompt.`),
-		service.NewIntField(bopFieldSeed).
-			Optional().
-			Advanced().
-			Description("Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt."),
-		service.NewIntField(bopFieldTopK).
-			Optional().
-			Advanced().
-			Description(`Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.`),
-		service.NewFloatField(bopFieldTopP).
-			Optional().
-			Advanced().
-			Description(`Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.`),
-		service.NewFloatField(bopFieldRepeatPenalty).
-			Optional().
-			Advanced().
-			Description(`Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.`),
-		service.NewFloatField(bopFieldPresencePenalty).
-			Optional().
-			Advanced().
-			Description(`Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.`),
-		service.NewFloatField(bopFieldFrequencyPenalty).
-			Optional().
-			Advanced().
-			Description(`Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.`),
-		service.NewStringListField(bopFieldStop).
-			Optional().
-			Advanced().
-			Description(`Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return.`),
 		service.NewObjectField(
 			bopFieldRunner,
 			service.NewIntField(bopFieldContextSize).
 				Optional().
-				Description("Sets the size of the context window used to generate the next token."),
+				Description("Sets the size of the context window used to generate the next token. Using a larger context window uses more memory and takes longer to processor."),
 			service.NewIntField(bopFieldBatchSize).
 				Optional().
 				Description("The maximum number of requests to process in parallel."),
 			service.NewIntField(bopFieldGPULayers).
 				Optional().
 				Advanced().
-				Description("This option allows offloading some layers to the GPU for computation. Generally results in increased performance. By default the runtime decides the number of layers dynamically."),
+				Description("This option allows offloading some layers to the GPU for computation. This generally results in increased performance. By default, the runtime decides the number of layers dynamically."),
 			service.NewIntField(bopFieldThreads).
 				Optional().
 				Advanced().
-				Description("Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default the runtime decides the optimal number of threads."),
+				Description("Set the number of threads to use during generation. For optimal performance, it is recommended to set this value to the number of physical CPU cores your system has. By default, the runtime decides the optimal number of threads."),
 			service.NewBoolField(bopFieldUseMMap).
 				Optional().
 				Advanced().
-				Description("If supported, map the model into memory. This allows the system to load only the necessary parts of the model as needed."),
+				Description("Map the model into memory. This is only support on unix systems and allows loading only the necessary parts of the model as needed."),
 			service.NewBoolField(bopFieldUseMLock).
 				Optional().
 				Advanced().
-				Description("Lock the model in memory, preventing it from being swapped out when memory-mapped. This can improve performance but trades away some of the advantages of memory-mapping by requiring more RAM to run and potentially slowing down load times as the model loads into RAM."),
+				Description("Lock the model in memory, preventing it from being swapped out when memory-mapped. This option can improve performance but reduces some of the advantages of memory-mapping because it uses more RAM to run and can slow down load times as the model loads into RAM."),
 		).Optional().Description(`Options for the model runner that are used when the model is first loaded into memory.`),
 		service.NewStringField(bopFieldServerAddress).
 			Description("The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.").
@@ -145,113 +96,113 @@ func commonFields() []*service.ConfigField {
 
 func extractOptions(conf *service.ParsedConfig) (map[string]any, error) {
 	opts := api.Options{}
-	if conf.Contains(bopFieldMaxTokens) {
-		v, err := conf.FieldInt(bopFieldMaxTokens)
+	if conf.Contains(ocpFieldMaxTokens) {
+		v, err := conf.FieldInt(ocpFieldMaxTokens)
 		if err != nil {
 			return nil, err
 		}
 		opts.NumPredict = v
 	}
-	if conf.Contains(bopFieldTemp) {
-		v, err := conf.FieldFloat(bopFieldTemp)
+	if conf.Contains(ocpFieldTemp) {
+		v, err := conf.FieldFloat(ocpFieldTemp)
 		if err != nil {
 			return nil, err
 		}
 		opts.Temperature = float32(v)
 	}
-	if conf.Contains(bopFieldNumKeep) {
-		v, err := conf.FieldInt(bopFieldNumKeep)
+	if conf.Contains(ocpFieldNumKeep) {
+		v, err := conf.FieldInt(ocpFieldNumKeep)
 		if err != nil {
 			return nil, err
 		}
 		opts.NumKeep = v
 	}
-	if conf.Contains(bopFieldSeed) {
-		v, err := conf.FieldInt(bopFieldSeed)
+	if conf.Contains(ocpFieldSeed) {
+		v, err := conf.FieldInt(ocpFieldSeed)
 		if err != nil {
 			return nil, err
 		}
 		opts.Seed = v
 	}
-	if conf.Contains(bopFieldTopK) {
-		v, err := conf.FieldInt(bopFieldTopK)
+	if conf.Contains(ocpFieldTopK) {
+		v, err := conf.FieldInt(ocpFieldTopK)
 		if err != nil {
 			return nil, err
 		}
 		opts.TopK = v
 	}
-	if conf.Contains(bopFieldTopP) {
-		v, err := conf.FieldFloat(bopFieldTopP)
+	if conf.Contains(ocpFieldTopP) {
+		v, err := conf.FieldFloat(ocpFieldTopP)
 		if err != nil {
 			return nil, err
 		}
 		opts.TopP = float32(v)
 	}
-	if conf.Contains(bopFieldRepeatPenalty) {
-		v, err := conf.FieldFloat(bopFieldTopP)
+	if conf.Contains(ocpFieldRepeatPenalty) {
+		v, err := conf.FieldFloat(ocpFieldTopP)
 		if err != nil {
 			return nil, err
 		}
 		opts.RepeatPenalty = float32(v)
 	}
-	if conf.Contains(bopFieldFrequencyPenalty) {
-		v, err := conf.FieldFloat(bopFieldFrequencyPenalty)
+	if conf.Contains(ocpFieldFrequencyPenalty) {
+		v, err := conf.FieldFloat(ocpFieldFrequencyPenalty)
 		if err != nil {
 			return nil, err
 		}
 		opts.FrequencyPenalty = float32(v)
 	}
-	if conf.Contains(bopFieldPresencePenalty) {
-		v, err := conf.FieldFloat(bopFieldPresencePenalty)
+	if conf.Contains(ocpFieldPresencePenalty) {
+		v, err := conf.FieldFloat(ocpFieldPresencePenalty)
 		if err != nil {
 			return nil, err
 		}
 		opts.PresencePenalty = float32(v)
 	}
-	if conf.Contains(bopFieldStop) {
-		v, err := conf.FieldStringList(bopFieldStop)
+	if conf.Contains(ocpFieldStop) {
+		v, err := conf.FieldStringList(ocpFieldStop)
 		if err != nil {
 			return nil, err
 		}
 		opts.Stop = v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldContextSize) {
-		v, err := conf.FieldInt(bopFieldStop, bopFieldContextSize)
+		v, err := conf.FieldInt(ocpFieldStop, bopFieldContextSize)
 		if err != nil {
 			return nil, err
 		}
 		opts.Runner.NumCtx = v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldBatchSize) {
-		v, err := conf.FieldInt(bopFieldStop, bopFieldBatchSize)
+		v, err := conf.FieldInt(ocpFieldStop, bopFieldBatchSize)
 		if err != nil {
 			return nil, err
 		}
 		opts.Runner.NumBatch = v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldGPULayers) {
-		v, err := conf.FieldInt(bopFieldStop, bopFieldGPULayers)
+		v, err := conf.FieldInt(ocpFieldStop, bopFieldGPULayers)
 		if err != nil {
 			return nil, err
 		}
 		opts.Runner.NumGPU = v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldThreads) {
-		v, err := conf.FieldInt(bopFieldStop, bopFieldThreads)
+		v, err := conf.FieldInt(ocpFieldStop, bopFieldThreads)
 		if err != nil {
 			return nil, err
 		}
 		opts.Runner.NumThread = v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldUseMMap) {
-		v, err := conf.FieldBool(bopFieldStop, bopFieldUseMMap)
+		v, err := conf.FieldBool(ocpFieldStop, bopFieldUseMMap)
 		if err != nil {
 			return nil, err
 		}
 		opts.Runner.UseMMap = &v
 	}
 	if conf.Contains(bopFieldRunner, bopFieldUseMLock) {
-		v, err := conf.FieldBool(bopFieldStop, bopFieldUseMLock)
+		v, err := conf.FieldBool(ocpFieldStop, bopFieldUseMLock)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/ollama/chat_processor.go
+++ b/internal/impl/ollama/chat_processor.go
@@ -44,10 +44,6 @@ By default, the processor starts and runs a locally installed Ollama server. Alt
 For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ollama documentation^].`).
 		Version("4.32.0").
 		Fields(
-			service.NewStringField(bopFieldServerAddress).
-				Description("The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.").
-				Example("http://127.0.0.1:11434").
-				Optional(),
 			service.NewStringField(bopFieldModel).
 				Description("The name of the Ollama LLM to use. For a full list of models, see the https://ollama.com/models[Ollama website].").
 				Examples("llama3.1", "gemma2", "qwen2", "phi3"),
@@ -58,16 +54,7 @@ For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ol
 				Description("The system prompt to submit to the Ollama LLM.").
 				Advanced().
 				Optional(),
-			service.NewStringField(bopFieldCacheDirectory).
-				Description("If `"+bopFieldServerAddress+"` is not set - the directory to download the ollama binary and use as a model cache.").
-				Example("/opt/cache/connect/ollama").
-				Advanced().
-				Optional(),
-			service.NewStringField(bopFieldDownloadURL).
-				Description("If `"+bopFieldServerAddress+"` is not set - the URL to download the ollama binary from. Defaults to the offical Ollama GitHub release for this platform.").
-				Advanced().
-				Optional(),
-		)
+		).Fields(commonFields()...)
 }
 
 func makeOllamaCompletionProcessor(conf *service.ParsedConfig, mgr *service.Resources) (service.Processor, error) {

--- a/internal/impl/ollama/chat_processor.go
+++ b/internal/impl/ollama/chat_processor.go
@@ -127,6 +127,7 @@ func (o *ollamaCompletionProcessor) computePrompt(msg *service.Message) (string,
 func (o *ollamaCompletionProcessor) generateCompletion(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
 	var req api.ChatRequest
 	req.Model = o.model
+	req.Options = o.opts
 	if systemPrompt != "" {
 		req.Messages = append(req.Messages, api.Message{
 			Role:    "system",

--- a/internal/impl/ollama/chat_processor.go
+++ b/internal/impl/ollama/chat_processor.go
@@ -75,7 +75,8 @@ For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ol
 				Description("The maximum number of tokens to predict and output. Limiting the amount of output means that requests are processed faster and have a fixed limit on the cost."),
 			service.NewIntField(ocpFieldTemp).
 				Optional().
-				Description("The temperature of the model. Increasing the temperature makes the model answer more creatively."),
+				Description("The temperature of the model. Increasing the temperature makes the model answer more creatively.").
+				LintRule(`root = if this > 2 || this < 0 { [ "field must be between 0.0 and 2.0" ] }`),
 			service.NewIntField(ocpFieldNumKeep).
 				Optional().
 				Advanced().
@@ -92,19 +93,23 @@ For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ol
 			service.NewFloatField(ocpFieldTopP).
 				Optional().
 				Advanced().
-				Description("Works together with `top-k`. A higher value, for example 0.95, will lead to more diverse text. A lower value, for example 0.5, will generate more focused and conservative text."),
+				Description("Works together with `top-k`. A higher value, for example 0.95, will lead to more diverse text. A lower value, for example 0.5, will generate more focused and conservative text.").
+				LintRule(`root = if this > 1 || this < 0 { [ "field must be between 0.0 and 1.0" ] }`),
 			service.NewFloatField(ocpFieldRepeatPenalty).
 				Optional().
 				Advanced().
-				Description(`Sets how strongly to penalize repetitions. A higher value, for example 1.5, will penalize repetitions more strongly. A lower value, for example 0.9, will be more lenient.`),
+				Description(`Sets how strongly to penalize repetitions. A higher value, for example 1.5, will penalize repetitions more strongly. A lower value, for example 0.9, will be more lenient.`).
+				LintRule(`root = if this > 2 || this < -2 { [ "field must be between -2.0 and 2.0" ] }`),
 			service.NewFloatField(ocpFieldPresencePenalty).
 				Optional().
 				Advanced().
-				Description(`Positive values penalize new tokens if they have appeared in the text so far. This increases the model's likelihood to talk about new topics.`),
+				Description(`Positive values penalize new tokens if they have appeared in the text so far. This increases the model's likelihood to talk about new topics.`).
+				LintRule(`root = if this > 2 || this < -2 { [ "field must be between -2.0 and 2.0" ] }`),
 			service.NewFloatField(ocpFieldFrequencyPenalty).
 				Optional().
 				Advanced().
-				Description(`Positive values penalize new tokens based on the frequency of their appearance in the text so far. This decreases the model's likelihood to repeat the same line verbatim.`),
+				Description(`Positive values penalize new tokens based on the frequency of their appearance in the text so far. This decreases the model's likelihood to repeat the same line verbatim.`).
+				LintRule(`root = if this > 2 || this < -2 { [ "field must be between -2.0 and 2.0" ] }`),
 			service.NewStringListField(ocpFieldStop).
 				Optional().
 				Advanced().

--- a/internal/impl/ollama/chat_processor.go
+++ b/internal/impl/ollama/chat_processor.go
@@ -22,6 +22,17 @@ const (
 	ocpFieldUserPrompt     = "prompt"
 	ocpFieldSystemPrompt   = "system_prompt"
 	ocpFieldResponseFormat = "response_format"
+	// Prediction options
+	ocpFieldMaxTokens        = "max_tokens"
+	ocpFieldNumKeep          = "num_keep"
+	ocpFieldSeed             = "seed"
+	ocpFieldTopK             = "top_k"
+	ocpFieldTopP             = "top_p"
+	ocpFieldTemp             = "temperature"
+	ocpFieldRepeatPenalty    = "repeat_penalty"
+	ocpFieldPresencePenalty  = "presence_penalty"
+	ocpFieldFrequencyPenalty = "frequency_penalty"
+	ocpFieldStop             = "stop"
 )
 
 func init() {
@@ -57,8 +68,47 @@ For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ol
 				Advanced().
 				Optional(),
 			service.NewStringEnumField(ocpFieldResponseFormat, "text", "json").
-				Description("The response format of generated type, the model must also be prompted to output the appropriate response type.").
+				Description("The format of the response that the Ollama model generates. If specifying JSON output, then the `"+ocpFieldUserPrompt+"` should specify that the output should be in JSON as well.").
 				Default("text"),
+			service.NewIntField(ocpFieldMaxTokens).
+				Optional().
+				Description("The maximum number of tokens to predict and output. Limiting the amount of output means that requests are processed faster and have a fixed limit on the cost."),
+			service.NewIntField(ocpFieldTemp).
+				Optional().
+				Description("The temperature of the model. Increasing the temperature makes the model answer more creatively."),
+			service.NewIntField(ocpFieldNumKeep).
+				Optional().
+				Advanced().
+				Description("Specify the number of tokens from the initial prompt to retain when the model resets its internal context. By default, this value is set to `4`. Use `-1` to retain all tokens from the initial prompt."),
+			service.NewIntField(ocpFieldSeed).
+				Optional().
+				Advanced().
+				Description("Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt.").
+				Example(42),
+			service.NewIntField(ocpFieldTopK).
+				Optional().
+				Advanced().
+				Description("Reduces the probability of generating nonsense. A higher value, for example `100`, will give more diverse answers. A lower value, for example `10`, will be more conservative."),
+			service.NewFloatField(ocpFieldTopP).
+				Optional().
+				Advanced().
+				Description("Works together with `top-k`. A higher value, for example 0.95, will lead to more diverse text. A lower value, for example 0.5, will generate more focused and conservative text."),
+			service.NewFloatField(ocpFieldRepeatPenalty).
+				Optional().
+				Advanced().
+				Description(`Sets how strongly to penalize repetitions. A higher value, for example 1.5, will penalize repetitions more strongly. A lower value, for example 0.9, will be more lenient.`),
+			service.NewFloatField(ocpFieldPresencePenalty).
+				Optional().
+				Advanced().
+				Description(`Positive values penalize new tokens if they have appeared in the text so far. This increases the model's likelihood to talk about new topics.`),
+			service.NewFloatField(ocpFieldFrequencyPenalty).
+				Optional().
+				Advanced().
+				Description(`Positive values penalize new tokens based on the frequency of their appearance in the text so far. This decreases the model's likelihood to repeat the same line verbatim.`),
+			service.NewStringListField(ocpFieldStop).
+				Optional().
+				Advanced().
+				Description(`Sets the stop sequences to use. When this pattern is encountered the LLM stops generating text and returns the final response.`),
 		).Fields(commonFields()...)
 
 }

--- a/internal/impl/ollama/embeddings_processor.go
+++ b/internal/impl/ollama/embeddings_processor.go
@@ -43,26 +43,13 @@ By default, the processor starts and runs a locally installed Ollama server. Alt
 For more information, see the https://github.com/ollama/ollama/tree/main/docs[Ollama documentation^].`).
 		Version("4.32.0").
 		Fields(
-			service.NewStringField(bopFieldServerAddress).
-				Description("The address of the Ollama server to use. Leave the field blank and the processor starts and runs a local Ollama server or specify the address of your own local or remote server.").
-				Example("http://127.0.0.1:11434").
-				Optional(),
 			service.NewStringField(bopFieldModel).
 				Description("The name of the Ollama LLM to use. For a full list of models, see the https://ollama.com/models[Ollama website].").
 				Examples("nomic-embed-text", "mxbai-embed-large", "snowflake-artic-embed", "all-minilm"),
 			service.NewInterpolatedStringField(oepFieldText).
 				Description("The text you want to create vector embeddings for. By default, the processor submits the entire payload as a string.").
 				Optional(),
-			service.NewStringField(bopFieldCacheDirectory).
-				Description("If `"+bopFieldServerAddress+"` is not set - the directory to download the ollama binary and use as a model cache.").
-				Example("/opt/cache/connect/ollama").
-				Advanced().
-				Optional(),
-			service.NewStringField(bopFieldDownloadURL).
-				Description("If `"+bopFieldServerAddress+"` is not set - the URL to download the ollama binary from. Defaults to the offical Ollama GitHub release for this platform.").
-				Advanced().
-				Optional(),
-		)
+		).Fields(commonFields()...)
 }
 
 func makeOllamaEmbeddingProcessor(conf *service.ParsedConfig, mgr *service.Resources) (service.Processor, error) {

--- a/internal/impl/ollama/embeddings_processor.go
+++ b/internal/impl/ollama/embeddings_processor.go
@@ -111,6 +111,7 @@ func (o *ollamaEmbeddingProcessor) generateEmbedding(ctx context.Context, text s
 	var req api.EmbeddingRequest
 	req.Model = o.model
 	req.Prompt = text
+	req.Options = o.opts
 	resp, err := o.client.Embeddings(ctx, &req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This changeset:
* Extracts common ollama options to a single place
* Adds a huge swath of additional common options that effect the model loading/inference
* Adds JSON format output support to the chat processor
