### PR TITLE
Add `kafka_lag` metadata to the `kafka_franz` and `ockam_kafka` inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Parameter `root_tag` added to the `format_xml()` Bloblang method. (@mihaitodor)
+- Metadata `kafka_lag` now emitted by the `kafka_franz` and `ockam_kafka` inputs. (@mihaitodor)
 
 ### Fixed
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -113,6 +113,7 @@ This input adds the following metadata fields to each message:
 - kafka_topic
 - kafka_partition
 - kafka_offset
+- kafka_lag
 - kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -42,6 +42,7 @@ This input adds the following metadata fields to each message:
 - kafka_topic
 - kafka_partition
 - kafka_offset
+- kafka_lag
 - kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/connect/issues/3434

This is a small chore as a follow-up to #3381.