### PR TITLE
Flush topic logs and add missing cloud components

### DIFF
--- a/public/schema/cloud_allow_list.txt
+++ b/public/schema/cloud_allow_list.txt
@@ -18,8 +18,6 @@ dedupe
 generate
 group_by
 group_by_value
-http
-http_client
 jmespath
 jq
 json_schema

--- a/public/schema/cloud_allow_list.txt
+++ b/public/schema/cloud_allow_list.txt
@@ -69,6 +69,7 @@ catch
 parallel
 processors
 switch
+split
 for_each
 drop
 batched

--- a/public/schema/cloud_allow_list.txt
+++ b/public/schema/cloud_allow_list.txt
@@ -24,6 +24,7 @@ json_schema
 kafka
 kafka_franz
 log
+local
 mapping
 memcached
 memory


### PR DESCRIPTION
This PR adds a ref counter to dispatched log messages so that we can wait for them to flush before shutting down. It's quite crude, especially within the close blocking loop, but it's a lot simpler than adding some form of lock.