### PR TITLE
Kinesis optimize shard balancer

### DIFF
--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -85,6 +85,7 @@ input:
     auto_replay_nacks: true
     commit_period: 5s
     rebalance_period: 30s
+    rebalance_ops: 10
     lease_period: 30s
     start_from_oldest: true
     region: "" # No default (optional)
@@ -322,6 +323,15 @@ The period of time between each attempt to rebalance shards across clients.
 *Type*: `string`
 
 *Default*: `"30s"`
+
+=== `rebalance_ops`
+
+The number of shard claim operations can happen in one rebalance cycle
+
+
+*Type*: `int`
+
+*Default*: `10`
 
 === `lease_period`
 

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -798,11 +798,11 @@ func (k *kinesisReader) runBalancedShards() {
 							k.log.Errorf("Failed to claim shard '%v': %v", shardID, err)
 						}
 						continue
-					} else {
-						k.log.Debugf("Successfully claimed shard '%v'", shardID)
-						selfClaimCount++
-						claimOps++
 					}
+
+					k.log.Debugf("Successfully claimed shard '%v'", shardID)
+					selfClaimCount++
+					claimOps++
 
 					wg.Add(1)
 					if err = k.runConsumer(&wg, *info, shardID, sequence); err != nil {
@@ -841,15 +841,15 @@ func (k *kinesisReader) runBalancedShards() {
 								info.id, randomShard, clientID, k.clientID,
 							)
 							continue
-						} else {
-							k.log.Debugf(
-								"Successfully stole stream '%v' shard '%v' from client '%v' as client '%v'",
-								info.id, randomShard, clientID, k.clientID,
-							)
-							k.shardsStolenMetric.Incr(1)
-							selfClaimCount++
-							claimOps++
 						}
+
+						k.log.Debugf(
+							"Successfully stole stream '%v' shard '%v' from client '%v' as client '%v'",
+							info.id, randomShard, clientID, k.clientID,
+						)
+						k.shardsStolenMetric.Incr(1)
+						selfClaimCount++
+						claimOps++
 
 						wg.Add(1)
 						if err = k.runConsumer(&wg, *info, randomShard, sequence); err != nil {

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -57,9 +57,6 @@ const (
 
 // These control shard balancing behavior
 const (
-	// prevents trying to claim the same shard too frequently
-	minReclaimInterval = 10 * time.Second
-
 	// ensures that each balancing cycle takes at least this long
 	minIterationTime = 1 * time.Second
 


### PR DESCRIPTION
- Add startup jitter to prevent thundering herd problem
- Add min cycle time to avoid hammering the cpu when the shards are already balanced
- Add max rebalance operations per cycle (default 10) for more control
- Add two new metrics for observability: 
  - `kinesis_client_shards`: number of claimed shards per client
  - `kinesis_shards_stolen_total`: number of shards stolen per client