### PR TITLE
snowflake: force singleshot object uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.47.1 - 2025-02-11
+
+### Fixed
+
+- Fix an issue with left over staging files being left around in the `snowflake_streaming` output. (@rockwotj)
+
 ## 4.47.0 - 2025-02-07
 
 ### Added

--- a/internal/impl/snowflake/streaming/uploader.go
+++ b/internal/impl/snowflake/streaming/uploader.go
@@ -173,6 +173,9 @@ func (u *gcsUploader) upload(ctx context.Context, path string, encrypted, md5Has
 	ow := object.NewWriter(ctx)
 	ow.Metadata = metadata
 	ow.MD5 = md5Hash
+	// Prevent resumable uploads and staging files in the bucket by removing the chunk size.
+	// https://cloud.google.com/storage/docs/uploading-objects-from-memory#storage-upload-object-from-memory-go
+	ow.ChunkSize = 0
 	for len(encrypted) > 0 {
 		n, err := ow.Write(encrypted)
 		if err != nil {


### PR DESCRIPTION
- **snowflake: don't use multipart uploads in AWS**
- **snowflake: don't use multipart uploads in GCP**
- Azure is already good 👍 
