### PR TITLE
pgcdc: add heartbeat mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - New `mongodb_cdc` input for change data capture (CDC) over MongoDB collections. (@rockwotj)
 - Field `is_high_watermark` added to the `redpanda_migrator_offsets` output. (@mihaitodor)
 - Metadata field `kafka_is_high_watermark` added to the `redpanda_migrator_offsets` input. (@mihaitodor)
+- Input `postgres_cdc` now emits logical messages to the WAL every hour by default to allow WAL reclaiming for low frequency tables, this frequency is controlled by field `heartbeat_interval`. (@rockwotj)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 
 ## 4.48.0 - TBD
 
-### Fixed
-
-- Fixed a bug with the `redpanda_migrator_offsets` input and output where the consumer group update migration logic based on timestamp lookup should no longer skip ahead in the destination cluster. This should enforce at-least-once delivery guarantees. (@mihaitodor)
-- The `redpanda_migrator_bundle` output no longer drops messages if either the `redpanda_migrator` or the `redpanda_migrator_offsets` child output throws an error. Connect will keep retrying to write the messages and apply backpressure to the input. (@mihaitodor)
-
 ### Added
 
 - Added a lint rule to verify field `private_key` for the `snowflake_streaming` output is in PEM format. (@rockwotj)
@@ -20,10 +15,14 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix an issue in the `snowflake_streaming` output when the user manually evolves the schema in their pipeline that could lead to elevated error rates in the connector. (@rockwotj)
+- Fixed a bug with the `redpanda_migrator_offsets` input and output where the consumer group update migration logic based on timestamp lookup should no longer skip ahead in the destination cluster. This should enforce at-least-once delivery guarantees. (@mihaitodor)
+- The `redpanda_migrator_bundle` output no longer drops messages if either the `redpanda_migrator` or the `redpanda_migrator_offsets` child output throws an error. Connect will keep retrying to write the messages and apply backpressure to the input. (@mihaitodor)
+
 
 ### Changed
 
 - Output `snowflake_streaming` has additional logging and debug information when errors arise. (@rockwotj)
+- Input `postgres_cdc` now does not add a prefix to the replication slot name, if upgrading from a previous version, prefix your current replication slot with `rs_` to continue to use the same replication slot. (@rockwotj)
 
 ## 4.47.1 - 2025-02-11
 

--- a/docs/modules/components/pages/inputs/pg_stream.adoc
+++ b/docs/modules/components/pages/inputs/pg_stream.adoc
@@ -53,7 +53,7 @@ input:
     tables: [] # No default (required)
     checkpoint_limit: 1024
     temporary_slot: false
-    slot_name: ""
+    slot_name: my_test_slot # No default (required)
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
@@ -84,11 +84,12 @@ input:
     tables: [] # No default (required)
     checkpoint_limit: 1024
     temporary_slot: false
-    slot_name: ""
+    slot_name: my_test_slot # No default (required)
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
     unchanged_toast_value: null
+    heartbeat_interval: 1h
     auto_replay_nacks: true
     batching:
       count: 0
@@ -239,7 +240,6 @@ The name of the PostgreSQL logical replication slot to use. If not provided, a r
 
 *Type*: `string`
 
-*Default*: `""`
 
 ```yml
 # Examples
@@ -299,6 +299,23 @@ The value to emit when there are unchanged TOAST values in the stream. This occu
 # Examples
 
 unchanged_toast_value: __redpanda_connect_unchanged_toast_value__
+```
+
+=== `heartbeat_interval`
+
+The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.
+
+
+*Type*: `string`
+
+*Default*: `"1h"`
+
+```yml
+# Examples
+
+heartbeat_interval: 0s
+
+heartbeat_interval: 24h
 ```
 
 === `auto_replay_nacks`

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -48,7 +48,7 @@ input:
     tables: [] # No default (required)
     checkpoint_limit: 1024
     temporary_slot: false
-    slot_name: ""
+    slot_name: my_test_slot # No default (required)
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
@@ -79,11 +79,12 @@ input:
     tables: [] # No default (required)
     checkpoint_limit: 1024
     temporary_slot: false
-    slot_name: ""
+    slot_name: my_test_slot # No default (required)
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
     unchanged_toast_value: null
+    heartbeat_interval: 1h
     auto_replay_nacks: true
     batching:
       count: 0
@@ -234,7 +235,6 @@ The name of the PostgreSQL logical replication slot to use. If not provided, a r
 
 *Type*: `string`
 
-*Default*: `""`
 
 ```yml
 # Examples
@@ -294,6 +294,23 @@ The value to emit when there are unchanged TOAST values in the stream. This occu
 # Examples
 
 unchanged_toast_value: __redpanda_connect_unchanged_toast_value__
+```
+
+=== `heartbeat_interval`
+
+The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.
+
+
+*Type*: `string`
+
+*Default*: `"1h"`
+
+```yml
+# Examples
+
+heartbeat_interval: 0s
+
+heartbeat_interval: 24h
 ```
 
 === `auto_replay_nacks`

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -46,4 +46,6 @@ type Config struct {
 	MaxParallelSnapshotTables int
 	// The value to use for unchanged toast columns
 	UnchangedToastValue any
+	// The interval to send logical messages
+	HeartbeatInterval time.Duration
 }

--- a/internal/impl/postgresql/pglogicalstream/heartbeat.go
+++ b/internal/impl/postgresql/pglogicalstream/heartbeat.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+)
+
+type heartbeat struct {
+	db            *sql.DB
+	task          *asyncroutine.Periodic
+	logger        *service.Logger
+	prefix, value string
+}
+
+func newHeartbeat(dsn string, interval time.Duration, logger *service.Logger, prefix, value string) (*heartbeat, error) {
+	dbConn, err := openPgConnectionFromConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	h := &heartbeat{db: dbConn, task: nil, logger: logger, prefix: prefix, value: value}
+	h.task = asyncroutine.NewPeriodicWithContext(interval, h.run)
+	return h, nil
+}
+
+func (h *heartbeat) Start() {
+	h.task.Start()
+}
+
+func (h *heartbeat) run(ctx context.Context) {
+	_, err := h.db.ExecContext(ctx, "SELECT pg_logical_emit_message(false, $1, $2)", h.prefix, h.value)
+	if err != nil {
+		h.logger.Warnf("unable to write heartbeat message: %v", err)
+	}
+}
+
+func (h *heartbeat) Stop() error {
+	h.task.Stop()
+	return h.db.Close()
+}

--- a/internal/impl/postgresql/pglogicalstream/pglogrepl_test.go
+++ b/internal/impl/postgresql/pglogicalstream/pglogrepl_test.go
@@ -461,6 +461,14 @@ drop table t;
 		return xld
 	}
 
+	decodeWALData := func(data []byte, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, unchangedToastValue any) (*StreamMessage, error) {
+		m, err := Parse(data)
+		if err != nil {
+			return nil, err
+		}
+		return toStreamMessage(m, relations, typeMap, unchangedToastValue)
+	}
+
 	rxKeepAlive()
 	xld := rxXLogData()
 	begin, _, err := isBeginMessage(xld.WALData)
@@ -469,40 +477,40 @@ drop table t;
 
 	xld = rxXLogData()
 	var streamMessage *StreamMessage
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	assert.Nil(t, streamMessage)
 
 	xld = rxXLogData()
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	jsonData, err := json.Marshal(&streamMessage)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"operation":"insert","schema":"public","table":"t","lsn":null,"data":{"id":1, "name":"foo"}}`, string(jsonData))
 
 	xld = rxXLogData()
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	jsonData, err = json.Marshal(&streamMessage)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"operation":"insert","schema":"public","table":"t","lsn":null,"data":{"id":2,"name":"bar"}}`, string(jsonData))
 
 	xld = rxXLogData()
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	jsonData, err = json.Marshal(&streamMessage)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"operation":"insert","schema":"public","table":"t","lsn":null,"data":{"id":3,"name":"baz"}}`, string(jsonData))
 
 	xld = rxXLogData()
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	jsonData, err = json.Marshal(&streamMessage)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"operation":"update","schema":"public","table":"t","lsn":null,"data":{"id":3,"name":"quz"}}`, string(jsonData))
 
 	xld = rxXLogData()
-	streamMessage, err = decodePgOutput(xld.WALData, relations, typeMap, nil)
+	streamMessage, err = decodeWALData(xld.WALData, relations, typeMap, nil)
 	require.NoError(t, err)
 	jsonData, err = json.Marshal(&streamMessage)
 	require.NoError(t, err)

--- a/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
+++ b/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
@@ -40,18 +40,13 @@ func isCommitMessage(WALData []byte) (bool, *CommitMessage, error) {
 	return ok, m, nil
 }
 
-// decodePgOutput decodes a logical replication message in pgoutput format.
+// toStreamMessage decodes a logical replication message in pgoutput format.
 // It uses the provided relations map to look up the relation metadata for the
 // as a side effect it updates the relations map with any new relation metadata
 // When the relation is changes in the database, the relation message is sent
 // before the change message.
-func decodePgOutput(WALData []byte, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, unchangedToastValue any) (*StreamMessage, error) {
-	logicalMsg, err := Parse(WALData)
+func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, unchangedToastValue any) (*StreamMessage, error) {
 	message := &StreamMessage{}
-
-	if err != nil {
-		return nil, err
-	}
 	switch logicalMsg := logicalMsg.(type) {
 	case *RelationMessage:
 		relations[logicalMsg.RelationID] = logicalMsg


### PR DESCRIPTION
See the commits for more details

- **pgcdc: don't prefix the replication slot name**
- **pgcdc: add heartbeat mechanism using logical wal messages**

Fixes: https://github.com/redpanda-data/connect/issues/3198