### PR TITLE
kafka_franz: Add option to change metadata.max.age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - New experimental `aws_bedrock_embeddings` processor. (@rockwotj)
 - New experimental `cohere_chat` and `cohere_embeddings` processors. (@rockwotj)
 - New experimental `questdb` output. (@sklarsa)
+- Field `metadata_max_age` added to the `kafka_franz` input. (@Scarjit)
 
 ## 4.36.0 - 2024-09-11
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -75,13 +75,13 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     multi_header: false
-    metadata_max_age: 5m
     batching:
       count: 0
       byte_size: 0
       period: ""
       check: ""
       processors: [] # No default (optional)
+    metadata_max_age: 5m
 ```
 
 --
@@ -593,15 +593,6 @@ Decode headers into lists to allow handling of multiple values with the same key
 
 *Default*: `false`
 
-=== `metadata_max_age`
-
-The maximum age of metadata before it is refreshed. This can help reduce the number of requests made to the broker or speed up the detection of new topics.
-
-
-*Type*: `string`
-
-*Default*: `5m`
-
 === `batching`
 
 Allows you to configure a xref:configuration:batching.adoc[batching policy] that applies to individual topic partitions in order to batch messages together before flushing them for processing. Batching can be beneficial for performance as well as useful for windowed processing, and doing so this way preserves the ordering of topic partitions.
@@ -703,5 +694,14 @@ processors:
   - archive:
       format: json_array
 ```
+
+=== `metadata_max_age`
+
+The maximum age of metadata before it is refreshed.
+
+
+*Type*: `string`
+
+*Default*: `"5m"`
 
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -75,6 +75,7 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     multi_header: false
+    metadata_max_age: 5m
     batching:
       count: 0
       byte_size: 0
@@ -591,6 +592,15 @@ Decode headers into lists to allow handling of multiple values with the same key
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `metadata_max_age`
+
+The maximum age of metadata before it is refreshed. This can help reduce the number of requests made to the broker or speed up the detection of new topics.
+
+
+*Type*: `string`
+
+*Default*: `5m`
 
 === `batching`
 

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -90,6 +90,7 @@ input:
         period: ""
         check: ""
         processors: [] # No default (optional)
+      metadata_max_age: 5m
       seed_brokers: [] # No default (optional)
     disable_content_encryption: false
     enrollment_ticket: "" # No default (optional)
@@ -700,6 +701,15 @@ processors:
   - archive:
       format: json_array
 ```
+
+=== `kafka.metadata_max_age`
+
+The maximum age of metadata before it is refreshed.
+
+
+*Type*: `string`
+
+*Default*: `"5m"`
 
 === `kafka.seed_brokers`
 

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -90,7 +90,6 @@ input:
         period: ""
         check: ""
         processors: [] # No default (optional)
-      metadata_max_age: 5m
       seed_brokers: [] # No default (optional)
     disable_content_encryption: false
     enrollment_ticket: "" # No default (optional)
@@ -701,15 +700,6 @@ processors:
   - archive:
       format: json_array
 ```
-
-=== `kafka.metadata_max_age`
-
-The maximum age of metadata before it is refreshed.
-
-
-*Type*: `string`
-
-*Default*: `"5m"`
 
 === `kafka.seed_brokers`
 


### PR DESCRIPTION
Fixes #2879 by introducing an optional field `metadata_max_age` with a default of 5 minutes.

See also https://redpandacommunity.slack.com/archives/C074ZF002HW/p1726663349522859