### PR TITLE
Feature: add support to extras field on sentry_capture processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## 4.55.0 - TBD
 
+### Added
+
+- Field `extras` added to the `sentry_capture` processor. (@peczenyj)
+
 ### Fixed
 
 - Fixed an issue with the experimental `redpanda` input where batch ordering could be mixed between two subsequent batches. (@mihaitodor, @rockwotj)

--- a/docs/modules/components/pages/processors/sentry_capture.adoc
+++ b/docs/modules/components/pages/processors/sentry_capture.adoc
@@ -33,6 +33,7 @@ sentry_capture:
   dsn: ""
   message: webhook event received # No default (required)
   context: 'root = {"order": {"product_id": "P93174", "quantity": 5}}' # No default (optional)
+  extras: root.foo = "bar" # No default (optional)
   tags: {} # No default (optional)
   environment: ""
   release: ""
@@ -84,6 +85,22 @@ A mapping that must evaluate to an object-of-objects or `deleted()`. If this map
 context: 'root = {"order": {"product_id": "P93174", "quantity": 5}}'
 
 context: root = deleted()
+```
+
+=== `extras`
+
+A mapping that must evaluate to an object. If this mapping produces a value, then it is set on a sentry event as extras.
+
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+extras: root.foo = "bar"
+
+extras: root = this.without("password")
 ```
 
 === `tags`

--- a/internal/impl/sentry/transport_mock_test.go
+++ b/internal/impl/sentry/transport_mock_test.go
@@ -27,6 +27,18 @@ type mockTransport struct {
 	mock.Mock
 }
 
+func NewTransport(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *mockTransport {
+	mock := &mockTransport{}
+	mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
 func (t *mockTransport) Flush(timeout time.Duration) bool {
 	args := t.Called(timeout)
 


### PR DESCRIPTION
I may need to add extra/ unstructured information on `sentry_capture`

also, I add a mock transport constructor that performs the registration of  `AssertExpectations` on test cleanup. mockery creates a constructor with this same pattern, and it simplifies the code.