### PR TITLE
feat(input_kinesis): Decouple DynamoDB session from kinesis to allow cross account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.53.0 - TBD
+
+### Added
+
+- Fields `region`, `endpoint` and `credentials` added to the `dynamodb` configuration section of the `aws_kinesis` input. (@jreyeshdez, @mihaitodor)
+
 ## 4.52.0 - 2025-04-03
 
 ### Added

--- a/docs/modules/components/pages/caches/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/caches/aws_dynamodb.adoc
@@ -62,16 +62,16 @@ aws_dynamodb:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
 ```
 
 --
@@ -199,7 +199,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -208,7 +207,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -225,7 +223,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -234,7 +231,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -248,7 +244,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -257,7 +252,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -266,7 +260,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -276,7 +269,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -285,6 +277,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/caches/aws_s3.adoc
+++ b/docs/modules/components/pages/caches/aws_s3.adoc
@@ -57,16 +57,16 @@ aws_s3:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
 ```
 
 --
@@ -168,7 +168,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -177,7 +176,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -194,7 +192,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -203,7 +200,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -217,7 +213,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -226,7 +221,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -235,7 +229,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -245,7 +238,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -254,6 +246,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -71,22 +71,32 @@ input:
       billing_mode: PAY_PER_REQUEST
       read_capacity_units: 0
       write_capacity_units: 0
+      region: "" # No default (optional)
+      endpoint: "" # No default (optional)
+      credentials:
+        profile: "" # No default (optional)
+        id: "" # No default (optional)
+        secret: "" # No default (optional)
+        token: "" # No default (optional)
+        from_ec2_role: false # No default (optional)
+        role: "" # No default (optional)
+        role_external_id: "" # No default (optional)
     checkpoint_limit: 1024
     auto_replay_nacks: true
     commit_period: 5s
     rebalance_period: 30s
     lease_period: 30s
     start_from_oldest: true
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     batching:
       count: 0
       byte_size: 0
@@ -191,6 +201,92 @@ Set the provisioned write capacity when creating the table with a `billing_mode`
 
 *Default*: `0`
 
+=== `dynamodb.region`
+
+The AWS region to target.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.endpoint`
+
+Allows you to specify a custom endpoint for the AWS API.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials`
+
+Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].
+
+
+*Type*: `object`
+
+
+=== `dynamodb.credentials.profile`
+
+A profile from `~/.aws/credentials` to use.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials.id`
+
+The ID of credentials to use.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials.secret`
+
+The secret for the credentials being used.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials.token`
+
+The token for the credentials being used, required when using short term credentials.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials.from_ec2_role`
+
+Use the credentials of a host EC2 machine configured to assume https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[an IAM role associated with the instance^].
+
+
+*Type*: `bool`
+
+Requires version 4.2.0 or newer
+
+=== `dynamodb.credentials.role`
+
+A role ARN to assume.
+
+
+*Type*: `string`
+
+
+=== `dynamodb.credentials.role_external_id`
+
+An external ID to provide when assuming a role.
+
+
+*Type*: `string`
+
+
 === `checkpoint_limit`
 
 The maximum gap between the in flight sequence versus the latest acknowledged sequence at a given time. Increasing this limit enables parallel processing and batching at the output level to work on individual shards. Any given sequence will not be committed unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.
@@ -252,7 +348,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -261,7 +356,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -278,7 +372,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -287,7 +380,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -301,7 +393,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -310,7 +401,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -319,7 +409,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -329,7 +418,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -338,7 +426,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `batching`
 

--- a/docs/modules/components/pages/inputs/aws_s3.adoc
+++ b/docs/modules/components/pages/inputs/aws_s3.adoc
@@ -60,16 +60,16 @@ input:
   aws_s3:
     bucket: ""
     prefix: ""
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     force_path_style_urls: false
     delete_objects: false
     scanner:
@@ -148,7 +148,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -157,7 +156,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -174,7 +172,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -183,7 +180,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -197,7 +193,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -206,7 +201,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -215,7 +209,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -225,7 +218,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -234,7 +226,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `force_path_style_urls`
 

--- a/docs/modules/components/pages/inputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/inputs/aws_sqs.adoc
@@ -58,16 +58,16 @@ input:
     max_outstanding_messages: 1000
     wait_time_seconds: 0
     message_timeout: 30s
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
 ```
 
 --
@@ -164,7 +164,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -173,7 +172,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -190,7 +188,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -199,7 +196,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -213,7 +209,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -222,7 +217,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -231,7 +225,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -241,7 +234,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -250,6 +242,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -408,7 +408,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -417,7 +416,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -434,7 +432,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -443,7 +440,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -457,7 +453,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -466,7 +461,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -475,7 +469,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -485,7 +478,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -494,7 +486,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -434,7 +434,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -443,7 +442,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -460,7 +458,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -469,7 +466,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -483,7 +479,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -492,7 +487,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -501,7 +495,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -511,7 +504,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -520,7 +512,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -411,7 +411,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -420,7 +419,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -437,7 +435,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -446,7 +443,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -460,7 +456,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -469,7 +464,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -478,7 +472,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -488,7 +481,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -497,7 +489,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -394,7 +394,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -403,7 +402,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -420,7 +418,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -429,7 +426,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -443,7 +439,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -452,7 +447,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -461,7 +455,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -471,7 +464,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -480,7 +472,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
+++ b/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
@@ -52,16 +52,16 @@ metrics:
   aws_cloudwatch:
     namespace: Benthos
     flush_period: 100ms
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
   mapping: ""
 ```
 
@@ -115,7 +115,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -124,7 +123,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -141,7 +139,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -150,7 +147,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -164,7 +160,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -173,7 +168,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -182,7 +176,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -192,7 +185,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -201,6 +193,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/outputs/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/outputs/aws_dynamodb.adoc
@@ -72,16 +72,16 @@ output:
       period: ""
       check: ""
       processors: [] # No default (optional)
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     max_retries: 3
     backoff:
       initial_interval: 1s
@@ -316,7 +316,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -325,7 +324,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -342,7 +340,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -351,7 +348,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -365,7 +361,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -374,7 +369,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -383,7 +377,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -393,7 +386,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -402,7 +394,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `max_retries`
 

--- a/docs/modules/components/pages/outputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis.adoc
@@ -69,16 +69,16 @@ output:
       period: ""
       check: ""
       processors: [] # No default (optional)
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     max_retries: 0
     backoff:
       initial_interval: 1s
@@ -255,7 +255,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -264,7 +263,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -281,7 +279,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -290,7 +287,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -304,7 +300,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -313,7 +308,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -322,7 +316,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -332,7 +325,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -341,7 +333,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `max_retries`
 

--- a/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
@@ -66,16 +66,16 @@ output:
       period: ""
       check: ""
       processors: [] # No default (optional)
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     max_retries: 0
     backoff:
       initial_interval: 1s
@@ -225,7 +225,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -234,7 +233,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -251,7 +249,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -260,7 +257,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -274,7 +270,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -283,7 +278,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -292,7 +286,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -302,7 +295,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -311,7 +303,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `max_retries`
 

--- a/docs/modules/components/pages/outputs/aws_s3.adoc
+++ b/docs/modules/components/pages/outputs/aws_s3.adoc
@@ -88,16 +88,16 @@ output:
       period: ""
       check: ""
       processors: [] # No default (optional)
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
 ```
 
 --
@@ -492,7 +492,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -501,7 +500,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -518,7 +516,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -527,7 +524,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -541,7 +537,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -550,7 +545,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -559,7 +553,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -569,7 +562,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -578,6 +570,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/outputs/aws_sns.adoc
+++ b/docs/modules/components/pages/outputs/aws_sns.adoc
@@ -64,16 +64,16 @@ output:
     metadata:
       exclude_prefixes: []
     timeout: 5s
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
 ```
 
 --
@@ -160,7 +160,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -169,7 +168,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -186,7 +184,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -195,7 +192,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -209,7 +205,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -218,7 +213,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -227,7 +221,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -237,7 +230,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -246,6 +238,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/outputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/outputs/aws_sqs.adoc
@@ -77,16 +77,16 @@ output:
       check: ""
       processors: [] # No default (optional)
     max_records_per_request: 10
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
-      from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      from_ec2_role: false # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     max_retries: 0
     backoff:
       initial_interval: 1s
@@ -293,7 +293,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -302,7 +301,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -319,7 +317,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -328,7 +325,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -342,7 +338,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -351,7 +346,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -360,7 +354,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -370,7 +363,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -379,7 +371,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `max_retries`
 

--- a/docs/modules/components/pages/outputs/elasticsearch.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch.adoc
@@ -97,16 +97,16 @@ output:
       processors: [] # No default (optional)
     aws:
       enabled: false
-      region: ""
-      endpoint: ""
+      region: "" # No default (optional)
+      endpoint: "" # No default (optional)
       credentials:
-        profile: ""
-        id: ""
-        secret: ""
-        token: ""
-        from_ec2_role: false
-        role: ""
-        role_external_id: ""
+        profile: "" # No default (optional)
+        id: "" # No default (optional)
+        secret: "" # No default (optional)
+        token: "" # No default (optional)
+        from_ec2_role: false # No default (optional)
+        role: "" # No default (optional)
+        role_external_id: "" # No default (optional)
     gzip_compression: false
 ```
 
@@ -653,7 +653,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.endpoint`
 
@@ -662,7 +661,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials`
 
@@ -679,7 +677,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.id`
 
@@ -688,7 +685,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.secret`
 
@@ -702,7 +698,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.token`
 
@@ -711,7 +706,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.from_ec2_role`
 
@@ -720,7 +714,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `aws.credentials.role`
@@ -730,7 +723,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.role_external_id`
 
@@ -739,7 +731,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `gzip_compression`
 

--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -396,7 +396,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -405,7 +404,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -422,7 +420,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -431,7 +428,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -445,7 +441,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -454,7 +449,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -463,7 +457,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -473,7 +466,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -482,7 +474,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/outputs/opensearch.adoc
+++ b/docs/modules/components/pages/outputs/opensearch.adoc
@@ -85,16 +85,16 @@ output:
       processors: [] # No default (optional)
     aws:
       enabled: false
-      region: ""
-      endpoint: ""
+      region: "" # No default (optional)
+      endpoint: "" # No default (optional)
       credentials:
-        profile: ""
-        id: ""
-        secret: ""
-        token: ""
-        from_ec2_role: false
-        role: ""
-        role_external_id: ""
+        profile: "" # No default (optional)
+        id: "" # No default (optional)
+        secret: "" # No default (optional)
+        token: "" # No default (optional)
+        from_ec2_role: false # No default (optional)
+        role: "" # No default (optional)
+        role_external_id: "" # No default (optional)
 ```
 
 --
@@ -539,7 +539,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.endpoint`
 
@@ -548,7 +547,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials`
 
@@ -565,7 +563,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.id`
 
@@ -574,7 +571,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.secret`
 
@@ -588,7 +584,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.token`
 
@@ -597,7 +592,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.from_ec2_role`
 
@@ -606,7 +600,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `aws.credentials.role`
@@ -616,7 +609,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `aws.credentials.role_external_id`
 
@@ -625,6 +617,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -381,7 +381,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -390,7 +389,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -407,7 +405,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -416,7 +413,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -430,7 +426,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -439,7 +434,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -448,7 +442,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -458,7 +451,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -467,7 +459,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -427,7 +427,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -436,7 +435,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -453,7 +451,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -462,7 +459,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -476,7 +472,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -485,7 +480,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -494,7 +488,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -504,7 +497,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -513,7 +505,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -381,7 +381,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -390,7 +389,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -407,7 +405,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -416,7 +413,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -430,7 +426,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -439,7 +434,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -448,7 +442,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -458,7 +451,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -467,7 +459,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
@@ -54,16 +54,16 @@ Advanced::
 # All config fields, showing default values
 label: ""
 aws_bedrock_chat:
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
   model: amazon.titan-text-express-v1 # No default (required)
   prompt: "" # No default (optional)
   system_prompt: "" # No default (optional)
@@ -88,7 +88,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -97,7 +96,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -114,7 +112,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -123,7 +120,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -137,7 +133,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -146,7 +141,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -155,7 +149,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -165,7 +158,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -174,7 +166,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `model`
 

--- a/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
@@ -51,16 +51,16 @@ Advanced::
 # All config fields, showing default values
 label: ""
 aws_bedrock_embeddings:
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
   model: amazon.titan-embed-text-v1 # No default (required)
   text: "" # No default (optional)
 ```
@@ -117,7 +117,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -126,7 +125,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -143,7 +141,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -152,7 +149,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -166,7 +162,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -175,7 +170,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -184,7 +178,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -194,7 +187,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -203,7 +195,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `model`
 

--- a/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
+++ b/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
@@ -54,16 +54,16 @@ aws_dynamodb_partiql:
   query: "" # No default (required)
   unsafe_dynamic_query: false
   args_mapping: ""
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
 ```
 
 --
@@ -132,7 +132,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -141,7 +140,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -158,7 +156,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -167,7 +164,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -181,7 +177,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -190,7 +185,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -199,7 +193,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -209,7 +202,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -218,6 +210,5 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 

--- a/docs/modules/components/pages/processors/aws_lambda.adoc
+++ b/docs/modules/components/pages/processors/aws_lambda.adoc
@@ -54,16 +54,16 @@ aws_lambda:
   parallel: false
   function: "" # No default (required)
   rate_limit: ""
-  region: ""
-  endpoint: ""
+  region: "" # No default (optional)
+  endpoint: "" # No default (optional)
   credentials:
-    profile: ""
-    id: ""
-    secret: ""
-    token: ""
-    from_ec2_role: false
-    role: ""
-    role_external_id: ""
+    profile: "" # No default (optional)
+    id: "" # No default (optional)
+    secret: "" # No default (optional)
+    token: "" # No default (optional)
+    from_ec2_role: false # No default (optional)
+    role: "" # No default (optional)
+    role_external_id: "" # No default (optional)
   timeout: 5s
   retries: 3
 ```
@@ -168,7 +168,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `endpoint`
 
@@ -177,7 +176,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials`
 
@@ -194,7 +192,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.id`
 
@@ -203,7 +200,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.secret`
 
@@ -217,7 +213,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.token`
 
@@ -226,7 +221,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.from_ec2_role`
 
@@ -235,7 +229,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `credentials.role`
@@ -245,7 +238,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `credentials.role_external_id`
 
@@ -254,7 +246,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `timeout`
 

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -358,7 +358,6 @@ The AWS region to target.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.endpoint`
 
@@ -367,7 +366,6 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials`
 
@@ -384,7 +382,6 @@ A profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.id`
 
@@ -393,7 +390,6 @@ The ID of credentials to use.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.secret`
 
@@ -407,7 +403,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.token`
 
@@ -416,7 +411,6 @@ The token for the credentials being used, required when using short term credent
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.from_ec2_role`
 
@@ -425,7 +419,6 @@ Use the credentials of a host EC2 machine configured to assume https://docs.aws.
 
 *Type*: `bool`
 
-*Default*: `false`
 Requires version 4.2.0 or newer
 
 === `sasl[].aws.credentials.role`
@@ -435,7 +428,6 @@ A role ARN to assume.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `sasl[].aws.credentials.role_external_id`
 
@@ -444,7 +436,6 @@ An external ID to provide when assuming a role.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `metadata_max_age`
 

--- a/internal/impl/aws/config/config.go
+++ b/internal/impl/aws/config/config.go
@@ -23,35 +23,36 @@ func SessionFields() []*service.ConfigField {
 	return []*service.ConfigField{
 		service.NewStringField("region").
 			Description("The AWS region to target.").
-			Default("").
+			Optional().
 			Advanced(),
 		service.NewStringField("endpoint").
 			Description("Allows you to specify a custom endpoint for the AWS API.").
-			Default("").
+			Optional().
 			Advanced(),
 		service.NewObjectField("credentials",
 			service.NewStringField("profile").
 				Description("A profile from `~/.aws/credentials` to use.").
-				Default(""),
+				Optional(),
 			service.NewStringField("id").
 				Description("The ID of credentials to use.").
-				Default("").Advanced(),
+				Optional().Advanced(),
 			service.NewStringField("secret").
 				Description("The secret for the credentials being used.").
-				Default("").Advanced().Secret(),
+				Optional().Advanced().Secret(),
 			service.NewStringField("token").
 				Description("The token for the credentials being used, required when using short term credentials.").
-				Default("").Advanced(),
+				Optional().Advanced(),
 			service.NewBoolField("from_ec2_role").
 				Description("Use the credentials of a host EC2 machine configured to assume https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[an IAM role associated with the instance^].").
-				Default(false).Version("4.2.0"),
+				Optional().Version("4.2.0"),
 			service.NewStringField("role").
 				Description("A role ARN to assume.").
-				Default("").Advanced(),
+				Optional().Advanced(),
 			service.NewStringField("role_external_id").
 				Description("An external ID to provide when assuming a role.").
-				Default("").Advanced()).
+				Optional().Advanced()).
 			Advanced().
+			Optional().
 			Description("Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[]."),
 	}
 }


### PR DESCRIPTION
DynamoDB table could be in different AWS account than kinesis input stream, this lets one to use different AWS credentials if needed for dynamodb.

Tackles https://github.com/redpanda-data/connect/issues/3159