### PR TITLE
git: clone commit history for catching up

### DIFF
--- a/internal/impl/git/input.go
+++ b/internal/impl/git/input.go
@@ -248,7 +248,6 @@ func (in *input) cloneRepo(ctx context.Context) error {
 		Auth:          auth,
 		ReferenceName: plumbing.NewBranchReferenceName(in.cfg.branch),
 		SingleBranch:  true,
-		Depth:         1,
 	})
 	if err != nil {
 		return fmt.Errorf("git clone failed: %w", err)


### PR DESCRIPTION
When catching up with a given commit we need to
also clone the commit history. Otherwise, the commit we try to continue with, will be unknown.