### PR TITLE
snowpipe: batch schema migration

### DIFF
--- a/internal/impl/snowflake/output_snowflake_streaming.go
+++ b/internal/impl/snowflake/output_snowflake_streaming.go
@@ -564,27 +564,12 @@ func (o *snowflakeStreamerOutput) WriteBatchInternal(ctx context.Context, batch 
 	} else {
 		// Only evolve the schema if requested.
 		if o.schemaEvolutionEnabled() {
-			nullColumnErr := streaming.NonNullColumnError{}
-			if errors.As(err, &nullColumnErr) {
+			schemaErr, ok := asSchemaMigrationError(o, err)
+			if ok {
 				// put the channel back so that we can reopen it along with the rest of the channels to
 				// pick up the new schema.
 				o.channelPool.Put(channel)
-				// Return an error so that we release our read lock and can take the write lock
-				// to forcibly reopen all our channels to get a new schema.
-				return schemaMigrationNeededError{
-					migrator: func(ctx context.Context) error {
-						return o.MigrateNotNullColumn(ctx, nullColumnErr)
-					},
-				}
-			}
-			missingColumnErr := streaming.MissingColumnError{}
-			if errors.As(err, &missingColumnErr) {
-				o.channelPool.Put(channel)
-				return schemaMigrationNeededError{
-					migrator: func(ctx context.Context) error {
-						return o.MigrateMissingColumn(ctx, missingColumnErr)
-					},
-				}
+				return schemaErr
 			}
 		}
 		reopened, reopenErr := o.openChannel(ctx, channel.Name, channel.ID)
@@ -603,6 +588,42 @@ func (o *snowflakeStreamerOutput) WriteBatchInternal(ctx context.Context, batch 
 	}
 	o.channelPool.Put(channel)
 	return err
+}
+
+func asSchemaMigrationError(o *snowflakeStreamerOutput, err error) (schemaMigrationNeededError, bool) {
+	nullColumnErr := streaming.NonNullColumnError{}
+	if errors.As(err, &nullColumnErr) {
+		// Return an error so that we release our read lock and can take the write lock
+		// to forcibly reopen all our channels to get a new schema.
+		return schemaMigrationNeededError{
+			migrator: func(ctx context.Context) error {
+				return o.MigrateNotNullColumn(ctx, nullColumnErr)
+			},
+		}, true
+	}
+	missingColumnErr := streaming.MissingColumnError{}
+	if errors.As(err, &missingColumnErr) {
+		return schemaMigrationNeededError{
+			migrator: func(ctx context.Context) error {
+				return o.MigrateMissingColumn(ctx, missingColumnErr)
+			},
+		}, true
+	}
+	batchErr := streaming.BatchSchemaMismatchError[streaming.MissingColumnError]{}
+	if errors.As(err, &batchErr) {
+		return schemaMigrationNeededError{
+			migrator: func(ctx context.Context) error {
+				for _, missingCol := range batchErr.Errors {
+					// TODO(rockwood): Consider a batch SQL statement that adds N columns at a time
+					if err := o.MigrateMissingColumn(ctx, missingCol); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		}, true
+	}
+	return schemaMigrationNeededError{}, false
 }
 
 type schemaMigrationNeededError struct {

--- a/internal/impl/snowflake/streaming/parquet.go
+++ b/internal/impl/snowflake/streaming/parquet.go
@@ -34,15 +34,19 @@ func messageToRow(msg *service.Message, out []any, nameToPosition map[string]int
 	if !ok {
 		return fmt.Errorf("expected object, got: %T", v)
 	}
+	var missingColumns []MissingColumnError
 	for k, v := range row {
 		idx, ok := nameToPosition[normalizeColumnName(k)]
 		if !ok {
 			if !allowExtraProperties && v != nil {
-				return MissingColumnError{columnName: k, val: v}
+				missingColumns = append(missingColumns, MissingColumnError{columnName: k, val: v})
 			}
 			continue
 		}
 		out[idx] = v
+	}
+	if len(missingColumns) > 0 {
+		return BatchSchemaMismatchError[MissingColumnError]{missingColumns}
 	}
 	return nil
 }


### PR DESCRIPTION
When first running a pipeline with heterogeneous data, you might need to
do a lot of column additions. Support a batch path for updating columns
so that we don't have to fallback to retrying the whole batch - also
it makes the experience much faster.
