### PR TITLE
Add error log when trial licenses are being used

### DIFF
--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -109,6 +109,11 @@ func (s *Service) readAndValidateLicense() (RedpandaLicense, error) {
 		if license, err = s.validateLicense(licenseBytes); err != nil {
 			return RedpandaLicense{}, fmt.Errorf("failed to validate license: %w", err)
 		}
+		if license.Type == 0 {
+			// If the license is a trial then we reject it because connect does
+			// not support trials.
+			return RedpandaLicense{}, errors.New("trial license detected, Redpanda Connect does not support enterprise license trials")
+		}
 	} else {
 		// An open source license is the final fall back.
 		year := time.Hour * 24 * 365


### PR DESCRIPTION
Most of our docs and pages for enterprise licenses are heavily pushing for generating trial licenses. However, we cannot support trial licenses in connect, and therefore these licenses are considered invalid for the purposes of running enterprise connect features.

This leaves us vulnerable to a poor user experience where a user tries to run enterprise features, is told by RPCN to visit https://cloud.redpanda.com/try-enterprise, where we then encourage them to create a trial (for Redpanda proper). When a user attempts to run the trial we will tell them it's invalid from Connect.

In order to at least clarify what is happening to the user I've added an explicit error log that notes the license is a trial, not a full license that connect will recognize.