### PR TITLE
Fix ga tag pattern and add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,36 @@ jobs:
       with:
         version: v1.61.0
         args: --timeout 30m cmd/... internal/... public/...
+
+  test-push-to-cloudsmith:
+    if: ${{ github.repository == 'redpanda-data/connect' || github.event_name != 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Mock cloudsmith cli
+      run: |
+        echo '#!/bin/bash' >cloudsmith
+        echo "echo \$@" >>cloudsmith
+        chmod +x cloudsmith
+        mv cloudsmith /usr/local/bin/
+
+    - name: Test GA
+      env:
+        CLOUDSMITH_API_KEY: thisisatest
+      run: |
+        test $(./resources/scripts/push_pkg_to_cloudsmith.sh artifact.deb 0.0.0 \
+          | grep "push deb redpanda/redpanda/" | wc -l) -eq 1
+        test $(./resources/scripts/push_pkg_to_cloudsmith.sh artifact.deb v0.0.0 \
+          | grep "push deb redpanda/redpanda/" | wc -l) -eq 1
+
+    - name: Test RC
+      env:
+        CLOUDSMITH_API_KEY: thisisatest
+      run: |
+        test $(./resources/scripts/push_pkg_to_cloudsmith.sh artifact.deb 0.0.0-rc1 \
+          | grep "push deb redpanda/redpanda-unstable/" | wc -l) -eq 1
+        test $(./resources/scripts/push_pkg_to_cloudsmith.sh artifact.deb v0.0.0-rc1 \
+          | grep "push deb redpanda/redpanda-unstable/" | wc -l) -eq 1

--- a/resources/scripts/push_pkg_to_cloudsmith.sh
+++ b/resources/scripts/push_pkg_to_cloudsmith.sh
@@ -40,7 +40,7 @@ else
     version=$PKG_VERSION
 fi
 
-GA_VERSION_PATTERN='^\d+\.\d+\.\d+$'
+GA_VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
 if [[ $version =~ $GA_VERSION_PATTERN ]]; then
   repo="redpanda"
 else


### PR DESCRIPTION
This PR:
* fixes GA tag pattern
goreleaser runs on an ubuntu VM managed by gh actions. ubuntu doesn't
understand `\d` for digits. Instead, using the equivalent pattern
`[0-9]` that works fine on ubuntu:

```
$ version=0.0.0
$ pattern='^\d+\.\d+\.\d+$'
$ if [[ $version =~ $pattern ]]; then echo match; fi
$ pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
$ if [[ $version =~ $pattern ]]; then echo match; fi
match
```
* adds gh action step to test push_pkg_to_cloudsmith.sh