### PR TITLE
Update Schema Registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - New `mysql_cdc` input supporting change data capture (CDC) from MySQL. (@rockwotj, @le-vlad)
 - Field `instance_id` added to `kafka`, `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs. (@rockwotj)
+- Fields `rebalance_timeout`, `session_timeout` and `heartbeat_interval` added to the `kafka_franz`, `redpanda`, `redpanda_common`, `redpanda_migrator` and `ockam_kafka` inputs. (@rockwotj)
 
 ## 4.45.1 - 2025-01-17
 

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/twmb/franz-go v1.18.0
 	github.com/twmb/franz-go/pkg/kadm v1.13.0
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0
-	github.com/twmb/franz-go/pkg/sr v1.2.0
+	github.com/twmb/franz-go/pkg/sr v1.3.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/xdg-go/scram v1.1.2
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1889,8 +1889,8 @@ github.com/twmb/franz-go/pkg/kadm v1.13.0 h1:bJq4C2ZikUE2jh/wl9MtMTQ/kpmnBgVFh8X
 github.com/twmb/franz-go/pkg/kadm v1.13.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
-github.com/twmb/franz-go/pkg/sr v1.2.0 h1:zYr0Ly7KLFfeCGaSr8teN6LvAVeYVrZoUsyyPHTYB+M=
-github.com/twmb/franz-go/pkg/sr v1.2.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
+github.com/twmb/franz-go/pkg/sr v1.3.0 h1:UlXpZ2suGgylzQBUb6Wn1jzqVShoPGzt7BbixznJ4qo=
+github.com/twmb/franz-go/pkg/sr v1.3.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
 github.com/uptrace/bun v1.1.12 h1:sOjDVHxNTuM6dNGaba0wUuz7KvDE1BmNu9Gqs2gJSXQ=
 github.com/uptrace/bun v1.1.12/go.mod h1:NPG6JGULBeQ9IU6yHp7YGELRa5Agmd7ATZdz4tGZ6z0=
 github.com/uptrace/bun/dialect/pgdialect v1.1.12 h1:m/CM1UfOkoBTglGO5CUTKnIKKOApOYxkcP2qn0F9tJk=

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -73,10 +73,6 @@ basic_auth:
 			require.NoError(t, err)
 
 			e, err := newSchemaRegistryDecoderFromConfig(conf, service.MockResources())
-			if e != nil {
-				assert.Equal(t, test.expectedBaseURL, e.client.SchemaRegistryBaseURL.String())
-			}
-
 			if err == nil {
 				_ = e.Close(context.Background())
 			}

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -106,10 +106,6 @@ subject: foo
 			require.NoError(t, err)
 
 			e, err := newSchemaRegistryEncoderFromConfig(conf, service.MockResources())
-			if e != nil {
-				assert.Equal(t, test.expectedBaseURL, e.client.SchemaRegistryBaseURL.String())
-			}
-
 			if err == nil {
 				_ = e.Close(context.Background())
 			}

--- a/internal/impl/kafka/enterprise/integration_test.go
+++ b/internal/impl/kafka/enterprise/integration_test.go
@@ -282,7 +282,7 @@ func deleteSubject(t *testing.T, url string, subject string, hardDelete bool) {
 		deleteMode = franz_sr.HardDelete
 	}
 
-	_, err = client.DeleteSubject(context.Background(), subject, franz_sr.DeleteHow(deleteMode))
+	_, err = client.DeleteSubject(context.Background(), subject, deleteMode)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/twmb/franz-go/pull/867.

Since `sr.URLs()` from franz-go doesn't validate URLs during client initialisation, I decided to leave our `url.Parse()` in there because this way we can catch malformed URLs on startup, before any HTTP requests are attempted.