### PR TITLE
Add pull delay config for kinesis consumer

### DIFF
--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -89,6 +89,7 @@ input:
     rebalance_period: 30s
     lease_period: 30s
     start_from_oldest: true
+    record_pull_delay: 0s
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
     credentials:
@@ -351,6 +352,15 @@ Whether to consume from the oldest message when a sequence does not yet exist fo
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `record_pull_delay`
+
+The minimum delay between GetRecords API calls for each shard. This can be used to prevent hitting AWS API rate limits (5 GetRecords calls per second per shard across all consumers). Set to 0s to disable the delay.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `region`
 


### PR DESCRIPTION
Adds a 'record_pull_delay' config option to the kinesis consumer to set a minimum wait time between GetRecords calls. This allows connect to co-exist with other consumers on a stream without immediately hitting AWS rate limits.

closes #1209