### PR TITLE
feat: added nkey field to nats

### DIFF
--- a/docs/modules/components/pages/caches/nats_kv.adoc
+++ b/docs/modules/components/pages/caches/nats_kv.adoc
@@ -62,6 +62,7 @@ nats_kv:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
+    nkey: ""
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -92,7 +93,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -325,6 +326,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/caches/nats_kv.adoc
+++ b/docs/modules/components/pages/caches/nats_kv.adoc
@@ -62,7 +62,7 @@ nats_kv:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
-    nkey: ""
+    nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -339,7 +339,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats.adoc
+++ b/docs/modules/components/pages/inputs/nats.adoc
@@ -70,6 +70,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -113,7 +114,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -401,6 +402,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats.adoc
+++ b/docs/modules/components/pages/inputs/nats.adoc
@@ -70,7 +70,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -415,7 +415,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/inputs/nats_jetstream.adoc
@@ -76,7 +76,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -462,7 +462,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/inputs/nats_jetstream.adoc
@@ -76,6 +76,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -128,7 +129,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -448,6 +449,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_kv.adoc
+++ b/docs/modules/components/pages/inputs/nats_kv.adoc
@@ -71,6 +71,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -114,7 +115,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -404,6 +405,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_kv.adoc
+++ b/docs/modules/components/pages/inputs/nats_kv.adoc
@@ -71,7 +71,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -418,7 +418,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_stream.adoc
+++ b/docs/modules/components/pages/inputs/nats_stream.adoc
@@ -75,7 +75,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -430,7 +430,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/inputs/nats_stream.adoc
+++ b/docs/modules/components/pages/inputs/nats_stream.adoc
@@ -75,6 +75,7 @@ input:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -117,7 +118,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -416,6 +417,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats.adoc
+++ b/docs/modules/components/pages/outputs/nats.adoc
@@ -72,7 +72,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -430,7 +430,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats.adoc
+++ b/docs/modules/components/pages/outputs/nats.adoc
@@ -72,6 +72,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -105,7 +106,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -416,6 +417,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/outputs/nats_jetstream.adoc
@@ -74,6 +74,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -105,7 +106,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -421,6 +422,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/outputs/nats_jetstream.adoc
@@ -74,7 +74,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -435,7 +435,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_kv.adoc
+++ b/docs/modules/components/pages/outputs/nats_kv.adoc
@@ -68,7 +68,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -377,7 +377,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_kv.adoc
+++ b/docs/modules/components/pages/outputs/nats_kv.adoc
@@ -68,6 +68,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -102,7 +103,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -363,6 +364,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_stream.adoc
+++ b/docs/modules/components/pages/outputs/nats_stream.adoc
@@ -68,7 +68,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
-      nkey: ""
+      nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -368,7 +368,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/outputs/nats_stream.adoc
+++ b/docs/modules/components/pages/outputs/nats_stream.adoc
@@ -68,6 +68,7 @@ output:
       client_certs: []
     auth:
       nkey_file: ./seed.nk # No default (optional)
+      nkey: ""
       user_credentials_file: ./user.creds # No default (optional)
       user_jwt: "" # No default (optional)
       user_nkey_seed: "" # No default (optional)
@@ -97,7 +98,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -354,6 +355,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/processors/nats_kv.adoc
+++ b/docs/modules/components/pages/processors/nats_kv.adoc
@@ -68,7 +68,7 @@ nats_kv:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
-    nkey: ""
+    nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -457,7 +457,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/processors/nats_kv.adoc
+++ b/docs/modules/components/pages/processors/nats_kv.adoc
@@ -68,6 +68,7 @@ nats_kv:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
+    nkey: ""
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -129,7 +130,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -443,6 +444,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/processors/nats_request_reply.adoc
+++ b/docs/modules/components/pages/processors/nats_request_reply.adoc
@@ -73,7 +73,7 @@ nats_request_reply:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
-    nkey: ""
+    nkey: '!!!SECRET_SCRUBBED!!!' # No default (optional)
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -462,7 +462,12 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
+
+```yml
+# Examples
+
+nkey: UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4
+```
 
 === `auth.user_credentials_file`
 

--- a/docs/modules/components/pages/processors/nats_request_reply.adoc
+++ b/docs/modules/components/pages/processors/nats_request_reply.adoc
@@ -73,6 +73,7 @@ nats_request_reply:
     client_certs: []
   auth:
     nkey_file: ./seed.nk # No default (optional)
+    nkey: ""
     user_credentials_file: ./user.creds # No default (optional)
     user_jwt: "" # No default (optional)
     user_nkey_seed: "" # No default (optional)
@@ -119,7 +120,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the `nkey_file` field.
+configured in the `nkey_file` or `nkey` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -448,6 +449,20 @@ An optional file containing a NKey seed.
 
 nkey_file: ./seed.nk
 ```
+
+=== `auth.nkey`
+
+The NKey seed.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auth.user_credentials_file`
 

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -71,9 +71,9 @@ func authFieldSpec() *service.ConfigField {
 			Optional(),
 		service.NewStringField("nkey").
 			Description("The NKey seed.").
-			Default("").
 			Secret().
-			Optional(),
+			Optional().
+			Example("UDXU4RCSJNZOIQHZNWXHXORDPRTGNJAHAHFRGZNEEJCPQTT2M7NLCNF4"), // don't worry, this sample seed is from Nats offical doc
 		service.NewStringField("user_credentials_file").
 			Description("An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.").
 			Example("./user.creds").
@@ -286,8 +286,7 @@ func saveTempNkeyFile(content string) (string, error) {
 	}
 	defer file.Close()
 
-	_, err = file.WriteString(content)
-	if err != nil {
+	if _, err = file.WriteString(content); err != nil {
 		return "", err
 	}
 

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -271,15 +271,15 @@ func loadFileContents(filename string, fs *service.FS) ([]byte, error) {
 func nkeyOptionFromString(nkey string) (nats.Option, error) {
 	kp, err := nkeys.ParseDecoratedNKey([]byte(nkey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse nkey")
+		return nil, errors.New("failed to parse nkey")
 	}
 
 	pub, err := kp.PublicKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract public key from nkey")
+		return nil, errors.New("failed to extract public key from nkey")
 	}
 	if !nkeys.IsValidPublicUserKey(pub) {
-		return nil, fmt.Errorf("invalid nkey user seed")
+		return nil, errors.New("invalid nkey user seed")
 	}
 
 	sigCB := func(nonce []byte) ([]byte, error) {

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -286,5 +286,5 @@ func nkeyOptionFromString(nkey string) (nats.Option, error) {
 		return kp.Sign(nonce)
 	}
 
-	return nats.Nkey(string(pub), sigCB), nil
+	return nats.Nkey(pub, sigCB), nil
 }

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -283,8 +283,7 @@ func nkeyOptionFromString(nkey string) (nats.Option, error) {
 	}
 
 	sigCB := func(nonce []byte) ([]byte, error) {
-		sig, _ := kp.Sign(nonce)
-		return sig, nil
+		return kp.Sign(nonce)
 	}
 
 	return nats.Nkey(string(pub), sigCB), nil

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -44,7 +44,7 @@ See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-de
 
 The NATS server can use these NKeys in several ways for authentication. The simplest is for the server to be configured
 with a list of known public keys and for the clients to respond to the challenge by signing it with its private NKey
-configured in the ` + "`nkey_file`" + ` field.
+configured in the ` + "`nkey_file`" + ` or ` + "`nkey`" + ` field.
 
 https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth[More details^].
 
@@ -69,6 +69,11 @@ func authFieldSpec() *service.ConfigField {
 			Description("An optional file containing a NKey seed.").
 			Example("./seed.nk").
 			Optional(),
+		service.NewStringField("nkey").
+			Description("The NKey seed.").
+			Default("").
+			Secret().
+			Optional(),
 		service.NewStringField("user_credentials_file").
 			Description("An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.").
 			Example("./user.creds").
@@ -87,6 +92,7 @@ func authFieldSpec() *service.ConfigField {
 
 type authConfig struct {
 	NKeyFile            string
+	NKey                string
 	UserCredentialsFile string
 	UserJWT             string
 	UserNkeySeed        string
@@ -101,6 +107,19 @@ func authConfToOptions(auth authConfig, fs *service.FS) []nats.Option {
 			opts = append(opts, func(*nats.Options) error { return err })
 		} else {
 			opts = append(opts, opt)
+		}
+	}
+
+	// in case a nkey file content is provided, save to a tmp file and load it
+	if auth.NKey != "" {
+		if file, err := saveTempNkeyFile(auth.NKey); err != nil {
+			opts = append(opts, func(*nats.Options) error { return err })
+		} else {
+			if opt, err := nats.NkeyOptionFromSeed(file); err != nil {
+				opts = append(opts, func(*nats.Options) error { return err })
+			} else {
+				opts = append(opts, opt)
+			}
 		}
 	}
 
@@ -129,6 +148,11 @@ func authConfToOptions(auth authConfig, fs *service.FS) []nats.Option {
 func AuthFromParsedConfig(p *service.ParsedConfig) (c authConfig, err error) {
 	if p.Contains("nkey_file") {
 		if c.NKeyFile, err = p.FieldString("nkey_file"); err != nil {
+			return
+		}
+	}
+	if p.Contains("nkey") {
+		if c.NKey, err = p.FieldString("nkey"); err != nil {
 			return
 		}
 	}
@@ -247,4 +271,25 @@ func loadFileContents(filename string, fs *service.FS) ([]byte, error) {
 	defer f.Close()
 
 	return io.ReadAll(f)
+}
+
+func saveTempNkeyFile(content string) (string, error) {
+	dir, err := os.MkdirTemp("", "nats")
+	if err != nil {
+		return "", err
+	}
+	nkeyFile := filepath.Join(dir, "nkeys")
+
+	file, err := os.Create(nkeyFile)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		return "", err
+	}
+
+	return nkeyFile, nil
 }


### PR DESCRIPTION
Currently in order to use nkey authentication, the user has to provide a local file that contains the nkey seed. This is OK if the user has full access of the deployment environment of redpanda-connect.
However, for managed redpanda-connect environment, the user doesn't have directly control of the file system. Thus, we'd like to introduce a new secret field called `nkey` to allow the user to specify the nkey seed directly in the config yaml.