### PR TITLE
Fix Redpanda Migrator versions

### DIFF
--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -25,7 +25,7 @@ component_type_dropdown::[]
 
 A Redpanda Migrator input using the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
-Introduced in version 4.35.0.
+Introduced in version 4.37.0.
 
 
 [tabs]

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -25,7 +25,7 @@ component_type_dropdown::[]
 
 A Redpanda Migrator output using the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
-Introduced in version 4.35.0.
+Introduced in version 4.37.0.
 
 
 [tabs]

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -25,7 +25,7 @@ component_type_dropdown::[]
 
 Redpanda Migrator consumer group offsets output using the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
-Introduced in version 4.35.0.
+Introduced in version 4.37.0.
 
 
 [tabs]

--- a/internal/impl/kafka/enterprise/redpanda_migrator_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_input.go
@@ -38,7 +38,7 @@ func redpandaMigratorInputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
-		Version("4.35.0").
+		Version("4.37.0").
 		Summary(`A Redpanda Migrator input using the https://github.com/twmb/franz-go[Franz Kafka client library^].`).
 		Description(`
 Reads a batch of messages from a Kafka broker and waits for the output to acknowledge the writes before updating the Kafka consumer group offset.

--- a/internal/impl/kafka/enterprise/redpanda_migrator_offsets_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_offsets_output.go
@@ -34,7 +34,7 @@ func redpandaMigratorOffsetsOutputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
-		Version("4.35.0").
+		Version("4.37.0").
 		Summary("Redpanda Migrator consumer group offsets output using the https://github.com/twmb/franz-go[Franz Kafka client library^].").
 		// TODO
 		Description("This output can be used in combination with the `kafka_franz` input that is configured to read the `__consumer_offsets` topic.").

--- a/internal/impl/kafka/enterprise/redpanda_migrator_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_output.go
@@ -35,7 +35,7 @@ func redpandaMigratorOutputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
-		Version("4.35.0").
+		Version("4.37.0").
 		Summary("A Redpanda Migrator output using the https://github.com/twmb/franz-go[Franz Kafka client library^].").
 		Description(`
 Writes a batch of messages to a Kafka broker and waits for acknowledgement before propagating it back to the input.

--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -190,11 +190,11 @@ redis_script              ,processor ,Redis Script              ,4.11.0  ,certif
 redis_streams             ,input     ,Redis Streams             ,0.0.0   ,certified  ,n          ,y     ,y
 redis_streams             ,output    ,Redis Streams             ,0.0.0   ,certified  ,n          ,y     ,y
 redpanda_data_transform   ,processor ,redpanda_data_transform   ,4.31.0  ,certified  ,n          ,n     ,n
-redpanda_migrator         ,input     ,redpanda_migrator         ,4.38.0  ,enterprise ,n          ,y     ,y
-redpanda_migrator         ,output    ,redpanda_migrator         ,4.38.0  ,enterprise ,n          ,y     ,y
-redpanda_migrator_bundle  ,input     ,redpanda_migrator_bundle  ,4.38.0  ,enterprise ,n          ,y     ,y
-redpanda_migrator_bundle  ,output    ,redpanda_migrator_bundle  ,4.38.0  ,enterprise ,n          ,y     ,y
-redpanda_migrator_offsets ,output    ,redpanda_migrator_offsets ,4.38.0  ,enterprise ,n          ,y     ,y
+redpanda_migrator         ,input     ,redpanda_migrator         ,4.37.0  ,enterprise ,n          ,y     ,y
+redpanda_migrator         ,output    ,redpanda_migrator         ,4.37.0  ,enterprise ,n          ,y     ,y
+redpanda_migrator_bundle  ,input     ,redpanda_migrator_bundle  ,4.37.0  ,enterprise ,n          ,y     ,y
+redpanda_migrator_bundle  ,output    ,redpanda_migrator_bundle  ,4.37.0  ,enterprise ,n          ,y     ,y
+redpanda_migrator_offsets ,output    ,redpanda_migrator_offsets ,4.37.0  ,enterprise ,n          ,y     ,y
 reject                    ,output    ,reject                    ,0.0.0   ,certified  ,n          ,y     ,y
 reject_errored            ,output    ,reject_errored            ,0.0.0   ,certified  ,n          ,y     ,y
 resource                  ,input     ,resource                  ,0.0.0   ,certified  ,n          ,y     ,y


### PR DESCRIPTION
Oops, the next release should be v4.37.0.