### PR TITLE
schema_registry_decode: Fix Schema Decoding Reference Order for Correct Schema Resolution Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue with the experimental `redpanda` input where batch ordering could be mixed between two subsequent batches. (@mihaitodor, @rockwotj)
+- Fixed an issue in `schema_registry_decode` where Avro schema references were not properly resolved. (@geniegeist)
 
 ## 4.54.1 - 2025-04-30
 

--- a/internal/impl/confluent/serde_goavro_test.go
+++ b/internal/impl/confluent/serde_goavro_test.go
@@ -88,16 +88,16 @@ func TestAvroReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/30", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 30,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    30,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 10},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"slices"
 	"strings"
 	"time"
 
@@ -35,16 +34,17 @@ func resolveHambaAvroReferences(ctx context.Context, client *sr.Client, schema f
 	if len(schema.References) == 0 {
 		return []franz_sr.Schema{schema}, nil
 	}
-	schemas := []franz_sr.Schema{schema}
+	schemas := []franz_sr.Schema{}
 	if err := client.WalkReferences(ctx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
 		schemas = append(schemas, schema)
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("unable to walk schema references: %w", err)
 	}
+
+	schemas = append(schemas, schema)
 	// We walk the above schemas in top down order, however when resolving references we need to add schemas to our codec
 	// in a bottom up manner.
-	slices.Reverse(schemas)
 	return schemas, nil
 }
 

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -43,8 +43,6 @@ func resolveHambaAvroReferences(ctx context.Context, client *sr.Client, schema f
 	}
 
 	schemas = append(schemas, schema)
-	// We walk the above schemas in top down order, however when resolving references we need to add schemas to our codec
-	// in a bottom up manner.
 	return schemas, nil
 }
 

--- a/internal/impl/confluent/serde_hamba_avro_test.go
+++ b/internal/impl/confluent/serde_hamba_avro_test.go
@@ -89,16 +89,16 @@ func TestHambaAvroReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/30", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 30,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    30,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 10},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -173,7 +173,7 @@ type refWalkFn func(ctx context.Context, name string, info sr.Schema) error
 
 // WalkReferences goes through the provided schema info in a topological order
 // (i.e. before a schema is traversed all its references schemas are traversed first)
-// and for each reference the provided closure is called recursively, which means 
+// and for each reference the provided closure is called recursively, which means
 // each reference obtained will also be walked.
 //
 // If a reference of a given subject but differing version is detected an error

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -171,9 +171,10 @@ func (c *Client) CreateSchemaWithIDAndVersion(ctx context.Context, subject strin
 
 type refWalkFn func(ctx context.Context, name string, info sr.Schema) error
 
-// WalkReferences goes through the provided schema info and for each reference
-// the provided closure is called recursively, which means each reference obtained
-// will also be walked.
+// WalkReferences goes through the provided schema info in a topological order
+// (i.e. before a schema is traversed all its references schemas are traversed first)
+// and for each reference the provided closure is called recursively, which means 
+// each reference obtained will also be walked.
 //
 // If a reference of a given subject but differing version is detected an error
 // is returned as this would put us in an invalid state.
@@ -183,13 +184,11 @@ func (c *Client) WalkReferences(ctx context.Context, refs []sr.SchemaReference, 
 
 func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int, refs []sr.SchemaReference, fn refWalkFn) error {
 	for _, ref := range refs {
-		var stopWalking = false
-
 		if i, exists := seen[ref.Name]; exists {
 			if i != ref.Version {
 				return fmt.Errorf("duplicate reference '%v' version mismatch of %v and %v, aborting in order to avoid invalid state", ref.Name, i, ref.Version)
 			}
-			stopWalking = true
+			continue
 		}
 
 		info, err := c.GetSchemaBySubjectAndVersion(ctx, ref.Subject, &ref.Version, false)
@@ -197,16 +196,12 @@ func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int,
 			return err
 		}
 
-		if err := fn(ctx, ref.Name, info.Schema); err != nil {
+		seen[ref.Name] = ref.Version
+		if err := c.walkReferencesTracked(ctx, seen, info.References, fn); err != nil {
 			return err
 		}
 
-		if stopWalking {
-			continue
-		}
-
-		seen[ref.Name] = ref.Version
-		if err := c.walkReferencesTracked(ctx, seen, info.References, fn); err != nil {
+		if err := fn(ctx, ref.Name, info.Schema); err != nil {
 			return err
 		}
 	}

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -189,7 +189,7 @@ func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int,
 			if i != ref.Version {
 				return fmt.Errorf("duplicate reference '%v' version mismatch of %v and %v, aborting in order to avoid invalid state", ref.Name, i, ref.Version)
 			}
-			stopWalking = exists
+			stopWalking = true
 		}
 
 		info, err := c.GetSchemaBySubjectAndVersion(ctx, ref.Subject, &ref.Version, false)

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -31,7 +31,7 @@ func mustJBytes(t testing.TB, obj any) []byte {
 }
 
 func TestWalkReferences(t *testing.T) {
-	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
+	tCtx, done := context.WithTimeout(t.Context(), time.Second*10)
 	defer done()
 
 	rootSchema := `[
@@ -117,61 +117,61 @@ func TestWalkReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/1", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 1,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    1,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 
 	tests := []struct {
-		name				string 
-		schemaId    int
-		output     	[]string
+		name     string
+		schemaId int
+		output   []string
 	}{
 		{
-			name: "root",
+			name:     "root",
 			schemaId: 1,
 			output: []string{
 				"benthos.namespace.com.foo",
 				"benthos.namespace.com.bar",
-  			"benthos.namespace.com.baz",
+				"benthos.namespace.com.baz",
 			},
 		},
 		{
-			name: "foo",
+			name:     "foo",
 			schemaId: 2,
-			output: []string{},
+			output:   []string{},
 		},
 		{
-			name: "baz",
+			name:     "baz",
 			schemaId: 4,
 			output: []string{
 				"benthos.namespace.com.foo",
 			},
 		},
 		{
-			name: "root2",
+			name:     "root2",
 			schemaId: 5,
 			output: []string{
 				"benthos.namespace.com.foo",
 				"benthos.namespace.com.baz",
-  			"benthos.namespace.com.bar",
+				"benthos.namespace.com.bar",
 			},
 		},
 		{
-			name: "root3",
+			name:     "root3",
 			schemaId: 6,
 			output: []string{
 				"benthos.namespace.com.bar",
 				"benthos.namespace.com.foo",
-  			"benthos.namespace.com.baz",
+				"benthos.namespace.com.baz",
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func TestWalkReferences(t *testing.T) {
 			walkErr := client.WalkReferences(tCtx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
 				schemas = append(schemas, name)
 				return nil
-			});
+			})
 			require.NoError(t, walkErr)
 			require.Len(t, schemas, len(test.output))
 			for i, name := range schemas {
@@ -197,7 +197,6 @@ func TestWalkReferences(t *testing.T) {
 		})
 	}
 }
-
 
 func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error)) string {
 	t.Helper()
@@ -222,4 +221,3 @@ func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error))
 
 	return ts.URL
 }
-

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -1,0 +1,225 @@
+package sr
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	franz_sr "github.com/twmb/franz-go/pkg/sr"
+	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+type Schema struct {
+	Name string `json:"name"`
+}
+
+var noopReqSign = func(fs.FS, *http.Request) error { return nil }
+
+func mustJBytes(t testing.TB, obj any) []byte {
+	t.Helper()
+	b, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return b
+}
+
+func TestWalkReferences(t *testing.T) {
+	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
+	defer done()
+
+	rootSchema := `[
+  "benthos.namespace.com.foo",
+  "benthos.namespace.com.bar",
+  "benthos.namespace.com.baz"
+]`
+
+	fooSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "foo",
+	"fields": [
+		{ "name": "Woof", "type": "string"}
+	]
+}`
+
+	barSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "bar",
+	"fields": [
+		{ "name": "Moo", "type": "string"}
+	]
+}`
+
+	bazSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "baz",
+	"fields": [
+		{ "name": "Miao", "type": "benthos.namespace.com.foo" }
+	]
+}`
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		switch path {
+		case "/subjects/root/versions/1", "/schemas/ids/1":
+			return mustJBytes(t, map[string]any{
+				"id":         1,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+				},
+			}), nil
+		case "/subjects/root2/versions/1", "/schemas/ids/5":
+			return mustJBytes(t, map[string]any{
+				"id":         5,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+		case "/subjects/root3/versions/1", "/schemas/ids/6":
+			return mustJBytes(t, map[string]any{
+				"id":         6,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+
+		case "/subjects/foo/versions/1", "/schemas/ids/2":
+			return mustJBytes(t, map[string]any{
+				"id": 2, "version": 1, "schemaType": "AVRO",
+				"schema": fooSchema,
+			}), nil
+		case "/subjects/bar/versions/1", "/schemas/ids/3":
+			return mustJBytes(t, map[string]any{
+				"id": 3, "version": 1, "schemaType": "AVRO",
+				"schema": barSchema,
+			}), nil
+		case "/subjects/baz/versions/1", "/schemas/ids/4":
+			return mustJBytes(t, map[string]any {
+				"id": 4, 
+				"version": 1,
+				"schema": bazSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+		}		
+		return nil, nil
+	})
+
+	tests := []struct {
+		name				string 
+		schemaId    int
+		output     	[]string
+	}{
+		{
+			name: "root",
+			schemaId: 1,
+			output: []string{
+				"benthos.namespace.com.foo",
+				"benthos.namespace.com.bar",
+  			"benthos.namespace.com.baz",
+			},
+		},
+		{
+			name: "foo",
+			schemaId: 2,
+			output: []string{},
+		},
+		{
+			name: "baz",
+			schemaId: 4,
+			output: []string{
+				"benthos.namespace.com.foo",
+			},
+		},
+		{
+			name: "root2",
+			schemaId: 5,
+			output: []string{
+				"benthos.namespace.com.foo",
+				"benthos.namespace.com.baz",
+  			"benthos.namespace.com.bar",
+			},
+		},
+		{
+			name: "root3",
+			schemaId: 6,
+			output: []string{
+				"benthos.namespace.com.bar",
+				"benthos.namespace.com.foo",
+  			"benthos.namespace.com.baz",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			client, err := NewClient(urlStr, noopReqSign, nil, service.MockResources())
+			require.NoError(t, err)
+			schema, err := client.GetSchemaByID(tCtx, test.schemaId, false)
+			require.NoError(t, err)
+
+			schemas := []string{}
+			walkErr := client.WalkReferences(tCtx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
+				schemas = append(schemas, name)
+				return nil
+			});
+			require.NoError(t, walkErr)
+			require.Len(t, schemas, len(test.output))
+			for i, name := range schemas {
+				require.Equal(t, test.output[i], name)
+			}
+		})
+	}
+}
+
+
+func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error)) string {
+	t.Helper()
+
+	var reqMut sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqMut.Lock()
+		defer reqMut.Unlock()
+
+		b, err := fn(r.URL.EscapedPath())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(b) == 0 {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(b)
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}
+

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	franz_sr "github.com/twmb/franz-go/pkg/sr"
 	"github.com/stretchr/testify/require"
+	franz_sr "github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	franz_sr "github.com/twmb/franz-go/pkg/sr"
-	//"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/benthos/v4/public/service"


### PR DESCRIPTION
This PR attempts to fix #3363. First reported here: https://redpandacommunity.slack.com/archives/C075M18MAEA/p1745906748439179?thread_ts=1745853266.775599&cid=C075M18MAEA

## Description

Given these Avro schemas
```
// foo
{
  "schema":"{
    \"type\":\"record\",
    \"name\":\"foo\",
    \"namespace\":\"example\",
    \"fields\":[{\"name\":\"A\",\"type\":\"string\"}]
  }"
}

// bar
{
  "schema":"{
    \"type\":\"record\",
    \"name\":\"bar\",
    \"namespace\":\"example\",
    \"fields\":[{\"name\":\"A\",\"type\":\"foo\"}]
  }"
}

// baz
{
  "schema":"{
    \"type\":\"record\",
    \"name\":\"baz\",
    \"namespace\":\"example\",
    \"fields\":[{\"name\":\"A\",\"type\":\"foo\"}]
  }"
}
```
the schema decoder fails with `Processor failed: unable to parse schema avro: unknown type: foo`.

## Issue

The walk references function does not invoke the callback function when a schema has already been visited causing issues upstream.

Let's say
```
Schema B references Schema A
Schema C references Schema A
```

Let's assume we invoke the walkReferences function in this order
```
walkReferences(A)
walkReferences(B)
walkReferences(C)
```
Since walkReferences is recursive, we have the following call stack.
```
walkReferences(A)
walkReferences(B)
    walkReferences(A)
walkReferences(C)
    walkReferences(A)
```

Note that the second and third time `walkReferences(A)` is called, the provided callback won't be invoked since schema A has already been visited.

So, this [supplier of the callbacks](https://github.com/redpanda-data/connect/blob/21f21aaa09a79f66f258edadbad2a6a1c6c27330/internal/impl/confluent/serde_hamba_avro.go#L34) processes the resolved schemas in the following (reversed) order
```
C
B
A
```

The correct order would be
```
A
C
B
``` 

Note that C depends on A; hence A should be processed first.

## Fix

~~This PR calls the provided callback even for already visited schemas.~~
This PR implements a proper topological sort.
