### PR TITLE
Add extra fields for the franz-go-based inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ All notable changes to this project will be documented in this file.
 - Field `use_enum_numbers` added to `protobuf` processor. (@benwebber)
 - Field `tools` added to `cohere_chat` processor. (@rockwotj)
 - Fields `region`, `endpoint` and `credentials` added to the `dynamodb` configuration section of the `aws_kinesis` input. (@jreyeshdez, @mihaitodor)
-- Field `isolation_level` added to `kafka`, `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs. (@rockwotj)
+- Field `transaction_isolation_level` added to `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs. (@rockwotj)
 - New `cohere_rerank` processor to rerank documents in RAG pipelines using Cohere. (@rockwotj)
+- Fields `request_timeout_overhead`, `conn_idle_timeout` and `start_offset` added to the `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs. (@mihaitodor)
+
+### Changed
+
+- Field `start_from_oldest` for the `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs is now deprecated in favour of `start_offset`. (@mihaitodor)
 
 ## 4.52.0 - 2025-04-03
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -68,6 +68,8 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
@@ -75,7 +77,7 @@ input:
     rebalance_timeout: 45s
     session_timeout: 1m
     heartbeat_interval: 3s
-    start_from_oldest: true
+    start_offset: earliest
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
@@ -496,6 +498,24 @@ The maximum age of metadata before it is refreshed.
 
 *Default*: `"5m"`
 
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
+
 === `topics`
 
 A list of topics to consume from. Multiple comma separated topics can be listed in a single element. When a `consumer_group` is specified partitions are automatically distributed across consumers of a topic, otherwise all partitions are consumed.
@@ -587,14 +607,26 @@ When using a consumer group, `heartbeat_interval` sets how long a group member g
 
 *Default*: `"3s"`
 
-=== `start_from_oldest`
+=== `start_offset`
 
-Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.
+Sets the offset to start consuming from, or if OffsetOutOfRange is seen while fetching, to restart consuming from.
 
 
-*Type*: `bool`
+*Type*: `string`
 
-*Default*: `true`
+*Default*: `"earliest"`
+
+|===
+| Option | Summary
+
+| `committed`
+| Prevents consuming a partition in a group if the partition has no prior commits. Corresponds to Kafka's `auto.offset.reset=none` option
+| `earliest`
+| Start from the earliest offset. Corresponds to Kafka's `auto.offset.reset=earliest` option.
+| `latest`
+| Start from the latest offset. Corresponds to Kafka's `auto.offset.reset=latest` option.
+
+|===
 
 === `fetch_max_bytes`
 

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -80,7 +80,7 @@ input:
       rebalance_timeout: 45s
       session_timeout: 1m
       heartbeat_interval: 3s
-      start_from_oldest: true
+      start_offset: earliest
       fetch_max_bytes: 50MiB
       fetch_max_wait: 5s
       fetch_min_bytes: 1B
@@ -393,14 +393,26 @@ When using a consumer group, `heartbeat_interval` sets how long a group member g
 
 *Default*: `"3s"`
 
-=== `kafka.start_from_oldest`
+=== `kafka.start_offset`
 
-Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.
+Sets the offset to start consuming from, or if OffsetOutOfRange is seen while fetching, to restart consuming from.
 
 
-*Type*: `bool`
+*Type*: `string`
 
-*Default*: `true`
+*Default*: `"earliest"`
+
+|===
+| Option | Summary
+
+| `committed`
+| Prevents consuming a partition in a group if the partition has no prior commits. Corresponds to Kafka's `auto.offset.reset=none` option
+| `earliest`
+| Start from the earliest offset. Corresponds to Kafka's `auto.offset.reset=earliest` option.
+| `latest`
+| Start from the latest offset. Corresponds to Kafka's `auto.offset.reset=latest` option.
+
+|===
 
 === `kafka.fetch_max_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -66,6 +66,8 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
@@ -73,7 +75,7 @@ input:
     rebalance_timeout: 45s
     session_timeout: 1m
     heartbeat_interval: 3s
-    start_from_oldest: true
+    start_offset: earliest
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
@@ -522,6 +524,24 @@ The maximum age of metadata before it is refreshed.
 
 *Default*: `"5m"`
 
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
+
 === `topics`
 
 A list of topics to consume from. Multiple comma separated topics can be listed in a single element. When a `consumer_group` is specified partitions are automatically distributed across consumers of a topic, otherwise all partitions are consumed.
@@ -613,14 +633,26 @@ When using a consumer group, `heartbeat_interval` sets how long a group member g
 
 *Default*: `"3s"`
 
-=== `start_from_oldest`
+=== `start_offset`
 
-Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.
+Sets the offset to start consuming from, or if OffsetOutOfRange is seen while fetching, to restart consuming from.
 
 
-*Type*: `bool`
+*Type*: `string`
 
-*Default*: `true`
+*Default*: `"earliest"`
+
+|===
+| Option | Summary
+
+| `committed`
+| Prevents consuming a partition in a group if the partition has no prior commits. Corresponds to Kafka's `auto.offset.reset=none` option
+| `earliest`
+| Start from the earliest offset. Corresponds to Kafka's `auto.offset.reset=earliest` option.
+| `latest`
+| Start from the latest offset. Corresponds to Kafka's `auto.offset.reset=latest` option.
+
+|===
 
 === `fetch_max_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda_common.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_common.adoc
@@ -61,7 +61,7 @@ input:
     rebalance_timeout: 45s
     session_timeout: 1m
     heartbeat_interval: 3s
-    start_from_oldest: true
+    start_offset: earliest
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
@@ -222,14 +222,26 @@ When using a consumer group, `heartbeat_interval` sets how long a group member g
 
 *Default*: `"3s"`
 
-=== `start_from_oldest`
+=== `start_offset`
 
-Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.
+Sets the offset to start consuming from, or if OffsetOutOfRange is seen while fetching, to restart consuming from.
 
 
-*Type*: `bool`
+*Type*: `string`
 
-*Default*: `true`
+*Default*: `"earliest"`
+
+|===
+| Option | Summary
+
+| `committed`
+| Prevents consuming a partition in a group if the partition has no prior commits. Corresponds to Kafka's `auto.offset.reset=none` option
+| `earliest`
+| Start from the earliest offset. Corresponds to Kafka's `auto.offset.reset=earliest` option.
+| `latest`
+| Start from the latest offset. Corresponds to Kafka's `auto.offset.reset=latest` option.
+
+|===
 
 === `fetch_max_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -68,6 +68,8 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
@@ -75,7 +77,7 @@ input:
     rebalance_timeout: 45s
     session_timeout: 1m
     heartbeat_interval: 3s
-    start_from_oldest: true
+    start_offset: earliest
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
@@ -499,6 +501,24 @@ The maximum age of metadata before it is refreshed.
 
 *Default*: `"5m"`
 
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
+
 === `topics`
 
 A list of topics to consume from. Multiple comma separated topics can be listed in a single element. When a `consumer_group` is specified partitions are automatically distributed across consumers of a topic, otherwise all partitions are consumed.
@@ -590,14 +610,26 @@ When using a consumer group, `heartbeat_interval` sets how long a group member g
 
 *Default*: `"3s"`
 
-=== `start_from_oldest`
+=== `start_offset`
 
-Determines whether to consume from the oldest available offset, otherwise messages are consumed from the latest offset. The setting is applied when creating a new consumer group or the saved offset no longer exists.
+Sets the offset to start consuming from, or if OffsetOutOfRange is seen while fetching, to restart consuming from.
 
 
-*Type*: `bool`
+*Type*: `string`
 
-*Default*: `true`
+*Default*: `"earliest"`
+
+|===
+| Option | Summary
+
+| `committed`
+| Prevents consuming a partition in a group if the partition has no prior commits. Corresponds to Kafka's `auto.offset.reset=none` option
+| `earliest`
+| Start from the earliest offset. Corresponds to Kafka's `auto.offset.reset=earliest` option.
+| `latest`
+| Start from the latest offset. Corresponds to Kafka's `auto.offset.reset=latest` option.
+
+|===
 
 === `fetch_max_bytes`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -67,6 +67,8 @@ input:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
@@ -481,6 +483,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `topics`
 

--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -75,6 +75,8 @@ output:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topic: "" # No default (required)
     key: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
@@ -483,6 +485,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `topic`
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -68,6 +68,8 @@ output:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topic: "" # No default (required)
     key: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
@@ -468,6 +470,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `topic`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -70,6 +70,8 @@ output:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     topic: "" # No default (required)
     key: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
@@ -514,6 +516,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `topic`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -69,6 +69,8 @@ output:
       client_certs: []
     sasl: [] # No default (optional)
     metadata_max_age: 5m
+    request_timeout_overhead: 10s
+    conn_idle_timeout: 20s
     offset_topic: ${! @kafka_offset_topic }
     offset_group: ${! @kafka_offset_group }
     offset_partition: ${! @kafka_offset_partition }
@@ -468,6 +470,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `offset_topic`
 

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -52,6 +52,8 @@ redpanda:
     client_certs: []
   sasl: [] # No default (optional)
   metadata_max_age: 5m
+  request_timeout_overhead: 10s
+  conn_idle_timeout: 20s
   pipeline_id: ""
   logs_topic: ""
   logs_level: info
@@ -445,6 +447,24 @@ The maximum age of metadata before it is refreshed.
 *Type*: `string`
 
 *Default*: `"5m"`
+
+=== `request_timeout_overhead`
+
+The request time overhead. Uses the given time as overhead while deadlining requests. Roughly equivalent to request.timeout.ms, but grants additional time to requests that have timeout fields.
+
+
+*Type*: `string`
+
+*Default*: `"10s"`
+
+=== `conn_idle_timeout`
+
+The rough amount of time to allow connections to idle before they are closed.
+
+
+*Type*: `string`
+
+*Default*: `"20s"`
 
 === `pipeline_id`
 

--- a/internal/impl/kafka/enterprise/redpanda_common_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_common_input.go
@@ -85,16 +85,7 @@ This input adds the following metadata fields to each message:
 - All record headers
 ` + "```" + `
 `).
-		LintRule(`
-let has_topic_partitions = this.topics.any(t -> t.contains(":"))
-root = if $has_topic_partitions {
-  if this.consumer_group.or("") != "" {
-    "this input does not support both a consumer group and explicit topic partitions"
-  } else if this.regexp_topics {
-    "this input does not support both regular expression topics and explicit topic partitions"
-  }
-}
-`)
+		LintRule(kafka.FranzConsumerFieldLintRules)
 }
 
 func init() {

--- a/internal/impl/kafka/enterprise/redpanda_migrator_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_input.go
@@ -67,20 +67,7 @@ This input adds the following metadata fields to each message:
 ` + "```" + `
 `).
 		Fields(redpandaMigratorInputConfigFields()...).
-		LintRule(`
-let has_topic_partitions = this.topics.any(t -> t.contains(":"))
-root = if $has_topic_partitions {
-  if this.consumer_group.or("") != "" {
-    "this input does not support both a consumer group and explicit topic partitions"
-  } else if this.regexp_topics {
-    "this input does not support both regular expression topics and explicit topic partitions"
-  }
-} else {
-  if this.consumer_group.or("") == "" {
-    "a consumer group is mandatory when not using explicit topic partitions"
-  }
-}
-`)
+		LintRule(kafka.FranzConsumerFieldLintRules)
 }
 
 func redpandaMigratorInputConfigFields() []*service.ConfigField {

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -48,20 +48,7 @@ This input adds the following metadata fields to each message:
 ` + "```" + `
 `).
 		Fields(FranzKafkaInputConfigFields()...).
-		LintRule(`
-let has_topic_partitions = this.topics.any(t -> t.contains(":"))
-root = if $has_topic_partitions {
-  if this.consumer_group.or("") != "" {
-    "this input does not support both a consumer group and explicit topic partitions"
-  } else if this.regexp_topics {
-    "this input does not support both regular expression topics and explicit topic partitions"
-  }
-} else {
-  if this.consumer_group.or("") == "" {
-    "a consumer group is mandatory when not using explicit topic partitions"
-  }
-}
-`)
+		LintRule(FranzConsumerFieldLintRules)
 }
 
 // FranzKafkaInputConfigFields returns the full suite of config fields for a

--- a/internal/impl/kafka/input_redpanda.go
+++ b/internal/impl/kafka/input_redpanda.go
@@ -81,20 +81,7 @@ This input adds the following metadata fields to each message:
 ` + "```" + `
 `).
 		Fields(redpandaInputConfigFields()...).
-		LintRule(`
-let has_topic_partitions = this.topics.any(t -> t.contains(":"))
-root = if $has_topic_partitions {
-  if this.consumer_group.or("") != "" {
-    "this input does not support both a consumer group and explicit topic partitions"
-  } else if this.regexp_topics {
-    "this input does not support both regular expression topics and explicit topic partitions"
-  }
-} else {
-  if this.consumer_group.or("") == "" {
-    "a consumer group is mandatory when not using explicit topic partitions"
-  }
-}
-`)
+		LintRule(FranzConsumerFieldLintRules)
 }
 
 func redpandaInputConfigFields() []*service.ConfigField {

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -56,7 +56,7 @@ func ockamKafkaInputConfig() *service.ConfigSpec {
 			},
 			kafka.FranzConsumerFields(),
 			kafka.FranzReaderUnorderedConfigFields(),
-		)...)).
+		)...).LintRule(kafka.FranzConsumerFieldLintRules)).
 		Field(service.NewBoolField("disable_content_encryption").Default(false)).
 		Field(service.NewStringField("enrollment_ticket").Optional()).
 		Field(service.NewStringField("identity_name").Optional()).


### PR DESCRIPTION
- Fields `request_timeout_overhead`, `conn_idle_timeout` and `start_offset` added to the `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs.
- Field `start_from_oldest` for the `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs is now deprecated in favour of `consume_reset_offset`.
- Cleaned up the lint rules a bit
- Also snuk in a small fix to the Changelog :) (cc @rockwotj)

Fixes #3337.