### PR TITLE
Adjust `redpanda_migrator_offsets` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - New `mcp-server lint` subcommand for linting config directories. (@Jeffail)
 - (Benthos) CLI flag `--env-file` added to the `blobl` command. (@mihaitodor)
 - The `mcp-server` subcommand now supports the new streamable HTTP spec when the `address` flag is specified. (@Jeffail)
+- Field `poll_interval` added to the `redpanda_migrator_offsets` input. (@mihaitodor)
+- Field `consumer_group_offsets_poll_interval` added to the `redpanda_migrator_bundle` input. (@mihaitodor)
 
 ### Fixed
 
@@ -20,6 +22,11 @@ All notable changes to this project will be documented in this file.
 - Fixed an issue where the `mongodb_cdc` inputs could have spurious errors when collections had no writes for > 30 seconds. (@rockwotj)
 - Fixed a regression bug when configuring TLS for the Schema Registry client used by the `schema_registry` input and output and the `schema_registry_decode` and `schema_registry_encode` processors. This was introduced via [#3135](https://github.com/redpanda-data/connect/pull/3135) in [v4.46.0](https://github.com/redpanda-data/connect/releases/tag/v4.46.0).(@mihaitodor)
 - (Benthos) Fixed a regression bug where the `echo` and `lint` commands no longer loaded environment variables. (@mihaitodor)
+
+### Changed
+
+- The `redpanda_migrator_offsets` input now polls the `OffsetFetch` API instead of reading from the `__consumer_offsets` topic. (@mihaitodor)
+- Fields `consumer_group`, `commit_period`, `partition_buffer_bytes`, `topic_lag_refresh_period`, and `max_yield_batch_bytes` for the `redpanda_migrator_offsets` input are now deprecated. (@mihaitodor)
 
 ## 4.55.1 - 2025-05-19
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
@@ -33,6 +33,7 @@ input:
     redpanda_migrator: {} # No default (required)
     schema_registry: {} # No default (required)
     migrate_schemas_before_data: true
+    consumer_group_offsets_poll_interval: 15s
 ```
 
 All-in-one input which reads messages and schemas from a Kafka or Redpanda cluster. This input is meant to be used
@@ -65,5 +66,14 @@ Migrate all schemas first before starting to migrate data.
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `consumer_group_offsets_poll_interval`
+
+Duration between OffsetFetch polling attempts in redpanda_migrator_offsets input.
+
+
+*Type*: `string`
+
+*Default*: `"15s"`
 
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -42,7 +42,6 @@ input:
     seed_brokers: [] # No default (required)
     topics: [] # No default (required)
     regexp_topics: false
-    consumer_group: "" # No default (optional)
     auto_replay_nacks: true
 ```
 
@@ -72,35 +71,20 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
-    consumer_group: "" # No default (optional)
-    commit_period: 5s
-    partition_buffer_bytes: 1MB
-    topic_lag_refresh_period: 5s
-    max_yield_batch_bytes: 32KB
+    poll_interval: 15s
     auto_replay_nacks: true
 ```
 
 --
 ======
 
-This input reads consumer group updates from the `__consumer_offsets` topic and should be used in combination with the `redpanda_migrator_offsets` output.
-
-== Metrics
-
-Emits a `redpanda_lag` metric with `topic` and `partition` labels for each consumed topic.
+This input reads consumer group updates via the `OffsetFetch` API and should be used in combination with the `redpanda_migrator_offsets` output.
 
 == Metadata
 
 This input adds the following metadata fields to each message:
 
 ```text
-- kafka_key
-- kafka_topic
-- kafka_partition
-- kafka_offset
-- kafka_timestamp_unix
-- kafka_timestamp_ms
-- kafka_tombstone_message
 - kafka_offset_topic
 - kafka_offset_group
 - kafka_offset_partition
@@ -547,49 +531,14 @@ A rack specifies where the client is physically located and changes fetch reques
 
 *Default*: `""`
 
-=== `consumer_group`
+=== `poll_interval`
 
-An optional consumer group to consume as. When specified the partitions of specified topics are automatically distributed across consumers sharing a consumer group, and partition offsets are automatically committed and resumed under this name. Consumer groups are not supported when specifying explicit partitions to consume from in the `topics` field.
-
-
-*Type*: `string`
-
-
-=== `commit_period`
-
-The period of time between each commit of the current partition offsets. Offsets are always committed during shutdown.
+Duration between OffsetFetch polling attempts.
 
 
 *Type*: `string`
 
-*Default*: `"5s"`
-
-=== `partition_buffer_bytes`
-
-A buffer size (in bytes) for each consumed partition, allowing records to be queued internally before flushing. Increasing this may improve throughput at the cost of higher memory utilisation. Note that each buffer can grow slightly beyond this value.
-
-
-*Type*: `string`
-
-*Default*: `"1MB"`
-
-=== `topic_lag_refresh_period`
-
-The period of time between each topic lag refresh cycle.
-
-
-*Type*: `string`
-
-*Default*: `"5s"`
-
-=== `max_yield_batch_bytes`
-
-The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.
-
-
-*Type*: `string`
-
-*Default*: `"32KB"`
+*Default*: `"15s"`
 
 === `auto_replay_nacks`
 

--- a/internal/impl/kafka/franz_reader_ordered.go
+++ b/internal/impl/kafka/franz_reader_ordered.go
@@ -37,7 +37,7 @@ const (
 	kroFieldCommitPeriod          = "commit_period"
 	kroFieldPartitionBuffer       = "partition_buffer_bytes"
 	kroFieldTopicLagRefreshPeriod = "topic_lag_refresh_period"
-	kroFieldBatchMaxSize          = "max_yield_batch_bytes"
+	kroFieldMaxYieldBatchBytes    = "max_yield_batch_bytes"
 )
 
 // FranzReaderOrderedConfigFields returns config fields for customising the
@@ -59,7 +59,7 @@ func FranzReaderOrderedConfigFields() []*service.ConfigField {
 			Description("The period of time between each topic lag refresh cycle.").
 			Default("5s").
 			Advanced(),
-		service.NewStringField(kroFieldBatchMaxSize).
+		service.NewStringField(kroFieldMaxYieldBatchBytes).
 			Description("The maximum size (in bytes) for each batch yielded by this input. When routed to a redpanda output without modification this would roughly translate to the batch.bytes config field of a traditional producer.").
 			Default("32KB").
 			Advanced(),
@@ -117,7 +117,7 @@ func NewFranzReaderOrderedFromConfig(conf *service.ParsedConfig, res *service.Re
 		return nil, err
 	}
 
-	if f.batchMaxSize, err = bytesFromStrField(kroFieldBatchMaxSize, conf); err != nil {
+	if f.batchMaxSize, err = bytesFromStrField(kroFieldMaxYieldBatchBytes, conf); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -978,7 +978,7 @@ func checkTopic(t *testing.T, brokerAddr, topic, retentionTime, principal string
 
 	aclResults, err := adm.DescribeACLs(t.Context(), builder)
 	require.NoError(t, err)
-	require.Len(t, aclResults[0].Described, 1)
+	require.Len(t, aclResults, 1)
 	require.NoError(t, aclResults[0].Err)
 	require.Len(t, aclResults[0].Described, 1)
 
@@ -1434,8 +1434,12 @@ func TestRedpandaMigratorTopicConfigAndACLsIntegration(t *testing.T) {
 
 	source, err := redpandatest.StartRedpanda(t, pool, true, true)
 	require.NoError(t, err)
+
 	destination, err := redpandatest.StartRedpanda(t, pool, true, true)
 	require.NoError(t, err)
+
+	t.Logf("Source broker: %s", source.BrokerAddr)
+	t.Logf("Destination broker: %s", destination.BrokerAddr)
 
 	dummyTopic := "test"
 

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -1002,7 +1002,6 @@ input:
                   kafka_offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
                   kafka_offset_metadata:         ${! @kafka_offset_metadata }
                   kafka_is_high_watermark:       ${! @kafka_is_high_watermark }
-                  kafka_offset:                  ${! @kafka_offset } # This is just the offset of the __consumer_offsets topic
         - check: '@input_label == "redpanda_migrator_input"'
           processors:
             - branch:

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -136,7 +136,7 @@ func createKafkaTopicSasl(address, id string, partitions int32) error {
 	return nil
 }
 
-func TestIntegrationRedpanda(t *testing.T) {
+func TestRedpandaIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 	t.Parallel()
 
@@ -289,7 +289,7 @@ input:
 	})
 }
 
-func TestRedpandaRecordOrder(t *testing.T) {
+func TestRedpandaRecordOrderIntegration(t *testing.T) {
 	// This test checks for out-of-order records being transferred between two Redpanda containers using the `redpanda`
 	// input and output with default settings. It used to fail occasionally before this fix was put in place:
 	// https://github.com/redpanda-data/connect/pull/3386.
@@ -414,7 +414,7 @@ output:
 	}, 30*time.Second, 1*time.Nanosecond)
 }
 
-func TestIntegrationRedpandaSasl(t *testing.T) {
+func TestRedpandaSaslIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 	t.Parallel()
 
@@ -522,7 +522,7 @@ input:
 	)
 }
 
-func TestIntegrationRedpandaOutputFixedTimestamp(t *testing.T) {
+func TestRedpandaOutputFixedTimestampIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 	t.Parallel()
 
@@ -595,7 +595,7 @@ input:
 	)
 }
 
-func BenchmarkIntegrationRedpanda(b *testing.B) {
+func BenchmarkRedpandaIntegration(b *testing.B) {
 	integration.CheckSkip(b)
 
 	pool, err := dockertest.NewPool("")

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -138,7 +138,6 @@ func createKafkaTopicSasl(address, id string, partitions int32) error {
 
 func TestRedpandaIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -216,7 +215,6 @@ input:
 	)
 
 	t.Run("only one partition", func(t *testing.T) {
-		t.Parallel()
 		suite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
@@ -229,7 +227,6 @@ input:
 	})
 
 	t.Run("explicit partitions", func(t *testing.T) {
-		t.Parallel()
 		suite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
@@ -243,7 +240,6 @@ input:
 		)
 
 		t.Run("range of partitions", func(t *testing.T) {
-			t.Parallel()
 			suite.Run(
 				t, template,
 				integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
@@ -416,7 +412,6 @@ output:
 
 func TestRedpandaSaslIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -524,7 +519,6 @@ input:
 
 func TestRedpandaOutputFixedTimestampIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -675,7 +669,6 @@ input:
 
 func TestSchemaRegistryIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -831,7 +824,6 @@ output:
 
 func TestSchemaRegistryIDTranslationIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -1194,7 +1186,6 @@ output:
 
 func TestRedpandaMigratorIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -1285,7 +1276,6 @@ func TestRedpandaMigratorIntegration(t *testing.T) {
 
 func TestRedpandaMigratorOffsetsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	tests := []struct {
 		name          string
@@ -1309,8 +1299,6 @@ func TestRedpandaMigratorOffsetsIntegration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
 			pool, err := dockertest.NewPool("")
 			require.NoError(t, err)
 			pool.MaxWait = time.Minute
@@ -1426,7 +1414,6 @@ output:
 
 func TestRedpandaMigratorOffsetsNonMonotonicallyIncreasingTimestampsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -1528,7 +1515,6 @@ output:
 
 func TestRedpandaMigratorTopicConfigAndACLsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -1681,7 +1667,6 @@ func fetchRecordKeys(t *testing.T, brokerAddress, topic, consumerGroup string, c
 // messages (even if it receives duplicates).
 func TestRedpandaMigratorConsumerGroupConsistencyIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Parallel()
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)

--- a/internal/impl/kafka/redpanda_migrator_bundle_input.tmpl.yaml
+++ b/internal/impl/kafka/redpanda_migrator_bundle_input.tmpl.yaml
@@ -41,6 +41,13 @@ fields:
     description: |
       Migrate all schemas first before starting to migrate data.
 
+  - name: consumer_group_offsets_poll_interval
+    type: string
+    kind: scalar
+    default: 15s
+    description: |
+      Duration between OffsetFetch polling attempts in redpanda_migrator_offsets input.
+
 mapping: |
   #!blobl
 
@@ -48,7 +55,22 @@ mapping: |
 
   let redpandaMigrator = this.redpanda_migrator.assign({"output_resource": "%s_redpanda_migrator_output".format($labelPrefix)})
 
-  let redpandaMigratorOffsets = this.redpanda_migrator.with("seed_brokers", "topics", "regexp_topics", "consumer_group", "topic_lag_refresh_period", "client_id", "rack_id", "tls", "sasl")
+  let redpandaMigratorOffsets = this.redpanda_migrator.with(
+    "seed_brokers",
+    "topics",
+    "regexp_topics",
+    "consumer_group",
+    "topic_lag_refresh_period",
+    "client_id",
+    "rack_id",
+    "tls",
+    "sasl").assign(
+      if this.exists("consumer_group_offsets_poll_interval") {
+        {"poll_interval": this.consumer_group_offsets_poll_interval}
+      } else {
+        {}
+      }
+    )
 
   root = if this.redpanda_migrator.length() == 0 {
     throw("the redpanda_migrator input must be configured")
@@ -163,6 +185,7 @@ tests:
               seed_brokers: [ "127.0.0.1:9092" ]
               topics: [ "foobar" ]
               consumer_group: "migrator"
+              poll_interval: "15s"
             processors:
               - mapping: meta input_label = "redpanda_migrator_offsets_input"
 
@@ -207,6 +230,7 @@ tests:
                     seed_brokers: [ "127.0.0.1:9092" ]
                     topics: [ "foobar" ]
                     consumer_group: "migrator"
+                    poll_interval: "15s"
                   processors:
                     - mapping: meta input_label = "redpanda_migrator_offsets_input"
 
@@ -233,5 +257,6 @@ tests:
               seed_brokers: [ "127.0.0.1:9092" ]
               topics: [ "foobar" ]
               consumer_group: "migrator"
+              poll_interval: "15s"
             processors:
               - mapping: meta input_label = "redpanda_migrator_offsets_input"

--- a/internal/impl/kafka/redpanda_migrator_output.go
+++ b/internal/impl/kafka/redpanda_migrator_output.go
@@ -260,7 +260,6 @@ func init() {
 									cfg.destTopic = destTopic
 									if err := createTopic(ctx, mgr.Logger(), inputClient, outputClient, cfg); err != nil {
 										if errors.Is(err, kerr.TopicAlreadyExists) {
-											topicCache.Store(topic, struct{}{})
 											mgr.Logger().Debugf("Topic %q already exists", topic)
 										} else {
 											// This may be a topic which doesn't have any messages in it, so if we
@@ -268,16 +267,17 @@ func init() {
 											// messages, we'll attempt to create it again anyway when receiving a
 											// message from it.
 											mgr.Logger().Errorf("Failed to create topic %q and ACLs: %s", topic, err)
+											continue
 										}
 									} else {
 										mgr.Logger().Infof("Created topic %q", destTopic)
-
-										if err := createACLs(ctx, topic, destTopic, inputClient, outputClient); err != nil {
-											mgr.Logger().Errorf("Failed to create ACLs for topic %q: %s", topic, err)
-										}
-
-										topicCache.Store(topic, struct{}{})
 									}
+
+									if err := createACLs(ctx, topic, destTopic, inputClient, outputClient); err != nil {
+										mgr.Logger().Errorf("Failed to create ACLs for topic %q: %s", topic, err)
+									}
+
+									topicCache.Store(topic, struct{}{})
 								}
 
 								return nil


### PR DESCRIPTION
This change switches the `redpanda_migrator_offsets` input implementation to a poll-based mechanism which queries the source broker consumer groups periodically and emits updates when changes are detected.

Also, a new test is added to assert behaviour for non-monotonically increasing timestamps. As expected, `ListOffsetsAfterMilli` will return the offset of the first record which has the specified timestamp (or newer), so, if record timestamps are not always increasing, consumer groups migration will lead to duplicate records for consumers. Assuming that timestamps do increase eventually, the number of duplicates is limited.