### PR TITLE
`kafka_migrator` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - New experimental `cohere_chat` and `cohere_embeddings` processors. (@rockwotj)
 - New experimental `questdb` output. (@sklarsa)
 - Field `metadata_max_age` added to the `kafka_franz` input. (@Scarjit)
+- Field `metadata_max_age` added to the `kafka_migrator` input. (@mihaitodor)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 - New experimental `questdb` output. (@sklarsa)
 - Field `metadata_max_age` added to the `kafka_franz` input. (@Scarjit)
 
+### Fixed
+
+- Fixed a bug with the `input_resource` field for the `kafka_migrator` output where new topics weren't created as expected. (@mihaitodor)
+- Fixed a bug in the `kafka_migrator` input which could lead to extra duplicate messages during a consumer group rebalance. (@mihaitodor)
+
 ## 4.36.0 - 2024-09-11
 
 ### Added

--- a/docs/modules/components/pages/inputs/kafka_migrator.adoc
+++ b/docs/modules/components/pages/inputs/kafka_migrator.adoc
@@ -85,6 +85,7 @@ input:
     output_resource: kafka_migrator_output
     replication_factor_override: true
     replication_factor: 3
+    metadata_max_age: 5m
 ```
 
 --
@@ -742,5 +743,14 @@ Replication factor for created topics. This is only used when `replication_facto
 *Type*: `int`
 
 *Default*: `3`
+
+=== `metadata_max_age`
+
+The maximum age of metadata before it is refreshed.
+
+
+*Type*: `string`
+
+*Default*: `"5m"`
 
 

--- a/internal/impl/kafka/enterprise/kafka_migrator_input.go
+++ b/internal/impl/kafka/enterprise/kafka_migrator_input.go
@@ -569,9 +569,6 @@ func (r *KafkaMigratorReader) ReadBatch(ctx context.Context) (service.MessageBat
 		resBatch = append(resBatch, r.recordToMessage(rec))
 	})
 
-	// TODO: Does this need to happen after the call to `MarkCommitRecords()`?
-	r.client.AllowRebalance()
-
 	return resBatch, func(ctx context.Context, res error) error {
 		r.readMut.Lock()
 		defer r.readMut.Unlock()
@@ -585,6 +582,7 @@ func (r *KafkaMigratorReader) ReadBatch(ctx context.Context) (service.MessageBat
 		}
 
 		r.client.MarkCommitRecords(fetches.Records()...)
+		r.client.AllowRebalance()
 
 		return nil
 	}, nil

--- a/internal/impl/kafka/enterprise/kafka_migrator_input.go
+++ b/internal/impl/kafka/enterprise/kafka_migrator_input.go
@@ -319,6 +319,12 @@ func NewKafkaMigratorReaderFromConfig(conf *service.ParsedConfig, mgr *service.R
 		return nil, err
 	}
 
+	if label := mgr.Label(); label != "" {
+		mgr.SetGeneric(mgr.Label(), &r)
+	} else {
+		mgr.SetGeneric(rpriDefaultLabel, &r)
+	}
+
 	return &r, nil
 }
 
@@ -536,7 +542,7 @@ func (r *KafkaMigratorReader) ReadBatch(ctx context.Context) (service.MessageBat
 		if res, ok := r.mgr.GetGeneric(r.outputResource); ok {
 			output = res.(*KafkaMigratorWriter)
 		} else {
-			r.mgr.Logger().Debugf("Writer for topic sink %q not found", r.outputResource)
+			r.mgr.Logger().Debugf("Writer for topic destination %q not found", r.outputResource)
 		}
 
 		if output != nil {


### PR DESCRIPTION
- Fixed a bug with the `input_resource` field for the `kafka_migrator` output where new topics weren't created as expected. 
- Fixed a bug in the `kafka_migrator` input which could lead to extra duplicate messages during a consumer group rebalance.