### PR TITLE
gha: use new cloudsmith secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       uses: aws-actions/aws-secretsmanager-get-secrets@v2
       with:
         secret-ids: |
-          ,sdlc/prod/github/cloudsmith_api_key
+          ,sdlc/prod/github/cloudsmith
         parse-json-secrets: true
 
     - name: Free up some disk space on ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         check-latest: true
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.61.0
         args: --timeout 30m cmd/... internal/... public/...


### PR DESCRIPTION
jira: [DEVPROD-2344]

Same privileges, so should be no functionality change.

Also bumped `golangci/golangci-lint-action` from `v4` to latest `v6` [release](https://github.com/golangci/golangci-lint-action/releases).

[DEVPROD-2344]: https://redpandadata.atlassian.net/browse/DEVPROD-2344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ