### PR TITLE
linter: fix common mistakes at lint time

### DIFF
--- a/internal/impl/kafka/enterprise/redpanda_migrator_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_input.go
@@ -77,6 +77,10 @@ root = if $has_topic_partitions {
   } else if this.regexp_topics {
     "this input does not support both regular expression topics and explicit topic partitions"
   }
+} else {
+  if this.consumer_group.or("") == "" {
+    "a consumer group is mandatory when not using explicit topic partitions"
+  }
 }
 `)
 }
@@ -278,8 +282,10 @@ func NewRedpandaMigratorReaderFromConfig(conf *service.ParsedConfig, mgr *servic
 		return nil, err
 	}
 
-	if r.consumerGroup, err = conf.FieldString("consumer_group"); err != nil {
-		return nil, err
+	if conf.Contains("consumer_group") {
+		if r.consumerGroup, err = conf.FieldString("consumer_group"); err != nil {
+			return nil, err
+		}
 	}
 
 	if r.batchSize, err = conf.FieldInt("batch_size"); err != nil {

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -67,6 +67,10 @@ root = if $has_topic_partitions {
   } else if this.regexp_topics {
     "this input does not support both regular expression topics and explicit topic partitions"
   }
+} else {
+  if this.consumer_group.or("") == "" {
+    "a consumer group is mandatory when not using explicit topic partitions"
+  }
 }
 `)
 }
@@ -245,8 +249,10 @@ func NewFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 		return nil, err
 	}
 
-	if f.consumerGroup, err = conf.FieldString("consumer_group"); err != nil {
-		return nil, err
+	if conf.Contains("consumer_group") {
+		if f.consumerGroup, err = conf.FieldString("consumer_group"); err != nil {
+			return nil, err
+		}
 	}
 
 	if f.checkpointLimit, err = conf.FieldInt("checkpoint_limit"); err != nil {

--- a/internal/impl/pinecone/output.go
+++ b/internal/impl/pinecone/output.go
@@ -46,7 +46,8 @@ func outputSpec() *service.ConfigSpec {
 			service.NewOutputMaxInFlightField(),
 			service.NewBatchPolicyField(poFieldBatching),
 			service.NewStringField(poFieldHost).
-				Description("The host for the Pinecone index."),
+				Description("The host for the Pinecone index.").
+				LintRule(`root = if this.has_prefix("https://") { ["host field must be a FQDN not a URL (remove the https:// prefix)"] }`),
 			service.NewStringField(poFieldAPIKey).
 				Secret().
 				Description("The Pinecone api key."),


### PR DESCRIPTION
This to give feedback before the pipeline is run and crashes at runtime.

From Kafka and migrator, the config without consumer group was not always working (unless the consumer group was explicitly set to "").
