### PR TITLE
Fix regression: Allow configuring TLS for the Schema Registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed an issue where the `aws_kinesis` input would cause high CPU utilization in cases where a shard has a trickle of data and a batching period is specified.
 - Fixed an issue where the `mongodb_cdc` inputs could have spurious errors when collections had no writes for > 30 seconds. (@rockwotj)
+- Fixed a regression bug when configuring TLS for the Schema Registry client used by the `schema_registry` input and output and the `schema_registry_decode` and `schema_registry_encode` processors. This was introduced via [#3135](https://github.com/redpanda-data/connect/pull/3135) in [v4.46.0](https://github.com/redpanda-data/connect/releases/tag/v4.46.0).(@mihaitodor)
 
 ## 4.55.1 - 2025-05-19
 

--- a/internal/impl/confluent/sr/client.go
+++ b/internal/impl/confluent/sr/client.go
@@ -45,7 +45,15 @@ func NewClient(
 		return nil, fmt.Errorf("failed to parse url: %w", err)
 	}
 
-	clientSR, err := sr.NewClient(sr.URLs(urlStr), sr.PreReq(func(req *http.Request) error { return reqSigner(mgr.FS(), req) }))
+	opts := []sr.ClientOpt{sr.URLs(urlStr)}
+	if tlsConf != nil {
+		opts = append(opts, sr.DialTLSConfig(tlsConf))
+	}
+	if reqSigner != nil {
+		opts = append(opts, sr.PreReq(func(req *http.Request) error { return reqSigner(mgr.FS(), req) }))
+	}
+
+	clientSR, err := sr.NewClient(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init client: %w", err)
 	}


### PR DESCRIPTION
This bug was introduced via [#3135](https://github.com/redpanda-data/connect/pull/3135) in [v4.46.0](https://github.com/redpanda-data/connect/releases/tag/v4.46.0).

Fixes #3440.

I'll add `unused-parameter` for the `revive` linter in a follow-up PR.