### PR TITLE
Fix FIPS builds

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -39,6 +39,20 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Install Microsoft Go
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        GO_VERSION=$(go version | cut -d' ' -f3 | cut -d'.' -f1,2)
+        curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/${GO_VERSION}.linux-amd64.tar.gz
+        [[ -d "$RUNNER_TEMP/bin" ]] || install -d -m 0755 "$RUNNER_TEMP/bin"
+        [[ -d "$RUNNER_TEMP/microsoft" ]] || install -d -m 0755 "$RUNNER_TEMP/microsoft"
+        tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"
+        [[ -x "$RUNNER_TEMP/microsoft/go/bin/go" ]] && ln -s "$RUNNER_TEMP/microsoft/go/bin/go" "$RUNNER_TEMP/bin/microsoft-go"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+    - name: Install patchelf
+      run: sudo apt-get update && sudo apt-get install -y patchelf
+
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
 
     - name: Install Microsoft Go
       run: |
-        GO_VERSION=$(go mod edit -json | jq -r .Go)
-        curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/go${GO_VERSION}-1.linux-amd64.tar.gz
+        GO_VERSION=$(go version | cut -d' ' -f3 | cut -d'.' -f1,2)
+        curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/${GO_VERSION}.linux-amd64.tar.gz
         [[ -d "$RUNNER_TEMP/bin" ]] || install -d -m 0755 "$RUNNER_TEMP/bin"
         [[ -d "$RUNNER_TEMP/microsoft" ]] || install -d -m 0755 "$RUNNER_TEMP/microsoft"
         tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"

--- a/.github/workflows/upload_plugin.yml
+++ b/.github/workflows/upload_plugin.yml
@@ -39,8 +39,8 @@ jobs:
           go-version: stable
       - name: Install Microsoft Go
         run: |
-          GO_VERSION=$(go mod edit -json | jq -r .Go)
-          curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/go${GO_VERSION}-1.linux-amd64.tar.gz
+          GO_VERSION=$(go version | cut -d' ' -f3 | cut -d'.' -f1,2)
+          curl -sSLf -o "$RUNNER_TEMP/msgo.tgz" https://aka.ms/golang/release/latest/${GO_VERSION}.linux-amd64.tar.gz
           [[ -d "$RUNNER_TEMP/bin" ]] || install -d -m 0755 "$RUNNER_TEMP/bin"
           [[ -d "$RUNNER_TEMP/microsoft" ]] || install -d -m 0755 "$RUNNER_TEMP/microsoft"
           tar -C "$RUNNER_TEMP/microsoft" -xf "$RUNNER_TEMP/msgo.tgz"


### PR DESCRIPTION
- Use the latest stable version for the FIPS builds
- Fix the nightly Cross Build action

The nightly Cross Build action started failing recently. See [here](https://github.com/redpanda-data/connect/actions/workflows/cross_build.yml).