### PR TITLE
github release perms - need contents:write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
 
     - name: Check Out Repo


### PR DESCRIPTION
The error: https://github.com/redpanda-data/connect/actions/runs/10852887553/job/30119936254#step:10:109 

The fix: https://github.com/orgs/community/discussions/30927