### PR TITLE
Add cli flag for secrets backends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -360,7 +360,7 @@ require (
 	github.com/tilinna/z85 v1.0.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect
 	github.com/tklauser/numcpus v0.7.0 // indirect
-	github.com/urfave/cli/v2 v2.27.4 // indirect
+	github.com/urfave/cli/v2 v2.27.4
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -107,6 +107,11 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				secretLookupFn, err = secrets.ParseLookupURNs(c.Context, slog.New(rpLogger), disableEnvLookup, secretsURNs...)
 				return err
 			}
+			if disableEnvLookup {
+				secretLookupFn = func(context.Context, string) (string, bool) {
+					return "", false
+				}
+			}
 			return nil
 		}),
 		service.CLIOptSetEnvVarLookup(func(ctx context.Context, key string) (string, bool) {

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -106,8 +106,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				var err error
 				secretLookupFn, err = secrets.ParseLookupURNs(c.Context, slog.New(rpLogger), disableEnvLookup, secretsURNs...)
 				return err
-			}
-			if disableEnvLookup {
+			} else if disableEnvLookup {
 				secretLookupFn = func(context.Context, string) (string, bool) {
 					return "", false
 				}

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/rs/xid"
+	"github.com/urfave/cli/v2"
 
 	"github.com/redpanda-data/connect/v4/internal/impl/kafka/enterprise"
+	"github.com/redpanda-data/connect/v4/internal/secrets"
 	"github.com/redpanda-data/connect/v4/internal/telemetry"
 )
 
@@ -37,6 +39,10 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
+	}
+
+	secretLookupFn := func(ctx context.Context, key string) (string, bool) {
+		return os.LookupEnv(key)
 	}
 
 	opts = append(opts,
@@ -81,6 +87,30 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 		service.CLIOptOnStreamStart(func(s *service.RunningStreamSummary) error {
 			rpLogger.SetStreamSummary(s)
 			return nil
+		}),
+
+		// Secrets management
+		service.CLIOptCustomRunFlags([]cli.Flag{
+			&cli.StringSliceFlag{
+				Name:  "secrets",
+				Usage: "Attempt to load secrets from a provided URN. If a referenced secret isn't identified using the provided method then environment variables will also be looked up, you can disable this behaviour with the --disable-env-lookup flag.",
+			},
+			&cli.BoolFlag{
+				Name:  "disable-env-lookup",
+				Usage: "Disable the ability for configs to interpolate environment variables with ${FOO} syntax",
+			},
+		}, func(c *cli.Context) error {
+			disableEnvLookup := c.Bool("disable-env-lookup")
+			secretsURNs := c.StringSlice("secrets")
+			if len(secretsURNs) > 0 {
+				var err error
+				secretLookupFn, err = secrets.ParseLookupURNs(c.Context, slog.New(rpLogger), disableEnvLookup, secretsURNs...)
+				return err
+			}
+			return nil
+		}),
+		service.CLIOptSetEnvVarLookup(func(ctx context.Context, key string) (string, bool) {
+			return secretLookupFn(ctx, key)
 		}),
 	)
 

--- a/internal/secrets/redis.go
+++ b/internal/secrets/redis.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type redisSecretsClient struct {
+	logger *slog.Logger
+	client *redis.Client
+}
+
+func (r *redisSecretsClient) lookup(ctx context.Context, key string) (string, bool) {
+	res, err := r.client.Get(ctx, key).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			// An error that isn't due to key-not-found gets logged
+			r.logger.With("error", err, "key", key).Error("Failed to look up secret")
+		}
+		return "", false
+	}
+	return res, true
+}
+
+func newRedisSecretsLookup(ctx context.Context, logger *slog.Logger, url *url.URL) (LookupFn, error) {
+	opts, err := redis.ParseURL(url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	r := &redisSecretsClient{
+		logger: logger,
+		client: redis.NewClient(opts),
+	}
+	return r.lookup, nil
+}

--- a/internal/secrets/redis.go
+++ b/internal/secrets/redis.go
@@ -1,16 +1,10 @@
 // Copyright 2024 Redpanda Data, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package secrets
 

--- a/internal/secrets/redis_test.go
+++ b/internal/secrets/redis_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+)
+
+func TestIntegrationRedis(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Second * 30
+	resource, err := pool.Run("redis", "latest", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	urlStr := fmt.Sprintf("redis://localhost:%v", resource.GetPort("6379/tcp"))
+	uri, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := redis.ParseURL(uri.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := redis.NewClient(opts)
+
+	_ = resource.Expire(900)
+	require.NoError(t, pool.Retry(func() error {
+		return client.Ping(context.Background()).Err()
+	}))
+
+	ctx, done := context.WithTimeout(context.Background(), time.Minute)
+	defer done()
+
+	require.NoError(t, client.Set(ctx, "bar", "meow", time.Minute).Err())
+
+	secretsLookup, err := parseSecretsLookupURN(ctx, slog.Default(), urlStr)
+	require.NoError(t, err)
+
+	v, exists := secretsLookup(ctx, "foo")
+	assert.False(t, exists)
+	assert.Equal(t, "", v)
+
+	v, exists = secretsLookup(ctx, "bar")
+	assert.True(t, exists)
+	assert.Equal(t, "meow", v)
+}

--- a/internal/secrets/redis_test.go
+++ b/internal/secrets/redis_test.go
@@ -1,16 +1,10 @@
 // Copyright 2024 Redpanda Data, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package secrets
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+)
+
+// LookupFn defines the common closure that a secrets management client provides
+// and is then fed into a Redpanda Connect cli constructor.
+type LookupFn func(context.Context, string) (string, bool)
+
+type lookupTiers []LookupFn
+
+func (l lookupTiers) Lookup(ctx context.Context, key string) (string, bool) {
+	for _, fn := range l {
+		if v, ok := fn(ctx, key); ok {
+			return v, ok
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return "", false
+}
+
+// ParseLookupURNs attempts to parse a series of secrets lookup solutions
+// defined as URNs and returns a single lookup func for obtaining secrets from
+// them in the order provided.
+//
+// A toggle can be provided that determines whether environment variables should
+// be considered the last look up option, in which case if all others fail to
+// provide a secret then an environment variable under the key is returned if
+// found.
+func ParseLookupURNs(ctx context.Context, logger *slog.Logger, disableEnvLookup bool, secretsMgmtUrns ...string) (LookupFn, error) {
+	var tiers lookupTiers
+
+	for _, urn := range secretsMgmtUrns {
+		tier, err := parseSecretsLookupURN(ctx, logger, urn)
+		if err != nil {
+			return nil, err
+		}
+		tiers = append(tiers, tier)
+	}
+
+	if !disableEnvLookup {
+		tiers = append(tiers, func(ctx context.Context, key string) (string, bool) {
+			return os.LookupEnv(key)
+		})
+	}
+	return tiers.Lookup, nil
+}
+
+func parseSecretsLookupURN(ctx context.Context, logger *slog.Logger, urn string) (LookupFn, error) {
+	u, err := url.Parse(urn)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "test":
+		return func(ctx context.Context, key string) (string, bool) {
+			return key + " " + u.Host, true
+		}, nil
+	case "redis":
+		return newRedisSecretsLookup(ctx, logger, u)
+	default:
+		return nil, fmt.Errorf("secrets scheme %v not recognized", u.Scheme)
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,16 +1,10 @@
 // Copyright 2024 Redpanda Data, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package secrets
 


### PR DESCRIPTION
This PRs adds the ability for us to add backends for accessing secrets during config parse time, where interpolation functions of the form `${FOO}` will prompt a secret lookup.

A new cli flag `--secrets` is being added, which can be specified any number of times. Each entry adds a mechanism for resolving interpolation lookups via a secrets management solution (defined entirely as a single URN, e.g. `redis://foo:bar@example.com/`). Each specified entry will be attempted until the lookup is successful.

By default there is a single entry that enables environment variable lookups with the urn `env:`, this preserves the current behaviour. A user can disable all lookups by specifying a single entry with the urn `none:`.

If none of the specified secrets backends yield a given key lookup then we will exit the config parse as usual, with an error indicating that an environment variable is referenced in the config but has not been found.