### PR TITLE
Fix aws_s3 input missing SQS keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a panic in the `sftp` input when Connect shuts down. (@mihaitodor)
 - Fixed an issue where `mysql_cdc` would not work with timestamps without the `parseTime=true` DSN parameter. (@rockwotj)
 - Fixed an issue where timestamps at extreme year bounds (i.e. year 0 or year 9999) would be encoded incorrectly in `snowflake_streaming`. (@rockwotj)
+- The `aws_s3` input now drops SQS notifications and emits a warning log message for files which have been deleted before Coonect was able to read them. (@mihaitodor)
 
 ### Changed
 


### PR DESCRIPTION
We currently keep retrying SQS messages which correspond to notifications about S3 files which have been deleted before we got a chance to process them. It makes more sense to just log a warning and drop the notification.