### PR TITLE
Draft: Goavro resolves references

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -320,7 +320,7 @@ func TestSchemaRegistryEncodeAvroLogicalTypes(t *testing.T) {
 		{
 			name:        "message doesnt match schema codec",
 			input:       `{"int_time_millis":35245000,"long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
-			errContains: "cannot decode textual union: expected:",
+			errContains: "cannot decode textual union:",
 		},
 		{
 			name:        "message doesnt match schema",

--- a/internal/impl/confluent/serde_goavro.go
+++ b/internal/impl/confluent/serde_goavro.go
@@ -89,7 +89,7 @@ func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, schema franz
 			return nil, fmt.Errorf("unexpected root schema type: %T", v)
 		}
 	} else {
-		return nil, fmt.Errorf("Expect at least one schema to decode, got: %d", numSchemas)
+		return nil, fmt.Errorf("expect at least one schema to decode, got: %d", numSchemas)
 	}
 
 	var schemaSpec string
@@ -142,6 +142,10 @@ func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, schema franz
 
 func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema franz_sr.Schema) (schemaDecoder, error) {
 	schemas, err := resolveGoAvroReferences(ctx, s.client, nil, schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve avro references: %w", err)
+	}
+
 	var schemaJson json.RawMessage
 	numSchemas := len(schemas)
 	var unionTypeBytesToAdd []byte
@@ -163,7 +167,7 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema fra
 			return nil, fmt.Errorf("unexpected root schema type: %T", v)
 		}
 	} else {
-		return nil, fmt.Errorf("Expect at least one schema to decode, got: %d", numSchemas)
+		return nil, fmt.Errorf("expect at least one schema to decode, got: %d", numSchemas)
 	}
 
 	var schemaSpec string
@@ -217,7 +221,7 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema fra
 				return fmt.Errorf("unexpected error when unmarshalling: %w", err)
 			}
 
-			if !(len(unionWrapper) == 1) {
+			if len(unionWrapper) != 1 {
 				return fmt.Errorf("expected native to be a map[string]interface{} with length one, got %d", len(unionWrapper))
 			}
 			for _, value := range unionWrapper {

--- a/internal/impl/confluent/serde_goavro_test.go
+++ b/internal/impl/confluent/serde_goavro_test.go
@@ -88,16 +88,16 @@ func TestAvroReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/30", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 30,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    30,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 10},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"slices"
 	"strings"
 	"time"
 
@@ -35,16 +34,17 @@ func resolveHambaAvroReferences(ctx context.Context, client *sr.Client, schema f
 	if len(schema.References) == 0 {
 		return []franz_sr.Schema{schema}, nil
 	}
-	schemas := []franz_sr.Schema{schema}
+	schemas := []franz_sr.Schema{}
 	if err := client.WalkReferences(ctx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
 		schemas = append(schemas, schema)
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("unable to walk schema references: %w", err)
 	}
+
+	schemas = append(schemas, schema)
 	// We walk the above schemas in top down order, however when resolving references we need to add schemas to our codec
 	// in a bottom up manner.
-	slices.Reverse(schemas)
 	return schemas, nil
 }
 

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -43,8 +43,6 @@ func resolveHambaAvroReferences(ctx context.Context, client *sr.Client, schema f
 	}
 
 	schemas = append(schemas, schema)
-	// We walk the above schemas in top down order, however when resolving references we need to add schemas to our codec
-	// in a bottom up manner.
 	return schemas, nil
 }
 

--- a/internal/impl/confluent/serde_hamba_avro_test.go
+++ b/internal/impl/confluent/serde_hamba_avro_test.go
@@ -89,16 +89,16 @@ func TestHambaAvroReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/30", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 30,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    30,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 10},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 

--- a/internal/impl/confluent/serde_hamba_avro_test.go
+++ b/internal/impl/confluent/serde_hamba_avro_test.go
@@ -122,10 +122,28 @@ func TestHambaAvroReferences(t *testing.T) {
 			subject: "root",
 		},
 		{
-			name:    "a baz",
+			name:    "a baz (root subject)",
 			input:   `{"Miao":{"Woof":"tssssssuuuuuuu"}}`,
 			output:  `{"Miao":{"Woof":"tssssssuuuuuuu"}}`,
 			subject: "root",
+		},
+		{
+			name:    "a foo (foo subject)",
+			input:   `{"Woof":"hhnnnnnnroooo"}`,
+			output:  `{"Woof":"hhnnnnnnroooo"}`,
+			subject: "foo",
+		},
+		{
+			name:    "a bar (bar subject)",
+			input:   `{"Moo":"mmuuuuuueew"}`,
+			output:  `{"Moo":"mmuuuuuueew"}`,
+			subject: "bar",
+		},
+		{
+			name:    "a baz (baz subject)",
+			input:   `{"Miao":{"Woof":"tssssssuuuuuuu"}}`,
+			output:  `{"Miao":{"Woof":"tssssssuuuuuuu"}}`,
+			subject: "baz",
 		},
 	}
 

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -173,7 +173,7 @@ type refWalkFn func(ctx context.Context, name string, info sr.Schema) error
 
 // WalkReferences goes through the provided schema info in a topological order
 // (i.e. before a schema is traversed all its references schemas are traversed first)
-// and for each reference the provided closure is called recursively, which means 
+// and for each reference the provided closure is called recursively, which means
 // each reference obtained will also be walked.
 //
 // If a reference of a given subject but differing version is detected an error

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -171,9 +171,10 @@ func (c *Client) CreateSchemaWithIDAndVersion(ctx context.Context, subject strin
 
 type refWalkFn func(ctx context.Context, name string, info sr.Schema) error
 
-// WalkReferences goes through the provided schema info and for each reference
-// the provided closure is called recursively, which means each reference obtained
-// will also be walked.
+// WalkReferences goes through the provided schema info in a topological order
+// (i.e. before a schema is traversed all its references schemas are traversed first)
+// and for each reference the provided closure is called recursively, which means 
+// each reference obtained will also be walked.
 //
 // If a reference of a given subject but differing version is detected an error
 // is returned as this would put us in an invalid state.
@@ -183,13 +184,11 @@ func (c *Client) WalkReferences(ctx context.Context, refs []sr.SchemaReference, 
 
 func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int, refs []sr.SchemaReference, fn refWalkFn) error {
 	for _, ref := range refs {
-		var stopWalking = false
-
 		if i, exists := seen[ref.Name]; exists {
 			if i != ref.Version {
 				return fmt.Errorf("duplicate reference '%v' version mismatch of %v and %v, aborting in order to avoid invalid state", ref.Name, i, ref.Version)
 			}
-			stopWalking = true
+			continue
 		}
 
 		info, err := c.GetSchemaBySubjectAndVersion(ctx, ref.Subject, &ref.Version, false)
@@ -197,16 +196,12 @@ func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int,
 			return err
 		}
 
-		if err := fn(ctx, ref.Name, info.Schema); err != nil {
+		seen[ref.Name] = ref.Version
+		if err := c.walkReferencesTracked(ctx, seen, info.References, fn); err != nil {
 			return err
 		}
 
-		if stopWalking {
-			continue
-		}
-
-		seen[ref.Name] = ref.Version
-		if err := c.walkReferencesTracked(ctx, seen, info.References, fn); err != nil {
+		if err := fn(ctx, ref.Name, info.Schema); err != nil {
 			return err
 		}
 	}

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -189,7 +189,7 @@ func (c *Client) walkReferencesTracked(ctx context.Context, seen map[string]int,
 			if i != ref.Version {
 				return fmt.Errorf("duplicate reference '%v' version mismatch of %v and %v, aborting in order to avoid invalid state", ref.Name, i, ref.Version)
 			}
-			stopWalking = exists
+			stopWalking = true
 		}
 
 		info, err := c.GetSchemaBySubjectAndVersion(ctx, ref.Subject, &ref.Version, false)

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -31,7 +31,7 @@ func mustJBytes(t testing.TB, obj any) []byte {
 }
 
 func TestWalkReferences(t *testing.T) {
-	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
+	tCtx, done := context.WithTimeout(t.Context(), time.Second*10)
 	defer done()
 
 	rootSchema := `[
@@ -117,61 +117,61 @@ func TestWalkReferences(t *testing.T) {
 				"schema": barSchema,
 			}), nil
 		case "/subjects/baz/versions/1", "/schemas/ids/4":
-			return mustJBytes(t, map[string]any {
-				"id": 4, 
-				"version": 1,
-				"schema": bazSchema,
+			return mustJBytes(t, map[string]any{
+				"id":         4,
+				"version":    1,
+				"schema":     bazSchema,
 				"schemaType": "AVRO",
 				"references": []any{
 					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
 				},
 			}), nil
-		}		
+		}
 		return nil, nil
 	})
 
 	tests := []struct {
-		name				string 
-		schemaId    int
-		output     	[]string
+		name     string
+		schemaId int
+		output   []string
 	}{
 		{
-			name: "root",
+			name:     "root",
 			schemaId: 1,
 			output: []string{
 				"benthos.namespace.com.foo",
 				"benthos.namespace.com.bar",
-  			"benthos.namespace.com.baz",
+				"benthos.namespace.com.baz",
 			},
 		},
 		{
-			name: "foo",
+			name:     "foo",
 			schemaId: 2,
-			output: []string{},
+			output:   []string{},
 		},
 		{
-			name: "baz",
+			name:     "baz",
 			schemaId: 4,
 			output: []string{
 				"benthos.namespace.com.foo",
 			},
 		},
 		{
-			name: "root2",
+			name:     "root2",
 			schemaId: 5,
 			output: []string{
 				"benthos.namespace.com.foo",
 				"benthos.namespace.com.baz",
-  			"benthos.namespace.com.bar",
+				"benthos.namespace.com.bar",
 			},
 		},
 		{
-			name: "root3",
+			name:     "root3",
 			schemaId: 6,
 			output: []string{
 				"benthos.namespace.com.bar",
 				"benthos.namespace.com.foo",
-  			"benthos.namespace.com.baz",
+				"benthos.namespace.com.baz",
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func TestWalkReferences(t *testing.T) {
 			walkErr := client.WalkReferences(tCtx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
 				schemas = append(schemas, name)
 				return nil
-			});
+			})
 			require.NoError(t, walkErr)
 			require.Len(t, schemas, len(test.output))
 			for i, name := range schemas {
@@ -197,7 +197,6 @@ func TestWalkReferences(t *testing.T) {
 		})
 	}
 }
-
 
 func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error)) string {
 	t.Helper()
@@ -222,4 +221,3 @@ func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error))
 
 	return ts.URL
 }
-

--- a/internal/impl/confluent/sr/client_test.go
+++ b/internal/impl/confluent/sr/client_test.go
@@ -1,0 +1,225 @@
+package sr
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	franz_sr "github.com/twmb/franz-go/pkg/sr"
+	//"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+type Schema struct {
+	Name string `json:"name"`
+}
+
+var noopReqSign = func(fs.FS, *http.Request) error { return nil }
+
+func mustJBytes(t testing.TB, obj any) []byte {
+	t.Helper()
+	b, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return b
+}
+
+func TestWalkReferences(t *testing.T) {
+	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
+	defer done()
+
+	rootSchema := `[
+  "benthos.namespace.com.foo",
+  "benthos.namespace.com.bar",
+  "benthos.namespace.com.baz"
+]`
+
+	fooSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "foo",
+	"fields": [
+		{ "name": "Woof", "type": "string"}
+	]
+}`
+
+	barSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "bar",
+	"fields": [
+		{ "name": "Moo", "type": "string"}
+	]
+}`
+
+	bazSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "baz",
+	"fields": [
+		{ "name": "Miao", "type": "benthos.namespace.com.foo" }
+	]
+}`
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		switch path {
+		case "/subjects/root/versions/1", "/schemas/ids/1":
+			return mustJBytes(t, map[string]any{
+				"id":         1,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+				},
+			}), nil
+		case "/subjects/root2/versions/1", "/schemas/ids/5":
+			return mustJBytes(t, map[string]any{
+				"id":         5,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+		case "/subjects/root3/versions/1", "/schemas/ids/6":
+			return mustJBytes(t, map[string]any{
+				"id":         6,
+				"version":    1,
+				"schema":     rootSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.baz", "subject": "baz", "version": 1},
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+
+		case "/subjects/foo/versions/1", "/schemas/ids/2":
+			return mustJBytes(t, map[string]any{
+				"id": 2, "version": 1, "schemaType": "AVRO",
+				"schema": fooSchema,
+			}), nil
+		case "/subjects/bar/versions/1", "/schemas/ids/3":
+			return mustJBytes(t, map[string]any{
+				"id": 3, "version": 1, "schemaType": "AVRO",
+				"schema": barSchema,
+			}), nil
+		case "/subjects/baz/versions/1", "/schemas/ids/4":
+			return mustJBytes(t, map[string]any {
+				"id": 4, 
+				"version": 1,
+				"schema": bazSchema,
+				"schemaType": "AVRO",
+				"references": []any{
+					map[string]any{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1},
+				},
+			}), nil
+		}		
+		return nil, nil
+	})
+
+	tests := []struct {
+		name				string 
+		schemaId    int
+		output     	[]string
+	}{
+		{
+			name: "root",
+			schemaId: 1,
+			output: []string{
+				"benthos.namespace.com.foo",
+				"benthos.namespace.com.bar",
+  			"benthos.namespace.com.baz",
+			},
+		},
+		{
+			name: "foo",
+			schemaId: 2,
+			output: []string{},
+		},
+		{
+			name: "baz",
+			schemaId: 4,
+			output: []string{
+				"benthos.namespace.com.foo",
+			},
+		},
+		{
+			name: "root2",
+			schemaId: 5,
+			output: []string{
+				"benthos.namespace.com.foo",
+				"benthos.namespace.com.baz",
+  			"benthos.namespace.com.bar",
+			},
+		},
+		{
+			name: "root3",
+			schemaId: 6,
+			output: []string{
+				"benthos.namespace.com.bar",
+				"benthos.namespace.com.foo",
+  			"benthos.namespace.com.baz",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			client, err := NewClient(urlStr, noopReqSign, nil, service.MockResources())
+			require.NoError(t, err)
+			schema, err := client.GetSchemaByID(tCtx, test.schemaId, false)
+			require.NoError(t, err)
+
+			schemas := []string{}
+			walkErr := client.WalkReferences(tCtx, schema.References, func(ctx context.Context, name string, schema franz_sr.Schema) error {
+				schemas = append(schemas, name)
+				return nil
+			});
+			require.NoError(t, walkErr)
+			require.Len(t, schemas, len(test.output))
+			for i, name := range schemas {
+				require.Equal(t, test.output[i], name)
+			}
+		})
+	}
+}
+
+
+func runSchemaRegistryServer(t testing.TB, fn func(path string) ([]byte, error)) string {
+	t.Helper()
+
+	var reqMut sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqMut.Lock()
+		defer reqMut.Unlock()
+
+		b, err := fn(r.URL.EscapedPath())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(b) == 0 {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(b)
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}
+


### PR DESCRIPTION
> [!NOTE]
> This is still in draft but the resolver algorithm is done. Before I proceed, I would like to hear feedback if this approach is feasible.

## Problem

The Goavro encoder is not able to resolve schemas with references such as

```
// foo
{
    "id":         1,
    "version":    1,
    "schema":    {
	"namespace": "benthos.namespace.com",
	"type": "record",
	"name": "foo",
	"fields": [
		{ "name": "Woof", "type": "bar"}
	]
    }, 
    "schemaType": "AVRO",
    "references": [{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1}]
}

// bar
{
     "id": 2, "version": 1, "schemaType": "AVRO",
     "schema": {
	"namespace": "benthos.namespace.com",
	"type": "record",
	"name": "bar",
	"fields": [
		{ "name": "Moo", "type": "string"}
	]
     },
}
```

It usually fails with
```
failed to parse root schema as enum: json: cannot unmarshal object into Go value of type
```

This PR attempts to fix this.

## Solution
Assume we want to encode payload `P` with schema `Q`.

### Solution 1: Inline all schemas
The obvious solution is to resolve all schemas and inline the required schemas in `Q`.

### Solution 2: `union` type solution
I propose an alternative (hacky) solution. Let me know your thoughts.

1. The Goavro encoder resolves all required schemas of `P` and collects them in an array `A`. 
2. We build a new Avro schema `S` of type `union` to hold all the required schemas in `A`.
3. We encode `P` using schema `S` obtaining encoding `B`.
4. Finally, we remove the first bytes of `B` that hold information about the union type. We need to remove these bytes because `P` is was encoded using a `union` type `S`. After removing these bytes, we obtain the encoding of `P` with schema `Q`.

## Limitations

There is still one limitation when we want to encode some object with a schema that is a union type such as `benthos.namespace.com.root`
```
// root
{
    "id":         1,
    "version":    1,
    "schema":    {
	"namespace": "benthos.namespace.com",
	"type": "record",
	"name": "root",
	"fields": ["benthos.namespace.com.bar"]
    }, 
    "schemaType": "AVRO",
    "references": [{"name": "benthos.namespace.com.bar", "subject": "bar", "version": 1}]
}
```
and where `benthos.namespace.com.root` references another schema `benthos.namespace.com.bar` which references another schema `benthos.namespace.com.foo`, e.g.
```
// bar
{
    "id":         2,
    "version":    1,
    "schema":    {
	"namespace": "benthos.namespace.com",
	"type": "record",
	"name": "bar",
	"fields": [{ "name": "Moo", "type": "foo"}]
    }, 
    "schemaType": "AVRO",
    "references": [{"name": "benthos.namespace.com.foo", "subject": "foo", "version": 1}]
}
```
I'm working on this by improving the [switch statement](https://github.com/redpanda-data/connect/blob/ada07c01539dad6ef10c1ef821522d9b05b42f75/internal/impl/confluent/serde_goavro.go#L85).

## State of this PR

Almost everything is done. I just need to fix the limitation above, and maybe write more tests.