### PR TITLE
docker: fix ai dockerfile

### DIFF
--- a/resources/docker/Dockerfile.ai
+++ b/resources/docker/Dockerfile.ai
@@ -25,13 +25,11 @@ RUN make TAGS="timetzdata" redpanda-connect-ai
 
 RUN touch /tmp/keep
 
-FROM ubuntu AS download
-
-RUN apt update && apt install -y curl
-RUN curl -fsSL https://ollama.com/install.sh | sh
-
 # Pack
-FROM nvidia/cuda:12.6.0-runtime-ubuntu24.04 AS package
+FROM ollama/ollama AS package
+
+# Override the HOST from the ollama dockerfile
+ENV OLLAMA_HOST=127.0.0.1
 
 LABEL maintainer="Tyler Rockwood <rockwood@redpanda.com>"
 LABEL org.opencontainers.image.source="https://github.com/redpanda-data/connect"
@@ -45,7 +43,6 @@ COPY ./config/docker.yaml /connect.yaml
 
 USER connect
 
-COPY --chown=connect:connect --from=download /usr/local/bin/ollama /usr/local/
 COPY --chown=connect:connect --from=build /tmp/keep /home/connect/.ollama/keep
 
 EXPOSE 4195


### PR DESCRIPTION
Instead of trying to package ollama ourselves, just use the upstream
docker image. I've tested this works and uses the local GPU on my
machine.
