### PR TITLE
gha: add permissions for goreleaser

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -13,6 +13,8 @@ jobs:
         go-version: [oldstable, stable]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       CGO_ENABLED: 0
     steps:


### PR DESCRIPTION
jira: [DEVPROD-2732]

The github org default permissions for `GITHUB_TOKEN` has changed. This PR add permissions as documented on:
https://github.com/goreleaser/goreleaser-action

This PR is similar to PR https://github.com/redpanda-data/kminion/pull/287

[DEVPROD-2732]: https://redpandadata.atlassian.net/browse/DEVPROD-2732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ