### PR TITLE
openai: use BloblangQuery instead of BloblangQueryValue

### DIFF
--- a/internal/impl/openai/embeddings_processor.go
+++ b/internal/impl/openai/embeddings_processor.go
@@ -96,11 +96,15 @@ func (p *embeddingsProcessor) Process(ctx context.Context, msg *service.Message)
 		body.Dimensions = *p.dimensions
 	}
 	if p.text != nil {
-		s, err := msg.BloblangQueryValue(p.text)
+		s, err := msg.BloblangQuery(p.text)
 		if err != nil {
 			return nil, fmt.Errorf("%s execution error: %w", oepFieldTextMapping, err)
 		}
-		body.Input = append(body.Input, bloblang.ValueToString(s))
+		r, err := s.AsBytes()
+		if err != nil {
+			return nil, fmt.Errorf("%s extraction error: %w", oepFieldTextMapping, err)
+		}
+		body.Input = append(body.Input, string(r))
 	} else {
 		b, err := msg.AsBytes()
 		if err != nil {

--- a/internal/impl/openai/image_processor.go
+++ b/internal/impl/openai/image_processor.go
@@ -124,12 +124,15 @@ func (p *moderationProcessor) Process(ctx context.Context, msg *service.Message)
 	body.Model = p.model
 	body.ResponseFormat = "b64_json"
 	if p.input != nil {
-		v, err := msg.BloblangQueryValue(p.input)
+		v, err := msg.BloblangQuery(p.input)
 		if err != nil {
 			return nil, fmt.Errorf("%s execution error: %w", oipFieldPrompt, err)
 		}
-		s := bloblang.ValueToString(v)
-		body.Prompt = s
+		r, err := v.AsBytes()
+		if err != nil {
+			return nil, fmt.Errorf("%s conversion error: %w", oipFieldPrompt, err)
+		}
+		body.Prompt = string(r)
 	} else {
 		b, err := msg.AsBytes()
 		if err != nil {

--- a/internal/impl/openai/speech_processor.go
+++ b/internal/impl/openai/speech_processor.go
@@ -108,11 +108,15 @@ func (p *speechProcessor) Process(ctx context.Context, msg *service.Message) (se
 	}
 	body.Voice = oai.SpeechVoice(v)
 	if p.input != nil {
-		v, err := msg.BloblangQueryValue(p.input)
+		m, err := msg.BloblangQuery(p.input)
 		if err != nil {
 			return nil, fmt.Errorf("%s execution error: %w", ospFieldInput, err)
 		}
-		body.Input = bloblang.ValueToString(v)
+		v, err := m.AsBytes()
+		if err != nil {
+			return nil, fmt.Errorf("%s conversion error: %w", ospFieldInput, err)
+		}
+		body.Input = string(v)
 	} else {
 		b, err := msg.AsBytes()
 		if err != nil {

--- a/internal/impl/openai/transcription_processor.go
+++ b/internal/impl/openai/transcription_processor.go
@@ -101,13 +101,13 @@ type transcriptionProcessor struct {
 func (p *transcriptionProcessor) Process(ctx context.Context, msg *service.Message) (service.MessageBatch, error) {
 	var body oai.AudioRequest
 	body.Model = p.model
-	f, err := msg.BloblangQueryValue(p.file)
+	m, err := msg.BloblangQuery(p.file)
 	if err != nil {
 		return nil, fmt.Errorf("%s execution error: %w", otspFieldFile, err)
 	}
-	b, err := bloblang.ValueAsBytes(f)
+	b, err := m.AsBytes()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s conversion error: %w", otspFieldFile, err)
 	}
 	body.Reader = bytes.NewReader(b)
 	if p.lang != nil {

--- a/internal/impl/openai/translation_processor.go
+++ b/internal/impl/openai/translation_processor.go
@@ -92,11 +92,11 @@ func (p *translationProcessor) Process(ctx context.Context, msg *service.Message
 	var body oai.AudioRequest
 	body.Model = p.model
 	if p.file != nil {
-		f, err := msg.BloblangQueryValue(p.file)
+		m, err := msg.BloblangQuery(p.file)
 		if err != nil {
 			return nil, fmt.Errorf("%s execution error: %w", otlpFieldFile, err)
 		}
-		b, err := bloblang.ValueAsBytes(f)
+		b, err := m.AsBytes()
 		if err != nil {
 			return nil, fmt.Errorf("%s conversion error: %w", otlpFieldFile, err)
 		}


### PR DESCRIPTION
Looking at QueryValue I'm quite confused what it's for - it doesn't bind
any variables, so stuff like `this.text` fails with `context was undefined,
unable to reference "text"`.

So switch to normal Query and extract the result using AsBytes
