### PR TITLE
sql_insert: support keyword options to add before the INTO clause of the query

### DIFF
--- a/docs/modules/components/pages/outputs/sql_insert.adoc
+++ b/docs/modules/components/pages/outputs/sql_insert.adoc
@@ -69,6 +69,7 @@ output:
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
     prefix: "" # No default (optional)
     suffix: ON CONFLICT (name) DO NOTHING # No default (optional)
+    options: [] # No default (optional)
     max_in_flight: 64
     init_files: [] # No default (optional)
     init_statement: | # No default (optional)
@@ -274,6 +275,22 @@ An optional suffix to append to the insert query.
 # Examples
 
 suffix: ON CONFLICT (name) DO NOTHING
+```
+
+=== `options`
+
+A list of keyword options to add before the INTO clause of the query.
+
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+options:
+  - DELAYED
+  - IGNORE
 ```
 
 === `max_in_flight`

--- a/docs/modules/components/pages/processors/sql_insert.adoc
+++ b/docs/modules/components/pages/processors/sql_insert.adoc
@@ -61,6 +61,7 @@ sql_insert:
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
   prefix: "" # No default (optional)
   suffix: ON CONFLICT (name) DO NOTHING # No default (optional)
+  options: [] # No default (optional)
   init_files: [] # No default (optional)
   init_statement: | # No default (optional)
     CREATE TABLE IF NOT EXISTS some_table (
@@ -262,6 +263,22 @@ An optional suffix to append to the insert query.
 # Examples
 
 suffix: ON CONFLICT (name) DO NOTHING
+```
+
+=== `options`
+
+A list of keyword options to add before the INTO clause of the query.
+
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+options:
+  - DELAYED
+  - IGNORE
 ```
 
 === `init_files`

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -55,6 +55,11 @@ func sqlInsertOutputConfig() *service.ConfigSpec {
 			Optional().
 			Advanced().
 			Example("ON CONFLICT (name) DO NOTHING")).
+		Field(service.NewStringListField("options").
+			Description("A list of keyword options to add before the INTO clause of the query.").
+			Optional().
+			Advanced().
+			Example([]string{"DELAYED", "IGNORE"})).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").
 			Default(64))
@@ -196,6 +201,14 @@ func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 			return nil, err
 		}
 		s.builder = s.builder.Suffix(suffixStr)
+	}
+
+	if conf.Contains("options") {
+		options, err := conf.FieldStringList("options")
+		if err != nil {
+			return nil, err
+		}
+		s.builder = s.builder.Options(options...)
 	}
 
 	if s.connSettings, err = connSettingsFromParsed(conf, mgr); err != nil {

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -56,7 +56,12 @@ If the insert fails to execute then the message will still remain unchanged and 
 			Description("An optional suffix to append to the insert query.").
 			Optional().
 			Advanced().
-			Example("ON CONFLICT (name) DO NOTHING"))
+			Example("ON CONFLICT (name) DO NOTHING")).
+		Field(service.NewStringListField("options").
+			Description("A list of keyword options to add before the INTO clause of the query.").
+			Optional().
+			Advanced().
+			Example([]string{"DELAYED", "IGNORE"}))
 
 	for _, f := range connFields() {
 		spec = spec.Field(f)
@@ -185,6 +190,14 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 			return nil, err
 		}
 		s.builder = s.builder.Suffix(suffixStr)
+	}
+
+	if conf.Contains("options") {
+		options, err := conf.FieldStringList("options")
+		if err != nil {
+			return nil, err
+		}
+		s.builder = s.builder.Options(options...)
 	}
 
 	connSettings, err := connSettingsFromParsed(conf, mgr)


### PR DESCRIPTION
Add support for including optionally a list of keyword options before the INTO clause of the query in `sql_insert` components.

It's useful when you want to insert into a MySQL ignoring duplicate key errors.