### PR TITLE
snowflake: add option to ignore null values in schema evolution

### DIFF
--- a/docs/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/docs/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -86,6 +86,7 @@ output:
       CREATE TABLE IF NOT EXISTS mytable (amount NUMBER);
     schema_evolution:
       enabled: false # No default (required)
+      ignore_nulls: true
       processors: [] # No default (optional)
     build_options:
       parallelism: 1
@@ -458,6 +459,15 @@ Whether schema evolution is enabled.
 
 *Type*: `bool`
 
+
+=== `schema_evolution.ignore_nulls`
+
+If `true`, then new columns that are `null` are ignored and schema evolution is not triggered. If `false` then null columns trigger schema migrations in Snowflake. NOTE: unless you already know what type this column will be in advance, it's highly encouraged to ignore null values.
+
+
+*Type*: `bool`
+
+*Default*: `true`
 
 === `schema_evolution.processors`
 

--- a/internal/impl/snowflake/schema_evolution.go
+++ b/internal/impl/snowflake/schema_evolution.go
@@ -68,6 +68,7 @@ func asSchemaMigrationError(err error) (*schemaMigrationNeededError, bool) {
 }
 
 type snowpipeSchemaEvolver struct {
+	mode                   streaming.SchemaMode
 	schemaEvolutionMapping *bloblang.Executor
 	pipeline               []*service.OwnedProcessor
 	logger                 *service.Logger
@@ -200,6 +201,9 @@ func (o *snowpipeSchemaEvolver) CreateOutputTable(ctx context.Context, batch ser
 	}
 	columns := []string{}
 	for k, v := range row {
+		if o.mode == streaming.SchemaModeStrict && v == nil {
+			continue
+		}
 		col := streaming.NewMissingColumnError(msg, k, v)
 		colType, err := o.ComputeMissingColumnType(ctx, col)
 		if err != nil {

--- a/internal/impl/snowflake/streaming/parquet_test.go
+++ b/internal/impl/snowflake/streaming/parquet_test.go
@@ -61,7 +61,7 @@ func TestWriteParquet(t *testing.T) {
 		batch,
 		schema,
 		transformers,
-		false,
+		SchemaModeIgnoreExtra,
 	)
 	require.NoError(t, err)
 	w := newParquetWriter("latest", schema)

--- a/internal/impl/snowflake/streaming/streaming.go
+++ b/internal/impl/snowflake/streaming/streaming.go
@@ -162,8 +162,8 @@ type ChannelOptions struct {
 	TableName string
 	// The max parallelism used to build parquet files and convert message batches into rows.
 	BuildOptions BuildOptions
-	// If set to true, don't ignore extra columns in user data, but raise an error.
-	StrictSchemaEnforcement bool
+	// How to handle schema differences
+	SchemaMode SchemaMode
 }
 
 type encryptionInfo struct {
@@ -337,7 +337,7 @@ func (c *SnowflakeIngestionChannel) constructBdecPart(batch service.MessageBatch
 		rowGroups = append(rowGroups, rowGroup{})
 		chunk := batch[i : i+end]
 		wg.Go(func() error {
-			rows, stats, err := constructRowGroup(chunk, c.schema, c.transformers, !c.StrictSchemaEnforcement)
+			rows, stats, err := constructRowGroup(chunk, c.schema, c.transformers, c.SchemaMode)
 			rowGroups[j] = rowGroup{rows, stats}
 			return err
 		})


### PR DESCRIPTION
Mor options! This allows folks to include nulls when managing the
schema. If you are managing the schema explicitly (ie. using a schema in
schema registry) this can make a lot of sense, by default we expect
people to just throw data at the connector and we should just drop nulls
because we don't know what type the column will eventually be.
