### PR TITLE
Add possibility to encrypt only specific fields in ockam kafka plugins

### DIFF
--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -52,6 +52,7 @@ input:
     allow_producer: self
     relay: "" # No default (optional)
     node_address: 127.0.0.1:6262
+    encrypted_fields: []
 ```
 
 --
@@ -99,6 +100,7 @@ input:
     allow_producer: self
     relay: "" # No default (optional)
     node_address: 127.0.0.1:6262
+    encrypted_fields: []
 ```
 
 --
@@ -791,5 +793,14 @@ Sorry! This field is missing documentation.
 *Type*: `string`
 
 *Default*: `"127.0.0.1:6262"`
+
+=== `encrypted_fields`
+
+The fields to encrypt in the kafka messages, assuming the record is a valid JSON map. By default, the whole record is encrypted.
+
+
+*Type*: `array`
+
+*Default*: `[]`
 
 

--- a/docs/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/outputs/ockam_kafka.adoc
@@ -59,6 +59,7 @@ output:
     route_to_kafka_outlet: self
     allow_consumer: self
     route_to_consumer: /ip4/127.0.0.1/tcp/6262
+    encrypted_fields: []
 ```
 
 --
@@ -110,6 +111,7 @@ output:
     route_to_kafka_outlet: self
     allow_consumer: self
     route_to_consumer: /ip4/127.0.0.1/tcp/6262
+    encrypted_fields: []
 ```
 
 --
@@ -877,5 +879,14 @@ Sorry! This field is missing documentation.
 *Type*: `string`
 
 *Default*: `"/ip4/127.0.0.1/tcp/6262"`
+
+=== `encrypted_fields`
+
+The fields to encrypt in the kafka messages, assuming the record is a valid JSON map. By default, the whole record is encrypted.
+
+
+*Type*: `array`
+
+*Default*: `[]`
 
 

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -58,7 +58,10 @@ func ockamKafkaInputConfig() *service.ConfigSpec {
 		Field(service.NewStringField("route_to_kafka_outlet").Default("self")).
 		Field(service.NewStringField("allow_producer").Default("self")).
 		Field(service.NewStringField("relay").Optional()).
-		Field(service.NewStringField("node_address").Default("127.0.0.1:6262"))
+		Field(service.NewStringField("node_address").Default("127.0.0.1:6262")).
+		Field(service.NewStringListField("encrypted_fields").
+			Description("The fields to encrypt in the kafka messages, assuming the record is a valid JSON map. By default, the whole record is encrypted.").
+			Default([]string{}))
 }
 
 //------------------------------------------------------------------------------
@@ -143,7 +146,13 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 		return nil, err
 	}
 
-	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, "self", allowOutlet, allowProducer, "", disableContentEncryption)
+	var encryptedFields []string
+	encryptedFields, err = conf.FieldStringList("encrypted_fields")
+	if err != nil {
+		return nil, err
+	}
+
+	err = n.createKafkaInlet("redpanda-connect-kafka-inlet", kafkaInletAddress, routeToKafkaOutlet, true, "self", allowOutlet, allowProducer, "", disableContentEncryption, encryptedFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -77,7 +77,7 @@ func (n *node) delete() error {
 }
 
 // TODO: improve this function's interface
-func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string, disableContentEncryption bool) error {
+func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string, disableContentEncryption bool, encryptedFields []string) error {
 	args := []string{"kafka-inlet", "create", "--addr", name, "--at", n.name, "--from", from, "--to", to}
 	if routeToConsumer != "" {
 		args = append(args, "--consumer", routeToConsumer)
@@ -89,6 +89,11 @@ func (n *node) createKafkaInlet(name string, from string, to string, avoidPublis
 
 	if disableContentEncryption {
 		args = append(args, "--disable-content-encryption")
+	}
+
+	for _, encryptedField := range encryptedFields {
+		args = append(args, "--encrypted-field")
+		args = append(args, encryptedField)
 	}
 
 	args = appendAllowArgs(args, "--allow", allowOutlet, n.identifier)


### PR DESCRIPTION
Ockam supports the `encrypted-field` parameter to encrypt only specific fields. In this PR, the parameter is exposed directly in Redpanda Connect.