### PR TITLE
packaging: rename typo in plugin name for linux pkgs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,7 +108,7 @@ nfpms:
     bindir: /usr/bin
     contents:
       - src: /usr/bin/redpanda-connect
-        dst: /usr/bin/.rpk-ac.connect
+        dst: /usr/bin/.rpk.ac-connect
         type: symlink
     builds:
       - connect


### PR DESCRIPTION
When installing `redpanda-connect` through our
linux package, we also add a symlink to a directory where rpk can pick up the binary and use it as a
plugin.

However, there was a typo and it was not possible.