### PR TITLE
[azure-blob-storage] Make `container` interpolated

### DIFF
--- a/docs/modules/components/pages/inputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/inputs/azure_blob_storage.adoc
@@ -150,6 +150,7 @@ The storage account SAS token. This field is ignored if `storage_connection_stri
 === `container`
 
 The name of the container from which to download blobs.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -49,11 +49,7 @@ func bsoConfigFromParsed(pConf *service.ParsedConfig) (conf bsoConfig, err error
 		return
 	}
 	var containerSASToken bool
-	c, err := conf.Container.TryString(service.NewMessage([]byte("")))
-	if err != nil {
-		return
-	}
-	if conf.client, containerSASToken, err = blobStorageClientFromParsed(pConf, c); err != nil {
+	if conf.client, containerSASToken, err = blobStorageClientFromParsed(pConf, conf.Container); err != nil {
 		return
 	}
 	if containerSASToken {


### PR DESCRIPTION
Support interpolation on `azure_blob_storage` input `container` parameter.

Example:

```yaml
input:
  azure_blob_storage:
    storage_connection_string: UseDevelopmentStorage=true;
    container: container-${! now().ts_format("2006") }
```

Fix output `container` parameter interpolation. It now interpolates correctly from message contents not only from bloblang functions.

Example:

```yaml
output:
  azure_blob_storage:
    storage_connection_string: UseDevelopmentStorage=true;
    container: container-${! this.event_timestamp.ts_format("2006") }
```