### PR TITLE
mycdc: fix snapshot consistency issue

### DIFF
--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -226,14 +226,16 @@ func (i *mysqlStreamInput) Connect(ctx context.Context) error {
 	// canalConfig.Logger
 
 	for _, table := range i.tables {
-		canalConfig.IncludeTableRegex = append(canalConfig.IncludeTableRegex, regexp.QuoteMeta(table))
+		canalConfig.IncludeTableRegex = append(
+			canalConfig.IncludeTableRegex,
+			"^"+regexp.QuoteMeta(i.mysqlConfig.DBName+"."+table)+"$",
+		)
 	}
 
 	c, err := canal.NewCanal(canalConfig)
 	if err != nil {
 		return err
 	}
-	c.AddDumpTables(i.mysqlConfig.DBName, i.tables...)
 
 	i.canal = c
 


### PR DESCRIPTION
We need to take the global lock, then we can create our consistent
snapshot. The lock is needed to prevent writes from sneaking in between.

The process is actually explained very nicely be debezium documentation.

https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-initial-snapshot-workflow-with-global-read-lock
