### PR TITLE
Fix `redpanda_migrator` output destination schema registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - Add support for `spanner` driver to SQL plugins. (@yufeng-deng)
 
+### Changed
+
+- The `redpanda_migrator` output now registers destination schemas with all the subjects associated with the source schema ID extracted from each message. (@mihaitodor)
+
 ## 4.41.0 - 2024-11-25
 
 ### Added

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -126,9 +126,13 @@ func (c *Client) GetSchemaByID(ctx context.Context, id int, includeDeleted bool)
 	return schema, nil
 }
 
-// GetSchemaByIDAndSubject gets a schema by its global identifier.
-func (c *Client) GetSchemaByIDAndSubject(ctx context.Context, id int, subject string, includeDeleted bool) (sr.Schema, error) {
-	return c.GetSchemaByID(sr.WithParams(ctx, sr.Subject(subject)), id, includeDeleted)
+// GetSubjectsBySchemaID returns the registered subjects for a given schema ID.
+func (c *Client) GetSubjectsBySchemaID(ctx context.Context, id int, includeDeleted bool) ([]string, error) {
+	if includeDeleted {
+		ctx = sr.WithParams(ctx, sr.ShowDeleted)
+	}
+
+	return c.clientSR.SubjectsByID(ctx, id)
 }
 
 // GetLatestSchemaVersionForSchemaIDAndSubject gets the latest version of a schema by its global identifier scoped to the provided subject.

--- a/internal/impl/kafka/enterprise/redpanda_migrator_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_output.go
@@ -274,14 +274,14 @@ func (w *RedpandaMigratorWriter) WriteBatch(ctx context.Context, b service.Messa
 		for recordIdx, record := range records {
 			schemaID, _, err := ch.DecodeID(record.Value)
 			if err != nil {
-				return fmt.Errorf("failed to extract schema ID from message index %d for topic %q: %s", recordIdx, record.Topic, err)
+				return fmt.Errorf("failed to extract schema ID from message index %d: %s", recordIdx, err)
 			}
 
 			var destSchemaID int
 			if cachedID, ok := w.schemaIDCache.Load(schemaID); !ok {
-				destSchemaID, err = w.schemaRegistryOutput.GetDestinationSchemaID(ctx, schemaID, record.Topic)
+				destSchemaID, err = w.schemaRegistryOutput.GetDestinationSchemaID(ctx, schemaID)
 				if err != nil {
-					return fmt.Errorf("failed to fetch destination schema ID from message index %d for topic %q: %s", recordIdx, record.Topic, err)
+					return fmt.Errorf("failed to fetch destination schema ID from message index %d: %s", recordIdx, err)
 				}
 				w.schemaIDCache.Store(schemaID, destSchemaID)
 			} else {
@@ -290,7 +290,7 @@ func (w *RedpandaMigratorWriter) WriteBatch(ctx context.Context, b service.Messa
 
 			err = sr.UpdateID(record.Value, destSchemaID)
 			if err != nil {
-				return fmt.Errorf("failed to extract schema ID from message index %d for topic %q: %s", recordIdx, record.Topic, err)
+				return fmt.Errorf("failed to update schema ID in message index %d: %s", recordIdx, err)
 			}
 		}
 	}

--- a/internal/impl/kafka/enterprise/schema_registry_test.go
+++ b/internal/impl/kafka/enterprise/schema_registry_test.go
@@ -70,6 +70,10 @@ func TestSchemaRegistry(t *testing.T) {
 				output = dummySchema
 			case "/schemas/ids/2":
 				output = dummySchemaWithRef
+			case "/schemas/ids/1/subjects":
+				output = []string{"foo"}
+			case "/schemas/ids/2/subjects":
+				output = []string{"bar"}
 			case "/schemas/ids/1/versions":
 				output = []map[string]any{{"subject": "foo", "version": 1}}
 			case "/schemas/ids/2/versions":
@@ -97,7 +101,6 @@ func TestSchemaRegistry(t *testing.T) {
 
 	inputConf, err := schemaRegistryInputSpec().ParseYAML(fmt.Sprintf(`
 url: %s
-subject: foo
 `, ts.URL), nil)
 	require.NoError(t, err)
 
@@ -139,10 +142,10 @@ subject: ${! @schema_registry_subject }
 
 	// Ensure that the written schemas are correctly returned.
 	// TODO: Use a secondary test server for the writer so we can check that they're actually written.
-	destID, err := writer.GetDestinationSchemaID(ctx, 1, "foo")
+	destID, err := writer.GetDestinationSchemaID(ctx, 1)
 	require.NoError(t, err)
 	assert.Equal(t, 1, destID)
-	destID, err = writer.GetDestinationSchemaID(ctx, 2, "bar")
+	destID, err = writer.GetDestinationSchemaID(ctx, 2)
 	require.NoError(t, err)
 	assert.Equal(t, 2, destID)
 }


### PR DESCRIPTION
The `redpanda_migrator` output now registers destination schemas with all the subjects associated with the source schema ID extracted from each message.