### PR TITLE
Fix `postgres_cdc` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `gcp_bigquery` output with parquet format no longer returns errors incorrectly. (@rockwotj)
-- `postgres_cdc` input now allows quoted identifiers for the table names. (@mihaitodor)
+- `postgres_cdc` input now allows quoted identifiers for the table names. (@mihaitodor, @rockwotj)
 
 ## 4.43.1 - 2024-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `gcp_bigquery` output with parquet format no longer returns errors incorrectly. (@rockwotj)
+- `postgres_cdc` input now allows quoted identifiers for the table names. (@mihaitodor)
 
 ## 4.43.1 - 2024-12-09
 

--- a/docs/modules/components/pages/inputs/pg_stream.adoc
+++ b/docs/modules/components/pages/inputs/pg_stream.adoc
@@ -193,6 +193,8 @@ The PostgreSQL schema from which to replicate data.
 # Examples
 
 schema: public
+
+schema: '"MyCaseSensitiveSchemaNeedingQuotes"'
 ```
 
 === `tables`
@@ -206,10 +208,9 @@ A list of table names to include in the logical replication. Each table should b
 ```yml
 # Examples
 
-tables: |2-
-  			- my_table
-  			- my_table_2
-  		
+tables:
+  - my_table_1
+  - '"MyCaseSensitiveTableNeedingQuotes"'
 ```
 
 === `checkpoint_limit`

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -188,6 +188,8 @@ The PostgreSQL schema from which to replicate data.
 # Examples
 
 schema: public
+
+schema: '"MyCaseSensitiveSchemaNeedingQuotes"'
 ```
 
 === `tables`
@@ -201,10 +203,9 @@ A list of table names to include in the logical replication. Each table should b
 ```yml
 # Examples
 
-tables: |2-
-  			- my_table
-  			- my_table_2
-  		
+tables:
+  - my_table_1
+  - '"MyCaseSensitiveTableNeedingQuotes"'
 ```
 
 === `checkpoint_limit`

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -85,13 +85,11 @@ This input adds the following metadata fields to each message:
 			Default(0)).
 		Field(service.NewStringField(fieldSchema).
 			Description("The PostgreSQL schema from which to replicate data.").
-			Example("public")).
+			Examples("public", `"MyCaseSensitiveSchemaNeedingQuotes"`),
+		).
 		Field(service.NewStringListField(fieldTables).
 			Description("A list of table names to include in the logical replication. Each table should be specified as a separate item.").
-			Example(`
-			- my_table
-			- my_table_2
-		`)).
+			Example([]string{"my_table_1", `"MyCaseSensitiveTableNeedingQuotes"`})).
 		Field(service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given LSN will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
 			Default(1024)).

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -321,7 +321,7 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 		// Periodically collect stats
 		report := pgStream.GetProgress()
 		for name, progress := range report.TableProgress {
-			p.snapshotMetrics.SetFloat64(progress, name)
+			p.snapshotMetrics.SetFloat64(progress, name.String())
 		}
 		p.replicationLag.Set(report.WalLagInBytes)
 	})

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -648,9 +648,13 @@ pg_stream:
     slot_name: test_slot_native_decoder
     stream_snapshot: true
     include_transaction_markers: false
-    schema: public
+     # This is intentionally with uppercase - we want to validate
+     # we treat identifiers the same as Postgres Queries.
+    schema: PuBliC
     tables:
-       - flights
+       # This is intentionally with uppercase - we want to validate
+       # we treat identifiers the same as Postgres Queries.
+       - FLIGHTS
 `, databaseURL)
 
 			cacheConf := fmt.Sprintf(`

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -128,7 +128,7 @@ func ResourceWithPostgreSQLVersion(t *testing.T, pool *dockertest.Pool, version 
 		}
 
 		_, err = db.Exec(`
-			CREATE TABLE IF NOT EXISTS flights_composite_pks (
+			CREATE TABLE IF NOT EXISTS "FlightsCompositePK" (
 				id serial, seq integer, name VARCHAR(50), created_at TIMESTAMP,
 				PRIMARY KEY (id, seq)
 			);`)
@@ -171,7 +171,7 @@ func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec("INSERT INTO flights_composite_pks (seq, name, created_at) VALUES ($1, $2, $3);", i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
 
@@ -184,7 +184,7 @@ pg_stream:
     snapshot_batch_size: 5
     schema: public
     tables:
-       - flights_composite_pks
+       - '"FlightsCompositePK"'
 `, databaseURL)
 
 	cacheConf := fmt.Sprintf(`
@@ -226,9 +226,9 @@ file:
 
 	for i := 10; i < 20; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec("INSERT INTO flights_composite_pks (seq, name, created_at) VALUES ($1, $2, $3);", i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
-		_, err = db.Exec("INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);`, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
 
@@ -270,7 +270,7 @@ file:
 	time.Sleep(time.Second * 5)
 	for i := 20; i < 30; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec("INSERT INTO flights_composite_pks (seq, name, created_at) VALUES ($1, $2, $3);", i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
 

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -127,10 +127,11 @@ func ResourceWithPostgreSQLVersion(t *testing.T, pool *dockertest.Pool, version 
 			return err
 		}
 
+		// This table explicitly uses identifiers that need quoting to ensure we work with those correctly.
 		_, err = db.Exec(`
 			CREATE TABLE IF NOT EXISTS "FlightsCompositePK" (
-				id serial, seq integer, name VARCHAR(50), created_at TIMESTAMP,
-				PRIMARY KEY (id, seq)
+				"ID" serial, "Seq" integer, "Name" VARCHAR(50), "CreatedAt" TIMESTAMP,
+				PRIMARY KEY ("ID", "Seq")
 			);`)
 		if err != nil {
 			return err
@@ -171,7 +172,7 @@ func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
 
@@ -194,7 +195,7 @@ file:
 `, tmpDir)
 
 	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: INFO`))
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: TRACE`))
 	require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
 	require.NoError(t, streamOutBuilder.AddInputYAML(template))
 
@@ -226,7 +227,7 @@ file:
 
 	for i := 10; i < 20; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 		_, err = db.Exec(`INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);`, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
@@ -270,7 +271,7 @@ file:
 	time.Sleep(time.Second * 5)
 	for i := 20; i < 30; i++ {
 		f := GetFakeFlightRecord()
-		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" (seq, name, created_at) VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
 

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -144,7 +144,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 
 	pubName := "pglog_stream_" + config.ReplicationSlotName
 	stream.logger.Infof("Creating publication %s for tables: %s", pubName, tableNames)
-	if err = CreatePublication(ctx, stream.pgConn, pubName, tableNames); err != nil {
+	if err = CreatePublication(ctx, stream.pgConn, pubName, config.DBSchema, tableNames); err != nil {
 		return nil, err
 	}
 	cleanups = append(cleanups, func() {

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -86,16 +86,18 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		return nil, err
 	}
 
-	if err := sanitize.ValidatePostgresIdentifier(config.DBSchema); err != nil {
+	schema, err := sanitize.NormalizePostgresIdentifier(config.DBSchema)
+	if err != nil {
 		return nil, fmt.Errorf("invalid schema name %q: %w", config.DBSchema, err)
 	}
 
 	tables := []TableFQN{}
 	for _, table := range config.DBTables {
-		if err := sanitize.ValidatePostgresIdentifier(table); err != nil {
+		normalized, err := sanitize.NormalizePostgresIdentifier(table)
+		if err != nil {
 			return nil, fmt.Errorf("invalid table name %q: %w", table, err)
 		}
-		tables = append(tables, TableFQN{Schema: config.DBSchema, Table: table})
+		tables = append(tables, TableFQN{Schema: schema, Table: normalized})
 	}
 	stream := &Stream{
 		pgConn:                     dbConn,

--- a/internal/impl/postgresql/pglogicalstream/pglogrepl.go
+++ b/internal/impl/postgresql/pglogicalstream/pglogrepl.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -343,7 +342,7 @@ func DropReplicationSlot(ctx context.Context, conn *pgconn.PgConn, slotName stri
 }
 
 // CreatePublication creates a new PostgreSQL publication with the given name for a list of tables and drop if exists flag
-func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName string, schema string, tables []string) error {
+func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName string, tables []TableFQN) error {
 	// Check if publication exists
 	pubQuery, err := sanitize.SQLQuery(`
 			SELECT pubname, puballtables
@@ -352,17 +351,6 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 		`, publicationName)
 	if err != nil {
 		return fmt.Errorf("failed to sanitize publication query: %w", err)
-	}
-
-	// Since we need to pass table names without quoting, we need to validate it
-	for _, table := range tables {
-		if err := sanitize.ValidatePostgresIdentifier(table); err != nil {
-			return errors.New("invalid table name")
-		}
-	}
-	// the same for publication name
-	if err := sanitize.ValidatePostgresIdentifier(publicationName); err != nil {
-		return errors.New("invalid publication name")
 	}
 
 	result := conn.Exec(ctx, pubQuery)
@@ -374,16 +362,13 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 
 	tablesClause := "FOR ALL TABLES"
 	if len(tables) > 0 {
-		// quotedTables := make([]string, len(tables))
-		// for i, table := range tables {
-		// 	// Use sanitize.SQLIdentifier to properly quote and escape table names
-		// 	quoted, err := sanitize.SQLIdentifier(table)
-		// 	if err != nil {
-		// 		return fmt.Errorf("invalid table name %q: %w", table, err)
-		// 	}
-		// 	quotedTables[i] = quoted
-		// }
-		tablesClause = "FOR TABLE " + strings.Join(tables, ", ")
+		tablesClause = "FOR TABLE "
+		for i, table := range tables {
+			if i > 0 {
+				tablesClause += ", "
+			}
+			tablesClause += table.String()
+		}
 	}
 
 	if len(rows) == 0 || len(rows[0].Rows) == 0 {
@@ -403,7 +388,7 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 
 	// assuming publication already exists
 	// get a list of tables in the publication
-	pubTables, forAllTables, err := GetPublicationTables(ctx, conn, publicationName, schema)
+	pubTables, forAllTables, err := GetPublicationTables(ctx, conn, publicationName)
 	if err != nil {
 		return fmt.Errorf("failed to get publication tables: %w", err)
 	}
@@ -414,8 +399,8 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 		return nil
 	}
 
-	var tablesToRemoveFromPublication = []string{}
-	var tablesToAddToPublication = []string{}
+	var tablesToRemoveFromPublication = []TableFQN{}
+	var tablesToAddToPublication = []TableFQN{}
 	for _, table := range tables {
 		if !slices.Contains(pubTables, table) {
 			tablesToAddToPublication = append(tablesToAddToPublication, table)
@@ -430,7 +415,7 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 
 	// remove tables from publication
 	for _, dropTable := range tablesToRemoveFromPublication {
-		sq, err := sanitize.SQLQuery(fmt.Sprintf(`ALTER PUBLICATION %s DROP TABLE %s."%s";`, publicationName, schema, dropTable))
+		sq, err := sanitize.SQLQuery(fmt.Sprintf(`ALTER PUBLICATION %s DROP TABLE %s;`, publicationName, dropTable.String()))
 		if err != nil {
 			return fmt.Errorf("failed to sanitize drop table query: %w", err)
 		}
@@ -442,7 +427,7 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 
 	// add tables to publication
 	for _, addTable := range tablesToAddToPublication {
-		sq, err := sanitize.SQLQuery(fmt.Sprintf("ALTER PUBLICATION %s ADD TABLE %s;", publicationName, addTable))
+		sq, err := sanitize.SQLQuery(fmt.Sprintf("ALTER PUBLICATION %s ADD TABLE %s;", publicationName, addTable.String()))
 		if err != nil {
 			return fmt.Errorf("failed to sanitize add table query: %w", err)
 		}
@@ -457,15 +442,15 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 
 // GetPublicationTables returns a list of tables currently in the publication
 // Arguments, in order: list of the tables, exist for all tables, errror
-func GetPublicationTables(ctx context.Context, conn *pgconn.PgConn, publicationName, schema string) ([]string, bool, error) {
+func GetPublicationTables(ctx context.Context, conn *pgconn.PgConn, publicationName string) ([]TableFQN, bool, error) {
 	query, err := sanitize.SQLQuery(`
 		SELECT DISTINCT
-			tablename as table_name
+			tablename as table_name,
+      schemaname as schema_name
 		FROM pg_publication_tables
 		WHERE pubname = $1
-		AND schemaname = $2
-		ORDER BY table_name;
-	`, publicationName, strings.Trim(schema, "\""))
+		ORDER BY schema_name, table_name;
+	`, publicationName)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get publication tables: %w", err)
 	}
@@ -482,9 +467,13 @@ func GetPublicationTables(ctx context.Context, conn *pgconn.PgConn, publicationN
 		return nil, true, nil // Publication exists and is for all tables
 	}
 
-	tables := make([]string, 0, len(rows))
+	tables := make([]TableFQN, 0, len(rows))
 	for _, row := range rows[0].Rows {
-		tables = append(tables, string(row[0]))
+		// These come from postgres so they are valid, but we have to quote them
+		// to prevent normalization
+		table := sanitize.QuotePostgresIdentifier(string(row[0]))
+		schema := sanitize.QuotePostgresIdentifier(string(row[1]))
+		tables = append(tables, TableFQN{Table: table, Schema: schema})
 	}
 
 	return tables, false, nil

--- a/internal/impl/postgresql/pglogicalstream/pglogrepl.go
+++ b/internal/impl/postgresql/pglogicalstream/pglogrepl.go
@@ -445,8 +445,8 @@ func CreatePublication(ctx context.Context, conn *pgconn.PgConn, publicationName
 func GetPublicationTables(ctx context.Context, conn *pgconn.PgConn, publicationName string) ([]TableFQN, bool, error) {
 	query, err := sanitize.SQLQuery(`
 		SELECT DISTINCT
-			tablename as table_name,
-      schemaname as schema_name
+		tablename as table_name,
+		schemaname as schema_name
 		FROM pg_publication_tables
 		WHERE pubname = $1
 		ORDER BY schema_name, table_name;

--- a/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
+++ b/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
@@ -363,6 +363,24 @@ func SQLQuery(sql string, args ...any) (string, error) {
 	return query.Sanitize(args...)
 }
 
+// QuotePostgresIdentifier returns the valid escaped identifier.
+func QuotePostgresIdentifier(name string) string {
+	var quoted strings.Builder
+	// Default to assume we're just going to add quotes and there won't
+	// be any double quotes inside the string that needs escaped.
+	quoted.Grow(len(name) + 2)
+	quoted.WriteByte('"')
+	for _, r := range name {
+		if r == '"' {
+			quoted.WriteString(`""`)
+		} else {
+			quoted.WriteRune(r)
+		}
+	}
+	quoted.WriteByte('"')
+	return quoted.String()
+}
+
 // ValidatePostgresIdentifier checks if a string is a valid PostgreSQL identifier
 // This follows PostgreSQL's standard naming rules
 func ValidatePostgresIdentifier(name string) error {

--- a/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
+++ b/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
@@ -366,6 +366,18 @@ func SQLQuery(sql string, args ...any) (string, error) {
 // ValidatePostgresIdentifier checks if a string is a valid PostgreSQL identifier
 // This follows PostgreSQL's standard naming rules
 func ValidatePostgresIdentifier(name string) error {
+	if parts := strings.Split(name, "."); len(parts) == 2 {
+		if err := ValidatePostgresIdentifier(parts[0]); err != nil {
+			return fmt.Errorf("invalid schema identifier: %s", err)
+		}
+		name = parts[1]
+	}
+
+	// Strip quotes if they are present
+	if strings.HasPrefix(name, "\"") && strings.HasSuffix(name, "\"") {
+		name = strings.Trim(name, "\"")
+	}
+
 	if len(name) == 0 {
 		return errors.New("empty identifier is not allowed")
 	}

--- a/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
+++ b/internal/impl/postgresql/pglogicalstream/sanitize/sanitize.go
@@ -381,54 +381,54 @@ func QuotePostgresIdentifier(name string) string {
 	return quoted.String()
 }
 
-// ValidatePostgresIdentifier checks if a string is a valid PostgreSQL identifier
+// NormalizePostgresIdentifier checks if a string is a valid PostgreSQL identifier
 // This follows PostgreSQL's standard naming rules
-func ValidatePostgresIdentifier(name string) error {
+func NormalizePostgresIdentifier(name string) (string, error) {
 	if len(name) == 0 {
-		return errors.New("empty identifier is not allowed")
+		return "", errors.New("empty identifier is not allowed")
 	}
 
 	// It's not fully clear to me if the max here is before or after unescaping the quotes.
 	// We'll just play it safe and validate before quotes, it seems unlikely folks are using large
 	// identifiers.
 	if len(name) > MaxIdentifierLength {
-		return fmt.Errorf("identifier length exceeds maximum of %d characters", MaxIdentifierLength)
+		return "", fmt.Errorf("identifier length exceeds maximum of %d characters", MaxIdentifierLength)
 	}
 
 	// Handle quoted identifiers.
 	if strings.HasPrefix(name, `"`) && strings.HasSuffix(name, `"`) && len(name) >= 2 {
-		name := name[1 : len(name)-1]
-		if name == "" {
-			return errors.New("quoted identifiers cannot be empty")
+		unquoted := name[1 : len(name)-1]
+		if unquoted == "" {
+			return "", errors.New("quoted identifiers cannot be empty")
 		}
-		for i := 0; i < len(name); i++ {
-			if name[i] != '"' {
+		for i := 0; i < len(unquoted); i++ {
+			if unquoted[i] != '"' {
 				continue
 			}
-			if i+1 >= len(name) {
-				return fmt.Errorf("invalid quoted identifier: %s", name)
+			if i+1 >= len(unquoted) {
+				return "", fmt.Errorf("invalid quoted identifier: %s", unquoted)
 			}
-			if name[i+1] != '"' {
-				return fmt.Errorf("invalid quoted identifier: %s", name)
+			if unquoted[i+1] != '"' {
+				return "", fmt.Errorf("invalid quoted identifier: %s", unquoted)
 			}
 			i++ // Skip over the next character to handle triple quotes
 		}
-		return nil
+		return name, nil
 	}
 
 	// First character must be a letter or underscore
 	if !unicode.IsLetter(rune(name[0])) && name[0] != '_' {
-		return errors.New("identifier must start with a letter or underscore")
+		return "", errors.New("identifier must start with a letter or underscore")
 	}
 
 	// Subsequent characters must be letters, numbers, underscores, or dots
 	for i, char := range name {
 		if !unicode.IsLetter(char) && !unicode.IsDigit(char) && char != '_' && char != '.' {
-			return fmt.Errorf("invalid character '%c' at position %d in identifier '%s'", char, i, name)
+			return "", fmt.Errorf("invalid character '%c' at position %d in identifier '%s'", char, i, name)
 		}
 	}
 
 	// TODO(cdc): We should also ensure that this is not a reserved keyword.
 
-	return nil
+	return QuotePostgresIdentifier(strings.ToLower(name)), nil
 }

--- a/internal/impl/postgresql/pglogicalstream/sanitize/sanitize_test.go
+++ b/internal/impl/postgresql/pglogicalstream/sanitize/sanitize_test.go
@@ -28,8 +28,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
 )
 
 func TestNewQuery(t *testing.T) {

--- a/internal/impl/postgresql/pglogicalstream/types.go
+++ b/internal/impl/postgresql/pglogicalstream/types.go
@@ -7,3 +7,18 @@
 // https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
 
 package pglogicalstream
+
+import "fmt"
+
+// TableFQN is both a table name AND a schema name
+//
+// TableFQN should always be SAFE and validated before creating
+type TableFQN struct {
+	Schema string
+	Table  string
+}
+
+// String satifies the Stringer interface
+func (t TableFQN) String() string {
+	return fmt.Sprintf("%s.%s", t.Schema, t.Table)
+}


### PR DESCRIPTION
Allow quoted identifiers for the table names.

Note: This is a very naive implementation and we might want to instead just quote the identifier like @rockwotj suggested (and implemented [here](https://github.com/redpanda-data/connect/blob/main/internal/impl/snowflake/streaming/compat.go#L189) for Snowflake).

If we always quote, then it's a bit unclear how to validate the identifiers because we can't tell when it genuinely needs to be quoted to apply the alternate validation rules: https://www.postgresql.org/docs/current/sql-syntax-lexical.html

> Quoted identifiers can contain any character, except the character with code zero. (To include a double quote, write two double quotes.) This allows constructing table or column names that would otherwise not be possible, such as ones containing spaces or ampersands. The length limitation still applies.

Also, users might get confused if they specify the table name as upper case in the config for a non-quoted table:

```sql
> CREATE TABLE MIHAI(ID INT NOT NULL, CATEGORY VARCHAR);
> INSERT INTO "MIHAI"(ID, CATEGORY) VALUES(13, 'FOOBAR');
relation "MIHAI" does not exist
LINE 1: INSERT INTO "MIHAI"(ID, CATEGORY) VALUES(13, 'FOOBAR')
```

## How to test

Run Postgres and connect to it via `pgcli`:

```shell
$ docker run --rm -it -e POSTGRES_USER=testuser -e "POSTGRES_PASSWORD=testpass" -e POSTGRES_DB=testdb -p5432:5432 postgres -c wal_level=logical
$ pgcli postgres://testuser:testpass@localhost:5432/testdb
```

Create a quoted table:

```sql
> CREATE SCHEMA "TestABC";
> CREATE TABLE "TestABC"."FooBar"(ID INT NOT NULL, CATEGORY VARCHAR);
> CREATE TABLE "TestABC"."BarFoo"(ID INT NOT NULL, CATEGORY VARCHAR);
```

Run Connect:

```yaml
input:
  postgres_cdc:
    dsn: postgres://testuser:testpass@localhost:5432/testdb?sslmode=disable
    include_transaction_markers: true
    stream_snapshot: false
    snapshot_memory_safety_factor: 1
    snapshot_batch_size: 0
    schema: public # No default (required)
    tables:
      - '"FooBar"'
      - '"BarFoo"'
    checkpoint_limit: 1024
    temporary_slot: false
    slot_name: "mihaifoo" # No default (optional)
    pg_standby_timeout: 10s
    pg_wal_monitor_interval: 3s
    max_parallel_snapshot_tables: 1
    auto_replay_nacks: true

output:
  stdout: {}
```

Insert rows:

```sql
> INSERT INTO "TestABC"."FooBar"(ID, CATEGORY) VALUES(13, 'FOOBAR');
> INSERT INTO "TestABC"."BarFoo"(ID, CATEGORY) VALUES(13, 'FOOBAR');
```

Comment out the `"BarFoo"` table in the Connect config, restart it and insert another row in `"FooBar"`.