### PR TITLE
snowflake: optimize performance of common data paths

### DIFF
--- a/docs/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/docs/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -81,6 +81,7 @@ output:
     mapping: "" # No default (optional)
     init_statement: | # No default (optional)
       CREATE TABLE IF NOT EXISTS mytable (amount NUMBER);
+    build_parallelism: 1
     batching:
       count: 0
       byte_size: 0
@@ -334,6 +335,15 @@ init_statement: |2
   ALTER TABLE t1 ALTER COLUMN c1 DROP NOT NULL;
   ALTER TABLE t1 ADD COLUMN a2 NUMBER;
 ```
+
+=== `build_parallelism`
+
+The maximum amount of parallelism to use when building the output for Snowflake. The metric to watch to see if you need to change this is `snowflake_build_output_latency_ns`.
+
+
+*Type*: `int`
+
+*Default*: `1`
 
 === `batching`
 

--- a/internal/impl/snowflake/streaming/int128/int128.go
+++ b/internal/impl/snowflake/streaming/int128/int128.go
@@ -227,8 +227,8 @@ func (i Num) ToBigEndian() []byte {
 
 // AppendBigEndian converts an Int128 into big endian bytes
 func (i Num) AppendBigEndian(b []byte) []byte {
-	b = binary.BigEndian.AppendUint64(b[0:8], uint64(i.hi))
-	return binary.BigEndian.AppendUint64(b[8:16], i.lo)
+	b = binary.BigEndian.AppendUint64(b, uint64(i.hi))
+	return binary.BigEndian.AppendUint64(b, i.lo)
 }
 
 // ToInt64 casts an Int128 to a int64 by truncating the bytes.

--- a/internal/impl/snowflake/streaming/int128/int128_test.go
+++ b/internal/impl/snowflake/streaming/int128/int128_test.go
@@ -11,8 +11,10 @@
 package int128
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -387,4 +389,18 @@ func TestFitsInPrec(t *testing.T) {
 	n, err := FromString(snowflakeNumberTiny, 38, 37)
 	require.NoError(t, err)
 	require.True(t, n.FitsInPrecision(38), snowflakeNumberTiny)
+}
+
+func TestToBytes(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		input := make([]byte, 16)
+		_, err := rand.Read(input)
+		require.NoError(t, err)
+		n := FromBigEndian(input)
+		require.Equal(t, input, n.ToBigEndian())
+		require.Equal(t, input, n.AppendBigEndian(nil))
+		cloned := slices.Clone(input)
+		require.Equal(t, input, n.AppendBigEndian(cloned)[16:32])
+		require.Equal(t, input, cloned) // Make sure cloned isn't mutated
+	}
 }

--- a/internal/impl/snowflake/streaming/integration_test.go
+++ b/internal/impl/snowflake/streaming/integration_test.go
@@ -88,10 +88,11 @@ func TestAllSnowflakeDatatypes(t *testing.T) {
 	ctx := context.Background()
 	restClient, streamClient := setup(t)
 	channelOpts := streaming.ChannelOptions{
-		Name:         t.Name(),
-		DatabaseName: envOr("SNOWFLAKE_DB", "BABY_DATABASE"),
-		SchemaName:   "PUBLIC",
-		TableName:    "TEST_TABLE_KITCHEN_SINK",
+		Name:             t.Name(),
+		DatabaseName:     envOr("SNOWFLAKE_DB", "BABY_DATABASE"),
+		SchemaName:       "PUBLIC",
+		TableName:        "TEST_TABLE_KITCHEN_SINK",
+		BuildParallelism: 1,
 	}
 	_, err := restClient.RunSQL(ctx, streaming.RunSQLRequest{
 		Database: channelOpts.DatabaseName,

--- a/internal/impl/snowflake/streaming/parquet_test.go
+++ b/internal/impl/snowflake/streaming/parquet_test.go
@@ -34,8 +34,9 @@ func TestWriteParquet(t *testing.T) {
 	inputDataSchema := parquet.Group{
 		"A": parquet.Decimal(0, 18, parquet.Int32Type),
 	}
-	transformers := map[string]*dataTransformer{
-		"A": {
+	transformers := []*dataTransformer{
+		{
+			name: "A",
 			converter: numberConverter{
 				nullable:  true,
 				scale:     0,

--- a/internal/impl/snowflake/streaming/parquet_test.go
+++ b/internal/impl/snowflake/streaming/parquet_test.go
@@ -27,7 +27,6 @@ func msg(s string) *service.Message {
 }
 
 func TestWriteParquet(t *testing.T) {
-	b := bytes.NewBuffer(nil)
 	batch := service.MessageBatch{
 		msg(`{"a":2}`),
 		msg(`{"a":12353}`),
@@ -53,7 +52,7 @@ func TestWriteParquet(t *testing.T) {
 				Scale:        ptr.Int32(0),
 				Nullable:     true,
 			},
-			buf: &int32Buffer{},
+			bufferFactory: int32TypedBufferFactory,
 		},
 	}
 	schema := parquet.NewSchema("bdec", inputDataSchema)
@@ -63,13 +62,13 @@ func TestWriteParquet(t *testing.T) {
 		transformers,
 	)
 	require.NoError(t, err)
-	err = writeParquetFile(b, "latest", parquetFileData{
+	b, err := writeParquetFile("latest", parquetFileData{
 		schema, rows, nil,
 	})
 	require.NoError(t, err)
 	actual, err := readGeneric(
-		bytes.NewReader(b.Bytes()),
-		int64(b.Len()),
+		bytes.NewReader(b),
+		int64(len(b)),
 		parquet.NewSchema("bdec", inputDataSchema),
 	)
 	require.NoError(t, err)

--- a/internal/impl/snowflake/streaming/stats.go
+++ b/internal/impl/snowflake/streaming/stats.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+package streaming
+
+import (
+	"bytes"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/snowflake/streaming/int128"
+)
+
+type statsBuffer struct {
+	minIntVal, maxIntVal   int128.Num
+	minRealVal, maxRealVal float64
+	minStrVal, maxStrVal   []byte
+	maxStrLen              int
+	nullCount              int64
+	hasData                bool
+}
+
+func mergeStats(a, b *statsBuffer) *statsBuffer {
+	c := &statsBuffer{hasData: true}
+	switch {
+	case a.hasData && b.hasData:
+		c.minIntVal = int128.Min(a.minIntVal, b.minIntVal)
+		c.maxIntVal = int128.Max(a.maxIntVal, b.maxIntVal)
+		c.minRealVal = min(a.minRealVal, b.minRealVal)
+		c.maxRealVal = max(a.maxRealVal, b.maxRealVal)
+		c.maxStrLen = max(a.maxStrLen, b.maxStrLen)
+		c.minStrVal = a.minStrVal
+		if bytes.Compare(b.minStrVal, a.minStrVal) < 0 {
+			c.minStrVal = b.minStrVal
+		}
+		c.maxStrVal = a.maxStrVal
+		if bytes.Compare(b.maxStrVal, a.maxStrVal) > 0 {
+			c.maxStrVal = b.maxStrVal
+		}
+	case a.hasData:
+		*c = *a
+	case b.hasData:
+		*c = *b
+	default:
+		c.hasData = false
+	}
+	c.nullCount = a.nullCount + b.nullCount
+	return c
+}
+
+func computeColumnEpInfo(transformers []*dataTransformer, stats []*statsBuffer) map[string]fileColumnProperties {
+	info := map[string]fileColumnProperties{}
+	for idx, transformer := range transformers {
+		stat := stats[idx]
+		var minStrVal *string = nil
+		if stat.minStrVal != nil {
+			s := truncateBytesAsHex(stat.minStrVal, false)
+			minStrVal = &s
+		}
+		var maxStrVal *string = nil
+		if stat.maxStrVal != nil {
+			s := truncateBytesAsHex(stat.maxStrVal, true)
+			maxStrVal = &s
+		}
+		info[transformer.column.Name] = fileColumnProperties{
+			ColumnOrdinal:  int32(transformer.column.Ordinal),
+			NullCount:      stat.nullCount,
+			MinStrValue:    minStrVal,
+			MaxStrValue:    maxStrVal,
+			MaxLength:      int64(stat.maxStrLen),
+			MinIntValue:    stat.minIntVal,
+			MaxIntValue:    stat.maxIntVal,
+			MinRealValue:   stat.minRealVal,
+			MaxRealValue:   stat.maxRealVal,
+			DistinctValues: -1,
+		}
+	}
+	return info
+}

--- a/internal/impl/snowflake/streaming/stats.go
+++ b/internal/impl/snowflake/streaming/stats.go
@@ -25,6 +25,45 @@ type statsBuffer struct {
 	hasData                bool
 }
 
+func (s *statsBuffer) UpdateIntStats(v int128.Num) {
+	if !s.hasData {
+		s.minIntVal = v
+		s.maxIntVal = v
+		s.hasData = true
+	} else {
+		s.minIntVal = int128.Min(s.minIntVal, v)
+		s.maxIntVal = int128.Max(s.maxIntVal, v)
+	}
+}
+
+func (s *statsBuffer) UpdateFloat64Stats(v float64) {
+	if !s.hasData {
+		s.minRealVal = v
+		s.maxRealVal = v
+		s.hasData = true
+	} else {
+		s.minRealVal = min(s.minRealVal, v)
+		s.maxRealVal = max(s.maxRealVal, v)
+	}
+}
+
+func (s *statsBuffer) UpdateBytesStats(v []byte) {
+	if !s.hasData {
+		s.minStrVal = v
+		s.maxStrVal = v
+		s.maxStrLen = len(v)
+		s.hasData = true
+	} else {
+		if bytes.Compare(v, s.minStrVal) < 0 {
+			s.minStrVal = v
+		}
+		if bytes.Compare(v, s.maxStrVal) > 0 {
+			s.maxStrVal = v
+		}
+		s.maxStrLen = max(s.maxStrLen, len(v))
+	}
+}
+
 func mergeStats(a, b *statsBuffer) *statsBuffer {
 	c := &statsBuffer{hasData: true}
 	switch {

--- a/internal/impl/snowflake/streaming/stats.go
+++ b/internal/impl/snowflake/streaming/stats.go
@@ -68,7 +68,7 @@ func computeColumnEpInfo(transformers []*dataTransformer, stats []*statsBuffer) 
 			maxStrVal = &s
 		}
 		info[transformer.column.Name] = fileColumnProperties{
-			ColumnOrdinal:  int32(transformer.column.Ordinal),
+			ColumnOrdinal:  transformer.column.Ordinal,
 			NullCount:      stat.nullCount,
 			MinStrValue:    minStrVal,
 			MaxStrValue:    maxStrVal,

--- a/internal/impl/snowflake/streaming/stats_test.go
+++ b/internal/impl/snowflake/streaming/stats_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+package streaming
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/snowflake/streaming/int128"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeInt(t *testing.T) {
+	s := mergeStats(&statsBuffer{
+		minIntVal: int128.FromInt64(-1),
+		maxIntVal: int128.FromInt64(4),
+		hasData:   true,
+	}, &statsBuffer{
+		minIntVal: int128.FromInt64(3),
+		maxIntVal: int128.FromInt64(5),
+		hasData:   true,
+	})
+	require.Equal(t, &statsBuffer{
+		minIntVal: int128.FromInt64(-1),
+		maxIntVal: int128.FromInt64(5),
+		hasData:   true,
+	}, s)
+}
+
+func TestMergeReal(t *testing.T) {
+	s := mergeStats(&statsBuffer{
+		minRealVal: -1.2,
+		maxRealVal: 4.5,
+		nullCount:  4,
+		hasData:    true,
+	}, &statsBuffer{
+		minRealVal: 3.4,
+		maxRealVal: 5.9,
+		nullCount:  2,
+		hasData:    true,
+	})
+	require.Equal(t, &statsBuffer{
+		minRealVal: -1.2,
+		maxRealVal: 5.9,
+		nullCount:  6,
+		hasData:    true,
+	}, s)
+}
+
+func TestMergeStr(t *testing.T) {
+	s := mergeStats(&statsBuffer{
+		minStrVal: []byte("aa"),
+		maxStrVal: []byte("bbbb"),
+		maxStrLen: 6,
+		nullCount: 1,
+		hasData:   true,
+	}, &statsBuffer{
+		minStrVal: []byte("aaaa"),
+		maxStrVal: []byte("cccccc"),
+		maxStrLen: 24,
+		nullCount: 1,
+		hasData:   true,
+	})
+	require.Equal(t, &statsBuffer{
+		minStrVal: []byte("aa"),
+		maxStrVal: []byte("cccccc"),
+		maxStrLen: 24,
+		nullCount: 2,
+		hasData:   true,
+	}, s)
+}

--- a/internal/impl/snowflake/streaming/streaming.go
+++ b/internal/impl/snowflake/streaming/streaming.go
@@ -256,7 +256,7 @@ type SnowflakeIngestionChannel struct {
 	encryptionInfo  *encryptionInfo
 	clientSequencer int64
 	rowSequencer    int64
-	transformers    map[string]*dataTransformer
+	transformers    []*dataTransformer
 	fileMetadata    map[string]string
 	buffer          *bytes.Buffer
 	// This is shared among the various open channels to get some uniqueness

--- a/internal/impl/snowflake/streaming/streaming.go
+++ b/internal/impl/snowflake/streaming/streaming.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/dustin/go-humanize"
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/format"
 	"github.com/redpanda-data/benthos/v4/public/service"

--- a/internal/impl/snowflake/streaming/userdata_converter.go
+++ b/internal/impl/snowflake/streaming/userdata_converter.go
@@ -133,10 +133,10 @@ func (c boolConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typed
 	if v {
 		i = int128.FromUint64(1)
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minIntVal = i
 		stats.maxIntVal = i
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minIntVal = int128.Min(stats.minIntVal, i)
 		stats.maxIntVal = int128.Max(stats.maxIntVal, i)
@@ -214,10 +214,10 @@ func (c numberConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typ
 	if err != nil {
 		return err
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minIntVal = v
 		stats.maxIntVal = v
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minIntVal = int128.Min(stats.minIntVal, v)
 		stats.maxIntVal = int128.Max(stats.maxIntVal, v)
@@ -243,10 +243,10 @@ func (c doubleConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typ
 	if err != nil {
 		return err
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minRealVal = v
 		stats.maxRealVal = v
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minRealVal = min(stats.minRealVal, v)
 		stats.maxRealVal = max(stats.maxRealVal, v)
@@ -297,11 +297,11 @@ func (c binaryConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typ
 	if c.utf8 && !utf8.Valid(v) {
 		return errors.New("invalid UTF8")
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minStrVal = v
 		stats.maxStrVal = v
 		stats.maxStrLen = len(v)
-		stats.first = false
+		stats.hasData = true
 	} else {
 		if bytes.Compare(v, stats.minStrVal) < 0 {
 			stats.minStrVal = v
@@ -333,11 +333,11 @@ func (c jsonConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typed
 	if len(v) > c.maxLength {
 		return fmt.Errorf("value too long, length: %d, max: %d", len(v), c.maxLength)
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minStrVal = v
 		stats.maxStrVal = v
 		stats.maxStrLen = len(v)
-		stats.first = false
+		stats.hasData = true
 	} else {
 		if bytes.Compare(v, stats.minStrVal) < 0 {
 			stats.minStrVal = v
@@ -427,10 +427,10 @@ func (c timestampConverter) ValidateAndConvert(stats *statsBuffer, val any, buf 
 			c.precision,
 		)
 	}
-	if stats.first {
+	if !stats.hasData {
 		stats.minIntVal = v
 		stats.maxIntVal = v
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minIntVal = int128.Min(stats.minIntVal, v)
 		stats.maxIntVal = int128.Max(stats.maxIntVal, v)
@@ -464,10 +464,10 @@ func (c timeConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typed
 		t.Second()*int(time.Second.Nanoseconds()) +
 		t.Nanosecond()
 	v := int128.FromInt64(int64(nanos) / pow10TableInt64[9-c.scale])
-	if stats.first {
+	if !stats.hasData {
 		stats.minIntVal = v
 		stats.maxIntVal = v
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minIntVal = int128.Min(stats.minIntVal, v)
 		stats.maxIntVal = int128.Max(stats.maxIntVal, v)
@@ -499,10 +499,10 @@ func (c dateConverter) ValidateAndConvert(stats *statsBuffer, val any, buf typed
 		return fmt.Errorf("DATE columns out of range, year: %d", t.Year())
 	}
 	v := int128.FromInt64(t.Unix() / int64(24*60*60))
-	if stats.first {
+	if !stats.hasData {
 		stats.minIntVal = v
 		stats.maxIntVal = v
-		stats.first = false
+		stats.hasData = true
 	} else {
 		stats.minIntVal = int128.Min(stats.minIntVal, v)
 		stats.maxIntVal = int128.Max(stats.maxIntVal, v)


### PR DESCRIPTION
Found from benchmarking some example workloads. This change allowed me to push about 2.5K records/sec per core *more*.
