### PR TITLE
openai: use interpolated string instead of bloblang for prompt

### DIFF
--- a/docs/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/docs/modules/components/pages/processors/openai_chat_completion.adoc
@@ -162,6 +162,7 @@ model: gpt4-turbo
 === `prompt`
 
 The user prompt you want to generate a response for. By default, the processor submits the entire payload as a string.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`

--- a/internal/impl/openai/chat_processor_test.go
+++ b/internal/impl/openai/chat_processor_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/go-faker/faker/v4"
-	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/service"
 	oai "github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +53,7 @@ func TestChat(t *testing.T) {
 }
 
 func TestChatInterpolationError(t *testing.T) {
-	text, err := bloblang.GlobalEnvironment().Parse(`throw("kaboom!")`)
+	text, err := service.NewInterpolatedString(`${!throw("kaboom!")}`)
 	assert.NoError(t, err)
 	p := chatProcessor{
 		baseProcessor: &baseProcessor{


### PR DESCRIPTION
This is for consistency between all the other AI processors.
