### PR TITLE
Fix time conversions in non-utc

### DIFF
--- a/internal/impl/snowflake/streaming/userdata_converter.go
+++ b/internal/impl/snowflake/streaming/userdata_converter.go
@@ -427,6 +427,7 @@ func (c timeConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typed
 	if err != nil {
 		return err
 	}
+	t = t.In(time.UTC)
 	// 24 hours in nanoseconds fits within uint64, so we can't overflow
 	nanos := t.Hour()*int(time.Hour.Nanoseconds()) +
 		t.Minute()*int(time.Minute.Nanoseconds()) +


### PR DESCRIPTION
Looks like unit tests were failing for me personally because of my timezone, forcing UTC in the converter fixes it for me but there might be other code paths that will need a similar look at.