### PR TITLE
fips: add wrapper script, build hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
         [[ -x "$RUNNER_TEMP/microsoft/go/bin/go" ]] && ln -s "$RUNNER_TEMP/microsoft/go/bin/go" "$RUNNER_TEMP/bin/microsoft-go"
         echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
+    - name: Install patchelf
+      run: sudo apt-get update && sudo apt-get install -y patchelf
+
     - name: Release Notes
       run: ./resources/scripts/release_notes.sh > ./release_notes.md
 

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -46,6 +46,8 @@ jobs:
           tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"
           [[ -x "$RUNNER_TEMP/microsoft/go/bin/go" ]] && ln -s "$RUNNER_TEMP/microsoft/go/bin/go" "$RUNNER_TEMP/bin/microsoft-go"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Install patchelf
+        run: sudo apt-get update && sudo apt-get install -y patchelf
       - name: Write telemetry private key
         env:
           CONNECT_TELEMETRY_PRIV_KEY: ${{ secrets.TELEMETRY_PRIVATE_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,9 @@ builds:
     binary: redpanda-connect-fips
     goos: [ linux ]
     goarch: [ amd64 ]
+    hooks:
+      post:
+        - cmd: ./resources/scripts/fips_patchelf.sh "{{ .Path }}"
     tool: 'microsoft-go'
     env:
       - GOEXPERIMENT=systemcrypto
@@ -90,15 +93,6 @@ archives:
       - CHANGELOG.md
       - licenses
 
-  - id: connect-fips
-    ids: [ connect-fips ]
-    formats: tar.gz
-    name_template: 'redpanda-connect-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
-    files:
-      - README.md
-      - CHANGELOG.md
-      - licenses
-
   - id: connect-cloud
     ids: [ connect-cloud ]
     formats: tar.gz
@@ -137,11 +131,34 @@ nfpms:
       - src: /usr/bin/redpanda-connect
         dst: /usr/bin/.rpk.ac-connect
         type: symlink
-      - src: /usr/bin/redpanda-connect-fips
-        dst: /usr/bin/.rpk.ac-connect-fips
-        type: symlink
     ids:
       - connect
+    vendor: Redpanda Data, Inc.
+    license: "https://github.com/redpanda-data/connect/blob/main/licenses/README.md"
+    homepage: redpanda.com
+    maintainer: Redpanda Data <support@redpanda.com>
+    formats:
+      - deb
+      - rpm
+  - id: connect-fips-pkgs
+    description: Redpanda Connect FIPS is a high performance and resilient stream processor.
+    package_name: redpanda-connect-fips
+    file_name_template: "{{ .ConventionalFileName }}"
+    bindir: /opt/redpanda/libexec
+    contents:
+      - src: resources/scripts/fips_wrapper.sh
+        dst: /usr/bin/redpanda-connect-fips
+        file_info:
+          mode: 0755
+          owner: root
+          group: root
+      # installs an alias so users can type `rpk connect`
+      - src: /opt/redpanda/libexec/redpanda-connect-fips
+        dst: /usr/bin/.rpk.ac-connect
+        type: symlink
+    dependencies:
+      - redpanda-rpk-fips
+    ids:
       - connect-fips
     vendor: Redpanda Data, Inc.
     license: "https://github.com/redpanda-data/connect/blob/main/licenses/README.md"
@@ -150,11 +167,13 @@ nfpms:
     formats:
       - deb
       - rpm
+
 publishers:
   # Gets run once per artifact (deb or rpm)
   - name: Publish Linux packages to Cloudsmith
     ids:
       - connect-linux-pkgs
+      - connect-fips-pkgs
     cmd: ./resources/scripts/push_pkg_to_cloudsmith.sh {{ .ArtifactPath }} {{ .Version }}
     env:
       - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}

--- a/resources/scripts/fips_patchelf.sh
+++ b/resources/scripts/fips_patchelf.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+test -z "$1" && echo "usage: $0 <path/to/binary>" && exit
+
+patchelf --set-interpreter "${PREFIX:=/opt/redpanda/rpk-fips}/lib/ld.so" $1

--- a/resources/scripts/fips_wrapper.sh
+++ b/resources/scripts/fips_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this wrapper gets installed as /usr/bin/redpanda-connect-fips
+# and overrides several environment variables to work with rpk-fips
+
+export PATH="/opt/redpanda/bin:${PATH}"
+export GOFIPS="1"
+export LD_LIBRARY_PATH="/opt/redpanda/rpk-fips/lib"
+export OPENSSL_CONF="/opt/redpanda/rpk-fips/openssl/openssl-rpk.cnf"
+export OPENSSL_MODULES="/opt/redpanda/rpk-fips/lib/ossl-modules/"
+
+exec -a "$0" "/opt/redpanda/libexec/redpanda-connect-fips" "$@"


### PR DESCRIPTION
Also generates separate redpanda-connect-fips packages, but no tar.gz archives.