### PR TITLE
Ensure address field is always set for rpingress

### DIFF
--- a/docs/modules/components/pages/inputs/rpingress.adoc
+++ b/docs/modules/components/pages/inputs/rpingress.adoc
@@ -37,7 +37,7 @@ Common::
 input:
   label: ""
   rpingress:
-    address: ""
+    address: "" # No default (required)
     path: /deliver
     rate_limit: ""
     rp_jwt_validator:
@@ -56,7 +56,7 @@ Advanced::
 input:
   label: ""
   rpingress:
-    address: ""
+    address: "" # No default (required)
     path: /deliver
     rate_limit: ""
     cert_file: ""
@@ -122,7 +122,6 @@ The address to host from.
 
 *Type*: `string`
 
-*Default*: `""`
 
 === `path`
 

--- a/internal/impl/rpingress/input_rpingress.go
+++ b/internal/impl/rpingress/input_rpingress.go
@@ -145,8 +145,7 @@ If HTTPS is enabled, the following fields are added as well:
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].`).
 		Fields(
 			service.NewStringField(hsiFieldAddress).
-				Description("The address to host from.").
-				Default(""),
+				Description("The address to host from."),
 			service.NewStringField(hsiFieldPath).
 				Description("The endpoint path to listen for data delivery requests.").
 				Default("/deliver"),

--- a/internal/impl/rpingress/input_rpingress_test.go
+++ b/internal/impl/rpingress/input_rpingress_test.go
@@ -39,6 +39,7 @@ func TestHTTPSinglePayloads(t *testing.T) {
 	mux := mux.NewRouter()
 
 	pConf, err := rpingress.InputSpec().ParseYAML(`
+address: 0.0.0.0:1234 # Unused
 path: /testpost
 `, nil)
 	require.NoError(t, err)
@@ -93,6 +94,7 @@ func TestHTTPBatchPayloads(t *testing.T) {
 	mux := mux.NewRouter()
 
 	pConf, err := rpingress.InputSpec().ParseYAML(`
+address: 0.0.0.0:1234 # Unused
 path: /testpost
 `, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
The address field was incorrectly documented to have a default value, I've removed this so that the linter complains if you forget to set it.