### PR TITLE
Delay mysql_cdc for a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+<!--
+
+## 4.46.0 - TBD
+
+### Added
+
+- New `mysql_cdc` input supporting change data capture (CDC) from MySQL. (@rockwotj, @le-vlad)
+
+-->
+
 ## 4.45.0 - TBD
 
 ### Added
@@ -16,7 +26,6 @@ All notable changes to this project will be documented in this file.
 - `snowpipe_streaming` now supports exactly once delivery using `offset_token`. (@rockwotj)
 - `ollama_chat` now supports tool calling. (@rockwotj)
 - New `ollama_moderation` which allows using LlamaGuard or ShieldGemma to check if LLM responses are safe. (@rockwotj)
-- New `mysql_cdc` input supporting change data capture (CDC) from MySQL. (@rockwotj, @le-vlad)
 
 ### Fixed
 


### PR DESCRIPTION
We've got a big honking release for v4.45.0, so let's delay mysql to limit what's needed for that release

