### PR TITLE
Schema registry decode forward options for protobuf

### DIFF
--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -40,6 +40,11 @@ schema_registry_decode:
     raw_unions: false # No default (optional)
     preserve_logical_types: false
     translate_kafka_connect_types: false
+  protobuf:
+    use_proto_names: false
+    use_enum_numbers: false
+    emit_unpopulated: false
+    emit_default_values: false
   cache_duration: 10m
   url: "" # No default (required)
 ```
@@ -72,6 +77,11 @@ schema_registry_decode:
         }
       }
       root = this.apply("debeziumTimestampToAvroTimestamp")
+  protobuf:
+    use_proto_names: false
+    use_enum_numbers: false
+    emit_unpopulated: false
+    emit_default_values: false
   cache_duration: 10m
   url: "" # No default (required)
   oauth:
@@ -248,6 +258,50 @@ mapping: |2
   }
   root = this.apply("debeziumTimestampToAvroTimestamp")
 ```
+
+=== `protobuf`
+
+Configuration for how to decode schemas that are of type PROTOBUF.
+
+
+*Type*: `object`
+
+
+=== `protobuf.use_proto_names`
+
+Use proto field name instead of lowerCamelCase name.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `protobuf.use_enum_numbers`
+
+Emits enum values as numbers.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `protobuf.emit_unpopulated`
+
+Whether to emit unpopulated fields. It does not emit unpopulated oneof fields or unpopulated extension fields.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `protobuf.emit_default_values`
+
+Whether to emit default-valued primitive fields, empty lists, and empty maps. emit_unpopulated takes precedence over emit_default_values
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `cache_duration`
 

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -262,29 +262,21 @@ func newSchemaRegistryDecoderFromConfig(conf *service.ParsedConfig, mgr *service
 			return nil, err
 		}
 	}
-	if conf.Contains("protobuf", "use_proto_names") {
-		cfg.protobuf.useProtoNames, err = conf.FieldBool("protobuf", "use_proto_names")
-		if err != nil {
-			return nil, err
-		}
+	cfg.protobuf.useProtoNames, err = conf.FieldBool("protobuf", "use_proto_names")
+	if err != nil {
+		return nil, err
 	}
-	if conf.Contains("protobuf", "use_enum_numbers") {
-		cfg.protobuf.useEnumNumbers, err = conf.FieldBool("protobuf", "use_enum_numbers")
-		if err != nil {
-			return nil, err
-		}
+	cfg.protobuf.useEnumNumbers, err = conf.FieldBool("protobuf", "use_enum_numbers")
+	if err != nil {
+		return nil, err
 	}
-	if conf.Contains("protobuf", "emit_unpopulated") {
-		cfg.protobuf.emitUnpopulated, err = conf.FieldBool("protobuf", "emit_unpopulated")
-		if err != nil {
-			return nil, err
-		}
+	cfg.protobuf.emitUnpopulated, err = conf.FieldBool("protobuf", "emit_unpopulated")
+	if err != nil {
+		return nil, err
 	}
-	if conf.Contains("protobuf", "emit_default_values") {
-		cfg.protobuf.emitDefaultValues, err = conf.FieldBool("protobuf", "emit_default_values")
-		if err != nil {
-			return nil, err
-		}
+	cfg.protobuf.emitDefaultValues, err = conf.FieldBool("protobuf", "emit_default_values")
+	if err != nil {
+		return nil, err
 	}
 	cacheDuration, err := conf.FieldDuration("cache_duration")
 	if err != nil {

--- a/internal/impl/confluent/serde_protobuf.go
+++ b/internal/impl/confluent/serde_protobuf.go
@@ -33,7 +33,14 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/protobuf"
 )
 
-func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, schema sr.Schema) (schemaDecoder, error) {
+func (s *schemaRegistryDecoder) getProtobufDecoder(
+	ctx context.Context,
+	useProtoNames bool,
+	useEnumNumbers bool,
+	emitUnpopulated bool,
+	emitDefaultValues bool,
+	schema sr.Schema,
+) (schemaDecoder, error) {
 	regMap := map[string]string{
 		".": schema.Schema,
 	}
@@ -87,7 +94,13 @@ func (s *schemaRegistryDecoder) getProtobufDecoder(ctx context.Context, schema s
 			return fmt.Errorf("failed to unmarshal protobuf message: %w", err)
 		}
 
-		data, err := protojson.MarshalOptions{Resolver: types}.Marshal(dynMsg)
+		data, err := protojson.MarshalOptions{
+			Resolver:          types,
+			UseProtoNames:     useProtoNames,
+			UseEnumNumbers:    useEnumNumbers,
+			EmitUnpopulated:   emitUnpopulated,
+			EmitDefaultValues: emitDefaultValues,
+		}.Marshal(dynMsg)
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON protobuf message: %w", err)
 		}


### PR DESCRIPTION
Adds 4 options for the processor schema_registry_decode that are propagated to the protojson library. This adds flexibility for the deserialisation of protobuf using schema registries. 