### PR TITLE
goreleaser: add connect-fips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,16 @@ jobs:
       with:
         go-version: stable
 
+    - name: Install Microsoft Go
+      run: |
+        GO_VERSION=$(go mod edit -json | jq -r .Go)
+        curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/go${GO_VERSION}-1.linux-amd64.tar.gz
+        [[ -d "$RUNNER_TEMP/bin" ]] || install -d -m 0755 "$RUNNER_TEMP/bin"
+        [[ -d "$RUNNER_TEMP/microsoft" ]] || install -d -m 0755 "$RUNNER_TEMP/microsoft"
+        tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"
+        [[ -x "$RUNNER_TEMP/microsoft/go/bin/go" ]] && ln -s "$RUNNER_TEMP/microsoft/go/bin/go" "$RUNNER_TEMP/bin/microsoft-go"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
     - name: Release Notes
       run: ./resources/scripts/release_notes.sh > ./release_notes.md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: oldstable
+        go-version: stable
 
     - name: Install dependencies for x_benthos_extra
       run: |

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -36,7 +36,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: oldstable
+          go-version: stable
+      - name: Install Microsoft Go
+        run: |
+          GO_VERSION=$(go mod edit -json | jq -r .Go)
+          curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/go${GO_VERSION}-1.linux-amd64.tar.gz
+          [[ -d "$RUNNER_TEMP/bin" ]] || install -d -m 0755 "$RUNNER_TEMP/bin"
+          [[ -d "$RUNNER_TEMP/microsoft" ]] || install -d -m 0755 "$RUNNER_TEMP/microsoft"
+          tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"
+          [[ -x "$RUNNER_TEMP/microsoft/go/bin/go" ]] && ln -s "$RUNNER_TEMP/microsoft/go/bin/go" "$RUNNER_TEMP/bin/microsoft-go"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
       - name: Write telemetry private key
         env:
           CONNECT_TELEMETRY_PRIV_KEY: ${{ secrets.TELEMETRY_PRIVATE_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,24 @@ builds:
       -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportDelay={{ if index .Env "CONNECT_TELEMETRY_DELAY"  }}{{ .Env.CONNECT_TELEMETRY_DELAY }}{{ else }}{{ end }}
       -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportPeriod={{ if index .Env "CONNECT_TELEMETRY_PERIOD"  }}{{ .Env.CONNECT_TELEMETRY_PERIOD }}{{ else }}{{ end }}
 
+  - id: connect-fips
+    main: cmd/redpanda-connect/main.go
+    binary: redpanda-connect-fips
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    tool: 'microsoft-go'
+    env:
+      - GOEXPERIMENT=systemcrypto
+      - CGO_ENABLED=1
+    ldflags:
+      -s -w
+      -X main.Version={{.Version}}
+      -X main.DateBuilt={{.Date}}
+      -X main.BinaryName=redpanda-connect-fips
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportHost={{ if index .Env "CONNECT_TELEMETRY_HOST"  }}{{ .Env.CONNECT_TELEMETRY_HOST }}{{ else }}{{ end }}
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportDelay={{ if index .Env "CONNECT_TELEMETRY_DELAY"  }}{{ .Env.CONNECT_TELEMETRY_DELAY }}{{ else }}{{ end }}
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportPeriod={{ if index .Env "CONNECT_TELEMETRY_PERIOD"  }}{{ .Env.CONNECT_TELEMETRY_PERIOD }}{{ else }}{{ end }}
+
   - id: connect-cloud
     main: cmd/redpanda-connect-cloud/main.go
     binary: redpanda-connect
@@ -66,6 +84,14 @@ builds:
 archives:
   - id: connect
     ids: [ connect ]
+    formats: tar.gz
+    files:
+      - README.md
+      - CHANGELOG.md
+      - licenses
+
+  - id: connect-fips
+    ids: [ connect-fips ]
     formats: tar.gz
     files:
       - README.md
@@ -110,8 +136,12 @@ nfpms:
       - src: /usr/bin/redpanda-connect
         dst: /usr/bin/.rpk.ac-connect
         type: symlink
+      - src: /usr/bin/redpanda-connect-fips
+        dst: /usr/bin/.rpk.ac-connect-fips
+        type: symlink
     ids:
       - connect
+      - connect-fips
     vendor: Redpanda Data, Inc.
     license: "https://github.com/redpanda-data/connect/blob/main/licenses/README.md"
     homepage: redpanda.com


### PR DESCRIPTION
This adds a new build target and a new step in the GitHub actions that should install the required microsoft-go compiler so that we can actually build said new target successfully.