### PR TITLE
Fix missing topic logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - The `sftp` input no longer creates new SSH connections for each file it reads. (@mihaitodor, @TColl)
 - Fixed a bug with the `redpanda_migrator_offsets` output where it was attempting to rewind consumer groups if it got restarted after consumers were migrated to the destination cluster. (@mihaitodor)
+- Fixed an issue where error logs would not be dispatched to topics when the CLI exited with a non-zero status code. (@Jeffail)
 
 ## 4.58.2 - 2025-06-17
 

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -182,6 +182,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 
 	exitCode, err := service.RunCLIToCode(context.Background(), opts...)
 	if err != nil {
+		slog.New(rpMgr.SlogHandler()).With("status", exitCode, "error", err).Error("Pipeline exited with non-zero status")
 		if fbLogger != nil {
 			fbLogger.Error(err.Error())
 		} else {


### PR DESCRIPTION
In cases where a config error means the config itself cannot be parsed (as opposed to a linting error) the logs were not being delivered to the Redpanda logs topic. Turns out there is no "log" event from the cli in this case, it actually just returns a non-zero status with an error type, so I needed to add in an explicit log for the rp manager.