### PR TITLE
Add --chroot flag that allows to chroot after parsing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## TBD
+
+### Added
+
+- New global CLI flag `--chroot`. (@mmatczuk) 
+
 ## 4.56.0 - 2025-06-05
 
 ### Added

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -26,6 +26,7 @@ func agentCli(rpMgr *enterprise.GlobalRedpandaManager) *cli.Command {
 	flags := []cli.Flag{
 		secretsFlag,
 		licenseFlag,
+		chrootFlag,
 	}
 
 	return &cli.Command{

--- a/internal/cli/chroot.go
+++ b/internal/cli/chroot.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package cli
+
+import (
+	"syscall"
+)
+
+// chroot changes the root directory to the provided path and then changes
+// the current directory to "/".
+//
+// NOTE: This function will only work if the binary is running with
+// sufficient privileges to call syscall.Chroot. If the binary does not
+// have the necessary privileges, this function will return an error.
+func chroot(path string) error {
+	if err := syscall.Chroot(path); err != nil {
+		return err
+	}
+	if err := syscall.Chdir("/"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/flags_redpanda.go
+++ b/internal/cli/flags_redpanda.go
@@ -72,6 +72,11 @@ func applyLicenseFlag(c *cli.Context, conf *license.Config) {
 	}
 }
 
+var chrootFlag = &cli.StringFlag{
+	Name:  "chroot",
+	Usage: "Chroot into the provided directory, after parsing configuration.",
+}
+
 func redpandaFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{

--- a/internal/cli/flags_redpanda.go
+++ b/internal/cli/flags_redpanda.go
@@ -45,6 +45,15 @@ var secretsFlag = &cli.StringSliceFlag{
 	Value: cli.NewStringSlice("env:"),
 }
 
+func parseSecretsFlag(logger *slog.Logger, c *cli.Context) (func(context.Context, string) (string, bool), error) {
+	if secretsURNs := c.StringSlice("secrets"); len(secretsURNs) > 0 {
+		return secrets.ParseLookupURNs(c.Context, logger, secretsURNs...)
+	}
+	return func(_ context.Context, _ string) (string, bool) {
+		return "", false
+	}, nil
+}
+
 var licenseFlag = &cli.StringFlag{
 	Name:  "redpanda-license",
 	Usage: "Provide an explicit Redpanda License, which enables enterprise functionality. By default licenses found at the path `/etc/redpanda/redpanda.license` are applied.",
@@ -61,15 +70,6 @@ func applyLicenseFlag(c *cli.Context, conf *license.Config) {
 	if inline := c.String("redpanda-license"); inline != "" {
 		conf.License = inline
 	}
-}
-
-func parseSecretsFlag(logger *slog.Logger, c *cli.Context) (func(context.Context, string) (string, bool), error) {
-	if secretsURNs := c.StringSlice("secrets"); len(secretsURNs) > 0 {
-		return secrets.ParseLookupURNs(c.Context, logger, secretsURNs...)
-	}
-	return func(context.Context, string) (string, bool) {
-		return "", false
-	}, nil
 }
 
 func redpandaFlags() []cli.Flag {

--- a/internal/cli/mcp_server.go
+++ b/internal/cli/mcp_server.go
@@ -36,6 +36,7 @@ func mcpServerCli(rpMgr *enterprise.GlobalRedpandaManager) *cli.Command {
 		secretsFlag,
 		envFileFlag,
 		licenseFlag,
+		chrootFlag,
 	}
 
 	return &cli.Command{

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -18,6 +18,8 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 RUN useradd -u 10001 connect
 
+RUN apt-get update && apt-get install -y libcap2-bin
+
 WORKDIR /go/src/github.com/redpanda-data/connect/
 # Update dependencies: On unchanged dependencies, cached layer will be reused
 COPY go.* /go/src/github.com/redpanda-data/connect/
@@ -28,6 +30,7 @@ COPY . /go/src/github.com/redpanda-data/connect/
 # Tag timetzdata required for busybox base image:
 # https://github.com/benthosdev/benthos/issues/897
 RUN make TAGS="timetzdata" redpanda-connect
+RUN setcap 'cap_sys_chroot=+ep' target/bin/redpanda-connect
 
 # Pack
 FROM busybox AS package

--- a/resources/docker/Dockerfile.ai
+++ b/resources/docker/Dockerfile.ai
@@ -12,6 +12,8 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 RUN useradd -u 10001 connect
 
+RUN apt-get update && apt-get install -y libcap2-bin
+
 WORKDIR /go/src/github.com/redpanda-data/connect/
 # Update dependencies: On unchanged dependencies, cached layer will be reused
 COPY go.* /go/src/github.com/redpanda-data/connect/
@@ -22,6 +24,7 @@ COPY . /go/src/github.com/redpanda-data/connect/
 # Tag timetzdata required for busybox base image:
 # https://github.com/benthosdev/benthos/issues/897
 RUN make TAGS="timetzdata" redpanda-connect-ai
+RUN setcap 'cap_sys_chroot=+ep' target/bin/redpanda-connect-ai
 
 RUN touch /tmp/keep
 

--- a/resources/docker/Dockerfile.cloud
+++ b/resources/docker/Dockerfile.cloud
@@ -12,6 +12,8 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 RUN useradd -u 10001 connect
 
+RUN apt-get update && apt-get install -y libcap2-bin
+
 WORKDIR /go/src/github.com/redpanda-data/connect/
 # Update dependencies: On unchanged dependencies, cached layer will be reused
 COPY go.* /go/src/github.com/redpanda-data/connect/
@@ -22,6 +24,7 @@ COPY . /go/src/github.com/redpanda-data/connect/
 # Tag timetzdata required for busybox base image:
 # https://github.com/benthosdev/benthos/issues/897
 RUN make TAGS="timetzdata" redpanda-connect-cloud
+RUN setcap 'cap_sys_chroot=+ep' target/bin/redpanda-connect-cloud
 
 # Pack
 FROM busybox AS package


### PR DESCRIPTION
Add --chroot flag that allows to chroot after parsing config

Tested manually in official Docker container.

Given file dev.yaml that writes to /data.txt

```
input:
  generate:
    mapping: root = "hello world" # No default (required)
    interval: 1s

output:
  file:
    path: /data.txt
    codec: lines
```

When chroot to /tmp/foo all works

```
$ /redpanda-connect run --chroot /tmp/foo /dev.yaml 
INFO Running main config from specified file       @service=redpanda-connect benthos_version=v4.56.0-3-g80bcd82c3 path=/dev.yaml
INFO Chrooting to '/tmp/foo'                       @service=redpanda-connect
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=redpanda-connect
INFO Successfully loaded Redpanda license          @service=redpanda-connect expires_at="2035-06-07T11:20:43Z" license_org="" license_type="open source"
INFO Launching a Redpanda Connect instance, use CTRL+C to close  @service=redpanda-connect
INFO Input type generate is now active             @service=redpanda-connect label="" path=root.input
INFO Output type file is now active                @service=redpanda-connect label="" path=root.output
^CINFO Received SIGINT, the service is closing       @service=redpanda-connect
```

While normally fails

```
$ /redpanda-connect run /dev.yaml 
INFO Running main config from specified file       @service=redpanda-connect benthos_version=v4.56.0-3-g80bcd82c3 path=/dev.yaml
INFO Successfully loaded Redpanda license          @service=redpanda-connect expires_at="2035-06-07T11:21:08Z" license_org="" license_type="open source"
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=redpanda-connect
INFO Launching a Redpanda Connect instance, use CTRL+C to close  @service=redpanda-connect
INFO Input type generate is now active             @service=redpanda-connect label="" path=root.input
INFO Output type file is now active                @service=redpanda-connect label="" path=root.output
ERRO Failed to send message to file: open /data.txt: permission denied  @service=redpanda-connect label="" path=root.output
ERRO Failed to send message to file: open /data.txt: permission denied  @service=redpanda-connect label="" path=root.output
ERRO Failed to send message to file: open /data.txt: permission denied  @service=redpanda-connect label="" path=root.output
ERRO Failed to send message to file: open /data.txt: permission denied  @service=redpanda-connect label="" path=root.output
^CINFO Received SIGINT, the service is closing       @service=redpanda-connect
```

It does not require any additional capabilities when running.

Fixes CON-100