### PR TITLE
fix(sftp): make sure to delete last file when `watch` and `delete_on_finish` are enabled

### DIFF
--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -369,7 +369,7 @@ func (w *watcherPathProvider) Next(ctx context.Context, client *sftp.Client) (st
 		return nextPath, nil
 	}
 
-	if waitFor := time.Until(w.nextPoll); waitFor > 0 {
+	if waitFor := time.Until(w.nextPoll); w.nextPoll.IsZero() || waitFor > 0 {
 		w.nextPoll = time.Now().Add(w.pollInterval)
 		select {
 		case <-time.After(waitFor):


### PR DESCRIPTION
Fixes #2435 

## Questions

I believe I have fixed the underlying issue, but I am not sure how to write an integration test to verify the fix. I have created a new integration test function with a `TODO` comment on where I got stuck. The questions I have around this are:

- My plan was to start a pipeline with `watch` and `delete_on_finished` enabled, the use an SFTP client directly to inspect which files exist on the server to make sure they are all deleted after the pipeline runs. However, I'm not sure how to actually run the pipeline. Is too specific of a test to run using `integration.StreamTests()`, and if not, could you point me in the right direction?
- The other pattern I've seen would be to call `newSFTPReaderFromParsed()` directly from the tests then use `Connect()`, and `ReadBatch()` to interact with the plugin. However this plugin appears to be unusually structured in the way that it progresses through the input files. What it does is finds the first file in `Connect()` and sets up the scanner for the file. In `ReadBatch()`, when the file is exhausted, `ReadBatch()` returns `service.ErrNotConnected` which will cause the engine to re-run `Connect()` which advances to the next file. If the plugin only required `Connect()` to be called once, I would be happy to drive the plugin directly in the tests, but because of the reconnection logic required, I was hesitant to reimplement the reconnection loop in the tests. Is there a utility somewhere that I can use from a test that implements the reconnect logic?