### PR TITLE
#3095 AMQP 1.0 Output - Support for message body type

### DIFF
--- a/docs/modules/components/pages/outputs/amqp_1.adoc
+++ b/docs/modules/components/pages/outputs/amqp_1.adoc
@@ -71,6 +71,7 @@ output:
       password: ""
     metadata:
       exclude_prefixes: []
+    content_type: opaque_binary
 ```
 
 --
@@ -384,5 +385,21 @@ Provide a list of explicit metadata key prefixes to be excluded when adding meta
 *Type*: `array`
 
 *Default*: `[]`
+
+=== `content_type`
+
+Define the message body content type.
+
+The option `string` will transfer the message as an AMQP value of type string. Consider choosing the option `string` if your intention is to transfer UTF-8 string messages (like JSON messages) to the destination.
+
+
+*Type*: `string`
+
+*Default*: `"opaque_binary"`
+
+Options:
+`opaque_binary`
+, `string`
+.
 
 

--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -42,6 +42,15 @@ const (
 	targetAddrField  = "target_address"
 	appPropsMapField = "application_properties_map"
 	metaFilterField  = "metadata"
+	contentTypeField = "content_type"
+)
+
+// Content Type Options
+const (
+	// Data section with opaque binary data
+	amqpContentTypeOpaqueBinary = "opaque_binary"
+	// Single AMQP string value
+	amqpContentTypeString = "string"
 )
 
 // ErrSASLMechanismNotSupported is returned if a SASL mechanism was not recognised.

--- a/internal/impl/amqp1/integration_test.go
+++ b/internal/impl/amqp1/integration_test.go
@@ -90,6 +90,21 @@ input:
     source_address: "queue:/$ID"
 `
 
+	templateWithContentTypeString := `
+output:
+  amqp_1:
+    url: amqp://guest:guest@localhost:$PORT/
+    target_address: "queue:/$ID"
+    max_in_flight: $MAX_IN_FLIGHT
+    content_type: "string"
+    metadata:
+      exclude_prefixes: [ $OUTPUT_META_EXCLUDE_PREFIX ]
+input:
+  amqp_1:
+    url: amqp://guest:guest@localhost:$PORT/
+    source_address: "queue:/$ID"
+`
+
 	testcases := []struct {
 		label    string
 		template string
@@ -101,6 +116,10 @@ input:
 		{
 			label:    "should handle new field urls",
 			template: templateWithFieldURLS,
+		},
+		{
+			label:    "should handle content type string",
+			template: templateWithContentTypeString,
 		},
 	}
 


### PR DESCRIPTION
See github issue for an explanation: #3095

The word "opaque" is mentioned in the documentation (https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-data); that is why I chose this word for the configuration option.

## How to test

You need a broker with AMQP 1 support. Example: Apache ActiveMQ with docker-compose:
```yaml
  activemq:
    container_name: activemq
    image: apache/activemq-classic:5.18.3
    restart: always
    ports:
      - 8161:8161
      - 5673:5672
```

Configuration to insert string messages:
```yaml
input:
  generate:
    interval: '@every 2s'
    mapping: root = {"id":uuid_v4(),"a":"а, е, ё, и, о, у, ы, э, ю, я","c":"幸福","b":"äöüÄÖÜßabc"}

output:
  amqp_1:
    urls: [ amqp://localhost:5673/ ]
    target_address: DEMOQUEUE
    max_in_flight: 64
    content_type: string
    sasl:
      mechanism: anonymous
      user: ""
      password: ""
    metadata:
      exclude_prefixes: [ "demo" ]
```
Reading the messages again:
```yaml
input:
  amqp_1:
    urls: [ amqp://localhost:5673/ ]
    source_address: "DEMOQUEUE"
    sasl:
      mechanism: anonymous
      user: ""
      password: ""

output:
  stdout:
    codec: lines
```