### PR TITLE
git: skip directories when walking repository files

### DIFF
--- a/internal/impl/git/input.go
+++ b/internal/impl/git/input.go
@@ -540,6 +540,11 @@ func (in *input) walkRepositoryFiles(ctx context.Context) (*sync.WaitGroup, erro
 			return err
 		}
 
+		// We need to recurse into directories, but aren't interested in directories itself
+		if d.IsDir() {
+			return nil
+		}
+
 		// Get relative path for pattern matching
 		relPath, err := filepath.Rel(scanPath, path)
 		if err != nil {


### PR DESCRIPTION
We haven't skipped the directories before, which can obviously not by opened as a file, hence causing errors.