### PR TITLE
update to goreleaser v2

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -41,5 +41,4 @@ jobs:
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
-        version: latest
         args: release --snapshot --timeout 120m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
-        version: latest
         args: release --release-notes=./release_notes.md --timeout 120m
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -48,14 +48,12 @@ jobs:
         if: ${{ env.DRY_RUN != 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
           args: build --snapshot
       - name: Build binaries
         # Only one way to not dry run - see 'false'. All other cases, conservatively assume --dry-run
         if: ${{ env.DRY_RUN == 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
           args: build
       - name: Upload connect plugin to S3
         uses: ./.github/actions/upload_managed_plugin

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -48,14 +48,14 @@ jobs:
         if: ${{ env.DRY_RUN != 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: 1.26.2
+          version: latest
           args: build --snapshot
       - name: Build binaries
         # Only one way to not dry run - see 'false'. All other cases, conservatively assume --dry-run
         if: ${{ env.DRY_RUN == 'false' }}
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: 1.26.2
+          version: latest
           args: build
       - name: Upload connect plugin to S3
         uses: ./.github/actions/upload_managed_plugin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
+---
 project_name: redpanda-connect
-version: 1
+version: 2
 builds:
   - id: connect
     main: cmd/redpanda-connect/main.go


### PR DESCRIPTION
jira: [DEVPROD-1690]

goreleaser has deprecated v1 config format and there has not been updates to that major ver since may. this PR [updates](https://goreleaser.com/blog/goreleaser-v2/#upgrading) goreleaser config file to the latest v2 format.

[DEVPROD-1690]: https://redpandadata.atlassian.net/browse/DEVPROD-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ