### PR TITLE
fix(sftp): clean up unused ssh connections

### DIFF
--- a/internal/impl/sftp/client_pool.go
+++ b/internal/impl/sftp/client_pool.go
@@ -27,7 +27,6 @@ func newClientPool(
 	newSshConn func() (*ssh.Client, error),
 	newClient func(*ssh.Client) (*sftp.Client, error),
 ) (*clientPool, error) {
-
 	cp := clientPool{
 		newSshConn: newSshConn,
 		newClient:  newClient,

--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -177,7 +177,7 @@ func (s *sftpReader) Connect(context.Context) error {
 
 	client, err := newClientPool(
 		func() (*ssh.Client, error) { return s.creds.GetConnection(s.address) },
-		func(conn *ssh.Client) (*sftp.Client, error) { return GetClient(s.mgr.FS(), conn) },
+		func(conn *ssh.Client) (*sftp.Client, error) { return sftp.NewClient(conn) },
 	)
 	if err != nil {
 		if errors.Is(err, sftp.ErrSSHFxConnectionLost) {

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -225,7 +225,11 @@ func getClient(resource *dockertest.Resource) (*sftp.Client, error) {
 		Username: sftpUsername,
 		Password: sftpPassword,
 	}
-	return creds.GetClient(&osPT{}, "localhost:"+resource.GetPort("22/tcp"))
+	sshConn, err := creds.GetConnection("localhost:" + resource.GetPort("22/tcp"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSH connection: %w", err)
+	}
+	return GetClient(&osPT{}, sshConn)
 }
 
 func writeSFTPFile(t *testing.T, client *sftp.Client, path, data string) {

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -229,7 +227,7 @@ func getClient(resource *dockertest.Resource) (*sftp.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SSH connection: %w", err)
 	}
-	return GetClient(&osPT{}, sshConn)
+	return sftp.NewClient(sshConn)
 }
 
 func writeSFTPFile(t *testing.T, client *sftp.Client, path, data string) {
@@ -239,26 +237,4 @@ func writeSFTPFile(t *testing.T, client *sftp.Client, path, data string) {
 	defer file.Close()
 	_, err = fmt.Fprint(file, data, "writing file contents")
 	require.NoError(t, err)
-}
-
-type osPT struct{}
-
-func (*osPT) Open(name string) (fs.File, error) {
-	return os.Open(name)
-}
-
-func (*osPT) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
-	return os.OpenFile(name, flag, perm)
-}
-
-func (*osPT) Stat(name string) (fs.FileInfo, error) {
-	return os.Stat(name)
-}
-
-func (*osPT) Remove(name string) error {
-	return os.Remove(name)
-}
-
-func (*osPT) MkdirAll(path string, perm fs.FileMode) error {
-	return os.MkdirAll(path, perm)
 }

--- a/internal/impl/sftp/output.go
+++ b/internal/impl/sftp/output.go
@@ -133,7 +133,7 @@ func (s *sftpWriter) Connect(context.Context) (err error) {
 	if err != nil {
 		return
 	}
-	s.client, err = GetClient(s.mgr.FS(), s.sshConn)
+	s.client, err = sftp.NewClient(s.sshConn)
 	return
 }
 

--- a/internal/impl/sftp/shared.go
+++ b/internal/impl/sftp/shared.go
@@ -16,10 +16,8 @@ package sftp
 
 import (
 	"fmt"
-	"io/fs"
 	"net"
 
-	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -146,14 +144,6 @@ func (c credentials) GetConnection(address string) (*ssh.Client, error) {
 		return nil, err
 	}
 	return conn, nil
-}
-
-// GetClient creates a new SFTP client on an established SSH connection.
-//
-// All SFTP clients should be closed before closing the underlying SSH
-// connection.
-func GetClient(_ fs.FS, conn *ssh.Client) (*sftp.Client, error) {
-	return sftp.NewClient(conn)
 }
 
 // Server contains connection data for connecting to an SFTP server.


### PR DESCRIPTION
Hi, this is my first PR here so please tell me if I'm missing anything!

fixes #3383 

The current SFTP implementation uses a pooled approach for reusing `sftp.Client` objects, but these client connections sit on top of an underlying `ssh.Client` connection to handle the tcp transport sessions, and the `ssh.Client` instances are never being closed even though the sftp clients on top of them are. This results in an ever-increasing number of idle connections on input SFTP servers over time, and adds memory pressure to the connect service.

This PR proposes a fix for this by:
* lifting the `ssh.Client` pointer up to struct level, so we can close the connections when needed instead of leaving them idling after shutting down the `sftp.Client`s they previously enabled
* replacing the old `GetClient` function with a cimple `sftp.NewClient` call to use our newly-promoted `ssh.Client` connections, since the old setup is now defunct (see [the diff between my first and second commit](https://github.com/redpanda-data/connect/pull/3492/commits/1f39873ad0d55804e6910906b1362b9a3b9c8cfc) to see what that looks like in practice, as this did mean dropping some DI work which wasn't actually in use as far as I can tell!)
* passes all existing unit/integration tests unmodified aside from modifying the client instantiation for the tests in line with the above bullet points
* passes linting, formatting, unit- and integration-testing in line with the 'contributing' guide section on the readme

In my [comment](https://github.com/redpanda-data/connect/issues/3383#issuecomment-2972310260) on the original issue I mentioned we could potentially multiplex SFTP connections over a single SSH transport connection through this kind of change; I've not included that complete functionality here but by promoting the `ssh.Client` object to a struct attribute in our pool we're able to do that kind of work much more easily from here too.