### PR TITLE
Add `max_yield_batch_size` field to redpanda inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Field `extras` added to the `sentry_capture` processor. (@peczenyj)
 - Field `steal_grace_period` added to the `aws_kinesis` input. (@Jeffail)
 - New `redpanda` cache that stores key/value pairs in a compacted topic. (@rockwotj)
-- Field `max_yield_batch_size` added to all `redpanda` flavored inputs. (@Jeffail)
+- Field `max_yield_batch_bytes` added to all `redpanda` flavored inputs. (@Jeffail)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Field `extras` added to the `sentry_capture` processor. (@peczenyj)
 - Field `steal_grace_period` added to the `aws_kinesis` input. (@Jeffail)
 - New `redpanda` cache that stores key/value pairs in a compacted topic. (@rockwotj)
+- Field `max_yield_batch_size` added to all `redpanda` flavored inputs. (@Jeffail)
 
 ### Fixed
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -85,6 +85,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
+    max_yield_batch_size: 32KB
     auto_replay_nacks: true
 ```
 
@@ -743,6 +744,15 @@ The period of time between each topic lag refresh cycle.
 *Type*: `string`
 
 *Default*: `"5s"`
+
+=== `max_yield_batch_size`
+
+The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
+
+
+*Type*: `string`
+
+*Default*: `"32KB"`
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -85,7 +85,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
-    max_yield_batch_size: 32KB
+    max_yield_batch_bytes: 32KB
     auto_replay_nacks: true
 ```
 
@@ -745,7 +745,7 @@ The period of time between each topic lag refresh cycle.
 
 *Default*: `"5s"`
 
-=== `max_yield_batch_size`
+=== `max_yield_batch_bytes`
 
 The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
 

--- a/docs/modules/components/pages/inputs/redpanda_common.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_common.adoc
@@ -71,6 +71,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
+    max_yield_batch_size: 32KB
     auto_replay_nacks: true
 ```
 
@@ -332,6 +333,15 @@ The period of time between each topic lag refresh cycle.
 *Type*: `string`
 
 *Default*: `"5s"`
+
+=== `max_yield_batch_size`
+
+The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
+
+
+*Type*: `string`
+
+*Default*: `"32KB"`
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/redpanda_common.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_common.adoc
@@ -71,7 +71,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
-    max_yield_batch_size: 32KB
+    max_yield_batch_bytes: 32KB
     auto_replay_nacks: true
 ```
 
@@ -334,7 +334,7 @@ The period of time between each topic lag refresh cycle.
 
 *Default*: `"5s"`
 
-=== `max_yield_batch_size`
+=== `max_yield_batch_bytes`
 
 The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -87,6 +87,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
+    max_yield_batch_size: 32KB
     auto_replay_nacks: true
 ```
 
@@ -720,6 +721,15 @@ The period of time between each topic lag refresh cycle.
 *Type*: `string`
 
 *Default*: `"5s"`
+
+=== `max_yield_batch_size`
+
+The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
+
+
+*Type*: `string`
+
+*Default*: `"32KB"`
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -87,7 +87,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
-    max_yield_batch_size: 32KB
+    max_yield_batch_bytes: 32KB
     auto_replay_nacks: true
 ```
 
@@ -722,7 +722,7 @@ The period of time between each topic lag refresh cycle.
 
 *Default*: `"5s"`
 
-=== `max_yield_batch_size`
+=== `max_yield_batch_bytes`
 
 The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -76,6 +76,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
+    max_yield_batch_size: 32KB
     auto_replay_nacks: true
 ```
 
@@ -576,6 +577,15 @@ The period of time between each topic lag refresh cycle.
 *Type*: `string`
 
 *Default*: `"5s"`
+
+=== `max_yield_batch_size`
+
+The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
+
+
+*Type*: `string`
+
+*Default*: `"32KB"`
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -76,7 +76,7 @@ input:
     commit_period: 5s
     partition_buffer_bytes: 1MB
     topic_lag_refresh_period: 5s
-    max_yield_batch_size: 32KB
+    max_yield_batch_bytes: 32KB
     auto_replay_nacks: true
 ```
 
@@ -578,7 +578,7 @@ The period of time between each topic lag refresh cycle.
 
 *Default*: `"5s"`
 
-=== `max_yield_batch_size`
+=== `max_yield_batch_bytes`
 
 The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
 

--- a/internal/impl/kafka/franz_reader_ordered.go
+++ b/internal/impl/kafka/franz_reader_ordered.go
@@ -37,7 +37,7 @@ const (
 	kroFieldCommitPeriod          = "commit_period"
 	kroFieldPartitionBuffer       = "partition_buffer_bytes"
 	kroFieldTopicLagRefreshPeriod = "topic_lag_refresh_period"
-	kroFieldBatchMaxSize          = "max_yield_batch_size"
+	kroFieldBatchMaxSize          = "max_yield_batch_bytes"
 )
 
 // FranzReaderOrderedConfigFields returns config fields for customising the


### PR DESCRIPTION
This now sets a more sensible cap to the batches yielded by the redpanda input, so it's no longer directly tied to the poll limit. I believe this fixes the performance issues being seen in the wild as users were trying to flush outrageously large batches.