### PR TITLE
Release Linux packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,26 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
 
     - name: Check Out Repo
       uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+        role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+    - name: Get secrets from AWS Secrets Manager
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          ,sdlc/prod/github/cloudsmith_api_key
+        parse-json-secrets: true
 
     - name: Free up some disk space on ubuntu
       if: ${{ runner.os == 'Linux' }}
@@ -32,6 +48,13 @@ jobs:
     - name: Release Notes
       run: ./resources/scripts/release_notes.sh > ./release_notes.md
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install cloudsmith CLI (for publishing Linux packages)
+      run: pip install cloudsmith-cli
+
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
@@ -39,6 +62,7 @@ jobs:
         args: release --release-notes=./release_notes.md --timeout 120m
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
 
   docker:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,3 +94,32 @@ release:
     name: connect
   prerelease: auto
   disable: false
+
+nfpms:
+  - id: connect-linux-pkgs
+    description: Redpanda Connect is a high performance and resilient stream processor.
+    package_name: redpanda-connect
+    file_name_template: "{{ .ConventionalFileName }}"
+    # this is the default value, but specifying explicitly it relates to the symlink creation below
+    bindir: /usr/bin
+    contents:
+      - src: /usr/bin/redpanda-connect
+        dst: /usr/bin/.rpk-ac.connect
+        type: symlink
+    builds:
+      - connect
+    vendor: Redpanda Data, Inc.
+    license: "https://github.com/redpanda-data/connect/blob/main/licenses/README.md"
+    homepage: redpanda.com
+    maintainer: Redpanda Data <support@redpanda.com>
+    formats:
+      - deb
+      - rpm
+publishers:
+  # Gets run once per artifact (deb or rpm)
+  - name: Publish Linux packages to Cloudsmith
+    ids:
+      - connect-linux-pkgs
+    cmd: ./resources/scripts/push_pkg_to_cloudsmith.sh {{ .ArtifactPath }}
+    env:
+      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}

--- a/resources/scripts/push_pkg_to_cloudsmith.sh
+++ b/resources/scripts/push_pkg_to_cloudsmith.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Push a rpm or deb to Cloudsmith
+
+set -ex
+
+PKG_FILE=$1
+
+if [[ "$PKG_FILE" == "" ]]; then
+    echo "Usage: $0 <pkg_file>"
+    exit 1
+fi
+
+if [[ "$CLOUDSMITH_API_KEY" == "" ]]; then
+    echo "CLOUDSMITH_API_KEY is not set"
+    exit 1
+fi
+
+if [[ "$PKG_FILE" == *.rpm ]]; then
+    PKG_TYPE="rpm"
+elif [[ "$PKG_FILE" == *.deb ]]; then
+    PKG_TYPE="deb"
+else
+    echo "Unknown package type"
+    exit 1
+fi
+
+cloudsmith push "$PKG_TYPE" redpanda/redpanda/any-distro/any-version "$PKG_FILE" --republish


### PR DESCRIPTION
Publishing `connect` via deb/rpm packages is part of the new `rpk connect` distribution strategy.  More context [here](https://docs.google.com/document/d/1ubeclJ9mwF5q2E0HzwOkRLOx2o5X8Ghnmm_kWQfnCSg/edit#heading=h.mvlqwsjv79vf).

This PR adds said Linux packaging.  Packages will be created and published to Redpanda's production Linux package repo on Cloudsmith.

Solution is modeled off [`redpanda-console`](https://github.com/redpanda-data/console-enterprise/blob/fd1e0d089f4b1969224494ec275f219cd338b222/.goreleaser.yml#L52), which also publishes packages easily via goreleaser's [nfpm](https://goreleaser.com/customization/nfpm/) integration.

This PR must merge after `CLOUDSMITH_API_KEY` access has been granted.  This means after [this PR](https://github.com/redpanda-data/qa-infra/pull/116) gets merged and TF applied.