### PR TITLE
plugin upload release workflow - fix dry-run determination

### DIFF
--- a/.github/actions/upload_managed_plugin/action.yml
+++ b/.github/actions/upload_managed_plugin/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: RPK Plugins repo hostname. E.g. rpk-plugins.redpanda.com
     required: true
   dry_run:
-    description: Dry run means skipping writes to S3
+    description: Dry run means skipping writes to S3 ("true" or "false")
     required: true
 
 runs:
@@ -61,7 +61,7 @@ runs:
       working-directory: resources/plugin_uploader
       shell: bash
       run: |
-        DRY_RUN_FLAG=${{ inputs.dry_run && '--dry-run' || '' }}
+        DRY_RUN_FLAG=${{ inputs.dry_run != 'false' && '--dry-run' || '' }}
         ./plugin_uploader.py upload-archives \
           --artifacts-file=${{ inputs.artifacts_file }} \
           --metadata-file=${{ inputs.metadata_file }} \
@@ -77,7 +77,7 @@ runs:
       working-directory: resources/plugin_uploader
       shell: bash
       run: |
-        DRY_RUN_FLAG=${{ inputs.dry_run && '--dry-run' || '' }}
+        DRY_RUN_FLAG=${{ inputs.dry_run != 'false' && '--dry-run' || '' }}
         ./plugin_uploader.py upload-manifest \
           --region=${{ inputs.aws_region }} \
           --bucket=${{ inputs.aws_s3_bucket }} \

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   # Do dry run in most cases, UNLESS the triggering event was a "tag".
-  DRY_RUN: ${{ ! github.ref_type == 'tag' }}
+  DRY_RUN: ${{ github.ref_type != 'tag' }}
 
 jobs:
   upload_rpk_connect_plugin:
@@ -52,14 +52,15 @@ jobs:
           check-latest: true
 
       - name: Build binaries (dry run / snapshot mode)
-        if: ${{ env.DRY_RUN }}
+        if: ${{ env.DRY_RUN != 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
           version: 1.26.2
           args: build --snapshot
 
       - name: Build binaries
-        if: ${{ ! env.DRY_RUN }}
+        # Only one way to not dry run - see 'false'. All other cases, conservatively assume --dry-run
+        if: ${{ env.DRY_RUN == 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
           version: 1.26.2
@@ -79,5 +80,5 @@ jobs:
           goos: linux,darwin
           goarch: amd64,arm64
           repo_hostname: rpk-plugins.redpanda.com
-          dry_run: ${{ env.DRY_RUN }}
+          dry_run: ${{ env.DRY_RUN != 'false' }}
 


### PR DESCRIPTION
Issue was that DRY_RUN always evaluated to true, due to misunderstanding about GHA expressions syntax and how that can be used as env vars under different contexts.  At least this is probably the least bad way to fail.

We fix it all up here.