### PR TITLE
Trigger docs update on tags

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,8 +1,9 @@
-name: update-docs
+name: Update Docs
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Our workflow wasn't getting triggered on releases. I checked the other workflows and they rely on tags.