### PR TITLE
cohere rerank: make it possible to interpolate top_n

### DIFF
--- a/docs/modules/components/pages/processors/cohere_rerank.adoc
+++ b/docs/modules/components/pages/processors/cohere_rerank.adoc
@@ -36,7 +36,7 @@ cohere_rerank:
   model: rerank-v3.5 # No default (required)
   query: "" # No default (required)
   documents: "" # No default (required)
-  top_n: 0
+  top_n: "0"
   max_tokens_per_doc: 4096
 ```
 
@@ -137,11 +137,12 @@ A list of texts that will be compared to the query. For optimal performance Cohe
 === `top_n`
 
 The number of documents to return, if 0 all documents are returned.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
-*Type*: `int`
+*Type*: `string`
 
-*Default*: `0`
+*Default*: `"0"`
 
 === `max_tokens_per_doc`
 


### PR DESCRIPTION
This allows us to take a value from http (gateway) input, and use it as value for cohere_rerank.top_n.