### PR TITLE
snowflake: fix rare data race

### DIFF
--- a/internal/impl/snowflake/integration_test.go
+++ b/internal/impl/snowflake/integration_test.go
@@ -548,6 +548,9 @@ snowflake_streaming:
   schema: $SCHEMA
   private_key_file: "$PRIVATE_KEY_FILE"
   table: integration_test_floats
+  build_options:
+    parallelism: 4
+    chunk_size: 2
   init_statement: |
     DROP TABLE IF EXISTS integration_test_floats;
     CREATE TABLE integration_test_floats(a FLOAT);


### PR DESCRIPTION
Technically it's possible to have a data race here where `append` can
realloc and the work function could write to `rowGroups[j]` while the
realloc is happening. In general that should be very rare since I expect
that loop to finish first, but still we should fix by moving the allocs
outside the loop :)

Also create a new writer for every parquet file incase that's an issue...