### PR TITLE
Re-enable connect-fips tar.gz archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,6 +93,15 @@ archives:
       - CHANGELOG.md
       - licenses
 
+  - id: connect-fips
+    ids: [ connect-fips ]
+    formats: tar.gz
+    name_template: 'redpanda-connect-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    files:
+      - README-FIPS.md
+      - CHANGELOG.md
+      - licenses
+
   - id: connect-cloud
     ids: [ connect-cloud ]
     formats: tar.gz

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -1,0 +1,7 @@
+# README (FIPS tar.gz archive)
+
+This tar contains a redpanda-connect-fips binary intended for
+automated installation by `rpk`. You probably want to install
+the `redpanda-connect-fips` RPM or debian package instead, if
+you want to actually use this software on a FIPS-enabled system.
+


### PR DESCRIPTION
Also add `README-FIPS.md` and include in `connect-fips` archive.

This should make it easier for `rpk-fips` to be able to manage a `connect-fips` plugin installation.