### PR TITLE
Added response_format option to openai_transcription processor

### DIFF
--- a/docs/modules/components/pages/processors/openai_transcription.adoc
+++ b/docs/modules/components/pages/processors/openai_transcription.adoc
@@ -59,6 +59,7 @@ openai_transcription:
   file: "" # No default (required)
   language: en # No default (optional)
   prompt: "" # No default (optional)
+  response_format: json
 ```
 
 --
@@ -143,5 +144,15 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
+
+=== `response_format`
+
+The format of the output, in one of these options: json, text, srt, verbose_json, or vtt.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `"json"`
 
 

--- a/internal/impl/openai/transcription_processor.go
+++ b/internal/impl/openai/transcription_processor.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	otspFieldFile   = "file"
-	otspFieldModel  = "model"
 	otspFieldLang   = "language"
 	otspFieldPrompt = "prompt"
 	otspFieldFormat = "response_format"


### PR DESCRIPTION
Hey @rockwotj, 

I added a missing option: [response_format](https://platform.openai.com/docs/api-reference/audio/createTranscription) to define alternatives to the default JSON response such as for VTT, SRT, plain text, and verbose JSON.