### PR TITLE
feat: new configuration parameters for input: kafka_franz

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -123,11 +123,11 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 		service.NewDurationField("heartbeat_period").
 			Description("HeartbeatInterval sets how long a group member goes between heartbeats to Kafka. Kafka uses heartbeats to ensure that a group member's session stays active. This value can be any value lower than the session timeout, but should be no higher than 1/3rd the session timeout.").
 			Default("3s").
-			Advanced(),		
+			Advanced(),
 		service.NewDurationField("rebalance_timeout").
 			Description("Sets how long group members are allowed to take when a rebalance has begun. This timeout is how long all members are allowed to complete work and commit offsets, minus the time it took to detect the rebalance (from a heartbeat).").
 			Default("60s").
-			Advanced(),		
+			Advanced(),
 		service.NewBoolField("start_from_oldest").
 			Description("Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.").
 			Default(true).
@@ -168,24 +168,24 @@ type batchWithAckFn struct {
 
 // FranzKafkaReader implements a kafka reader using the franz-go library.
 type FranzKafkaReader struct {
-	SeedBrokers       []string
-	topics            []string
-	topicPartitions   map[string]map[int32]kgo.Offset
-	clientID          string
-	rackID            string
-	consumerGroup     string
-	TLSConf           *tls.Config
-	saslConfs         []sasl.Mechanism
-	checkpointLimit   int
-	startFromOldest   bool
-	commitPeriod      time.Duration
-	heartbeatPeriod   time.Duration
-	sessionTimeout    time.Duration
-	rebalanceTimeout  time.Duration
-	regexPattern      bool
-	multiHeader       bool
-	batchPolicy       service.BatchPolicy
-	metadataMaxAge    time.Duration
+	SeedBrokers      []string
+	topics           []string
+	topicPartitions  map[string]map[int32]kgo.Offset
+	clientID         string
+	rackID           string
+	consumerGroup    string
+	TLSConf          *tls.Config
+	saslConfs        []sasl.Mechanism
+	checkpointLimit  int
+	startFromOldest  bool
+	commitPeriod     time.Duration
+	heartbeatPeriod  time.Duration
+	sessionTimeout   time.Duration
+	rebalanceTimeout time.Duration
+	regexPattern     bool
+	multiHeader      bool
+	batchPolicy      service.BatchPolicy
+	metadataMaxAge   time.Duration
 
 	batchChan atomic.Value
 	res       *service.Resources
@@ -282,7 +282,7 @@ func NewFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 
 	if f.rebalanceTimeout, err = conf.FieldDuration("rebalance_timeout"); err != nil {
 		return nil, err
-	}	
+	}
 
 	if f.batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
 		return nil, err
@@ -696,7 +696,7 @@ func (f *FranzKafkaReader) Connect(ctx context.Context) error {
 			kgo.AutoCommitInterval(f.commitPeriod),
 			kgo.SessionTimeout(f.sessionTimeout),
 			kgo.HeartbeatInterval(f.heartbeatPeriod),
-			kgo.RebalanceTimeout(f.rebalanceTimeout),	    
+			kgo.RebalanceTimeout(f.rebalanceTimeout),
 			kgo.WithLogger(&KGoLogger{f.log}),
 		)
 	}

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -121,7 +121,7 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Default("45s").
 			Advanced(),
 		service.NewDurationField("heartbeat_period").
-			Description("HeartbeatInterval sets how long a group member goes between heartbeats to Kafka. Kafka uses heartbeats to ensure that a group member's session stays active. This value can be any value lower than the session timeout, but should be no higher than 1/3rd the session timeout.").
+			Description("Sets how long a group member goes between heartbeats to Kafka. Kafka uses heartbeats to ensure that a group member's session stays active. This value can be any value lower than the session timeout, but should be no higher than 1/3rd the session timeout.").
 			Default("3s").
 			Advanced(),
 		service.NewDurationField("rebalance_timeout").


### PR DESCRIPTION
This PR enables the following configuration parameters to be used for the input kafka_franz:

**session_timeout**: "Sets how long a member in the group can go between heartbeats. If a member does not heartbeat in this timeout, the broker will remove the member from the group and initiate a rebalance." 
defaults to 45 secs

**heartbeat_period** "Sets how long a group member goes between heartbeats to Kafka. Kafka uses heartbeats to ensure that a group member's session stays active. This value can be any value lower than the session timeout, but should be no higher than 1/3rd the session timeout." 
defaults to 3 secs

**rebalance_timeout** "Sets how long group members are allowed to take when a rebalance has begun. This timeout is how long all members are allowed to complete work and commit offsets, minus the time it took to detect the rebalance (from a heartbeat)."
defaults to 60 secs

Default values are based on frank-go defaults:
https://github.com/twmb/franz-go/blob/b77dd13e2bfaee7f5181df27b40ee4a4f6a73b09/pkg/kgo/config.go#L1448
https://github.com/twmb/franz-go/blob/b77dd13e2bfaee7f5181df27b40ee4a4f6a73b09/pkg/kgo/config.go#L1467
https://github.com/twmb/franz-go/blob/b77dd13e2bfaee7f5181df27b40ee4a4f6a73b09/pkg/kgo/config.go#L1481

Supporting these parameters helps to support workloads where processing 1 single message might take longer than 1 or 2 minutes, as longer session timeouts with longer heartbeat intervals helps to avoid or reduce rebalances.


