### PR TITLE
Sftp refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Fix an issue in `aws_sqs` with refreshing in-flight message leases which could prevent acks from processed. (@rockwotj)
 - Fix an issue with `postgres_cdc` with TOAST values not being propagated with `REPLICA IDENTITY FULL`. (@rockwotj)
 - Fix a initial snapshot streaming consistency issue with `postgres_cdc`. (@rockwotj)
+- Fix bug in `sftp` input where the last file was not deleted when `watcher` and `delete_on_finish` were enabled (@ooesili)
 
 ## 4.44.0 - 2024-12-13
 

--- a/internal/impl/sftp/client_pool.go
+++ b/internal/impl/sftp/client_pool.go
@@ -1,0 +1,126 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sftp
+
+import (
+	"errors"
+	"io/fs"
+	"sync"
+
+	"github.com/pkg/sftp"
+)
+
+func newClientPool(newClient func() (*sftp.Client, error)) (*clientPool, error) {
+	client, err := newClient()
+	if err != nil {
+		return nil, err
+	}
+	return &clientPool{
+		newClient: newClient,
+		client:    client,
+	}, nil
+}
+
+type clientPool struct {
+	newClient func() (*sftp.Client, error)
+
+	lock   sync.Mutex
+	client *sftp.Client
+	closed bool
+}
+
+func (c *clientPool) Open(path string) (*sftp.File, error) {
+	return clientPoolDoReturning(c, func(client *sftp.Client) (*sftp.File, error) {
+		return client.Open(path)
+	})
+}
+
+func (c *clientPool) Glob(path string) ([]string, error) {
+	return clientPoolDoReturning(c, func(client *sftp.Client) ([]string, error) {
+		return client.Glob(path)
+	})
+}
+
+func (c *clientPool) Stat(path string) (fs.FileInfo, error) {
+	return clientPoolDoReturning(c, func(client *sftp.Client) (fs.FileInfo, error) {
+		return client.Stat(path)
+	})
+}
+
+func (c *clientPool) Remove(path string) error {
+	return clientPoolDo(c, func(client *sftp.Client) error {
+		return client.Remove(path)
+	})
+}
+
+func (c *clientPool) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	if c.client != nil {
+		err := c.client.Close()
+		c.client = nil
+		return err
+	}
+	return nil
+}
+
+func clientPoolDo(c *clientPool, fn func(*sftp.Client) error) error {
+	_, err := clientPoolDoReturning(c, func(client *sftp.Client) (struct{}, error) {
+		err := fn(client)
+		return struct{}{}, err
+	})
+	return err
+}
+
+func clientPoolDoReturning[T any](c *clientPool, fn func(*sftp.Client) (T, error)) (T, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var zero T
+
+	// In the case that the clientPool is used from an AckFn after the input is
+	// closed, we create temporary client to fulfil the operation, then
+	// immediately close it.
+	if c.closed {
+		client, err := c.newClient()
+		if err != nil {
+			return zero, err
+		}
+		result, err := fn(client)
+		_ = client.Close()
+		return result, err
+	}
+
+	if c.client == nil {
+		client, err := c.newClient()
+		if err != nil {
+			return zero, err
+		}
+		c.client = client
+	}
+
+	result, err := fn(c.client)
+	if errors.Is(err, sftp.ErrSSHFxConnectionLost) {
+		_ = c.client.Close()
+		c.client = nil
+	}
+	return result, err
+}

--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -369,7 +369,7 @@ func (w *watcherPathProvider) Next(ctx context.Context, client *sftp.Client) (st
 		return nextPath, nil
 	}
 
-	if waitFor := time.Until(w.nextPoll); waitFor > 0 {
+	if waitFor := time.Until(w.nextPoll); w.nextPoll.IsZero() || waitFor > 0 {
 		w.nextPoll = time.Now().Add(w.pollInterval)
 		select {
 		case <-time.After(waitFor):

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -186,7 +186,7 @@ cache_resources:
 		files, err := client.Glob("/upload/*.txt")
 		assert.NoError(c, err)
 		assert.Empty(c, files)
-	}, time.Second, time.Millisecond*100)
+	}, time.Second*10, time.Millisecond*100)
 }
 
 func setupDockerPool(t *testing.T) *dockertest.Resource {


### PR DESCRIPTION
Before this commit, when a file was exuasted the `ReadBatch` method
returned ErrNotConnected which cause the engine to call `Connect` again.
Aside from being awkward, this causes the connection status to
incorrectly be reported as disconnected during normal operation.

This commit moves the logic to advance to the next file when the current
file is exhuasted into a the ReadBatch method.

Builds on top of #3037