### PR TITLE
schema_reg: support mapping avro schemas for custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `arguments` added to the `amqp_0_9` input and output. (@calini)
+- Field `avro.mapping` added to the `schema_registry_decode` processor to support converting custom avro types to standard avro types for legacy tooling. (@rockwotj)
 
 ## 4.46.0 - 2025-01-29
 

--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -54,7 +54,21 @@ schema_registry_decode:
   avro:
     raw_unions: false # No default (optional)
     preserve_logical_types: false
-    mapping: "\nmap debeziumTimestampToAvroTimestamp {\n  let mapped_fields = this.fields.or([]).map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))\n  root = if this.type == \"record\" {\n    this.assign({\"fields\": $mapped_fields})\n  } else if this.type.type() == \"array\" {\n    this.assign({\"type\": this.type.map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))})\n  } else if this.type.type() == \"object\" && this.type.type == \"long\" && this.type.\"connect.name\" == \"io.debezium.time.Timestamp\" && !this.type.exists(\"logicalType\") {\n    # Add a logical type so that it's decoded as a timestamp instead of a long.\n    this.merge({\"type\":{\"logicalType\": \"timestamp-millis\"}})\n  } else {\n    this\n  }\n}\nroot = this.apply(\"debeziumTimestampToAvroTimestamp\")\n\n        " # No default (optional)
+    mapping: | # No default (optional)
+      map isDebeziumTimestampType {
+        root = this.type == "long" && this."connect.name" == "io.debezium.time.Timestamp" && !this.exists("logicalType")
+      }
+      map debeziumTimestampToAvroTimestamp {
+        let mapped_fields = this.fields.or([]).map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))
+        root = match {
+          this.type == "record" => this.assign({"fields": $mapped_fields})
+          this.type.type() == "array" => this.assign({"type": this.type.map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))})
+          # Add a logical type so that it's decoded as a timestamp instead of a long.
+          this.type.type() == "object" && this.type.apply("isDebeziumTimestampType") => this.merge({"type":{"logicalType": "timestamp-millis"}})
+          _ => this
+        }
+      }
+      root = this.apply("debeziumTimestampToAvroTimestamp")
   url: "" # No default (required)
   oauth:
     enabled: false
@@ -161,7 +175,21 @@ A custom mapping to apply to Avro schemas JSON representation. This is useful to
 ```yml
 # Examples
 
-mapping: "\nmap debeziumTimestampToAvroTimestamp {\n  let mapped_fields = this.fields.or([]).map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))\n  root = if this.type == \"record\" {\n    this.assign({\"fields\": $mapped_fields})\n  } else if this.type.type() == \"array\" {\n    this.assign({\"type\": this.type.map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))})\n  } else if this.type.type() == \"object\" && this.type.type == \"long\" && this.type.\"connect.name\" == \"io.debezium.time.Timestamp\" && !this.type.exists(\"logicalType\") {\n    # Add a logical type so that it's decoded as a timestamp instead of a long.\n    this.merge({\"type\":{\"logicalType\": \"timestamp-millis\"}})\n  } else {\n    this\n  }\n}\nroot = this.apply(\"debeziumTimestampToAvroTimestamp\")\n\n        "
+mapping: |2
+  map isDebeziumTimestampType {
+    root = this.type == "long" && this."connect.name" == "io.debezium.time.Timestamp" && !this.exists("logicalType")
+  }
+  map debeziumTimestampToAvroTimestamp {
+    let mapped_fields = this.fields.or([]).map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))
+    root = match {
+      this.type == "record" => this.assign({"fields": $mapped_fields})
+      this.type.type() == "array" => this.assign({"type": this.type.map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))})
+      # Add a logical type so that it's decoded as a timestamp instead of a long.
+      this.type.type() == "object" && this.type.apply("isDebeziumTimestampType") => this.merge({"type":{"logicalType": "timestamp-millis"}})
+      _ => this
+    }
+  }
+  root = this.apply("debeziumTimestampToAvroTimestamp")
 ```
 
 === `url`

--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -54,6 +54,7 @@ schema_registry_decode:
   avro:
     raw_unions: false # No default (optional)
     preserve_logical_types: false
+    mapping: "\nmap debeziumTimestampToAvroTimestamp {\n  let mapped_fields = this.fields.or([]).map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))\n  root = if this.type == \"record\" {\n    this.assign({\"fields\": $mapped_fields})\n  } else if this.type.type() == \"array\" {\n    this.assign({\"type\": this.type.map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))})\n  } else if this.type.type() == \"object\" && this.type.type == \"long\" && this.type.\"connect.name\" == \"io.debezium.time.Timestamp\" && !this.type.exists(\"logicalType\") {\n    # Add a logical type so that it's decoded as a timestamp instead of a long.\n    this.merge({\"type\":{\"logicalType\": \"timestamp-millis\"}})\n  } else {\n    this\n  }\n}\nroot = this.apply(\"debeziumTimestampToAvroTimestamp\")\n\n        " # No default (optional)
   url: "" # No default (required)
   oauth:
     enabled: false
@@ -148,6 +149,20 @@ Whether logical types should be preserved or transformed back into their primiti
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `avro.mapping`
+
+A custom mapping to apply to Avro schemas JSON representation. This is useful to transform custom types emitted by other tools into standard avro.
+
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+mapping: "\nmap debeziumTimestampToAvroTimestamp {\n  let mapped_fields = this.fields.or([]).map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))\n  root = if this.type == \"record\" {\n    this.assign({\"fields\": $mapped_fields})\n  } else if this.type.type() == \"array\" {\n    this.assign({\"type\": this.type.map_each(item -> item.apply(\"debeziumTimestampToAvroTimestamp\"))})\n  } else if this.type.type() == \"object\" && this.type.type == \"long\" && this.type.\"connect.name\" == \"io.debezium.time.Timestamp\" && !this.type.exists(\"logicalType\") {\n    # Add a logical type so that it's decoded as a timestamp instead of a long.\n    this.merge({\"type\":{\"logicalType\": \"timestamp-millis\"}})\n  } else {\n    this\n  }\n}\nroot = this.apply(\"debeziumTimestampToAvroTimestamp\")\n\n        "
+```
 
 === `url`
 


### PR DESCRIPTION
In order to preserve annoying debezium types like:

```
{
                            "name": "created",
                            "type": {
                                "type": "long",
                                "connect.version": 1,
                                "connect.parameters": {
                                    "__debezium.source.column.type": "DATETIME"
                                },
                                "connect.default": 0,
                                "connect.name": "io.debezium.time.Timestamp"
                            },
                            "default": 0
                        },
```

In connect we want to mark that as a proper `timestamp-millis` value so it's decoded as a date in bloblang when preserving logical types.