### PR TITLE
Fix Redpanda Migrator consumer group offset migration logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to this project will be documented in this file.
 
 ## 4.48.0 - TBD
 
+### Fixed
+
+- Fixed a bug with the `redpanda_migrator_offsets` input and output where the consumer group update migration logic based on timestamp lookup should no longer skip ahead in the destination cluster. This should enforce at-least-once delivery guarantees. (@mihaitodor)
+- The `redpanda_migrator_bundle` output no longer drops messages if either the `redpanda_migrator` or the `redpanda_migrator_offsets` child output throws an error. Connect will keep retrying to write the messages and apply backpressure to the input. (@mihaitodor)
+
 ### Added
 
 - Added a lint rule to verify field `private_key` for the `snowflake_streaming` output is in PEM format. (@rockwotj)
 - New `mongodb_cdc` input for change data capture (CDC) over MongoDB collections. (@rockwotj)
+- Field `is_end_offset` added to the `redpanda_migrator_offsets` output. (@mihaitodor)
+- Metadata field `kafka_is_end_offset` added to the `redpanda_migrator_offsets` input. (@mihaitodor)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - Added a lint rule to verify field `private_key` for the `snowflake_streaming` output is in PEM format. (@rockwotj)
 - New `mongodb_cdc` input for change data capture (CDC) over MongoDB collections. (@rockwotj)
-- Field `is_end_offset` added to the `redpanda_migrator_offsets` output. (@mihaitodor)
-- Metadata field `kafka_is_end_offset` added to the `redpanda_migrator_offsets` input. (@mihaitodor)
+- Field `is_high_watermark` added to the `redpanda_migrator_offsets` output. (@mihaitodor)
+- Metadata field `kafka_is_high_watermark` added to the `redpanda_migrator_offsets` input. (@mihaitodor)
 
 ### Changed
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -99,6 +99,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset_partition
 - kafka_offset_commit_timestamp
 - kafka_offset_metadata
+- kafka_is_end_offset
 ```
 
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -99,7 +99,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset_partition
 - kafka_offset_commit_timestamp
 - kafka_offset_metadata
-- kafka_is_end_offset
+- kafka_is_high_watermark
 ```
 
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -45,6 +45,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
+    is_end_offset: ${! @kafka_is_end_offset }
 ```
 
 --
@@ -73,6 +74,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
+    is_end_offset: ${! @kafka_is_end_offset }
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
@@ -525,6 +527,16 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 *Type*: `string`
 
 *Default*: `"${! @kafka_offset_metadata }"`
+
+=== `is_end_offset`
+
+Indicates if the update represents the end offset of the Kafka topic partition.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `"${! @kafka_is_end_offset }"`
 
 === `timeout`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -45,7 +45,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
-    is_end_offset: ${! @kafka_is_end_offset }
+    is_high_watermark: ${! @kafka_is_high_watermark }
 ```
 
 --
@@ -74,7 +74,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
-    is_end_offset: ${! @kafka_is_end_offset }
+    is_high_watermark: ${! @kafka_is_high_watermark }
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
@@ -528,15 +528,15 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Default*: `"${! @kafka_offset_metadata }"`
 
-=== `is_end_offset`
+=== `is_high_watermark`
 
-Indicates if the update represents the end offset of the Kafka topic partition.
+Indicates if the update represents the high watermark of the Kafka topic partition.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
 
-*Default*: `"${! @kafka_is_end_offset }"`
+*Default*: `"${! @kafka_is_high_watermark }"`
 
 === `timeout`
 

--- a/internal/impl/kafka/enterprise/integration_test.go
+++ b/internal/impl/kafka/enterprise/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -654,20 +656,30 @@ func startRedpanda(t *testing.T, pool *dockertest.Pool, exposeBroker bool, autoc
 	}, nil
 }
 
-func produceMessage(t *testing.T, rpe redpandaEndpoints, topic, message string) {
+// produceMessages produces `count` messages to the given `topic` with the given `message` content. The
+// `timestampOffset` indicates an offset which gets added to the `counter()` Bloblang function which is used to generate
+// the message timestamps sequentially, the first one being `1 + timestampOffset`.
+func produceMessages(t *testing.T, rpe redpandaEndpoints, topic, message string, timestampOffset, count int, encode bool) {
 	streamBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamBuilder.SetYAML(fmt.Sprintf(`
+	config := ""
+	if encode {
+		config = fmt.Sprintf(`
 pipeline:
   processors:
     - schema_registry_encode:
         url: %s
         subject: %s
         avro_raw_json: true
+`, rpe.schemaRegistryURL, topic)
+	}
+	config += fmt.Sprintf(`
 output:
   kafka_franz:
     seed_brokers: [ %s ]
     topic: %s
-`, rpe.schemaRegistryURL, topic, rpe.brokerAddr, topic)))
+    timestamp_ms: ${! counter() + %d}
+`, rpe.brokerAddr, topic, timestampOffset)
+	require.NoError(t, streamBuilder.SetYAML(config))
 	require.NoError(t, streamBuilder.SetLoggerYAML(`level: OFF`))
 
 	inFunc, err := streamBuilder.AddProducerFunc()
@@ -682,7 +694,9 @@ output:
 	t.Cleanup(done)
 
 	go func() {
-		require.NoError(t, inFunc(ctx, service.NewMessage([]byte(message))))
+		for range count {
+			require.NoError(t, inFunc(ctx, service.NewMessage([]byte(message))))
+		}
 
 		require.NoError(t, stream.StopWithin(3*time.Second))
 	}()
@@ -691,34 +705,46 @@ output:
 	require.NoError(t, err)
 }
 
-func readMessageWithCG(t *testing.T, rpe redpandaEndpoints, topic, consumerGroup, message string) {
+// readMessagesWithCG reads `count` messages from the given `topic` with the given `consumerGroup`.
+// TODO: Since `read_until` can't guarantee that we will read `count` messages, `topic` needs to have exactly `count`
+// messages in it. We should add some mechanism to the Kafka inputs to allow us to read a range of offsets if possible
+// (or up to a certain offset).
+func readMessagesWithCG(t *testing.T, rpe redpandaEndpoints, topic, consumerGroup, message string, count int, decode bool) {
 	streamBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamBuilder.SetYAML(fmt.Sprintf(`
+	config := fmt.Sprintf(`
 input:
   kafka_franz:
     seed_brokers: [ %s ]
     topics: [ %s ]
     consumer_group: %s
     start_from_oldest: true
+`, rpe.brokerAddr, topic, consumerGroup)
+	if decode {
+		config += fmt.Sprintf(`
   processors:
     - schema_registry_decode:
         url: %s
         avro_raw_json: true
+`, rpe.schemaRegistryURL)
+	}
+	config += `
 output:
   # Need to use drop explicitly with SetYAML(). Otherwise, the output will be inproc
   # (or stdout if we import github.com/redpanda-data/benthos/v4/public/components/io)
   drop: {}
-`, rpe.brokerAddr, topic, consumerGroup, rpe.schemaRegistryURL)))
+`
+	require.NoError(t, streamBuilder.SetYAML(config))
 	require.NoError(t, streamBuilder.SetLoggerYAML(`level: OFF`))
 
-	recvChan := make(chan struct{})
+	recvMsgWG := sync.WaitGroup{}
+	recvMsgWG.Add(count)
 	err := streamBuilder.AddConsumerFunc(func(ctx context.Context, m *service.Message) error {
+		defer recvMsgWG.Done()
 		b, err := m.AsBytes()
 		require.NoError(t, err)
 
 		assert.Equal(t, message, string(b))
 
-		close(recvChan)
 		return nil
 	})
 	require.NoError(t, err)
@@ -735,7 +761,8 @@ output:
 		require.NoError(t, stream.Run(ctx))
 	}()
 
-	<-recvChan
+	recvMsgWG.Wait()
+
 	require.NoError(t, stream.StopWithin(3*time.Second))
 }
 
@@ -812,7 +839,7 @@ output:
 		err = stream.Run(context.Background())
 		require.NoError(t, err)
 
-		t.Log("Migrator shut down")
+		t.Log("Migrator pipeline shut down")
 
 		close(closeChan)
 	}()
@@ -846,7 +873,7 @@ func TestRedpandaMigratorIntegration(t *testing.T) {
 
 	// Produce one message
 	dummyMessage := `{"test":"foo"}`
-	produceMessage(t, source, dummyTopic, dummyMessage)
+	produceMessages(t, source, dummyTopic, dummyMessage, 0, 1, true)
 	t.Log("Finished producing first message in source")
 
 	// Run the Redpanda Migrator bundle
@@ -891,7 +918,7 @@ func TestRedpandaMigratorIntegration(t *testing.T) {
 
 	dummyCG := "foobar_cg"
 	// Read the message from source using a consumer group
-	readMessageWithCG(t, source, dummyTopic, dummyCG, dummyMessage)
+	readMessagesWithCG(t, source, dummyTopic, dummyCG, dummyMessage, 1, true)
 	checkMigrated("redpanda_migrator_offsets_input", func(_ string, meta map[string]string) {
 		assert.Equal(t, dummyTopic, meta["kafka_offset_topic"])
 	})
@@ -899,16 +926,163 @@ func TestRedpandaMigratorIntegration(t *testing.T) {
 
 	// Produce one more message in the source
 	secondDummyMessage := `{"test":"bar"}`
-	produceMessage(t, source, dummyTopic, secondDummyMessage)
+	produceMessages(t, source, dummyTopic, secondDummyMessage, 0, 1, true)
 	checkMigrated("redpanda_migrator_input", func(msg string, _ map[string]string) {
 		assert.Equal(t, "\x00\x00\x00\x00\x01\x06bar", msg)
 	})
 	t.Log("Finished producing second message in source")
 
 	// Read the new message from the destination using a consumer group
-	readMessageWithCG(t, destination, dummyTopic, dummyCG, secondDummyMessage)
+	readMessagesWithCG(t, destination, dummyTopic, dummyCG, secondDummyMessage, 1, true)
 	checkMigrated("redpanda_migrator_offsets_input", func(_ string, meta map[string]string) {
 		assert.Equal(t, dummyTopic, meta["kafka_offset_topic"])
 	})
 	t.Logf("Finished reading second message from destination with consumer group %q", dummyCG)
+}
+
+func TestRedpandaMigratorOffsetsIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cgAtEndOffset bool
+		extraCGUpdate bool
+	}{
+		{
+			name:          "source consumer group points to the topic end offset",
+			cgAtEndOffset: true,
+		},
+		{
+			name:          "source consumer group points to an older offset inside the topic",
+			cgAtEndOffset: false,
+		},
+		{
+			name:          "subsequent consumer group updates are processed correctly",
+			cgAtEndOffset: true,
+			extraCGUpdate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+			pool.MaxWait = time.Minute
+
+			source, err := startRedpanda(t, pool, true, true)
+			require.NoError(t, err)
+			destination, err := startRedpanda(t, pool, true, true)
+			require.NoError(t, err)
+
+			t.Logf("Source broker: %s", source.brokerAddr)
+			t.Logf("Destination broker: %s", destination.brokerAddr)
+
+			dummyTopic := "test"
+			dummyMessage := `{"test":"foo"}`
+			dummyConsumerGroup := "test_cg"
+			messageCount := 5
+
+			// Produce messages in the source cluster
+			// The message timestamps are produced in ascending order, starting from 1 all the way to messageCount
+			produceMessages(t, source, dummyTopic, dummyMessage, 0, messageCount, false)
+
+			// Produce the exact same messages in the destination cluster
+			produceMessages(t, destination, dummyTopic, dummyMessage, 0, messageCount, false)
+
+			// Read the messages from the source cluster using a consumer group
+			readMessagesWithCG(t, source, dummyTopic, dummyConsumerGroup, dummyMessage, 5, false)
+
+			if !test.cgAtEndOffset {
+				// The next messages need to have more recent timestamps than the existing messages, so we use
+				// `messageCount` as an offset for their timestamps
+				produceMessages(t, source, dummyTopic, dummyMessage, messageCount, messageCount, false)
+			}
+
+			if test.extraCGUpdate {
+				// Make sure both source and destination have extra messages after the current consumer group offset
+				produceMessages(t, source, dummyTopic, dummyMessage, messageCount, messageCount, false)
+				produceMessages(t, destination, dummyTopic, dummyMessage, messageCount, messageCount, false)
+			}
+
+			t.Log("Finished setting up messages in the source and destination clusters")
+
+			// Migrate the consumer group offset
+			streamBuilder := service.NewStreamBuilder()
+			require.NoError(t, streamBuilder.SetYAML(fmt.Sprintf(`
+input:
+  redpanda_migrator_offsets:
+    seed_brokers: [ %s ]
+    topics: [ %s ]
+
+output:
+  redpanda_migrator_offsets:
+    seed_brokers: [ %s ]
+`, source.brokerAddr, dummyTopic, destination.brokerAddr)))
+			require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+
+			migratorUpdateWG := sync.WaitGroup{}
+			migratorUpdateWG.Add(1)
+			require.NoError(t, streamBuilder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+				defer migratorUpdateWG.Done()
+				return nil
+			}))
+
+			// Ensure the callback function is called after the output wrote the message
+			streamBuilder.SetOutputBrokerPattern(service.OutputBrokerPatternFanOutSequential)
+
+			stream, err := streamBuilder.Build()
+			require.NoError(t, err)
+
+			license.InjectTestService(stream.Resources())
+
+			// Run stream in the background
+			migratorCloseChan := make(chan struct{})
+			go func() {
+				err = stream.Run(context.Background())
+				require.NoError(t, err)
+
+				t.Log("redpanda_migrator_offsets pipeline shut down")
+
+				close(migratorCloseChan)
+			}()
+
+			t.Cleanup(func() {
+				require.NoError(t, stream.StopWithin(3*time.Second))
+
+				<-migratorCloseChan
+			})
+
+			migratorUpdateWG.Wait()
+
+			if test.extraCGUpdate {
+				// Trigger another consumer group update to get it to point to the end of the topic
+				migratorUpdateWG.Add(1)
+				readMessagesWithCG(t, source, dummyTopic, dummyConsumerGroup, dummyMessage, messageCount, false)
+				migratorUpdateWG.Wait()
+			}
+
+			client, err := kgo.NewClient(kgo.SeedBrokers([]string{destination.brokerAddr}...))
+			require.NoError(t, err)
+			defer client.Close()
+
+			adm := kadm.NewClient(client)
+			offsets, err := adm.FetchOffsets(context.Background(), dummyConsumerGroup)
+			currentCGOffset, ok := offsets.Lookup(dummyTopic, 0)
+			require.True(t, ok)
+
+			endOffset := int64(messageCount)
+			if test.cgAtEndOffset {
+				offsets, err := adm.ListEndOffsets(context.Background(), dummyTopic)
+				require.NoError(t, err)
+				o, ok := offsets.Lookup(dummyTopic, 0)
+				require.True(t, ok)
+				endOffset = o.Offset
+			}
+			assert.Equal(t, endOffset, currentCGOffset.At)
+			assert.Equal(t, dummyTopic, currentCGOffset.Topic)
+		})
+	}
 }

--- a/internal/impl/kafka/enterprise/redpanda_migrator.md
+++ b/internal/impl/kafka/enterprise/redpanda_migrator.md
@@ -1,0 +1,45 @@
+# Redpanda Migrator
+
+Redpanda Migrator is a tool for migrating data (records, consumer group updates and schemas) between various Kafka clusters.
+
+It guarantees at-least-once delivery semantics for Kafka records, so the destination cluster can end up receiving duplicate records.
+
+Given this delivery guarantee model, record offsets in the destination cluster will differ from the source offsets. This forces us to perform record offset translation when migrating consumer group updates.
+
+While more sophisticated approaches have been implemented (see [here](https://web.archive.org/web/20250112205959/https://blog.cloudera.com/a-look-inside-kafka-mirrormaker-2/) and [here](https://current.confluent.io/2024-sessions/mirrormaker-2s-offset-translation-isnt-exactly-once-and-thats-okay)), they are difficult to reason about and troubleshoot.
+
+In Redpanda Migrator, we chose a simple record timestamp-based approach, where, each time we get an update on the `__consumer_offsets` topic in the source cluster, we first try to determine the timestamp of the consumed record which triggered this update and then use this timestamp to do another lookup in the destination cluster to determine the offset of the corresponding migrated record.
+
+This approach requires that all topics which need to be migrated contain records which have monotonically-increasing timestamps, including duplicates.
+
+## Sequence diagrams
+
+Migrate consumer group update for record `R` in topic `T` partition `P` located at an arbitrary offset `O` in the `[start, end)` interval in the Source cluster which translates to offset `O'` in the Destination cluster.
+
+```mermaid
+sequenceDiagram
+Source->>Source: O = Receive(__consumer_offsets)
+Source->>Source: X = ListEndOffsets(T, P)
+Source->>Source: X > O
+Source->>Source: TS = ReadTimestamp(T, P, O)
+Source->>Destination: TS
+Destination->>Destination: O' = ListOffsetsAfterMilli(T, P, TS)
+Destination->>Destination: CommitOffsets(T, P, O')
+```
+
+Migrate consumer group update for record `R` from the end of topic topic `T` partition `P` with offset `O` the Source cluster which translates to offset `O'` in the Destination cluster.
+
+Note: `-1` is used to retrieve the last record offset from a topic.
+
+```mermaid
+sequenceDiagram
+Source->>Source: O = Receive(__consumer_offsets)
+Source->>Source: X = ListEndOffsets(T, P)
+Source->>Source: X == O
+Source->>Source: TS = ReadTimestamp(T, P, -1)
+Source->>Destination: TS
+Destination->>Destination: O' = ListOffsetsAfterMilli(T, P, TS)
+Destination->>Destination: O'' = ReadOffset(T, P, -1)
+Destination->>Destination: If O'' == O' then O' = ListEndOffsets(T, P)
+Destination->>Destination: CommitOffsets(T, P, O')
+```

--- a/internal/impl/kafka/enterprise/redpanda_migrator.md
+++ b/internal/impl/kafka/enterprise/redpanda_migrator.md
@@ -22,7 +22,7 @@ Source->>Source: O = Receive(__consumer_offsets)
 Source->>Source: X = ListEndOffsets(T, P)
 Source->>Source: X > O
 Source->>Source: TS = ReadTimestamp(T, P, O)
-Source->>Destination: TS
+Source->>Destination: (T, P, TS)
 Destination->>Destination: O' = ListOffsetsAfterMilli(T, P, TS)
 Destination->>Destination: CommitOffsets(T, P, O')
 ```
@@ -37,7 +37,7 @@ Source->>Source: O = Receive(__consumer_offsets)
 Source->>Source: X = ListEndOffsets(T, P)
 Source->>Source: X == O
 Source->>Source: TS = ReadTimestamp(T, P, -1)
-Source->>Destination: TS
+Source->>Destination: (T, P, TS)
 Destination->>Destination: O' = ListOffsetsAfterMilli(T, P, TS)
 Destination->>Destination: O'' = ReadOffset(T, P, -1)
 Destination->>Destination: If O'' == O' then O' = ListEndOffsets(T, P)

--- a/internal/impl/kafka/enterprise/redpanda_migrator.md
+++ b/internal/impl/kafka/enterprise/redpanda_migrator.md
@@ -23,6 +23,11 @@ Consumer group offsets are migrated independently from records and schemas.
 ```mermaid
 sequenceDiagram
 
+participant Source
+participant Offsets Input
+participant Offsets Output
+participant Destination
+
 Source->>Offsets Input: O = Receive(__consumer_offsets)
 Source->>Offsets Input: X = ListEndOffsets(T, P)
 Source->>Offsets Input: Check X < O
@@ -39,29 +44,47 @@ Note: `-1` is used to retrieve the last record offset from a topic.
 ```mermaid
 sequenceDiagram
 
+participant Source
+participant Offsets Input
+participant Offsets Output
+participant Destination
+
 Source->>Offsets Input: O = Receive(__consumer_offsets)
 Source->>Offsets Input: X = ListEndOffsets(T, P)
 Source->>Offsets Input: Check X == O
 Source->>Offsets Input: TS = ReadTimestamp(T, P, -1)
 Offsets Input->>Offsets Output: (T, P, TS)
-Offsets Output->>Destination: O' = ListOffsetsAfterMilli(T, P, TS)
-Offsets Output->>Destination: O'' = ReadOffset(T, P, -1)
-Offsets Output->>Destination: If O'' == O' then O''' = ListEndOffsets(T, P)
-Offsets Output->>Destination: O'' = ReadOffset(T, P, -1)
-Offsets Output->>Destination: If O'' == O' then O' = O'''
-Offsets Output->>Destination: CommitOffsets(T, P, O')
+Offsets Output->>Destination: O', TS' = ListOffsetsAfterMilli(T, P, TS)
+Offsets Output->>Destination: If TS' != -1 then O'' = ListEndOffsets(T, P)
+Offsets Output->>Destination: CommitOffsets(T, P, O' + 1 ==  O'' ? O'' : O')
 ```
 
 ### Record and schema migration
 
+1. End to end flow.
+
 ```mermaid
 sequenceDiagram
+
+participant Source SR
+participant SR Input
+participant SR Output
+participant Destination SR
+participant Source
+participant Migrator Input
+participant Migrator Output
+participant Destination
 
 Source SR->>SR Input: Read all via REST API
 SR Input->>SR Output: Stream schemas
 SR Output->>Destination SR: POST via REST API
+Source->>Migrator Output: Read all topics on startup
+Migrator Output->>Destination: Create all topics & ACLs
 Source->>Migrator Input: Record batch
 Migrator Input->>Migrator Output: Record batch
+Migrator Output->>Migrator Output: Lookup topic in local cache
+Migrator Output->>Source: Fetch topic config
+Migrator Output->>Destination: Create topic & ACLs and update local cache
 Migrator Output->>Migrator Output: R = Foreach record
 Migrator Output->>Migrator Output: Lookup schema ID X in local cache
 Migrator Output->>SR Output: GetDestinationSchemaID(X)
@@ -71,4 +94,23 @@ SR Output->>Destination SR: Y = getOrCreateSchemaID(S)
 SR Output->>Migrator Output: Y
 Migrator Output->>Migrator Output: UpdateID(R, Y)
 Migrator Output->>Destination: Record batch
+```
+
+2. Detailed view of schema creation when given ID `X`, subject `S` and version `V` along with the schema body `B` as input.
+
+```mermaid
+sequenceDiagram
+
+participant Source SR
+participant SR Output
+participant Destination SR
+
+SR Output->>SR Output: Lookup ID Y = (X,S,V) in local cache
+SR Output->>Source SR: Fetch B.references recursively
+SR Output->>Destination SR: Backfill references and cache new IDs locally
+SR Output->>Source SR: Fetch previous versions for S
+SR Output->>Destination SR: Backfill previous versions and cache new IDs locally
+SR Output->>Destination SR: Create Y from (S,V,B)
+SR Output->>SR Output: Cache Y = (X,S,V) in the local cache
+
 ```

--- a/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
@@ -105,7 +105,10 @@ mapping: |
                     cases:
                       - check: '@fallback_error == "request returned status: 422"'
                         output:
-                          drop: {} # TODO: Use a DLQ?
+                          # We want to drop these messages, because they indicate that the provided schema already
+                          # exists in the destination.
+                          # TODO: Use a DLQ?
+                          drop: {}
                           processors:
                             - log:
                                 message: |

--- a/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
@@ -87,29 +87,15 @@ mapping: |
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: %s_redpanda_migrator_output
-                  redpanda_migrator: %s
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                # TODO: Use a DLQ
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: %s_redpanda_migrator_output
+              redpanda_migrator: %s
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: %s_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets: %s
-                # TODO: Use a DLQ
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: %s_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets: %s
           - check: metadata("input_label") == "schema_registry_input"
             output:
               fallback:
@@ -119,8 +105,7 @@ mapping: |
                     cases:
                       - check: '@fallback_error == "request returned status: 422"'
                         output:
-                          # TODO: Use a DLQ
-                          drop: {}
+                          drop: {} # TODO: Use a DLQ?
                           processors:
                             - log:
                                 message: |
@@ -134,29 +119,15 @@ mapping: |
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: %s_redpanda_migrator_output
-                  redpanda_migrator: %s
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                # TODO: Use a DLQ
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: %s_redpanda_migrator_output
+              redpanda_migrator: %s
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: %s_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets: %s
-                # TODO: Use a DLQ
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: %s_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets: %s
     """.format($labelPrefix, $redpandaMigrator.string(), $labelPrefix, $redpandaMigratorOffsets.string()).parse_yaml()
   }
 
@@ -175,43 +146,31 @@ tests:
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_output
-                  redpanda_migrator:
-                    key: ${! metadata("kafka_key") }
-                    max_in_flight: 1
-                    partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
-                    partitioner: manual
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                    timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
-                    topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
-                    metadata:
-                      include_patterns:
-                        -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
-                    translate_schema_ids: true
-                    input_resource: redpanda_migrator_bundle_redpanda_migrator_input
-                    schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_output
+              redpanda_migrator:
+                key: ${! metadata("kafka_key") }
+                max_in_flight: 1
+                partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
+                partitioner: manual
+                seed_brokers:
+                  - 127.0.0.1:9092
+                timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
+                topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
+                metadata:
+                  include_patterns:
+                    -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
+                translate_schema_ids: true
+                input_resource: redpanda_migrator_bundle_redpanda_migrator_input
+                schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets:
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets:
+                seed_brokers:
+                  - 127.0.0.1:9092
           - check: metadata("input_label") == "schema_registry_input"
             output:
               fallback:
@@ -248,43 +207,31 @@ tests:
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_output
-                  redpanda_migrator:
-                    key: ${! metadata("kafka_key") }
-                    max_in_flight: 1
-                    partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
-                    partitioner: manual
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                    timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
-                    topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
-                    metadata:
-                      include_patterns:
-                        -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
-                    translate_schema_ids: false
-                    input_resource: redpanda_migrator_bundle_redpanda_migrator_input
-                    schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_output
+              redpanda_migrator:
+                key: ${! metadata("kafka_key") }
+                max_in_flight: 1
+                partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
+                partitioner: manual
+                seed_brokers:
+                  - 127.0.0.1:9092
+                timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
+                topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
+                metadata:
+                  include_patterns:
+                    -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
+                translate_schema_ids: false
+                input_resource: redpanda_migrator_bundle_redpanda_migrator_input
+                schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets:
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets:
+                seed_brokers:
+                  - 127.0.0.1:9092
           - check: metadata("input_label") == "schema_registry_input"
             output:
               fallback:
@@ -321,43 +268,31 @@ tests:
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_output
-                  redpanda_migrator:
-                    key: ${! metadata("kafka_key") }
-                    max_in_flight: 1
-                    partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
-                    partitioner: manual
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                    timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
-                    topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
-                    metadata:
-                      include_patterns:
-                        -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
-                    translate_schema_ids: true
-                    input_resource: redpanda_migrator_bundle_redpanda_migrator_input
-                    schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_output
+              redpanda_migrator:
+                key: ${! metadata("kafka_key") }
+                max_in_flight: 1
+                partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
+                partitioner: manual
+                seed_brokers:
+                  - 127.0.0.1:9092
+                timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
+                topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
+                metadata:
+                  include_patterns:
+                    -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
+                translate_schema_ids: true
+                input_resource: redpanda_migrator_bundle_redpanda_migrator_input
+                schema_registry_output_resource: redpanda_migrator_bundle_schema_registry_output
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets:
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets:
+                seed_brokers:
+                  - 127.0.0.1:9092
           - check: metadata("input_label") == "schema_registry_input"
             output:
               fallback:
@@ -390,39 +325,27 @@ tests:
         cases:
           - check: metadata("input_label") == "redpanda_migrator_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_output
-                  redpanda_migrator:
-                    key: ${! metadata("kafka_key") }
-                    max_in_flight: 1
-                    partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
-                    partitioner: manual
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                    timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
-                    topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
-                    metadata:
-                      include_patterns:
-                        -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
-                    translate_schema_ids: false
-                    input_resource: redpanda_migrator_bundle_redpanda_migrator_input
-                  processors:
-                    - mapping: |
-                        meta input_label = deleted()
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_output
+              redpanda_migrator:
+                key: ${! metadata("kafka_key") }
+                max_in_flight: 1
+                partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
+                partitioner: manual
+                seed_brokers:
+                  - 127.0.0.1:9092
+                timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
+                topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
+                metadata:
+                  include_patterns:
+                    -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
+                translate_schema_ids: false
+                input_resource: redpanda_migrator_bundle_redpanda_migrator_input
+              processors:
+                - mapping: |
+                    meta input_label = deleted()
           - check: metadata("input_label") == "redpanda_migrator_offsets_input"
             output:
-              fallback:
-                - label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
-                  redpanda_migrator_offsets:
-                    seed_brokers:
-                      - 127.0.0.1:9092
-                - drop: {}
-                  processors:
-                    - log:
-                        message: |
-                          Dropping message: ${! content() } / ${! metadata() }
+              label: redpanda_migrator_bundle_redpanda_migrator_offsets_output
+              redpanda_migrator_offsets:
+                seed_brokers:
+                  - 127.0.0.1:9092

--- a/internal/impl/kafka/enterprise/redpanda_migrator_offsets_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_offsets_input.go
@@ -207,7 +207,7 @@ func (rmoi *redpandaMigratorOffsetsInput) getKeyAndOffset(msg *service.Message) 
 	return key, offset, true
 }
 
-func (rmoi *redpandaMigratorOffsetsInput) getEndTimestamp(ctx context.Context, topic string, partition int32, offset int64) (int64, bool, error) {
+func (rmoi *redpandaMigratorOffsetsInput) getEndTimestamp(ctx context.Context, topic string, partition int32, offset int64) (timestamp int64, isEndOffset bool, err error) {
 	client, err := kgo.NewClient(rmoi.clientOpts...)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to create Kafka client: %s", err)

--- a/internal/impl/kafka/enterprise/redpanda_migrator_offsets_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_offsets_output.go
@@ -338,12 +338,12 @@ func (w *redpandaMigratorOffsetsWriter) Write(ctx context.Context, msg *service.
 							return fmt.Errorf("failed to read the end offset for topic %q and partition %q: %s", topic, partition, err)
 						}
 
-						committedOffset, ok := offsets.Lookup(topic, partition)
+						endOffset, ok := offsets.Lookup(topic, partition)
 						if !ok {
 							return fmt.Errorf("failed to find the end offset for topic %q and partition %q: %s", topic, partition, err)
 						}
 
-						offset.At = committedOffset.Offset
+						offset.At = endOffset.Offset
 					}
 				}
 


### PR DESCRIPTION
- Field `is_high_watermark` added to the `redpanda_migrator_offsets` output.
- Metadata field `kafka_is_high_watermark` added to the `redpanda_migrator_offsets` input.
- Fixed a bug with the `redpanda_migrator_offsets` input and output where the consumer group update migration logic based on timestamp lookup should no longer skip ahead in the destination cluster. This should enforce at-least-once delivery guarantees.
- The `redpanda_migrator_bundle` output no longer drops messages if either the `redpanda_migrator` or the `redpanda_migrator_offsets` child output throws an error. Connect will keep retrying to write the messages and apply backpressure to the input.

TODO:
- [x] Push extra integration tests