### PR TITLE
DOC-883 trigger workflow to update Blobl playground on new tags

### DIFF
--- a/.github/workflows/update-blobl-playground.yml
+++ b/.github/workflows/update-blobl-playground.yml
@@ -1,0 +1,28 @@
+---
+  # Dispatches an event to trigger an update of Go modules for the Bloblang playground
+  name: update-blobl-playground-modules
+  on:
+    push:
+      tags:
+        - '*'
+  permissions:
+    id-token: write
+    contents: read
+  jobs:
+    dispatch:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: aws-actions/configure-aws-credentials@v4
+          with:
+            aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+            role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+        - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          with:
+            secret-ids: |
+              ,sdlc/prod/github/actions_bot_token
+            parse-json-secrets: true
+        - uses: peter-evans/repository-dispatch@v3
+          with:
+            token: ${{ env.ACTIONS_BOT_TOKEN }}
+            repository: redpanda-data/docs-ui
+            event-type: update-go-mod


### PR DESCRIPTION
This PR adds a workflow to trigger a `repository_dispatch` event whenever a new tag is pushed to the `connect` repository. The receiving repository (the docs UI project) will then run its Go module update workflow, ensuring that any new releases from RPCN are automatically reflected in the Blobl playground environment.

For details on how the Blobl playground handles these updates, see the workflow here: [redpanda-data/docs-ui#243](https://github.com/redpanda-data/docs-ui/pull/243/).

Relies on https://github.com/redpanda-data/devprod-infra/pull/184