### PR TITLE
pgcdc: remove stats passing as part of message

### DIFF
--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -523,10 +523,6 @@ func (s *Stream) processSnapshot() error {
 						s.monitor.UpdateSnapshotProgressForTable(tableWithoutSchema, rowsCount+offset)
 					}
 
-					tableProgress := s.monitor.GetSnapshotProgressForTable(tableWithoutSchema)
-					snapshotChangePacket.Changes[0].TableSnapshotProgress = &tableProgress
-					snapshotChangePacket.Mode = StreamModeSnapshot
-
 					waitingFromBenthos := time.Now()
 					select {
 					case s.messages <- snapshotChangePacket:

--- a/internal/impl/postgresql/pglogicalstream/monitor.go
+++ b/internal/impl/postgresql/pglogicalstream/monitor.go
@@ -80,13 +80,6 @@ func NewMonitor(
 	return m, nil
 }
 
-// GetSnapshotProgressForTable returns the snapshot ingestion progress for a given table
-func (m *Monitor) GetSnapshotProgressForTable(table string) float64 {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.snapshotProgress[table]
-}
-
 // UpdateSnapshotProgressForTable updates the snapshot ingestion progress for a given table
 func (m *Monitor) UpdateSnapshotProgressForTable(table string, position int) {
 	m.lock.Lock()

--- a/internal/impl/postgresql/pglogicalstream/pluginhandlers.go
+++ b/internal/impl/postgresql/pglogicalstream/pluginhandlers.go
@@ -97,10 +97,9 @@ func (p *PgOutputUnbufferedPluginHandler) Handle(ctx context.Context, clientXLog
 	if message != nil {
 		lsn := clientXLogPos.String()
 		msg := StreamMessage{
-			Lsn:         &lsn,
-			Changes:     []StreamMessageChanges{*message},
-			Mode:        StreamModeStreaming,
-			WALLagBytes: &p.monitor.Report().WalLagInBytes,
+			Lsn:     &lsn,
+			Changes: []StreamMessageChanges{*message},
+			Mode:    StreamModeStreaming,
 		}
 		select {
 		case p.messages <- msg:
@@ -150,10 +149,9 @@ func (p *PgOutputBufferedPluginHandler) Handle(ctx context.Context, clientXLogPo
 		// send all collected changes
 		lsn := clientXLogPos.String()
 		msg := StreamMessage{
-			Lsn:         &lsn,
-			Changes:     p.pgoutputChanges,
-			Mode:        StreamModeStreaming,
-			WALLagBytes: &p.monitor.Report().WalLagInBytes,
+			Lsn:     &lsn,
+			Changes: p.pgoutputChanges,
+			Mode:    StreamModeStreaming,
 		}
 		select {
 		case p.messages <- msg:

--- a/internal/impl/postgresql/pglogicalstream/stream_message.go
+++ b/internal/impl/postgresql/pglogicalstream/stream_message.go
@@ -11,18 +11,11 @@ package pglogicalstream
 // StreamMessageChanges represents the changes in a single message
 // Single message can have multiple changes
 type StreamMessageChanges struct {
-	Operation             string   `json:"operation"`
-	Schema                string   `json:"schema"`
-	Table                 string   `json:"table"`
-	TableSnapshotProgress *float64 `json:"table_snapshot_progress,omitempty"`
+	Operation string `json:"operation"`
+	Schema    string `json:"schema"`
+	Table     string `json:"table"`
 	// For deleted messages - there will be old changes if replica identity set to full or empty changes
 	Data map[string]any `json:"data"`
-}
-
-// StreamMessageMetrics represents the metrics of a stream. Passed to each message
-type StreamMessageMetrics struct {
-	WALLagBytes *int64 `json:"wal_lag_bytes"`
-	IsStreaming bool   `json:"is_streaming"`
 }
 
 // StreamMode represents the mode of the stream at the time of the message
@@ -37,8 +30,7 @@ const (
 
 // StreamMessage represents a single message after it has been decoded by the plugin
 type StreamMessage struct {
-	Lsn         *string                `json:"lsn"`
-	Changes     []StreamMessageChanges `json:"changes"`
-	Mode        StreamMode             `json:"mode"`
-	WALLagBytes *int64                 `json:"wal_lag_bytes,omitempty"`
+	Lsn     *string                `json:"lsn"`
+	Changes []StreamMessageChanges `json:"changes"`
+	Mode    StreamMode             `json:"mode"`
 }


### PR DESCRIPTION
In reality we should just be periodically reporting these stats, and not
tying them to data being emitted on the stream
