### PR TITLE
fix vulnerability GO-2025-3540

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/r3labs/diff/v3 v3.0.1
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
-	github.com/redis/go-redis/v9 v9.7.0
+	github.com/redis/go-redis/v9 v9.7.3
 	github.com/redpanda-data/benthos/v4 v4.50.0
 	github.com/redpanda-data/common-go/secrets v0.1.3
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.31.0

--- a/go.sum
+++ b/go.sum
@@ -1806,8 +1806,8 @@ github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzuk
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
-github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/redpanda-data/benthos/v4 v4.50.0 h1:4Gf3N47AZMYbYMOfxQEiwoszpC1llER7DrPVE8qn2zo=
 github.com/redpanda-data/benthos/v4 v4.50.0/go.mod h1:Rb0pNRrb1o2ItX5BcoAktw6dTJ+Aa58cn1d9LAiQ1mc=
 github.com/redpanda-data/common-go/secrets v0.1.3 h1:VRo+OFS4Zgb2UMvwcIuUujdMhAPNGoGESZgcF4gjgcY=


### PR DESCRIPTION
by running `govulncheck` I found

```
Vulnerability #7: GO-2025-3540
    Potential out of order responses when CLIENT SETINFO times out during
    connection establishment in github.com/redis/go-redis
  More info: https://pkg.go.dev/vuln/GO-2025-3540
  Module: github.com/redis/go-redis/v9
    Found in: github.com/redis/go-redis/v9@v9.7.0
    Fixed in: github.com/redis/go-redis/v9@v9.7.3
```
