### PR TITLE
mk: add run target to streamline running dev configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ fmt:
 lint:
 	@golangci-lint run cmd/... internal/... public/...
 
+run: CONF ?= ./config/dev.yaml
+run:
+	go run ./cmd/redpanda-connect --config $(CONF)
+
 test: $(APPS)
 	@go test $(GO_FLAGS) -ldflags "$(LD_FLAGS)" -timeout 3m ./...
 	@$(PATHINSTBIN)/redpanda-connect template lint $(TEMPLATE_FILES)

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+dev.yaml


### PR DESCRIPTION
Calling make run would compile redpanda-connect CLI and call it with --config ./config/dev.yaml.