### PR TITLE
Improvement: mongodb processor: run aggregation pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Field `handle_logical_types` added to `parquet_decode` input to provide better handling of Parquet logical types (@ooesili)
 - New `gateway` input. (@Jeffail)
 - New `text_chunker` processor for splitting text for creating document vector embeddings. (@rockwotj)
+- New `aggregate` operation added to the `mongodb` processor to provide support for aggregation pipelines. (@mihaitodor)
 
 ### Fixed
 

--- a/docs/modules/components/pages/outputs/mongodb.adoc
+++ b/docs/modules/components/pages/outputs/mongodb.adoc
@@ -224,7 +224,7 @@ The write concern timeout.
 
 === `document_map`
 
-A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one and update-one.
+A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one, update-one and aggregate.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/mongodb.adoc
+++ b/docs/modules/components/pages/processors/mongodb.adoc
@@ -204,7 +204,7 @@ The write concern timeout.
 
 === `document_map`
 
-A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one and update-one.
+A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one, update-one and aggregate.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/mongodb.adoc
+++ b/docs/modules/components/pages/processors/mongodb.adoc
@@ -164,6 +164,7 @@ Options:
 , `replace-one`
 , `update-one`
 , `find-one`
+, `aggregate`
 .
 
 === `write_concern`

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -248,7 +248,7 @@ func operationFromParsed(pConf *service.ParsedConfig) (operation Operation, err 
 	}
 
 	if operation = NewOperation(operationStr); operation == OperationInvalid {
-		err = fmt.Errorf("mongodb operation '%s' unknown: must be insert-one, delete-one, delete-many, replace-one, update-one or aggregate", operationStr)
+		err = fmt.Errorf("mongodb operation %q unknown: must be insert-one, delete-one, delete-many, replace-one, update-one or aggregate", operationStr)
 	}
 	return
 }
@@ -331,7 +331,7 @@ func writeMapsFields() []*service.ConfigField {
 	return []*service.ConfigField{
 		service.NewBloblangField(commonFieldDocumentMap).
 			Description("A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations " +
-				"insert-one, replace-one and update-one.").
+				"insert-one, replace-one, update-one and aggregate.").
 			Examples(mapExamples()...).
 			Default(""),
 		service.NewBloblangField(commonFieldFilterMap).

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -136,6 +136,8 @@ const (
 	OperationUpdateOne Operation = "update-one"
 	// OperationFindOne Find one operation.
 	OperationFindOne Operation = "find-one"
+	// OperationAggregate Execute Aggregation Pipeline operation.
+	OperationAggregate Operation = "aggregate"
 	// OperationInvalid Invalid operation.
 	OperationInvalid Operation = "invalid"
 )
@@ -144,7 +146,8 @@ func (op Operation) isDocumentAllowed() bool {
 	switch op {
 	case OperationInsertOne,
 		OperationReplaceOne,
-		OperationUpdateOne:
+		OperationUpdateOne,
+		OperationAggregate:
 		return true
 	default:
 		return false
@@ -202,6 +205,8 @@ func NewOperation(op string) Operation {
 		return OperationUpdateOne
 	case "find-one":
 		return OperationFindOne
+	case "aggregate":
+		return OperationAggregate
 	default:
 		return OperationInvalid
 	}
@@ -220,6 +225,7 @@ func processorOperationDocs(defaultOperation Operation) *service.ConfigField {
 		string(OperationReplaceOne),
 		string(OperationUpdateOne),
 		string(OperationFindOne),
+		string(OperationAggregate),
 	).Description("The mongodb operation to perform.").
 		Default(string(defaultOperation))
 }
@@ -242,7 +248,7 @@ func operationFromParsed(pConf *service.ParsedConfig) (operation Operation, err 
 	}
 
 	if operation = NewOperation(operationStr); operation == OperationInvalid {
-		err = fmt.Errorf("mongodb operation '%s' unknown: must be insert-one, delete-one, delete-many, replace-one or update-one", operationStr)
+		err = fmt.Errorf("mongodb operation '%s' unknown: must be insert-one, delete-one, delete-many, replace-one, update-one or aggregate", operationStr)
 	}
 	return
 }

--- a/internal/impl/mongodb/processor_test.go
+++ b/internal/impl/mongodb/processor_test.go
@@ -101,6 +101,9 @@ func TestProcessorIntegration(t *testing.T) {
 	t.Run("upsert", func(t *testing.T) {
 		testMongoDBProcessorUpsert(mongoClient, port, t)
 	})
+	t.Run("aggregate", func(t *testing.T) {
+		testMongoDBProcessorAggregate(mongoClient, port, t)
+	})
 }
 
 func testMProc(t testing.TB, port, collection, configYAML string) *mongodb.Processor {
@@ -483,4 +486,55 @@ json_marshal_mode: %v
 		diff, explanation := jsondiff.Compare(mBytes, []byte(tt.expected), &jdopts)
 		assert.Equalf(t, jsondiff.SupersetMatch.String(), diff.String(), "%s: %s", tt.name, explanation)
 	}
+}
+
+func testMongoDBProcessorAggregate(mongoClient *mongo.Client, port string, t *testing.T) {
+	tCtx := context.Background()
+	m := testMProc(t, port, "", `
+operation: aggregate
+document_map: |
+  root = [
+    {
+      "$match": { "size": "medium" }
+    },
+	{
+	  "$group": { "_id": "$name", "totalQuantity": { "$sum": "$quantity" } }
+	}
+  ]
+	`)
+
+	collection := mongoClient.Database("TestDB").Collection("TestCollection")
+
+	_, err := collection.InsertMany(context.Background(), []bson.M{
+		{"_id": 0, "name": "Pepperoni", "size": "small", "price": 19,
+			"quantity": 10, "date": time.Date(2021, 3, 13, 8, 14, 30, 0, time.UTC)},
+		{"_id": 1, "name": "Pepperoni", "size": "medium", "price": 20,
+			"quantity": 20, "date": time.Date(2021, 3, 13, 9, 13, 24, 0, time.UTC)},
+		{"_id": 2, "name": "Pepperoni", "size": "large", "price": 21,
+			"quantity": 30, "date": time.Date(2021, 3, 17, 9, 22, 12, 0, time.UTC)},
+		{"_id": 3, "name": "Cheese", "size": "small", "price": 12,
+			"quantity": 15, "date": time.Date(2021, 3, 13, 11, 21, 39, 736000000, time.UTC)},
+		{"_id": 4, "name": "Cheese", "size": "medium", "price": 13,
+			"quantity": 50, "date": time.Date(2022, 1, 12, 21, 23, 13, 331000000, time.UTC)},
+		{"_id": 5, "name": "Cheese", "size": "large", "price": 14,
+			"quantity": 10, "date": time.Date(2022, 1, 12, 5, 8, 13, 0, time.UTC)},
+		{"_id": 6, "name": "Vegan", "size": "small", "price": 17,
+			"quantity": 10, "date": time.Date(2021, 1, 13, 5, 8, 13, 0, time.UTC)},
+		{"_id": 7, "name": "Vegan", "size": "medium", "price": 18,
+			"quantity": 10, "date": time.Date(2021, 1, 13, 5, 10, 13, 0, time.UTC)},
+	})
+	assert.NoError(t, err)
+	resMsg, err := m.ProcessBatch(tCtx, service.MessageBatch{
+		service.NewMessage([]byte{}),
+	})
+	require.NoError(t, err)
+	require.Len(t, resMsg, 1)
+
+	mBytes, err := resMsg[0][0].AsBytes()
+	require.NoError(t, err)
+
+	var expected = `[{ "_id": { "$string": "Cheese" }, "totalQuantity": { "$int32": 50 } }, { "_id": { "$string": "Vegan" }, "totalQuantity": { "$int32": 10 } }, { "_id": { "$string": "Pepperoni" }, "totalQuantity": { "$int32": 20 } }]]`
+	jdopts := jsondiff.DefaultJSONOptions()
+	diff, explanation := jsondiff.Compare(mBytes, []byte(expected), &jdopts)
+	assert.Equalf(t, jsondiff.SupersetMatch.String(), diff.String(), "%s: %s", t.Name(), explanation)
 }


### PR DESCRIPTION
This change enables us to run MongoDB aggregation pipelines from the `mongodb` processor.

Given a collection populated like this:
```
db.orders.insertMany( [
   { _id: 0, name: "Pepperoni", size: "small", price: 19,
     quantity: 10, date: ISODate( "2021-03-13T08:14:30Z" ) },
   { _id: 1, name: "Pepperoni", size: "medium", price: 20,
     quantity: 20, date : ISODate( "2021-03-13T09:13:24Z" ) },
   { _id: 2, name: "Pepperoni", size: "large", price: 21,
     quantity: 30, date : ISODate( "2021-03-17T09:22:12Z" ) },
   { _id: 3, name: "Cheese", size: "small", price: 12,
     quantity: 15, date : ISODate( "2021-03-13T11:21:39.736Z" ) },
   { _id: 4, name: "Cheese", size: "medium", price: 13,
     quantity:50, date : ISODate( "2022-01-12T21:23:13.331Z" ) },
   { _id: 5, name: "Cheese", size: "large", price: 14,
     quantity: 10, date : ISODate( "2022-01-12T05:08:13Z" ) },
   { _id: 6, name: "Vegan", size: "small", price: 17,
     quantity: 10, date : ISODate( "2021-01-13T05:08:13Z" ) },
   { _id: 7, name: "Vegan", size: "medium", price: 18,
     quantity: 10, date : ISODate( "2021-01-13T05:10:13Z" ) }
] )
```

We could write a query like the following:
```
       processors:
          - mongodb:
              url: ${MONGODB_URL}
              database: ${MONGODB_DB}
              collection: ${MONGODB_COLLECTION}
              operation: aggregate
              document_map: |
                root = [
                 { "$match": { "size": "medium" }  },
                 { "$group": { "_id": "$name", "totalQuantity": { "$sum": "$quantity" } } }                
               ]
```

To obtain an output like this:
`[{ "_id": { "$string": "Cheese" }, "totalQuantity": { "$int32": 50 } }, { "_id": { "$string": "Vegan" }, "totalQuantity": { "$int32": 10 } }, { "_id": { "$string": "Pepperoni" }, "totalQuantity": { "$int32": 20 } }]`