### PR TITLE
Improve field descriptions

### DIFF
--- a/docs/modules/components/pages/inputs/sftp.adoc
+++ b/docs/modules/components/pages/inputs/sftp.adoc
@@ -133,7 +133,7 @@ The credentials to use to log into the target server.
 
 === `credentials.username`
 
-The username to connect to the SFTP server.
+The username to authenticate with the SFTP server.
 
 
 *Type*: `string`
@@ -142,7 +142,7 @@ The username to connect to the SFTP server.
 
 === `credentials.password`
 
-The password for the username to connect to the SFTP server.
+The password for the specified username to connect to the SFTP server.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
@@ -156,7 +156,7 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 === `credentials.host_public_key_file`
 
-The public key of the SFTP server.
+The path to the SFTP server's public key file, used for host key verification.
 
 
 *Type*: `string`
@@ -164,7 +164,7 @@ The public key of the SFTP server.
 
 === `credentials.host_public_key`
 
-The public key file of the SFTP server.
+The raw contents of the SFTP server's public key, used for host key verification.
 
 
 *Type*: `string`
@@ -172,7 +172,7 @@ The public key file of the SFTP server.
 
 === `credentials.private_key_file`
 
-The private key file for the username to connect to the SFTP server.
+The path to the private key file, used for authenticating the username.
 
 
 *Type*: `string`
@@ -180,7 +180,7 @@ The private key file for the username to connect to the SFTP server.
 
 === `credentials.private_key`
 
-The private key for the username to connect to the SFTP server.
+The raw contents of the private key, used for authenticating the username.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
@@ -193,7 +193,7 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 === `credentials.private_key_pass`
 
-Optional passphrase for private key.
+Optional passphrase for decrypting the private key, if it's encrypted.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].

--- a/docs/modules/components/pages/outputs/sftp.adoc
+++ b/docs/modules/components/pages/outputs/sftp.adoc
@@ -116,7 +116,7 @@ The credentials to use to log into the target server.
 
 === `credentials.username`
 
-The username to connect to the SFTP server.
+The username to authenticate with the SFTP server.
 
 
 *Type*: `string`
@@ -125,7 +125,7 @@ The username to connect to the SFTP server.
 
 === `credentials.password`
 
-The password for the username to connect to the SFTP server.
+The password for the specified username to connect to the SFTP server.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
@@ -139,7 +139,7 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 === `credentials.host_public_key_file`
 
-The public key of the SFTP server.
+The path to the SFTP server's public key file, used for host key verification.
 
 
 *Type*: `string`
@@ -147,7 +147,7 @@ The public key of the SFTP server.
 
 === `credentials.host_public_key`
 
-The public key file of the SFTP server.
+The raw contents of the SFTP server's public key, used for host key verification.
 
 
 *Type*: `string`
@@ -155,7 +155,7 @@ The public key file of the SFTP server.
 
 === `credentials.private_key_file`
 
-The private key file for the username to connect to the SFTP server.
+The path to the private key file, used for authenticating the username.
 
 
 *Type*: `string`
@@ -163,7 +163,7 @@ The private key file for the username to connect to the SFTP server.
 
 === `credentials.private_key`
 
-The private key for the username to connect to the SFTP server.
+The raw contents of the private key, used for authenticating the username.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
@@ -176,7 +176,7 @@ This field contains sensitive information that usually shouldn't be added to a c
 
 === `credentials.private_key_pass`
 
-Optional passphrase for private key.
+Optional passphrase for decrypting the private key, if it's encrypted.
 [CAUTION]
 ====
 This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].

--- a/internal/impl/sftp/config.go
+++ b/internal/impl/sftp/config.go
@@ -50,13 +50,13 @@ func connectionFields() []*service.ConfigField {
 			Advanced(),
 		service.NewObjectField(sFieldCredentials,
 			[]*service.ConfigField{
-				service.NewStringField(sFieldCredentialsUsername).Description("The username to connect to the SFTP server.").Default(""),
-				service.NewStringField(sFieldCredentialsPassword).Description("The password for the username to connect to the SFTP server.").Secret().Default(""),
-				service.NewStringField(sFieldCredentialsHostPublicKeyFile).Description("The public key of the SFTP server.").Optional(),
-				service.NewStringField(sFieldCredentialsHostPublicKey).Description("The public key file of the SFTP server.").Optional(),
-				service.NewStringField(sFieldCredentialsPrivateKeyFile).Description("The private key file for the username to connect to the SFTP server.").Optional(),
-				service.NewStringField(sFieldCredentialsPrivateKey).Description("The private key for the username to connect to the SFTP server.").Optional().Secret(),
-				service.NewStringField(sFieldCredentialsPrivateKeyPass).Description("Optional passphrase for private key.").Secret().Default(""),
+				service.NewStringField(sFieldCredentialsUsername).Description("The username to authenticate with the SFTP server.").Default(""),
+				service.NewStringField(sFieldCredentialsPassword).Description("The password for the specified username to connect to the SFTP server.").Secret().Default(""),
+				service.NewStringField(sFieldCredentialsHostPublicKeyFile).Description("The path to the SFTP server's public key file, used for host key verification.").Optional(),
+				service.NewStringField(sFieldCredentialsHostPublicKey).Description("The raw contents of the SFTP server's public key, used for host key verification.").Optional(),
+				service.NewStringField(sFieldCredentialsPrivateKeyFile).Description("The path to the private key file, used for authenticating the username.").Optional(),
+				service.NewStringField(sFieldCredentialsPrivateKey).Description("The raw contents of the private key, used for authenticating the username.").Optional().Secret(),
+				service.NewStringField(sFieldCredentialsPrivateKeyPass).Description("Optional passphrase for decrypting the private key, if it's encrypted.").Secret().Default(""),
 			}...,
 		).Description("The credentials to use to log into the target server.").
 			LintRule(`


### PR DESCRIPTION
`credentials.host_public_key` said “file of the SFTP server”, while `credentials.host_public_key_file` said “public key”. These appear to be reversed.

This pull request updates the descriptions of configuration fields in the `connectionFields` function for the SFTP service. The changes enhance clarity and provide more precise details about the purpose and usage of each field.

### Improvements to field descriptions:

* Updated the description of `sFieldCredentialsUsername` to clarify that it is used to authenticate with the SFTP server.
* Improved the description of `sFieldCredentialsPassword` to specify that it is for the provided username.
* Refined descriptions for `sFieldCredentialsHostPublicKeyFile` and `sFieldCredentialsHostPublicKey` to emphasize their role in host key verification.
* Enhanced the descriptions for `sFieldCredentialsPrivateKeyFile` and `sFieldCredentialsPrivateKey` to specify their use in authenticating the username.
* Clarified the purpose of `sFieldCredentialsPrivateKeyPass` as decrypting an encrypted private key.