### PR TITLE
Add use_enum_numbers option to protobuf processor

### DIFF
--- a/config/test/protobuf/schema/person.proto
+++ b/config/test/protobuf/schema/person.proto
@@ -4,6 +4,12 @@ package testing;
 import "google/protobuf/timestamp.proto";
 
 message Person {
+  enum Device {
+    DEVICE_UNSPECIFIED = 0;
+    DEVICE_IOS = 1;
+    DEVICE_ANDROID = 2;
+  }
+
   string first_name = 1;
   string last_name = 2;
   string full_name = 3;
@@ -12,4 +18,6 @@ message Person {
   string email = 6;
 
   google.protobuf.Timestamp last_updated = 7;
+
+  Device device = 8;
 }

--- a/docs/modules/components/pages/processors/protobuf.adoc
+++ b/docs/modules/components/pages/processors/protobuf.adoc
@@ -36,6 +36,7 @@ protobuf:
   discard_unknown: false
   use_proto_names: false
   import_paths: []
+  use_enum_numbers: false
 ```
 
 The main functionality of this processor is to map to and from JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json[https://developers.google.com/protocol-buffers/docs/proto3#json^]
@@ -202,5 +203,14 @@ A list of directories containing .proto files, including all definitions require
 *Type*: `array`
 
 *Default*: `[]`
+
+=== `use_enum_numbers`
+
+If `true`, the `to_json` operator deserializes enums as numerical values instead of string names.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -120,12 +120,13 @@ discard_unknown: %t
 
 func TestProtobufToJSON(t *testing.T) {
 	type testCase struct {
-		name          string
-		message       string
-		importPath    string
-		input         []byte
-		output        string
-		useProtoNames bool
+		name           string
+		message        string
+		importPath     string
+		input          []byte
+		output         string
+		useProtoNames  bool
+		useEnumNumbers bool
 	}
 
 	tests := []testCase{
@@ -150,9 +151,9 @@ func TestProtobufToJSON(t *testing.T) {
 			input: []byte{
 				0x0a, 0x05, 0x63, 0x61, 0x6c, 0x65, 0x62, 0x12, 0x05, 0x71, 0x75, 0x61, 0x79, 0x65, 0x32, 0x11,
 				0x63, 0x61, 0x6c, 0x65, 0x62, 0x40, 0x6d, 0x79, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2e, 0x63, 0x6f,
-				0x6d,
+				0x6d, 0x40, 0x01,
 			},
-			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com"}`,
+			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com","device":"DEVICE_IOS"}`,
 		},
 		{
 			name:          "protobuf to json with use_proto_names",
@@ -165,6 +166,18 @@ func TestProtobufToJSON(t *testing.T) {
 				0x6d,
 			},
 			output: `{"first_name":"caleb","last_name":"quaye","email":"caleb@myspace.com"}`,
+		},
+		{
+			name:           "protobuf to json with use_enum_numbers",
+			message:        "testing.Person",
+			importPath:     "../../../config/test/protobuf/schema",
+			useEnumNumbers: true,
+			input: []byte{
+				0x0a, 0x05, 0x63, 0x61, 0x6c, 0x65, 0x62, 0x12, 0x05, 0x71, 0x75, 0x61, 0x79, 0x65, 0x32, 0x11,
+				0x63, 0x61, 0x6c, 0x65, 0x62, 0x40, 0x6d, 0x79, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2e, 0x63, 0x6f,
+				0x6d, 0x40, 0x01,
+			},
+			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com","device":1}`,
 		},
 		{
 			name:       "any: protobuf to json 1",
@@ -197,7 +210,8 @@ operator: to_json
 message: %v
 import_paths: [ %v ]
 use_proto_names: %t
-`, test.message, test.importPath, test.useProtoNames), nil)
+use_enum_numbers: %t
+`, test.message, test.importPath, test.useProtoNames, test.useEnumNumbers), nil)
 			require.NoError(t, err)
 
 			proc, err := newProtobuf(conf, service.MockResources())


### PR DESCRIPTION
When true, this option serializes protobuf enum members to JSON by value instead of by name. The default is false.

Closes: #3299