### PR TITLE
feat(sftp): add private_key field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.51.0 - TBD
+
+### Added
+
+- Field `private_key` added to `ssh` input and output to let users directly specify their private key contents in their config instead of writing it to a file (@ooesili)
+
 ## 4.50.0 - 2025-03-18
 
 ### Added

--- a/docs/modules/components/pages/inputs/sftp.adoc
+++ b/docs/modules/components/pages/inputs/sftp.adoc
@@ -44,6 +44,7 @@ input:
       username: ""
       password: ""
       private_key_file: ""
+      private_key: ""
       private_key_pass: ""
     paths: [] # No default (required)
     auto_replay_nacks: true
@@ -71,6 +72,7 @@ input:
       username: ""
       password: ""
       private_key_file: ""
+      private_key: ""
       private_key_pass: ""
     paths: [] # No default (required)
     auto_replay_nacks: true
@@ -139,6 +141,20 @@ This field contains sensitive information that usually shouldn't be added to a c
 === `credentials.private_key_file`
 
 The private key for the username to connect to the SFTP server.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `credentials.private_key`
+
+The private key file for the username to connect to the SFTP server.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/sftp.adoc
+++ b/docs/modules/components/pages/outputs/sftp.adoc
@@ -39,6 +39,7 @@ output:
       username: ""
       password: ""
       private_key_file: ""
+      private_key: ""
       private_key_pass: ""
     max_in_flight: 64
 ```
@@ -135,6 +136,20 @@ This field contains sensitive information that usually shouldn't be added to a c
 === `credentials.private_key_file`
 
 The private key for the username to connect to the SFTP server.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `credentials.private_key`
+
+The private key file for the username to connect to the SFTP server.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
 
 
 *Type*: `string`

--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -142,7 +142,7 @@ func newSFTPReaderFromParsed(conf *service.ParsedConfig, mgr *service.Resources)
 	if s.paths, err = conf.FieldStringList(siFieldPaths); err != nil {
 		return
 	}
-	if s.creds, err = credentialsFromParsed(conf.Namespace(siFieldCredentials)); err != nil {
+	if s.creds, err = credentialsFromParsed(conf.Namespace(siFieldCredentials), mgr); err != nil {
 		return
 	}
 	if s.scannerCtor, err = codec.DeprecatedCodecFromParsed(conf); err != nil {

--- a/internal/impl/sftp/output.go
+++ b/internal/impl/sftp/output.go
@@ -115,7 +115,7 @@ func newWriterFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (s 
 	if s.path, err = conf.FieldInterpolatedString(soFieldPath); err != nil {
 		return
 	}
-	if s.creds, err = credentialsFromParsed(conf.Namespace(soFieldCredentials)); err != nil {
+	if s.creds, err = credentialsFromParsed(conf.Namespace(soFieldCredentials), mgr); err != nil {
 		return
 	}
 


### PR DESCRIPTION
This allows users to directly include their private key into the config if they don't or can't write it to a file. 