### PR TITLE
Fix docker images matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,27 +44,26 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flavor: [default, cgo, cloud, ai]
-        platform: ["linux/amd64", "linux/arm64"]
-        exclude:
-        - flavor: cgo
-          platform: linux/arm64
         include:
           - flavor: default
             latest: auto
             suffix: ""
+            platform: linux/amd64,linux/arm64
             file: ./resources/docker/Dockerfile
           - flavor: cgo
             latest: false
             suffix: -cgo
+            platform: linux/amd64
             file: ./resources/docker/Dockerfile.cgo
           - flavor: cloud
             latest: false
             suffix: -cloud
+            platform: linux/amd64,linux/arm64
             file: ./resources/docker/Dockerfile.cloud
           - flavor: ai
             latest: false
             suffix: -ai
+            platform: linux/amd64,linux/arm64
             file: ./resources/docker/Dockerfile.ai
     permissions:
       id-token: write


### PR DESCRIPTION
For buildx to work we need the combined arch linux/amd64,linux/arm64 in order to create a combined image, otherwise one will be overriden by the other.

I've also removed the matrix variables as we basically just have an explicit include list for everything anyway.