### PR TITLE
inputs/redpanda: add fetch_max_wait option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - `avro` scanner now emits metadata for the Avro schema it used along with the schema fingerprint. (@rockwotj)
 - Field `content_type` added to the `amqp_1` output. (@timo102)
+- `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, `redpanda_migrator` now support `fetch_max_wait` configuration field.
 
 ### Fixed
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -72,6 +72,7 @@ input:
     rack_id: ""
     start_from_oldest: true
     fetch_max_bytes: 50MiB
+    fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
     consumer_group: "" # No default (optional)
@@ -570,6 +571,15 @@ Sets the maximum amount of bytes a broker will try to send during a fetch. Note 
 *Type*: `string`
 
 *Default*: `"50MiB"`
+
+=== `fetch_max_wait`
+
+Sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes. This is the equivalent to the Java fetch.max.wait.ms setting.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `fetch_min_bytes`
 

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -77,6 +77,7 @@ input:
       rack_id: ""
       start_from_oldest: true
       fetch_max_bytes: 50MiB
+      fetch_max_wait: 5s
       fetch_min_bytes: 1B
       fetch_max_partition_bytes: 1MiB
       consumer_group: "" # No default (optional)
@@ -367,6 +368,15 @@ Sets the maximum amount of bytes a broker will try to send during a fetch. Note 
 *Type*: `string`
 
 *Default*: `"50MiB"`
+
+=== `kafka.fetch_max_wait`
+
+Sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes. This is the equivalent to the Java fetch.max.wait.ms setting.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `kafka.fetch_min_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -70,6 +70,7 @@ input:
     rack_id: ""
     start_from_oldest: true
     fetch_max_bytes: 50MiB
+    fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
     consumer_group: "" # No default (optional)
@@ -590,6 +591,15 @@ Sets the maximum amount of bytes a broker will try to send during a fetch. Note 
 *Type*: `string`
 
 *Default*: `"50MiB"`
+
+=== `fetch_max_wait`
+
+Sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes. This is the equivalent to the Java fetch.max.wait.ms setting.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `fetch_min_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda_common.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_common.adoc
@@ -58,6 +58,7 @@ input:
     rack_id: ""
     start_from_oldest: true
     fetch_max_bytes: 50MiB
+    fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
     consumer_group: "" # No default (optional)
@@ -190,6 +191,15 @@ Sets the maximum amount of bytes a broker will try to send during a fetch. Note 
 *Type*: `string`
 
 *Default*: `"50MiB"`
+
+=== `fetch_max_wait`
+
+Sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes. This is the equivalent to the Java fetch.max.wait.ms setting.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `fetch_min_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -72,6 +72,7 @@ input:
     rack_id: ""
     start_from_oldest: true
     fetch_max_bytes: 50MiB
+    fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
     consumer_group: "" # No default (optional)
@@ -577,6 +578,15 @@ Sets the maximum amount of bytes a broker will try to send during a fetch. Note 
 *Type*: `string`
 
 *Default*: `"50MiB"`
+
+=== `fetch_max_wait`
+
+Sets the maximum amount of time a broker will wait for a fetch response to hit the minimum number of required bytes. This is the equivalent to the Java fetch.max.wait.ms setting.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `fetch_min_bytes`
 


### PR DESCRIPTION
kgo.FetchMaxWait is a config option supported by franz-go. It makes it possible to use kgo.FetchMinBytes to force big batches, but have a rather low max wait time to fill the batch. This makes it possible to force the broker to send big batches if possible, but still wait only for a short time if there's not enough data.

Why add this option now?
This is especially important with the redpanda input, as it's using ordered franz-go. It will only send batches, if the previous batch with the partition has been consumed. If the broker keeps sending very small batches, e.g. size 1, it's likely to stall batched outputs. I could reproduce locally by using a producer that sends lots of batches of size 1.
I tried to overcome this ordering limitation by using batching in my output, but it doesn't work in this specific case. It will only add more records to the batch, if the previous batch of the partition was consumed, so in the extreme case of getting one record per kafka batch, for only one partition, i can't overcome it, rpcn will do only one record at a time.

Using kgo.FetchMinBytes in combination with kgo.FetchMaxWait can solve this problem.
But in any case, it is a useful tuning knob offered by franz-go, but also the standard Java client.