### PR TITLE
Bugfix: amqp_0_9 output: only enforce dots in routing keys for topic exchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@ All notable changes to this project will be documented in this file.
 - New `gateway` input. (@Jeffail)
 - New `git` input. (@weeco, @rockwotj)
 - New `text_chunker` processor for splitting text for creating document vector embeddings. (@rockwotj)
-- New `aggregate` operation added to the `mongodb` processor to provide support for aggregation pipelines. (@mihaitodor)
+- New `aggregate` operation added to the `mongodb` processor to provide support for aggregation pipelines. (@brknstrngz, @mihaitodor)
 - New `slack` input reading from slack using socketmode. (@rockwotj)
+- Option `headers` added to field `type` on the `amqp_0_9` output. (@brknstrngz)
 
 ### Fixed
 
 - The `azure_blob_storage` input now drops `targets_input` notifications and emits a warning log message for blobs which have been deleted before Connect was able to read them. (@mihaitodor)
+
+### Changed
+
+- Field `type` on the `amqp_0_9` output now only enforces dots in routing keys and message types for `topic` exchanges. (@brknstrngz)
 
 ## 4.50.0 - 2025-03-18
 

--- a/docs/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/docs/modules/components/pages/outputs/amqp_0_9.adoc
@@ -165,6 +165,7 @@ Options:
 `direct`
 , `fanout`
 , `topic`
+, `headers`
 , `x-custom`
 .
 

--- a/internal/impl/amqp09/output.go
+++ b/internal/impl/amqp09/output.go
@@ -55,7 +55,7 @@ The fields 'key', 'exchange' and 'type' can be dynamically set using xref:config
 				service.NewBoolField(exchangeDeclareEnabledField).
 					Description("Whether to declare the exchange.").
 					Default(false),
-				service.NewStringEnumField(exchangeDeclareTypeField, "direct", "fanout", "topic", "x-custom").
+				service.NewStringEnumField(exchangeDeclareTypeField, "direct", "fanout", "topic", "headers", "x-custom").
 					Description("The type of the exchange.").
 					Default("direct"),
 				service.NewBoolField(exchangeDeclareDurableField).
@@ -414,14 +414,17 @@ func (a *amqp09Writer) Write(ctx context.Context, msg *service.Message) error {
 	if err != nil {
 		return fmt.Errorf("binding key interpolation error: %w", err)
 	}
-	bindingKey = strings.ReplaceAll(bindingKey, "/", ".")
+	if a.exchangeDeclareType == "topic" {
+		bindingKey = strings.ReplaceAll(bindingKey, "/", ".")
+	}
 
 	msgType, err := a.msgType.TryString(msg)
 	if err != nil {
 		return fmt.Errorf("msg type interpolation error: %w", err)
 	}
-	msgType = strings.ReplaceAll(msgType, "/", ".")
-
+	if a.exchangeDeclareType == "topic" {
+		msgType = strings.ReplaceAll(msgType, "/", ".")
+	}
 	contentType, err := a.contentType.TryString(msg)
 	if err != nil {
 		return fmt.Errorf("content type interpolation error: %w", err)

--- a/internal/impl/amqp09/output.go
+++ b/internal/impl/amqp09/output.go
@@ -425,6 +425,7 @@ func (a *amqp09Writer) Write(ctx context.Context, msg *service.Message) error {
 	if a.exchangeDeclareType == "topic" {
 		msgType = strings.ReplaceAll(msgType, "/", ".")
 	}
+
 	contentType, err := a.contentType.TryString(msg)
 	if err != nil {
 		return fmt.Errorf("content type interpolation error: %w", err)


### PR DESCRIPTION
- we currently replace all slashes in routing keys and message types with dots; this is however not mandated for any other exchange type than 'topic'. This change adds a check that skips the replacement for non-topic exchanges, such as 'direct'
- add support for the 'headers' exchange type