### PR TITLE
Fix RP input reconnection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed an issue where the `kafka_franz`, `redpanda` and `redpanda_common` inputs could stall for an unreasonable length of time after losing connection to a broker. (@Jeffail)
+- Fixed an issue where the `kafka_franz`, `redpanda`, `redpanda_common`, `redpanda_migrator`, `redpanda_migrator_offsets` and `ockam_kafka` inputs could stall for an unreasonable length of time after losing connection to a broker. (@Jeffail)
 
 ## 4.55.0 - 2025-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.55.1 - 2025-05-16
+## 4.55.1 - TBD
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.55.1 - 2025-05-16
+
+### Fixed
+
+- Fixed an issue where the `kafka_franz`, `redpanda` and `redpanda_common` inputs could stall for an unreasonable length of time after losing connection to a broker. (@Jeffail)
+
 ## 4.55.0 - 2025-05-15
 
 ### Added

--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/Jeffail/checkpoint"
@@ -507,6 +508,11 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 		return fmt.Errorf("failed to connect to cluster: %s", err)
 	}
 
+	connErrBackOff := backoff.NewExponentialBackOff()
+	connErrBackOff.InitialInterval = time.Millisecond * 100
+	connErrBackOff.MaxInterval = time.Second
+	connErrBackOff.MaxElapsedTime = 0
+
 	go func() {
 		if f.consumerGroup != "" {
 			topicLagGauge := f.res.Metrics().NewGauge("kafka_lag", "topic", "partition")
@@ -560,9 +566,12 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 					}
 				}
 
-				if nonTemporalErr {
-					cl.Close()
-					return
+				if nonTemporalErr && fetches.Empty() {
+					select {
+					case <-time.After(connErrBackOff.NextBackOff()):
+					case <-closeCtx.Done():
+						return
+					}
 				}
 			}
 			if closeCtx.Err() != nil {

--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -573,7 +573,10 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 						return
 					}
 				}
+			} else {
+				connErrBackOff.Reset()
 			}
+
 			if closeCtx.Err() != nil {
 				return
 			}

--- a/resources/docker/profiling/config.yaml
+++ b/resources/docker/profiling/config.yaml
@@ -21,10 +21,7 @@ output:
     ]'
 
 metrics:
-  prometheus:
-    push_interval: 1s
-    push_job_name: benthos_push
-    push_url: "http://localhost:9091"
+  prometheus: {}
 
 # tracer:
 #   jaeger:

--- a/resources/docker/profiling/docker-compose.yaml
+++ b/resources/docker/profiling/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 volumes:
  prometheus_data: {}
  grafana_data: {}
@@ -16,6 +14,8 @@ services:
     volumes:
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus
+    extra_hosts:
+      - host.docker.internal:host-gateway
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -23,30 +23,6 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
       - 9090:9090
-
-  traefik:
-    image: "traefik"
-    command:
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    ports:
-      - "80:80"
-      - "8080:8080"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
-  pushgateway:
-    image: prom/pushgateway
-    ports:
-      - 9091:9091
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.whoami.rule=Host(`push.localhost`)"
-      - "traefik.http.routers.whoami.entrypoints=web"
-      - "traefik.http.routers.whoami.middlewares=secured"
-      - "traefik.http.middlewares.secured.basicauth.users=foo:$$2y$$05$$zwyVyaTBE.hdSl8Xs./bJuv3nrlIgiFCsHNDvnWy4C3GRnR4L5cl6"
 
   grafana:
     image: grafana/grafana

--- a/resources/docker/profiling/prometheus/prometheus.yml
+++ b/resources/docker/profiling/prometheus/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval:     15s
   evaluation_interval: 15s
   external_labels:
-    monitor: 'benthos-benchmark'
+    monitor: 'rpcn-benchmark'
 
 scrape_configs:
   - job_name: 'prometheus'
@@ -10,8 +10,8 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'push_gateway'
+  - job_name: 'rpcn'
     scrape_interval: 5s
-    honor_labels: true
     static_configs:
-      - targets: ['pushgateway:9091']
+      - targets: ['host.docker.internal:4195']
+

--- a/resources/docker/redpanda_benchmarking/docker-compose.yaml
+++ b/resources/docker/redpanda_benchmarking/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
     volumes:
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus
+    extra_hosts:
+      - host.docker.internal:host-gateway
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -21,30 +23,6 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
       - 9090:9090
-
-  traefik:
-    image: "traefik"
-    command:
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    ports:
-      - "80:80"
-      - "8080:8080"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
-  pushgateway:
-    image: prom/pushgateway
-    ports:
-      - 9091:9091
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.whoami.rule=Host(`push.localhost`)"
-      - "traefik.http.routers.whoami.entrypoints=web"
-      - "traefik.http.routers.whoami.middlewares=secured"
-      - "traefik.http.middlewares.secured.basicauth.users=foo:$$2y$$05$$zwyVyaTBE.hdSl8Xs./bJuv3nrlIgiFCsHNDvnWy4C3GRnR4L5cl6"
 
   grafana:
     image: grafana/grafana

--- a/resources/docker/redpanda_benchmarking/generate.yaml
+++ b/resources/docker/redpanda_benchmarking/generate.yaml
@@ -1,9 +1,10 @@
 http:
-  enabled: false
+  address: 0.0.0.0:4197
+  enabled: true
 
 input:
   generate:
-    interval: 3s
+    interval: 1s
     count: 100_000_000
     batch_size: 1
     mapping: |
@@ -22,8 +23,5 @@ redpanda:
     status_topic: generate.status
 
 metrics:
-  prometheus:
-    push_interval: 1s
-    push_job_name: benthos_push
-    push_url: "http://localhost:9091"
+  prometheus: {}
 

--- a/resources/docker/redpanda_benchmarking/out_bridge.yaml
+++ b/resources/docker/redpanda_benchmarking/out_bridge.yaml
@@ -1,5 +1,6 @@
 http:
-  enabled: false
+  address: 0.0.0.0:4196
+  enabled: true
 
 input:
   redpanda_common:
@@ -22,12 +23,9 @@ output:
         - mapping: |
             root = "Uh oh: %v failed to deliver due to: %v".format(content().string(), @fallback_error)
 
-redpanda_common:
+redpanda:
   seed_brokers: [ localhost:9092 ]
 
 metrics:
-  prometheus:
-    push_interval: 1s
-    push_job_name: benthos_push
-    push_url: "http://localhost:9091"
+  prometheus: {}
 

--- a/resources/docker/redpanda_benchmarking/out_stdout.yaml
+++ b/resources/docker/redpanda_benchmarking/out_stdout.yaml
@@ -1,9 +1,10 @@
 http:
-  enabled: false
+  address: 0.0.0.0:4195
+  enabled: true
 
 input:
   redpanda_common:
-    consumer_group: cg_d
+    consumer_group: cg_b
     topics: [ '.*' ]
     regexp_topics: true
     auto_replay_nacks: false
@@ -19,8 +20,5 @@ redpanda:
   seed_brokers: [ localhost:9092 ]
 
 metrics:
-  prometheus:
-    push_interval: 1s
-    push_job_name: benthos_push
-    push_url: "http://localhost:9091"
+  prometheus: {}
 

--- a/resources/docker/redpanda_benchmarking/prometheus/prometheus.yml
+++ b/resources/docker/redpanda_benchmarking/prometheus/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval:     15s
   evaluation_interval: 15s
   external_labels:
-    monitor: 'benthos-benchmark'
+    monitor: 'rpcn-benchmark'
 
 scrape_configs:
   - job_name: 'prometheus'
@@ -10,8 +10,18 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'push_gateway'
+  - job_name: 'rpcn-stdout'
     scrape_interval: 5s
-    honor_labels: true
     static_configs:
-      - targets: ['pushgateway:9091']
+      - targets: ['host.docker.internal:4195']
+
+  - job_name: 'rpcn-bridge'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:4196']
+
+  - job_name: 'rpcn-generate'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:4197']
+


### PR DESCRIPTION
Previously we were stalling after closing the client during broker outages. In reality we can back off our polling and continue using the client as it will recover on its own.