### PR TITLE
chat_processor: use msg.Copy instead of New to preserve metadata

### DIFF
--- a/internal/impl/openai/chat_processor.go
+++ b/internal/impl/openai/chat_processor.go
@@ -736,7 +736,8 @@ func (p *chatProcessor) Process(ctx context.Context, msg *service.Message) (serv
 		if idx == -1 {
 			return nil, fmt.Errorf("unknown tool call from model %s", invoked.Function.Name)
 		}
-		toolMsg := service.NewMessage([]byte(invoked.Function.Arguments))
+		toolMsg := msg.Copy()
+		toolMsg.SetBytes([]byte(invoked.Function.Arguments))
 		toolBatches, err := service.ExecuteProcessors(ctx, p.tools[idx].processors, service.MessageBatch{toolMsg})
 		if err != nil {
 			return nil, fmt.Errorf("error calling tool %s: %w", invoked.Function.Name, err)


### PR DESCRIPTION
New loses meta, so no meta can be access within tools :/

not 100% sure this works