### PR TITLE
snowflake: uppercase db, schema and roles

### DIFF
--- a/internal/impl/snowflake/output_snowflake_streaming.go
+++ b/internal/impl/snowflake/output_snowflake_streaming.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
@@ -315,6 +316,14 @@ func newSnowflakeStreamer(
 		// stream to write to a single table.
 		channelPrefix = fmt.Sprintf("Redpanda_Connect_%s.%s.%s", db, schema, table)
 	}
+
+	// Normalize role, db and schema as they are case-sensitive in the API calls.
+	// Maybe we should use the golang SQL driver for SQL statements so we don't have
+	// to handle this, instead of the REST API directly.
+	role = strings.ToUpper(role)
+	db = strings.ToUpper(db)
+	schema = strings.ToUpper(schema)
+
 	var initStatementsFn func(context.Context, *streaming.SnowflakeRestClient) error
 	if conf.Contains(ssoFieldInitStatement) {
 		initStatements, err := conf.FieldString(ssoFieldInitStatement)


### PR DESCRIPTION
It seems that these fields are case sensitive in the API calls and by
default everything is uppercased, so just upper case these fields. If
someone is using weird quoted database/schema/roles then we can handle
that as needed.
