### PR TITLE
feat: add Azure Data Lake Gen2 Output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.0.3
 	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.2.0
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0
 	github.com/Azure/go-amqp v1.0.5
 	github.com/ClickHouse/clickhouse-go/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xP
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0/go.mod h1:oDrbWx4ewMylP7xHivfgixbfGBT6APAwsSoHRKotnIc=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0 h1:Be6KInmFEKV81c0pOAEbRYehLMwmmGI1exuFj248AMk=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0/go.mod h1:WCPBHsOXfBVnivScjs2ypRfimjEW0qPVLGgJkZlrIOA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1 h1:cf+OIKbkmMHBaC3u78AXomweqM0oxQSgBXRZf3WH4yM=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1/go.mod h1:ap1dmS6vQKJxSMNiGJcq4QuUQkOynyD93gLw6MDF7ek=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.1 h1:qhYAuEKEz8jDGV1Tyf3Gz44ppGZP53xJGi4qdH2PLsc=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake v1.2.1/go.mod h1:8QbU31D+n+SDJDstJXJWnOBKAgv8ZTz/x7su5KQ31Kk=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0 h1:lJwNFV+xYjHREUTHJKx/ZF6CJSt9znxmLw9DqSTvyRU=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0/go.mod h1:GfT0aGew8Qj5yiQVqOO5v7N8fanbJGyUoHqXg56qcVY=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=

--- a/internal/impl/azure/auth.go
+++ b/internal/impl/azure/auth.go
@@ -17,6 +17,8 @@ package azure
 import (
 	"errors"
 	"fmt"
+	"log"
+	"net/url"
 	"os"
 	"strings"
 
@@ -25,6 +27,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake"
+	dlservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
 )
 
@@ -80,8 +84,90 @@ func blobStorageClientFromParsed(pConf *service.ParsedConfig, container *service
 	return getBlobStorageClient(connectionString, storageAccount, storageAccessKey, storageSASToken, container)
 }
 
+func adlsClientFromParsed(pConf *service.ParsedConfig, fsName *service.InterpolatedString) (*dlservice.Client, bool, error) {
+	connectionString, err := pConf.FieldString(bscFieldStorageConnectionString)
+	if err != nil {
+		return nil, false, err
+	}
+	storageAccount, err := pConf.FieldString(bscFieldStorageAccount)
+	if err != nil {
+		return nil, false, err
+	}
+	storageAccessKey, err := pConf.FieldString(bscFieldStorageAccessKey)
+	if err != nil {
+		return nil, false, err
+	}
+	storageSASToken, err := pConf.FieldString(bscFieldStorageSASToken)
+	if err != nil {
+		return nil, false, err
+	}
+	if storageAccount == "" && connectionString == "" {
+		return nil, false, errors.New("invalid azure storage account credentials")
+	}
+	return getADLSClient(connectionString, storageAccount, storageAccessKey, storageSASToken, fsName)
+}
+
+func getADLSClient(storageConnectionString, storageAccount, storageAccessKey, storageSASToken string, fsName *service.InterpolatedString) (*dlservice.Client, bool, error) {
+	if storageConnectionString != "" {
+		storageConnectionString := parseStorageConnectionString(storageConnectionString, storageAccount)
+		client, err := dlservice.NewClientFromConnectionString(storageConnectionString, nil)
+		if err != nil {
+			return nil, false, fmt.Errorf("creating new ADLS file client from connection string: %w", err)
+		}
+		return client, false, nil
+	}
+
+	serviceURL := fmt.Sprintf(dfsEndpointExpr, storageAccount)
+
+	if storageAccessKey != "" {
+		cred, err := azdatalake.NewSharedKeyCredential(storageAccount, storageAccessKey)
+		if err != nil {
+			return nil, false, fmt.Errorf("creating new shared key credential: %w", err)
+		}
+		client, err := dlservice.NewClientWithSharedKeyCredential(serviceURL, cred, nil)
+		if err != nil {
+			return nil, false, fmt.Errorf("creating new client from shared key credential: %w", err)
+		}
+		return client, false, nil
+	}
+
+	if storageSASToken != "" {
+		var isFilesystemSASToken bool
+		if isServiceSASToken(storageSASToken) {
+			// container/filesystem scoped SAS token
+			isFilesystemSASToken = true
+			fsNameStr, err := fsName.TryString(service.NewMessage([]byte("")))
+			if err != nil {
+				return nil, false, fmt.Errorf("interpolating filesystem name: %w", err)
+			}
+			serviceURL = fmt.Sprintf("%s/%s?%s", serviceURL, fsNameStr, storageSASToken)
+		} else {
+			// storage account SAS token
+			serviceURL = fmt.Sprintf("%s?%s", serviceURL, storageSASToken)
+			log.Println("serviceURL:", serviceURL)
+		}
+		client, err := dlservice.NewClientWithNoCredential(serviceURL, nil)
+		if err != nil {
+			return nil, false, fmt.Errorf("creating client with no credentials: %w", err)
+		}
+		return client, isFilesystemSASToken, nil
+	}
+
+	// default credentials
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("getting default Azure credentials: %w", err)
+	}
+	client, err := dlservice.NewClient(serviceURL, cred, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("creating client from default credentials: %w", err)
+	}
+	return client, false, err
+}
+
 const (
 	blobEndpointExp = "https://%s.blob.core.windows.net"
+	dfsEndpointExpr = "https://%s.dfs.core.windows.net"
 )
 
 func getBlobStorageClient(storageConnectionString, storageAccount, storageAccessKey, storageSASToken string, container *service.InterpolatedString) (*azblob.Client, bool, error) {
@@ -289,4 +375,15 @@ func getTablesServiceClient(account, accessKey, connectionString, storageSASToke
 		client, err = aztables.NewServiceClient(serviceURL, cred, nil)
 	}
 	return client, err
+}
+
+func isServiceSASToken(token string) bool {
+	query, err := url.ParseQuery(token)
+	if err != nil {
+		return false
+	}
+	// 2024-10-09: `sr` parameter is present and required in service SAS tokens,
+	// and is not valid in storage account SAS tokens
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#specify-the-signed-resource-blob-storage-only
+	return query.Has("sr")
 }

--- a/internal/impl/azure/output_adls.go
+++ b/internal/impl/azure/output_adls.go
@@ -1,0 +1,158 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	dlservice "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+const (
+	// Azure Data Lake Storage Output Fields
+	adlsFieldFilesystem = "filesystem"
+	adlsFieldPath       = "path"
+)
+
+type adlsConfig struct {
+	client     *dlservice.Client
+	path       *service.InterpolatedString
+	filesystem *service.InterpolatedString
+}
+
+func init() {
+	err := service.RegisterOutput("azure_data_lake_gen2", adlsSpec(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (out service.Output, mif int, err error) {
+			var pConf *adlsConfig
+			if pConf, err = adlsConfigFromParsed(conf); err != nil {
+				return
+			}
+			if mif, err = conf.FieldMaxInFlight(); err != nil {
+				return
+			}
+			if out, err = newAzureADLSWriter(pConf, mgr.Logger()); err != nil {
+				return
+			}
+			return
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func adlsConfigFromParsed(pConf *service.ParsedConfig) (*adlsConfig, error) {
+	var conf adlsConfig
+	var err error
+	conf.filesystem, err = pConf.FieldInterpolatedString(adlsFieldFilesystem)
+	if err != nil {
+		return nil, err
+	}
+	conf.path, err = pConf.FieldInterpolatedString(adlsFieldPath)
+	if err != nil {
+		return nil, err
+	}
+	var isFilesystemSASToken bool
+	conf.client, isFilesystemSASToken, err = adlsClientFromParsed(pConf, conf.filesystem)
+	if err != nil {
+		return nil, err
+	}
+	if isFilesystemSASToken {
+		conf.filesystem, _ = service.NewInterpolatedString("")
+	}
+	return &conf, nil
+}
+
+func newAzureADLSWriter(conf *adlsConfig, log *service.Logger) (*azureADLSWriter, error) {
+	return &azureADLSWriter{
+		conf: conf,
+		log:  log,
+	}, nil
+}
+
+type azureADLSWriter struct {
+	conf *adlsConfig
+	log  *service.Logger
+}
+
+func (a *azureADLSWriter) Connect(ctx context.Context) error {
+	return nil
+}
+
+func (a *azureADLSWriter) Write(ctx context.Context, msg *service.Message) error {
+	fsName, err := a.conf.filesystem.TryString(msg)
+	if err != nil {
+		return fmt.Errorf("interpolating filesystem name: %w", err)
+	}
+	path, err := a.conf.path.TryString(msg)
+	if err != nil {
+		return fmt.Errorf("interpolating file path: %w", err)
+	}
+	mBytes, err := msg.AsBytes()
+	if err != nil {
+		return fmt.Errorf("reading message body: %w", err)
+	}
+
+	fileClient := a.conf.client.NewFileSystemClient(fsName).NewFileClient(path)
+	_, err = fileClient.Create(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+	err = fileClient.UploadBuffer(ctx, mBytes, nil)
+	if err != nil {
+		return fmt.Errorf("uploading message body: %w", err)
+	}
+	return nil
+}
+
+func (a *azureADLSWriter) Close(ctx context.Context) error {
+	return nil
+}
+
+func adlsSpec() *service.ConfigSpec {
+	return azureComponentSpec(true).
+		Beta().
+		Version("4.37.0").
+		Summary(`Sends message parts as files to an Azure Data Lake Gen2 filesystem. Each file is uploaded with the filename specified with the `+"`"+adlsFieldPath+"`"+` field.`).
+		Description(`
+In order to have a different path for each file you should use function
+interpolations described xref:configuration:interpolation.adoc#bloblang-queries[here], which are
+calculated per message of a batch.
+
+Supports multiple authentication methods but only one of the following is required:
+
+- `+"`storage_connection_string`"+`
+- `+"`storage_account` and `storage_access_key`"+`
+- `+"`storage_account` and `storage_sas_token`"+`
+- `+"`storage_account` to access via https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DefaultAzureCredential[DefaultAzureCredential^]"+`
+
+If multiple are set then the `+"`storage_connection_string`"+` is given priority.
+
+If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+` parameter, please specify it in the
+`+"`storage_account`"+` field.`+service.OutputPerformanceDocs(true, false)).
+		Fields(
+			service.NewInterpolatedStringField(adlsFieldFilesystem).
+				Description("The ADLS filesystem name for uploading the messages to.").
+				Example(`messages-${!timestamp("2006")}`),
+			service.NewInterpolatedStringField(adlsFieldPath).
+				Description("The path of each message to upload within the filesystem.").
+				Example(`${!count("files")}-${!timestamp_unix_nano()}.json`).
+				Example(`${!meta("kafka_key")}.json`).
+				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
+				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
+			service.NewOutputMaxInFlightField(),
+		)
+}

--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -28,6 +28,7 @@ azure_blob_storage        ,output    ,azure_blob_storage        ,3.36.0  ,certif
 azure_cosmosdb            ,input     ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
 azure_cosmosdb            ,output    ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
 azure_cosmosdb            ,processor ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
+azure_data_lake_gen2      ,output    ,azure_data_lake_gen2      ,4.37.0  ,certified  ,n          ,n     ,n
 azure_queue_storage       ,input     ,azure_queue_storage       ,3.42.0  ,certified  ,n          ,y     ,y
 azure_queue_storage       ,output    ,azure_queue_storage       ,3.36.0  ,certified  ,n          ,y     ,y
 azure_table_storage       ,input     ,azure_table_storage       ,4.10.0  ,certified  ,n          ,y     ,y


### PR DESCRIPTION
This PR adds an output plugin for [Azure's Data Lake Storage Gen2](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction).

## Notes
- Unfortunately at the time of this change, [Azurite does not yet support the Data Lake Gen2 APIs](https://github.com/Azure/Azurite/issues/553), so we can't use the integration test pattern that the blob storage plugin also uses. I could write an integration test that interacts with Azure, but I wasn't sure if that would be worth it.