### PR TITLE
gha: add a ECR registry to push images to

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,7 @@ jobs:
       with:
         images: |
           redpandadata/connect
+          public.ecr.aws/l9j0i2e0/connect
         flavor: |
           latest=${{ matrix.latest }}
           suffix=${{ matrix.suffix }}
@@ -174,6 +175,17 @@ jobs:
           type=semver,suffix=${{ matrix.suffix }},pattern={{version}}
           type=semver,suffix=${{ matrix.suffix }},pattern={{major}}.{{minor}}
           type=semver,suffix=${{ matrix.suffix }},pattern={{major}}
+
+    - uses: aws-actions/configure-aws-credentials@v4
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      with:
+        aws-region: us-east-1
+        role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+    - uses: aws-actions/amazon-ecr-login@v2
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      with:
+        registry-type: public
 
     - name: Build and push
       uses: docker/build-push-action@v6


### PR DESCRIPTION
Adds an ECR registry as another publishing target for images. The AWS IAM role that is assumed as part of the execution of this workflow contains the right permissions to allow the login and push operation to work as it should (see https://github.com/redpanda-data/devprod-infra/pull/223).

fixes https://redpandadata.atlassian.net/browse/DEVPROD-2735