### PR TITLE
fix(elasticsearch): retry on http 429

### DIFF
--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -356,7 +356,10 @@ func (e *Output) Connect(ctx context.Context) error {
 }
 
 func shouldRetry(s int) bool {
-	if s >= 500 && s <= 599 {
+	// Retry if the status code is 429 (Too Many Requests) or any 5xx server error.
+	// HTTP 429 indicates the elasticsearch cluster is rate-limiting the client and expects the client to backoff
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html#multiple-workers-threads
+	if s == 429 || (s >= 500 && s <= 599) {
 		return true
 	}
 	return false


### PR DESCRIPTION
### PR Description
This PR modifies the `shouldRetry` function to include HTTP status code `429 (Too Many Requests)` for retry logic. Retrying on 429 ensures that the client properly backs off when Elasticsearch rate-limits due to high request volume, as recommended by the Elasticsearch documentation.

### Changes:

- Added HTTP 429 to the `shouldRetry` function alongside 5xx errors.

### Related issues:

- https://github.com/redpanda-data/connect/issues/2673