### PR TITLE
release: re-enable arm ai images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           - flavor: ai
             latest: false
             suffix: -ai
-            platform: linux/amd64
+            platform: linux/amd64,linux/arm64
             file: ./resources/docker/Dockerfile.ai
     permissions:
       id-token: write


### PR DESCRIPTION
We were once only downloading the x86_64 version of ollama, but now we
use the correct platform, so we can build both.
