### PR TITLE
Remove count references in favour of counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - Field `checksum_algorithm` added to the `aws_s3` output. (@dom-lee-naimuri)
 
+### Changed
+
+- All components with a default `path` field value (such as the `aws_s3` output) containing the deprecated function `count` have now been changed to use the new function `counter`. This could potentially change behaviour in cases where multiple components are executing a mapping with a `count` function sharing the same of the old default count, and these counters need to cascade. This is an extremely unlikely scenario, but for all users of these components it is recommended that your `path` is defined explicitly, and in a future major version we will be removing the defaults.
+
 ## 4.37.0 - 2024-09-26
 
 ### Added

--- a/docs/modules/components/pages/outputs/aws_s3.adoc
+++ b/docs/modules/components/pages/outputs/aws_s3.adoc
@@ -40,7 +40,7 @@ output:
   label: ""
   aws_s3:
     bucket: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     tags: {}
     content_type: application/octet-stream
     metadata:
@@ -64,7 +64,7 @@ output:
   label: ""
   aws_s3:
     bucket: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     tags: {}
     content_type: application/octet-stream
     content_encoding: ""
@@ -117,7 +117,7 @@ The tags field allows you to specify key/value pairs to attach to objects as tag
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
       Timestamp: ${!meta("Timestamp")}
@@ -137,7 +137,7 @@ For example, if we wished to upload messages as a .tar.gz archive of documents w
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     batching:
       count: 100
       period: 10s
@@ -154,7 +154,7 @@ Alternatively, if we wished to upload JSON documents as a single large document 
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.json
+    path: ${!counter()}-${!timestamp_unix_nano()}.json
     batching:
       count: 100
       processors:
@@ -184,12 +184,12 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
-*Default*: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
+*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
 
 ```yml
 # Examples
 
-path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+path: ${!counter()}-${!timestamp_unix_nano()}.txt
 
 path: ${!meta("kafka_key")}.json
 

--- a/docs/modules/components/pages/outputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_blob_storage.adoc
@@ -44,7 +44,7 @@ output:
     storage_connection_string: ""
     storage_sas_token: ""
     container: messages-${!timestamp("2006")} # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     max_in_flight: 64
 ```
 
@@ -63,7 +63,7 @@ output:
     storage_connection_string: ""
     storage_sas_token: ""
     container: messages-${!timestamp("2006")} # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     blob_type: BLOCK
     public_access_level: PRIVATE
     max_in_flight: 64
@@ -153,12 +153,12 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
-*Default*: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
+*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
 
 ```yml
 # Examples
 
-path: ${!count("files")}-${!timestamp_unix_nano()}.json
+path: ${!counter()}-${!timestamp_unix_nano()}.json
 
 path: ${!meta("kafka_key")}.json
 

--- a/docs/modules/components/pages/outputs/elasticsearch.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch.adoc
@@ -39,7 +39,7 @@ output:
   elasticsearch:
     urls: [] # No default (required)
     index: "" # No default (required)
-    id: ${!count("elastic_ids")}-${!timestamp_unix()}
+    id: ${!counter()}-${!timestamp_unix()}
     type: ""
     api_key: "" # No default (optional)
     max_in_flight: 64
@@ -64,7 +64,7 @@ output:
     index: "" # No default (required)
     action: index
     pipeline: ""
-    id: ${!count("elastic_ids")}-${!timestamp_unix()}
+    id: ${!counter()}-${!timestamp_unix()}
     type: ""
     routing: ""
     sniff: true
@@ -141,7 +141,7 @@ output:
     sniff: false
     healthcheck: false
     index: "my-elasticsearch-index"
-    id: my-document-id-${!count("elastic_ids")}-${!timestamp_unix()}
+    id: my-document-id-${!counter()}-${!timestamp_unix()}
     api_key: "${ELASTIC_CLOUD_API_KEY}"
 ```
 
@@ -202,7 +202,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
-*Default*: `"${!count(\"elastic_ids\")}-${!timestamp_unix()}"`
+*Default*: `"${!counter()}-${!timestamp_unix()}"`
 
 === `type`
 

--- a/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
@@ -40,7 +40,7 @@ output:
   label: ""
   gcp_cloud_storage:
     bucket: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     content_type: application/octet-stream
     collision_mode: overwrite
     timeout: 3s
@@ -64,7 +64,7 @@ output:
   label: ""
   gcp_cloud_storage:
     bucket: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     content_type: application/octet-stream
     content_encoding: ""
     collision_mode: overwrite
@@ -103,7 +103,7 @@ For example, if we wished to upload messages as a .tar.gz archive of documents w
 output:
   gcp_cloud_storage:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     batching:
       count: 100
       period: 10s
@@ -120,7 +120,7 @@ Alternatively, if we wished to upload JSON documents as a single large document 
 output:
   gcp_cloud_storage:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.json
+    path: ${!counter()}-${!timestamp_unix_nano()}.json
     batching:
       count: 100
       processors:
@@ -152,12 +152,12 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
-*Default*: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
+*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
 
 ```yml
 # Examples
 
-path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+path: ${!counter()}-${!timestamp_unix_nano()}.txt
 
 path: ${!meta("kafka_key")}.json
 

--- a/docs/modules/components/pages/outputs/hdfs.adoc
+++ b/docs/modules/components/pages/outputs/hdfs.adoc
@@ -40,7 +40,7 @@ output:
     hosts: [] # No default (required)
     user: ""
     directory: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     max_in_flight: 64
     batching:
       count: 0
@@ -62,7 +62,7 @@ output:
     hosts: [] # No default (required)
     user: ""
     directory: "" # No default (required)
-    path: ${!count("files")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     max_in_flight: 64
     batching:
       count: 0
@@ -123,7 +123,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Type*: `string`
 
-*Default*: `"${!count(\"files\")}-${!timestamp_unix_nano()}.txt"`
+*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/outputs/redis_hash.adoc
+++ b/docs/modules/components/pages/outputs/redis_hash.adoc
@@ -342,7 +342,7 @@ key: ${! @.kafka_key )}
 
 key: ${! this.doc.id }
 
-key: ${! count("msgs") }
+key: ${! counter() }
 ```
 
 === `walk_metadata`

--- a/docs/modules/components/pages/outputs/redis_list.adoc
+++ b/docs/modules/components/pages/outputs/redis_list.adoc
@@ -327,7 +327,7 @@ key: ${! @.kafka_key )}
 
 key: ${! this.doc.id }
 
-key: ${! count("msgs") }
+key: ${! counter() }
 ```
 
 === `max_in_flight`

--- a/internal/impl/aws/integration_s3_test.go
+++ b/internal/impl/aws/integration_s3_test.go
@@ -181,7 +181,7 @@ output:
     endpoint: http://localhost:$PORT
     force_path_style_urls: true
     region: eu-west-1
-    path: ${!count("$ID")}.txt
+    path: ${!counter()}.txt
     credentials:
       id: xxxxx
       secret: xxxxx
@@ -232,7 +232,7 @@ output:
     endpoint: http://localhost:$PORT
     force_path_style_urls: true
     region: eu-west-1
-    path: ${!count("$ID")}.txt
+    path: ${!counter()}.txt
     credentials:
       id: xxxxx
       secret: xxxxx
@@ -287,7 +287,7 @@ output:
     endpoint: http://localhost:$PORT
     force_path_style_urls: true
     region: eu-west-1
-    path: ${!count("$ID")}.txt
+    path: ${!counter()}.txt
     credentials:
       id: xxxxx
       secret: xxxxx
@@ -342,7 +342,7 @@ output:
     endpoint: http://localhost:$PORT
     force_path_style_urls: true
     region: eu-west-1
-    path: ${!count("$ID")}.txt
+    path: ${!counter()}.txt
     credentials:
       id: xxxxx
       secret: xxxxx

--- a/internal/impl/aws/output_s3.go
+++ b/internal/impl/aws/output_s3.go
@@ -176,7 +176,7 @@ The tags field allows you to specify key/value pairs to attach to objects as tag
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     tags:
       Key1: Value1
       Timestamp: ${!meta("Timestamp")}
@@ -196,7 +196,7 @@ For example, if we wished to upload messages as a .tar.gz archive of documents w
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     batching:
       count: 100
       period: 10s
@@ -213,7 +213,7 @@ Alternatively, if we wished to upload JSON documents as a single large document 
 output:
   aws_s3:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.json
+    path: ${!counter()}-${!timestamp_unix_nano()}.json
     batching:
       count: 100
       processors:
@@ -225,8 +225,8 @@ output:
 				Description("The bucket to upload messages to."),
 			service.NewInterpolatedStringField(s3oFieldPath).
 				Description("The path of each message to upload.").
-				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
-				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
+				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`).
+				Example(`${!counter()}-${!timestamp_unix_nano()}.txt`).
 				Example(`${!meta("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`),
 			service.NewInterpolatedStringMapField(s3oFieldTags).

--- a/internal/impl/azure/integration_test.go
+++ b/internal/impl/azure/integration_test.go
@@ -95,7 +95,7 @@ output:
     blob_type: BLOCK
     container: $VAR1-$ID
     max_in_flight: 1
-    path: $VAR2/${!count("$ID")}.txt
+    path: $VAR2/${!counter()}.txt
     public_access_level: PRIVATE
     storage_connection_string: $VAR3
 
@@ -123,7 +123,7 @@ output:
     blob_type: BLOCK
     container: $VAR1-$ID
     max_in_flight: 1
-    path: $VAR2/${!count("$ID")}.txt
+    path: $VAR2/${!counter()}.txt
     public_access_level: PRIVATE
     storage_connection_string: $VAR3
 

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -95,10 +95,10 @@ If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+
 				Example(`messages-${!timestamp("2006")}`),
 			service.NewInterpolatedStringField(bsoFieldPath).
 				Description("The path of each message to upload.").
-				Example(`${!count("files")}-${!timestamp_unix_nano()}.json`).
+				Example(`${!counter()}-${!timestamp_unix_nano()}.json`).
 				Example(`${!meta("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
-				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
+				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringEnumField(bsoFieldBlobType, "BLOCK", "APPEND").
 				Description("Block and Append blobs are comprized of blocks, and each blob can support up to 50,000 blocks. The default value is `+\"`BLOCK`\"+`.`").
 				Advanced().

--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -237,7 +237,7 @@ It's possible to enable AWS connectivity with this output using the `+"`aws`"+` 
 				Default(""),
 			service.NewInterpolatedStringField(esoFieldID).
 				Description("The ID for indexed messages. Interpolation should be used in order to create a unique ID for each message.").
-				Default(`${!count("elastic_ids")}-${!timestamp_unix()}`),
+				Default(`${!counter()}-${!timestamp_unix()}`),
 			service.NewInterpolatedStringField(esoFieldType).
 				Description("The document mapping type. This field is required for versions of elasticsearch earlier than 6.0.0, but are invalid for versions 7.0.0 or later.").
 				Default(""),
@@ -296,7 +296,7 @@ output:
     sniff: false
     healthcheck: false
     index: "my-elasticsearch-index"
-    id: my-document-id-${!count("elastic_ids")}-${!timestamp_unix()}
+    id: my-document-id-${!counter()}-${!timestamp_unix()}
     api_key: "${ELASTIC_CLOUD_API_KEY}"
 `)
 }

--- a/internal/impl/elasticsearch/writer_integration_test.go
+++ b/internal/impl/elasticsearch/writer_integration_test.go
@@ -162,7 +162,7 @@ func testElasticNoIndex(urls []string, client *elastic.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: does_not_exist
-id: 'foo-${!count("noIndexTest")}'
+id: 'foo-${!counter()}'
 urls: %v
 max_retries: 1
 backoff:
@@ -289,7 +289,7 @@ func testElasticConnect(urls []string, client *elastic.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: test_conn_index
-id: 'foo-${!count("foo")}'
+id: 'foo-${!counter()}'
 urls: %v
 type: _doc
 sniff: false
@@ -336,7 +336,7 @@ func testElasticIndexInterpolation(urls []string, client *elastic.Client, t *tes
 
 	m := outputFromConf(t, `
 index: ${! @index }
-id: 'bar-${!count("bar")}'
+id: 'bar-${!counter()}'
 urls: %v
 type: _doc
 sniff: false
@@ -382,7 +382,7 @@ func testElasticBatch(urls []string, client *elastic.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: ${! @index }
-id: 'baz-${!count("baz")}'
+id: 'baz-${!counter()}'
 urls: %v
 type: _doc
 sniff: false
@@ -429,7 +429,7 @@ func testElasticBatchDelete(urls []string, client *elastic.Client, t *testing.T)
 
 	m := outputFromConf(t, `
 index: ${! @index }
-id: 'buz-${!count("elasticBatchDeleteMessages")}'
+id: 'buz-${!counter()}'
 urls: %v
 action: ${! @elastic_action }
 type: _doc

--- a/internal/impl/gcp/integration_test.go
+++ b/internal/impl/gcp/integration_test.go
@@ -103,7 +103,7 @@ func TestIntegrationGCP(t *testing.T) {
 output:
   gcp_cloud_storage:
     bucket: $VAR1-$ID
-    path: $VAR2/${!count("$ID")}.txt
+    path: $VAR2/${!counter()}.txt
     max_in_flight: 1
     collision_mode: overwrite
 

--- a/internal/impl/gcp/output_cloud_storage.go
+++ b/internal/impl/gcp/output_cloud_storage.go
@@ -122,7 +122,7 @@ For example, if we wished to upload messages as a .tar.gz archive of documents w
 output:
   gcp_cloud_storage:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.tar.gz
+    path: ${!counter()}-${!timestamp_unix_nano()}.tar.gz
     batching:
       count: 100
       period: 10s
@@ -139,7 +139,7 @@ Alternatively, if we wished to upload JSON documents as a single large document 
 output:
   gcp_cloud_storage:
     bucket: TODO
-    path: ${!count("files")}-${!timestamp_unix_nano()}.json
+    path: ${!counter()}-${!timestamp_unix_nano()}.json
     batching:
       count: 100
       processors:
@@ -151,10 +151,10 @@ output:
 				Description("The bucket to upload messages to."),
 			service.NewInterpolatedStringField(csoFieldPath).
 				Description("The path of each message to upload.").
-				Example(`${!count("files")}-${!timestamp_unix_nano()}.txt`).
+				Example(`${!counter()}-${!timestamp_unix_nano()}.txt`).
 				Example(`${!meta("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
-				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
+				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringField(csoFieldContentType).
 				Description("The content type to set for each object.").
 				Default("application/octet-stream"),

--- a/internal/impl/gcp/output_pubsub_test.go
+++ b/internal/impl/gcp/output_pubsub_test.go
@@ -93,7 +93,7 @@ func TestPubSubOutput_MessageAttr(t *testing.T) {
 	conf, err := newPubSubOutputConfig().ParseYAML(`
     project: sample-project
     topic: test
-    ordering_key: '${! content().string() }_${! count(content().string()) }'
+    ordering_key: '${! content().string() }_${! counter() }'
     metadata:
       exclude_prefixes:
         - drop_

--- a/internal/impl/hdfs/integration_test.go
+++ b/internal/impl/hdfs/integration_test.go
@@ -87,7 +87,7 @@ output:
     hosts: [ localhost:9000 ]
     user: root
     directory: /$ID
-    path: ${!count("$ID")}-${!timestamp_unix_nano()}.txt
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
     max_in_flight: $MAX_IN_FLIGHT
     batching:
       count: $OUTPUT_BATCH_COUNT

--- a/internal/impl/hdfs/output.go
+++ b/internal/impl/hdfs/output.go
@@ -50,7 +50,7 @@ func outputSpec() *service.ConfigSpec {
 				Description("A directory to store message files within. If the directory does not exist it will be created."),
 			service.NewInterpolatedStringField(oFieldPath).
 				Description("The path to upload messages as, interpolation functions should be used in order to generate unique file paths.").
-				Default(`${!count("files")}-${!timestamp_unix_nano()}.txt`),
+				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`),
 			service.NewOutputMaxInFlightField(),
 			service.NewBatchPolicyField(oFieldBatching),
 		)

--- a/internal/impl/opensearch/integration_test.go
+++ b/internal/impl/opensearch/integration_test.go
@@ -161,7 +161,7 @@ func testOpenSearchNoIndex(urls []string, client *os.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: does_not_exist
-id: 'foo-${!count("noIndexTest")}'
+id: 'foo-${!counter()}'
 urls: %v
 action: index
 `, urls)
@@ -284,7 +284,7 @@ func testOpenSearchConnect(urls []string, client *os.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: test_conn_index
-id: 'foo-${!count("foo")}'
+id: 'foo-${!counter()}'
 urls: %v
 action: index
 `, urls)
@@ -325,7 +325,7 @@ func testOpenSearchIndexInterpolation(urls []string, client *os.Client, t *testi
 
 	m := outputFromConf(t, `
 index: ${! @index }
-id: 'bar-${!count("bar")}'
+id: 'bar-${!counter()}'
 urls: %v
 action: index
 `, urls)
@@ -365,7 +365,7 @@ func testOpenSearchBatch(urls []string, client *os.Client, t *testing.T) {
 
 	m := outputFromConf(t, `
 index: ${! @index }
-id: 'baz-${!count("baz")}'
+id: 'baz-${!counter()}'
 urls: %v
 action: index
 `, urls)

--- a/internal/impl/redis/output_hash.go
+++ b/internal/impl/redis/output_hash.go
@@ -68,7 +68,7 @@ Where latter stages will overwrite matching field names of a former stage.`+serv
 		Fields(
 			service.NewInterpolatedStringField(hoFieldKey).
 				Description("The key for each message, function interpolations should be used to create a unique key per message.").
-				Examples("${! @.kafka_key )}", "${! this.doc.id }", "${! count(\"msgs\") }"),
+				Examples("${! @.kafka_key )}", "${! this.doc.id }", "${! counter() }"),
 			service.NewBoolField(hoFieldWalkMetadata).
 				Description("Whether all metadata fields of messages should be walked and added to the list of hash fields to set.").
 				Default(false),

--- a/internal/impl/redis/output_list.go
+++ b/internal/impl/redis/output_list.go
@@ -46,7 +46,7 @@ func redisListOutputConfig() *service.ConfigSpec {
 		Fields(
 			service.NewInterpolatedStringField(loFieldKey).
 				Description("The key for each message, function interpolations can be optionally used to create a unique key per message.").
-				Examples("some_list", "${! @.kafka_key )}", "${! this.doc.id }", "${! count(\"msgs\") }"),
+				Examples("some_list", "${! @.kafka_key )}", "${! this.doc.id }", "${! counter() }"),
 			service.NewOutputMaxInFlightField(),
 			service.NewBatchPolicyField(loFieldBatching),
 			service.NewStringEnumField("command", string(rPush), string(lPush)).


### PR DESCRIPTION
This is _technically_ a breaking change, as the behaviour of a default path previously using `count` would potentially conflict with another `count` under the same name and they would cascade their counts. However, given that `count` has been long deprecated, and that the "ideal" behaviour here would be to have no default `path` value at all, this is a good middle ground before we can eventually (in a V5 release) remove all the path defaults entirely.