### PR TITLE
Revert "remove unused MacOS quill signing logic"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,16 @@ builds:
     goos: [ windows, darwin, linux, freebsd, openbsd ]
     goarch: [ amd64, arm64 ]
     # goarm: [ 6, 7 ]
+    hooks:
+      post:
+        # The binary is signed and notarized when running a production release, but for snapshot builds notarization is
+        # skipped and only ad-hoc signing is performed (not cryptographic material is needed).
+        #
+        # note: environment variables required for signing and notarization (set in CI) but are not needed for snapshot builds
+        #    QUILL_SIGN_P12, QUILL_SIGN_PASSWORD, QUILL_NOTARY_KEY, QUILL_NOTARY_KEY_ID, QUILL_NOTARY_ISSUER
+        - cmd: ./resources/scripts/sign_for_darwin.sh "{{ .Os }}" "{{ .Path }}" "{{ .IsSnapshot }}"
+          env:
+            - QUILL_LOG_FILE=target/dist/quill-{{ .Target }}.log
     ignore:
       - goos: windows
         goarch: arm

--- a/resources/scripts/sign_for_darwin.sh
+++ b/resources/scripts/sign_for_darwin.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eux
+
+_OS=$1
+_PATH_TO_SIGN=$2
+_IS_SNAPSHOT=$3
+
+check_cmd() {
+	command -v "$1" > /dev/null 2>&1
+}
+
+if [ "$_OS" = "darwin" ]; then
+  if check_cmd "quill"; then
+    quill sign-and-notarize "$_PATH_TO_SIGN" --dry-run="$_IS_SNAPSHOT" --ad-hoc="$_IS_SNAPSHOT" -vv
+  else
+    echo "Aborted, missing quill"
+  fi
+else
+  echo "No need to sign binaries for ${_OS}"
+fi


### PR DESCRIPTION
This reverts commit 9fcaf6b3c20ff7f48f3c177b6ff93c02df6509a6. (PR https://github.com/redpanda-data/connect/pull/2837)

I was mistaken - this IS used. We can only remove this code once the `rpk connect` distribution redo is fully complete.

