### PR TITLE
gha: remove hard-coded dockerhub username

### DIFF
--- a/.github/workflows/docker_edge.yml
+++ b/.github/workflows/docker_edge.yml
@@ -38,13 +38,13 @@ jobs:
       uses: aws-actions/aws-secretsmanager-get-secrets@v2
       with:
         secret-ids: |
-          ,sdlc/prod/github/dockerhub_token
+          ,sdlc/prod/github/dockerhub
         parse-json-secrets: true
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: vectorizedbot
+        username: ${{ env.DOCKERHUB_USER }}
         password: ${{ env.DOCKERHUB_TOKEN }}
 
     - name: Install Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,13 @@ jobs:
       uses: aws-actions/aws-secretsmanager-get-secrets@v2
       with:
         secret-ids: |
-          ,sdlc/prod/github/dockerhub_token
+          ,sdlc/prod/github/dockerhub
         parse-json-secrets: true
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: vectorizedbot
+        username: ${{ env.DOCKERHUB_USER }}
         password: ${{ env.DOCKERHUB_TOKEN }}
 
     - name: Install Buildx


### PR DESCRIPTION
Change the secret being fetched by a new one that is named following our secret naming guidelines. In addition, remove hard-coded username to allow easy change in the future of this value