### PR TITLE
emit default values for non populated fields in protobuf

### DIFF
--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -50,6 +50,7 @@ label: ""
 schema_registry_decode:
   avro_raw_json: false
   url: "" # No default (required)
+  emit_default_values: false
   oauth:
     enabled: false
     consumer_key: ""
@@ -119,6 +120,15 @@ The base URL of the schema registry service.
 
 *Type*: `string`
 
+
+=== `emit_default_values`
+
+Emit default values for non populated fileds in protobuf.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `oauth`
 

--- a/internal/impl/confluent/serde_avro_test.go
+++ b/internal/impl/confluent/serde_avro_test.go
@@ -107,7 +107,7 @@ func TestAvroReferences(t *testing.T) {
 			encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
 			require.NoError(t, err)
 
-			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, service.MockResources())
+			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, false, service.MockResources())
 			require.NoError(t, err)
 
 			t.Cleanup(func() {

--- a/internal/impl/confluent/serde_json_test.go
+++ b/internal/impl/confluent/serde_json_test.go
@@ -110,7 +110,7 @@ func TestResolveJsonSchema(t *testing.T) {
 			encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
 			require.NoError(t, err)
 
-			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, service.MockResources())
+			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, false, service.MockResources())
 			require.NoError(t, err)
 
 			t.Cleanup(func() {

--- a/internal/impl/confluent/serde_protobuf.go
+++ b/internal/impl/confluent/serde_protobuf.go
@@ -87,7 +87,7 @@ func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, info sr.
 			return fmt.Errorf("failed to unmarshal protobuf message: %w", err)
 		}
 
-		data, err := protojson.MarshalOptions{Resolver: types}.Marshal(dynMsg)
+		data, err := protojson.MarshalOptions{Resolver: types, EmitDefaultValues: s.emitDefaultValues}.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON protobuf message: %w", err)
 		}

--- a/internal/impl/confluent/serde_protobuf_test.go
+++ b/internal/impl/confluent/serde_protobuf_test.go
@@ -96,7 +96,7 @@ message bar {
 			encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
 			require.NoError(t, err)
 
-			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, service.MockResources())
+			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, false, service.MockResources())
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -226,7 +226,7 @@ message bar {
 			encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
 			require.NoError(t, err)
 
-			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, service.MockResources())
+			decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, true, false, service.MockResources())
 			require.NoError(t, err)
 
 			t.Cleanup(func() {


### PR DESCRIPTION
When you use schema_registry_decode processor, the protobuf default values (0 for int32, "" for string, false for bool, 0.0 for float, etc...) are not populated in the row. 
With this new parameter you can have all those default values populated, no need to check for nulls after that processor