### PR TITLE
Add gateway jwt auth to mcp

### DIFF
--- a/internal/gateway/jwt_test.go
+++ b/internal/gateway/jwt_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/gateway"
+)
+
+func TestJWTConfigErrors(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		values      map[string]string
+		errContains string
+	}{
+		{
+			name:   "nothing set",
+			values: map[string]string{},
+		},
+		{
+			name: "everything set",
+			values: map[string]string{
+				"REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL":      "http://localhost:1234",
+				"REDPANDA_CLOUD_GATEWAY_JWT_AUDIENCE":        "foo",
+				"REDPANDA_CLOUD_GATEWAY_JWT_ORGANIZATION_ID": "bar",
+			},
+		},
+		{
+			name: "no audience no org",
+			values: map[string]string{
+				"REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL": "http://localhost:1234",
+			},
+			errContains: "requires an audience",
+		},
+		{
+			name: "no org",
+			values: map[string]string{
+				"REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL": "http://localhost:1234",
+				"REDPANDA_CLOUD_GATEWAY_JWT_AUDIENCE":   "foo",
+			},
+			errContains: "requires an org",
+		},
+		{
+			name: "invalid issuer url",
+			values: map[string]string{
+				"REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL":      "::://nahnope",
+				"REDPANDA_CLOUD_GATEWAY_JWT_AUDIENCE":        "foo",
+				"REDPANDA_CLOUD_GATEWAY_JWT_ORGANIZATION_ID": "bar",
+			},
+			errContains: "missing protocol scheme",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.values {
+				t.Setenv(k, v)
+			}
+
+			_, err := gateway.NewRPJWTMiddleware(nil)
+			if test.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			}
+		})
+	}
+}

--- a/internal/gateway/jwt_validator.go
+++ b/internal/gateway/jwt_validator.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -24,14 +25,15 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-type rpjwtConfig struct {
-	enabled   bool
-	issuerURL string
-	audience  string
-	orgID     string
-}
+const (
+	rpEnvJWTIssuer   = "REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL"
+	rpEnvJWTAudience = "REDPANDA_CLOUD_GATEWAY_JWT_AUDIENCE"
+	rpEnvJWTOrgID    = "REDPANDA_CLOUD_GATEWAY_JWT_ORGANIZATION_ID"
+)
 
-type rpJWTValidatorMiddleware struct {
+// RPJWTMiddleware implements a custom JWT validation for the RP platform that
+// ensures a given request matches a specified organisation and audience.
+type RPJWTMiddleware struct {
 	logger       *service.Logger
 	jwtValidator *validator.Validator
 	orgID        string
@@ -39,14 +41,26 @@ type rpJWTValidatorMiddleware struct {
 	validationCache *cache.Cache[string, *validator.ValidatedClaims]
 }
 
-func newRPJWTValidatorMiddleware(_ context.Context, log *service.Logger, conf rpjwtConfig) (*rpJWTValidatorMiddleware, error) {
-	if !conf.enabled {
+// NewRPJWTMiddleware creates a new RP JWT middleware.
+func NewRPJWTMiddleware(log *service.Logger) (*RPJWTMiddleware, error) {
+	issuerURLStr := os.Getenv(rpEnvJWTIssuer)
+	if issuerURLStr == "" {
 		return nil, nil
 	}
 
-	issuerURL, err := url.Parse(conf.issuerURL)
+	audience := os.Getenv(rpEnvJWTAudience)
+	if audience == "" {
+		return nil, fmt.Errorf("gateway JWT authentication requires an audience set via %v", rpEnvJWTAudience)
+	}
+
+	orgID := os.Getenv(rpEnvJWTOrgID)
+	if orgID == "" {
+		return nil, fmt.Errorf("gateway JWT authentication requires an organisation ID set via %v", rpEnvJWTOrgID)
+	}
+
+	issuerURL, err := url.Parse(issuerURLStr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse issuer URL: %w", err)
+		return nil, fmt.Errorf("failed to parse gateway JWT issuer URL: %w", err)
 	}
 
 	provider := jwks.NewCachingProvider(issuerURL, time.Minute)
@@ -55,7 +69,7 @@ func newRPJWTValidatorMiddleware(_ context.Context, log *service.Logger, conf rp
 		provider.KeyFunc,
 		validator.RS256,
 		issuerURL.String(),
-		[]string{conf.audience},
+		[]string{audience},
 		validator.WithAllowedClockSkew(time.Minute),
 		validator.WithCustomClaims(
 			func() validator.CustomClaims {
@@ -67,10 +81,10 @@ func newRPJWTValidatorMiddleware(_ context.Context, log *service.Logger, conf rp
 		return nil, errors.New("failed to set up the jwt validator")
 	}
 
-	return &rpJWTValidatorMiddleware{
+	return &RPJWTMiddleware{
 		logger:       log,
 		jwtValidator: jwtValidator,
-		orgID:        conf.orgID,
+		orgID:        orgID,
 
 		validationCache: cache.New[string, *validator.ValidatedClaims](cache.MaxAge(10*time.Second), cache.MaxErrorAge(time.Second)),
 	}, nil
@@ -87,7 +101,9 @@ func (r *rpCustomClaims) Validate(_ context.Context) error {
 	return nil
 }
 
-func (r *rpJWTValidatorMiddleware) wrap(next http.Handler) http.Handler {
+// Wrap a handler with JWT validation. Any request that fails validation will
+// be rejected and next will not be called.
+func (r *RPJWTMiddleware) Wrap(next http.Handler) http.Handler {
 	if r == nil {
 		return next
 	}
@@ -100,7 +116,7 @@ func (r *rpJWTValidatorMiddleware) wrap(next http.Handler) http.Handler {
 		}
 
 		var claims *validator.ValidatedClaims
-		if claims, err = r.ValidateToken(req.Context(), authToken); err != nil {
+		if claims, err = r.validateToken(req.Context(), authToken); err != nil {
 			r.logger.With("error", err).Error("Authentication token was not valid")
 			http.Error(w, "authentication token was invalid", http.StatusBadRequest)
 			return
@@ -137,7 +153,7 @@ func extractAuthenticationToken(r *http.Request) (string, error) {
 	return authHeaderParts[1], nil
 }
 
-func (r *rpJWTValidatorMiddleware) ValidateToken(ctx context.Context, tokenString string) (*validator.ValidatedClaims, error) {
+func (r *RPJWTMiddleware) validateToken(ctx context.Context, tokenString string) (*validator.ValidatedClaims, error) {
 	parsedToken, err, _ := r.validationCache.Get(tokenString, func() (*validator.ValidatedClaims, error) {
 		parsedToken, err := r.jwtValidator.ValidateToken(ctx, tokenString)
 		if err != nil {

--- a/internal/impl/gateway/input.go
+++ b/internal/impl/gateway/input.go
@@ -228,7 +228,7 @@ func InputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*Inpu
 		mgr:     mgr,
 		batches: make(chan batchAndAck),
 	}
-	if h.rpJWTValidator, err = gateway.NewRPJWTMiddleware(mgr.Logger()); err != nil {
+	if h.rpJWTValidator, err = gateway.NewRPJWTMiddleware(mgr); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/gateway/input.go
+++ b/internal/impl/gateway/input.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Jeffail/shutdown"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/gateway"
 )
 
 const (
@@ -49,9 +50,8 @@ type hsiConfig struct {
 	Response  hsiResponseConfig
 
 	// Set via environment variables
-	Address        string
-	RPJWTValidator rpjwtConfig
-	CORS           corsConfig
+	Address string
+	CORS    corsConfig
 }
 
 type corsConfig struct {
@@ -91,21 +91,12 @@ func hsiConfigFromParsed(pConf *service.ParsedConfig) (conf hsiConfig, err error
 
 const (
 	rpEnvAddress     = "REDPANDA_CLOUD_GATEWAY_ADDRESS"
-	rpEnvJWTIssuer   = "REDPANDA_CLOUD_GATEWAY_JWT_ISSUER_URL"
-	rpEnvJWTAudience = "REDPANDA_CLOUD_GATEWAY_JWT_AUDIENCE"
-	rpEnvJWTOrgID    = "REDPANDA_CLOUD_GATEWAY_JWT_ORGANIZATION_ID"
 	rpEnvCorsOrigins = "REDPANDA_CLOUD_GATEWAY_CORS_ORIGINS"
 )
 
 func (h *hsiConfig) applyEnvVarOverrides() error {
 	if h.Address = os.Getenv(rpEnvAddress); h.Address == "" {
 		return errors.New("an address must be specified via env var for this input to be functional")
-	}
-
-	if h.RPJWTValidator.issuerURL = os.Getenv(rpEnvJWTIssuer); h.RPJWTValidator.issuerURL != "" {
-		h.RPJWTValidator.enabled = true
-		h.RPJWTValidator.audience = os.Getenv(rpEnvJWTAudience)
-		h.RPJWTValidator.orgID = os.Getenv(rpEnvJWTOrgID)
 	}
 
 	if v := os.Getenv(rpEnvCorsOrigins); v != "" {
@@ -212,7 +203,7 @@ type Input struct {
 	mux    *mux.Router
 	server *http.Server
 
-	rpJWTValidator *rpJWTValidatorMiddleware
+	rpJWTValidator *gateway.RPJWTMiddleware
 
 	batches chan batchAndAck
 
@@ -237,6 +228,9 @@ func InputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*Inpu
 		mgr:     mgr,
 		batches: make(chan batchAndAck),
 	}
+	if h.rpJWTValidator, err = gateway.NewRPJWTMiddleware(mgr.Logger()); err != nil {
+		return nil, err
+	}
 
 	if h.conf.RateLimit != "" {
 		if !h.mgr.HasRateLimit(h.conf.RateLimit) {
@@ -252,33 +246,23 @@ func InputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*Inpu
 func (ri *Input) createHandler() (h http.Handler) {
 	h = http.HandlerFunc(ri.deliverHandler)
 	h = gzipHandler(h)
-	h = ri.rpJWTValidator.wrap(h)
+	h = ri.rpJWTValidator.Wrap(h)
 	h = ri.conf.CORS.WrapHandler(h)
 	return
 }
 
 // RegisterCustomMux adds the server endpoint to a mux instead of running its
 // own server, this is for testing purposes only.
-func (ri *Input) RegisterCustomMux(ctx context.Context, mux *mux.Router) error {
-	var err error
-	if ri.rpJWTValidator, err = newRPJWTValidatorMiddleware(ctx, ri.log, ri.conf.RPJWTValidator); err != nil {
-		return err
-	}
-
+func (ri *Input) RegisterCustomMux(mux *mux.Router) error {
 	mux.PathPrefix(ri.conf.Path).Handler(ri.createHandler())
 	return nil
 }
 
 // Connect attempts to run a server with the appropriate endpoints registered
 // for receiving data.
-func (ri *Input) Connect(ctx context.Context) error {
+func (ri *Input) Connect(_ context.Context) error {
 	if ri.server != nil {
 		return nil
-	}
-
-	var err error
-	if ri.rpJWTValidator, err = newRPJWTValidatorMiddleware(ctx, ri.log, ri.conf.RPJWTValidator); err != nil {
-		return err
 	}
 
 	ri.mux = mux.NewRouter()

--- a/internal/impl/gateway/input_test.go
+++ b/internal/impl/gateway/input_test.go
@@ -46,7 +46,7 @@ path: /testpost
 	h, err := gateway.InputFromParsed(pConf, service.MockResources())
 	require.NoError(t, err)
 
-	require.NoError(t, h.RegisterCustomMux(tCtx, mux))
+	require.NoError(t, h.RegisterCustomMux(mux))
 
 	server := httptest.NewServer(mux)
 	defer server.Close()
@@ -100,7 +100,7 @@ path: /testpost
 	h, err := gateway.InputFromParsed(pConf, service.MockResources())
 	require.NoError(t, err)
 
-	require.NoError(t, h.RegisterCustomMux(tCtx, mux))
+	require.NoError(t, h.RegisterCustomMux(mux))
 
 	server := httptest.NewServer(mux)
 	defer server.Close()

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -153,7 +153,7 @@ func NewServer(
 
 	license.RegisterService(resources, licenseConfig)
 
-	rpJWT, err := gateway.NewRPJWTMiddleware(service.NewLoggerFromSlog(logger))
+	rpJWT, err := gateway.NewRPJWTMiddleware(resources)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR moves the JWT validation that we use in cloud to a separate package and adds it to the mcp-server subcommand whenever we're running an HTTP server.