### PR TITLE
Fix Go versions in CI

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [oldstable, stable]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -36,7 +36,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-        check-latest: true
 
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
-        check-latest: true
+        go-version: oldstable
 
     - name: Release Notes
       run: ./resources/scripts/release_notes.sh > ./release_notes.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
-        check-latest: true
+        go-version: oldstable
 
     - name: Install dependencies for x_benthos_extra
       run: |
@@ -57,13 +56,12 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
-        check-latest: true
+        go-version: oldstable
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.61.0
+        version: v1.64.5
         args: --timeout 30m cmd/... internal/... public/...
 
   test-push-to-cloudsmith:

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -36,8 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
-          check-latest: true
+          go-version: oldstable
       - name: Write telemetry private key
         env:
           CONNECT_TELEMETRY_PRIV_KEY: ${{ secrets.TELEMETRY_PRIVATE_KEY }}


### PR DESCRIPTION
This is a small cleanup to switch to the [`stable`/`oldstable` aliases](https://github.com/actions/setup-go?tab=readme-ov-file#using-stableoldstable-aliases) and I'm not 100% sure if it works well in practice. We have the `toolchain` specified in the `go.mod` [for Benthos](https://github.com/redpanda-data/benthos/blob/4d6fce617665d27d5599fc4a6b44769193d09cb9/go.mod#L78) and I'm not sure exactly why it doesn't get added for Connect as well (might have something to do with the [`replace` directive](https://github.com/redpanda-data/connect/blob/4196ff3294a2af12ef6df79cbfba5ae0b0030272/go.mod#L5) we have in `go.mod`), so I think Go will download the appropriate version anyway...

WDYT?