### PR TITLE
Add topic prefix support for Redpanda Migrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Field `start_from_oldest` for the `kafka_franz`, `ockam_kafka`, `redpanda`, `redpanda_common`, and `redpanda_migrator` inputs is now deprecated in favour of `start_offset`. (@mihaitodor)
+- Field `topic_prefix` added to the `redpanda_migrator` output. (@mihaitodor)
+- Field `offset_topic_prefix` added to the `redpanda_migrator_offsets` output. (@mihaitodor)
 
 ## 4.52.0 - 2025-04-03
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -79,6 +79,7 @@ output:
       include_prefixes: []
       include_patterns: []
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
+    topic_prefix: ""
     max_in_flight: 256
     input_resource: redpanda_migrator_input
     replication_factor_override: true
@@ -634,6 +635,16 @@ timestamp_ms: ${! timestamp_unix_milli() }
 
 timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
+
+=== `topic_prefix`
+
+The topic prefix.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -72,6 +72,7 @@ output:
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
     offset_topic: ${! @kafka_offset_topic }
+    offset_topic_prefix: ""
     offset_group: ${! @kafka_offset_group }
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
@@ -498,6 +499,16 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 *Type*: `string`
 
 *Default*: `"${! @kafka_offset_topic }"`
+
+=== `offset_topic_prefix`
+
+Kafka offset topic prefix.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `offset_group`
 

--- a/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
+++ b/internal/impl/kafka/enterprise/redpanda_migrator_bundle_output.tmpl.yaml
@@ -51,8 +51,8 @@ mapping: |
     root = throw("redpanda_migrator_bundle.translate_schema_ids must be used instead of schema_registry.translate_ids and redpanda_migrator.translate_schema_ids")
   }
 
-  if ["topic", "key", "partition", "partitioner", "timestamp"].any(f -> this.redpanda_migrator.keys().contains(f)) {
-    root = throw("The topic, key, partition, partitioner and timestamp fields of the redpanda_migrator output must be left empty")
+  if ["topic", "key", "partition", "partitioner", "timestamp", "timestamp_ms"].any(f -> this.redpanda_migrator.keys().contains(f)) {
+    root = throw("The topic, key, partition, partitioner, timestamp and timestamp_ms fields of the redpanda_migrator output must be left empty")
   }
 
   let redpandaMigrator = this.redpanda_migrator.assign(
@@ -62,7 +62,6 @@ mapping: |
       "partition": "${! metadata(\"kafka_partition\").or(throw(\"missing kafka_partition metadata\")) }",
       "partitioner": "manual",
       "timestamp_ms": "${! metadata(\"kafka_timestamp_ms\").or(timestamp_unix_milli()) }",
-      "max_in_flight": this.redpanda_migrator.max_in_flight.or(1),
       "metadata": {
         "include_patterns": [
           # Exclude metadata fields which start with `kafka_`
@@ -80,7 +79,11 @@ mapping: |
     })
   }
 
-  let redpandaMigratorOffsets = this.redpanda_migrator.with("seed_brokers", "consumer_group", "client_id", "rack_id", "max_message_bytes", "broker_write_max_bytes", "tls", "sasl")
+  let redpandaMigratorOffsets = this.redpanda_migrator.with("seed_brokers", "consumer_group", "client_id", "rack_id", "max_message_bytes", "broker_write_max_bytes", "tls", "sasl").assign(
+    {
+      "offset_topic_prefix": this.redpanda_migrator.topic_prefix.or(deleted()),
+    }
+  )
 
   if this.schema_registry.keys().contains("subject") {
     root = throw("The subject field of the schema_registry output must not be set")
@@ -156,6 +159,7 @@ tests:
     config:
       redpanda_migrator:
         seed_brokers: [ "127.0.0.1:9092" ]
+        topic_prefix: dest.
         max_in_flight: 1
       schema_registry:
         url: http://localhost:8081
@@ -176,6 +180,7 @@ tests:
                   - 127.0.0.1:9092
                 timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
                 topic: ${! metadata("kafka_topic").or(throw("missing kafka_topic metadata")) }
+                topic_prefix: "dest."
                 metadata:
                   include_patterns:
                     -  ^(?:[^k].*|k[^a].*|ka[^f].*|kaf[^k].*|kafk[^a].*|kafka[^_].*)
@@ -191,6 +196,7 @@ tests:
               redpanda_migrator_offsets:
                 seed_brokers:
                   - 127.0.0.1:9092
+                offset_topic_prefix: "dest."
           - check: metadata("input_label") == "schema_registry_input"
             output:
               fallback:


### PR DESCRIPTION
Also clean up logic a bit to only iterate the batch records once in the `redpanda_migrator` output. The existing code goes over them once when translating schema IDs and another time when creating topics.