### PR TITLE
feat: add extra metadata for pubsub input

### DIFF
--- a/docs/modules/components/pages/inputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/inputs/gcp_pubsub.adoc
@@ -79,6 +79,8 @@ This input adds the following metadata fields to each message:
 
 - gcp_pubsub_publish_time_unix - The time at which the message was published to the topic.
 - gcp_pubsub_delivery_attempt - When dead lettering is enabled, this is set to the number of times PubSub has attempted to deliver a message.
+- gcp_pubsub_message_id - The unique identifier of the message.
+- gcp_pubsub_ordering_key - The ordering key of the message.
 - All message attributes
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].

--- a/internal/impl/gcp/input_pubsub_test.go
+++ b/internal/impl/gcp/input_pubsub_test.go
@@ -1,0 +1,110 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestGCPPubSubReaderRead(t *testing.T) {
+	t.Run("respects context cancellation", func(t *testing.T) {
+		reader := &gcpPubSubReader{
+			msgsChan: make(chan *pubsub.Message),
+			log:      service.MockResources().Logger(),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, _, err := reader.Read(ctx)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("returns ErrNotConnected when msgsChan is nil", func(t *testing.T) {
+		reader := &gcpPubSubReader{
+			msgsChan: nil,
+			log:      service.MockResources().Logger(),
+		}
+
+		_, _, err := reader.Read(context.Background())
+		assert.Equal(t, service.ErrNotConnected, err)
+	})
+
+	t.Run("returns ErrNotConnected when channel is closed", func(t *testing.T) {
+		ch := make(chan *pubsub.Message)
+		close(ch)
+
+		reader := &gcpPubSubReader{
+			msgsChan: ch,
+			log:      service.MockResources().Logger(),
+		}
+
+		_, _, err := reader.Read(context.Background())
+		assert.Equal(t, service.ErrNotConnected, err)
+	})
+
+	t.Run("correctly processes message", func(t *testing.T) {
+		ch := make(chan *pubsub.Message, 1)
+
+		publishTime := time.Now()
+		deliveryAttempt := int(3)
+
+		// Create a pubsub message with test data
+		psMsg := &pubsub.Message{
+			Data:            []byte("test data"),
+			ID:              "test-id",
+			PublishTime:     publishTime,
+			Attributes:      map[string]string{"key1": "value1", "key2": "value2"},
+			DeliveryAttempt: &deliveryAttempt,
+			OrderingKey:     "test-ordering-key",
+		}
+
+		ch <- psMsg
+
+		reader := &gcpPubSubReader{
+			msgsChan: ch,
+			log:      service.MockResources().Logger(),
+		}
+
+		msg, ackFn, err := reader.Read(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		require.NotNil(t, ackFn)
+
+		data, err := msg.AsBytes()
+		assert.NoError(t, err)
+		// Verify message content
+		assert.Equal(t, "test data", string(data))
+
+		// Verify metadata
+		metaValue, found := msg.MetaGet("key1")
+		require.True(t, found)
+		assert.Equal(t, "value1", metaValue)
+
+		metaValue, found = msg.MetaGet("key2")
+		require.True(t, found)
+		assert.Equal(t, "value2", metaValue)
+
+		metaValue, found = msg.MetaGet(metaMessageID)
+		require.True(t, found)
+		assert.Equal(t, "test-id", metaValue)
+
+		gotTime, found := msg.MetaGetMut(metaPublishTimeUnix)
+		require.True(t, found)
+		assert.Equal(t, publishTime.Unix(), gotTime.(int64))
+
+		metaValue, found = msg.MetaGet(metaDeliveryAttempt)
+		require.True(t, found)
+		assert.Equal(t, "3", metaValue)
+
+		metaValue, found = msg.MetaGet(metaOrderingKey)
+		require.True(t, found)
+		assert.Equal(t, "test-ordering-key", metaValue)
+	})
+}

--- a/internal/impl/gcp/input_pubsub_test.go
+++ b/internal/impl/gcp/input_pubsub_test.go
@@ -19,7 +19,7 @@ func TestGCPPubSubReaderRead(t *testing.T) {
 			log:      service.MockResources().Logger(),
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		_, _, err := reader.Read(ctx)
@@ -32,7 +32,7 @@ func TestGCPPubSubReaderRead(t *testing.T) {
 			log:      service.MockResources().Logger(),
 		}
 
-		_, _, err := reader.Read(context.Background())
+		_, _, err := reader.Read(t.Context())
 		assert.Equal(t, service.ErrNotConnected, err)
 	})
 
@@ -45,7 +45,7 @@ func TestGCPPubSubReaderRead(t *testing.T) {
 			log:      service.MockResources().Logger(),
 		}
 
-		_, _, err := reader.Read(context.Background())
+		_, _, err := reader.Read(t.Context())
 		assert.Equal(t, service.ErrNotConnected, err)
 	})
 
@@ -72,7 +72,7 @@ func TestGCPPubSubReaderRead(t *testing.T) {
 			log:      service.MockResources().Logger(),
 		}
 
-		msg, ackFn, err := reader.Read(context.Background())
+		msg, ackFn, err := reader.Read(t.Context())
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 		require.NotNil(t, ackFn)


### PR DESCRIPTION
Add in message metadata for pubsub input where missing.
Updated docs.
Added unit tests to validate changes

resolves #3465