### PR TITLE
Auto schemas from avro to parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `store_schema_metadata` added to the `schema_registry_decode` processor. (@Jeffail)
+- Field `schema_metadata` added to the `parquet_encode` processor. (@Jeffail)
 
 ## 4.61.0 - 2025-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.62.0 - TBD
+
+### Added
+
+- Field `store_schema_metadata` added to the `schema_registry_decode` processor. (@Jeffail)
+
 ## 4.61.0 - 2025-07-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 - Field `store_schema_metadata` added to the `schema_registry_decode` processor. (@Jeffail)
 - Field `schema_metadata` added to the `parquet_encode` processor. (@Jeffail)
+- (Benthos) Added TLS support to the input and output `socket` components. (@eadwright)
+- (Benthos) New Bloblang method `infer_schema`. (@Jeffail)
 
 ## 4.61.0 - 2025-07-18
 

--- a/docs/modules/components/pages/inputs/socket.adoc
+++ b/docs/modules/components/pages/inputs/socket.adoc
@@ -25,8 +25,15 @@ component_type_dropdown::[]
 
 Connects to a tcp or unix socket and consumes a continuous stream of messages.
 
+
+[tabs]
+======
+Common::
++
+--
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 input:
   label: ""
   socket:
@@ -37,6 +44,34 @@ input:
     scanner:
       lines: {}
 ```
+
+--
+Advanced::
++
+--
+
+```yml
+# All config fields, showing default values
+input:
+  label: ""
+  socket:
+    network: "" # No default (required)
+    address: /tmp/benthos.sock # No default (required)
+    auto_replay_nacks: true
+    open_message_mapping: root = "username,password" # No default (optional)
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+    scanner:
+      lines: {}
+```
+
+--
+======
 
 == Fields
 
@@ -90,6 +125,166 @@ An optional xref:guides:bloblang/about.adoc[Bloblang mapping] which should evalu
 # Examples
 
 open_message_mapping: root = "username,password"
+```
+
+=== `tls`
+
+Custom TLS settings can be used to override system defaults.
+
+
+*Type*: `object`
+
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server side certificate verification.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 3.45.0 or newer
+
+=== `tls.root_cas`
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+A plain text certificate key to use.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
 ```
 
 === `scanner`

--- a/docs/modules/components/pages/outputs/socket.adoc
+++ b/docs/modules/components/pages/outputs/socket.adoc
@@ -25,8 +25,15 @@ component_type_dropdown::[]
 
 Connects to a (tcp/udp/unix) server and sends a continuous stream of data, dividing messages according to the specified codec.
 
+
+[tabs]
+======
+Common::
++
+--
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 output:
   label: ""
   socket:
@@ -34,6 +41,31 @@ output:
     address: /tmp/benthos.sock # No default (required)
     codec: lines
 ```
+
+--
+Advanced::
++
+--
+
+```yml
+# All config fields, showing default values
+output:
+  label: ""
+  socket:
+    network: "" # No default (required)
+    address: /tmp/benthos.sock # No default (required)
+    codec: lines
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+```
+
+--
+======
 
 == Fields
 
@@ -98,6 +130,166 @@ codec: lines
 codec: "delim:\t"
 
 codec: delim:foobar
+```
+
+=== `tls`
+
+Custom TLS settings can be used to override system defaults.
+
+
+*Type*: `object`
+
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server side certificate verification.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 3.45.0 or newer
+
+=== `tls.root_cas`
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+A plain text certificate key to use.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
 ```
 
 

--- a/docs/modules/components/pages/processors/parquet_encode.adoc
+++ b/docs/modules/components/pages/processors/parquet_encode.adoc
@@ -38,7 +38,8 @@ Common::
 # Common config fields, showing default values
 label: ""
 parquet_encode:
-  schema: [] # No default (required)
+  schema: [] # No default (optional)
+  schema_metadata: ""
   default_compression: uncompressed
 ```
 
@@ -51,7 +52,8 @@ Advanced::
 # All config fields, showing default values
 label: ""
 parquet_encode:
-  schema: [] # No default (required)
+  schema: [] # No default (optional)
+  schema_metadata: ""
   default_compression: uncompressed
   default_encoding: DELTA_LENGTH_BYTE_ARRAY
 ```
@@ -171,6 +173,15 @@ fields:
   - name: bar
     type: BYTE_ARRAY
 ```
+
+=== `schema_metadata`
+
+Optionally specify a metadata field containing a schema definition to use for encoding instead of a statically defined schema. For batches of messages the first messages schema will be applied for all subsequent messages of the batch.
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `default_compression`
 

--- a/docs/modules/components/pages/processors/parquet_encode.adoc
+++ b/docs/modules/components/pages/processors/parquet_encode.adoc
@@ -176,7 +176,7 @@ fields:
 
 === `schema_metadata`
 
-Optionally specify a metadata field containing a schema definition to use for encoding instead of a statically defined schema. For batches of messages the first messages schema will be applied for all subsequent messages of the batch.
+Optionally specify a metadata field containing a schema definition to use for encoding instead of a statically defined schema. For batches of messages, the first message's schema will be applied to all subsequent messages of the batch.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -40,6 +40,7 @@ schema_registry_decode:
     raw_unions: false # No default (optional)
     preserve_logical_types: false
     translate_kafka_connect_types: false
+    store_schema_metadata: "" # No default (optional)
   protobuf:
     use_proto_names: false
     use_enum_numbers: false
@@ -77,6 +78,7 @@ schema_registry_decode:
         }
       }
       root = this.apply("debeziumTimestampToAvroTimestamp")
+    store_schema_metadata: "" # No default (optional)
   protobuf:
     use_proto_names: false
     use_enum_numbers: false
@@ -258,6 +260,14 @@ mapping: |2
   }
   root = this.apply("debeziumTimestampToAvroTimestamp")
 ```
+
+=== `avro.store_schema_metadata`
+
+Optionally store the schema used to decode messages as a metadata field under the given name. This field can later be referenced in other components such as a `parquet_encode` processor in order to automatically infer their schema.
+
+
+*Type*: `string`
+
 
 === `protobuf`
 

--- a/docs/modules/guides/pages/bloblang/methods.adoc
+++ b/docs/modules/guides/pages/bloblang/methods.adoc
@@ -3187,6 +3187,10 @@ root.doc = this.doc.format_yaml().string()
 # Out: {"doc":"foo: bar\n"}
 ```
 
+=== `infer_schema`
+
+Attempt to infer the schema of a given value. The resulting schema can then be used as an input to schema conversion and enforcement methods.
+
 === `parse_csv`
 
 Attempts to parse a string into an array of objects by following the CSV format described in RFC 4180.

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/redis/go-redis/v9 v9.7.3
-	github.com/redpanda-data/benthos/v4 v4.53.1
+	github.com/redpanda-data/benthos/v4 v4.54.0
 	github.com/redpanda-data/common-go/secrets v0.1.4
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.31.0
 	github.com/rs/xid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1805,8 +1805,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
-github.com/redpanda-data/benthos/v4 v4.53.1 h1:l9LTUC1ZeD757TSTvozK6ESAh0UX1jDKXozmijtdYuk=
-github.com/redpanda-data/benthos/v4 v4.53.1/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
+github.com/redpanda-data/benthos/v4 v4.54.0 h1:JytQ6KEqRH//2iOQ2Y6SJ/8aO5JgpmKCAGqyQXvzES4=
+github.com/redpanda-data/benthos/v4 v4.54.0/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.31.0 h1:Qiz4Q8ZO17n8797hgDdJ2f1XN7wh6J2hIRgeeSw4F24=

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -1,0 +1,252 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+type ecsAvroConfig struct {
+	rawUnion bool // Whether unions are going to be serialized as raw JSON
+}
+
+// Extract common schema from avro bytes
+func ecsAvroFromBytes(cfg ecsAvroConfig, specBytes []byte) (any, error) {
+	var as any
+	if err := json.Unmarshal(specBytes, &as); err != nil {
+		return nil, err
+	}
+
+	switch t := as.(type) {
+	case map[string]any:
+		s, err := ecsAvroFromAnyMap(cfg, t)
+		if err != nil {
+			return nil, err
+		}
+		return s.ToAny(), nil
+	case []any:
+		root := schema.Common{Type: schema.Union}
+		for i, e := range t {
+			eObj, ok := e.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("expected element %v of root array to be an object, got %T", i, e)
+			}
+
+			cObj, err := ecsAvroFromAnyMap(cfg, eObj)
+			if err != nil {
+				return nil, fmt.Errorf("expected element %v: %w", i, err)
+			}
+
+			root.Children = append(root.Children, cObj)
+		}
+		return root.ToAny(), nil
+	}
+	return nil, fmt.Errorf("expected either an array or object at root of schema, got %T", as)
+}
+
+// If the union is actually just a verbose way of defining an optional field
+// then we return the real type and true. E.g. if we see:
+//
+// `"type": [ "null", "string" ]`
+//
+// Then we return string and true.
+func ecsAvroIsUnionJustOptional(types []any) (schema.CommonType, bool) {
+	if len(types) != 2 {
+		return schema.CommonType(-1), false
+	}
+
+	firstTypeStr, ok := types[0].(string)
+	if !ok || firstTypeStr != "null" {
+		return schema.CommonType(-1), false
+	}
+
+	secondTypeStr, ok := types[1].(string)
+	if !ok {
+		return schema.CommonType(-1), false
+	}
+
+	return ecsAvroTypeToCommon(secondTypeStr), true
+}
+
+func ecsAvroTypeToCommon(t string) schema.CommonType {
+	switch t {
+	case "record":
+		return schema.Object
+	case "null":
+		return schema.Null
+	case "int":
+		return schema.Int32
+	case "long":
+		return schema.Int64
+	case "float":
+		return schema.Float32
+	case "double":
+		return schema.Float64
+	case "boolean":
+		return schema.Boolean
+	case "bytes":
+		return schema.ByteArray
+	case "string":
+		return schema.String
+	case "enum":
+		return schema.String
+	case "map":
+		return schema.Map
+	case "array":
+		return schema.Array
+	}
+	return schema.CommonType(-1)
+}
+
+func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) error {
+	if c.Type, c.Optional = ecsAvroIsUnionJustOptional(types); c.Optional {
+		return nil
+	}
+
+	c.Type = schema.Union
+	for i, uObj := range types {
+		switch ut := uObj.(type) {
+		case string:
+			c.Children = append(c.Children, schema.Common{
+				Type: ecsAvroTypeToCommon(ut),
+			})
+		case map[string]any:
+			tmpC, err := ecsAvroFromAnyMap(cfg, ut)
+			if err != nil {
+				return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
+			}
+			c.Children = append(c.Children, tmpC)
+		}
+	}
+	return nil
+}
+
+func ecsAvroHydrateLameUnion(cfg ecsAvroConfig, c *schema.Common, types []any) error {
+	c.Type = schema.Union
+	for i, uObj := range types {
+		var childT schema.Common
+
+		switch ut := uObj.(type) {
+		case string:
+			childT = schema.Common{
+				Name: ut,
+				Type: ecsAvroTypeToCommon(ut),
+			}
+		case map[string]any:
+			var err error
+			if childT, err = ecsAvroFromAnyMap(cfg, ut); err != nil {
+				return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
+			}
+		}
+
+		if childT.Type == schema.Null {
+			// Null is the only type that encodes in its raw form:
+			// https://avro.apache.org/docs/1.10.2/spec.html#json_encoding
+			// It's all very silly.
+			childT.Name = ""
+			c.Children = append(c.Children, childT)
+			continue
+		}
+
+		c.Children = append(c.Children, schema.Common{
+			Type:     schema.Object,
+			Children: []schema.Common{childT},
+		})
+	}
+
+	return nil
+}
+
+func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, error) {
+	var c schema.Common
+	c.Name, _ = as["name"].(string)
+
+	switch t := as["type"].(type) {
+	case []any:
+		if cfg.rawUnion {
+			if err := ecsAvroHydrateRawUnion(cfg, &c, t); err != nil {
+				return c, err
+			}
+		} else {
+			if err := ecsAvroHydrateLameUnion(cfg, &c, t); err != nil {
+				return c, err
+			}
+		}
+	case string:
+		c.Type = ecsAvroTypeToCommon(t)
+	case map[string]any:
+		// This is so ridiculous, I can't believe they've allowed the type field
+		// to be a union of three different types SMDH.
+		if typeStr, ok := t["type"].(string); ok {
+			c.Type = ecsAvroTypeToCommon(typeStr)
+		} else {
+			return schema.Common{}, errors.New("detected an unrecognized `type` field of type object, missing a `type` field")
+		}
+	default:
+		return schema.Common{}, fmt.Errorf("expected `type` field of type string or array, got %T", t)
+	}
+
+	switch c.Type {
+	case schema.Map:
+		valuesType, exists := as["values"].(string)
+		if !exists {
+			return schema.Common{}, fmt.Errorf("expected `values` field of type string, got %T", as["values"])
+		}
+
+		c.Children = []schema.Common{
+			{
+				Type: ecsAvroTypeToCommon(valuesType),
+			},
+		}
+
+	case schema.Array:
+		itemsType, exists := as["items"].(string)
+		if !exists {
+			return schema.Common{}, fmt.Errorf("expected `items` field of type string, got %T", as["items"])
+		}
+
+		c.Children = []schema.Common{
+			{
+				Type: ecsAvroTypeToCommon(itemsType),
+			},
+		}
+
+	case schema.Object:
+		fields, exists := as["fields"].([]any)
+		if !exists {
+			return schema.Common{}, fmt.Errorf("expected `fields` field of type array, got %T", as["fields"])
+		}
+
+		for i, f := range fields {
+			fobj, ok := f.(map[string]any)
+			if !ok {
+				return schema.Common{}, fmt.Errorf("record `%v` field '%v': expected object, got %T", c.Name, i, f)
+			}
+
+			cField, err := ecsAvroFromAnyMap(cfg, fobj)
+			if err != nil {
+				return schema.Common{}, fmt.Errorf("record `%v` field '%v': %w", c.Name, i, err)
+			}
+
+			c.Children = append(c.Children, cField)
+		}
+	}
+
+	return c, nil
+}

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -47,16 +47,16 @@ Avro, Protobuf and Json schemas are supported, all are capable of expanding from
 
 This processor creates documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
-- if its type is `+"`null`, then it is encoded as a JSON `null`"+`;
+- if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
 
-For example, the union schema `+"`[\"null\",\"string\",\"Foo\"]`, where `Foo`"+` is a record name, would encode:
+For example, the union schema ` + "`[\"null\",\"string\",\"Foo\"]`, where `Foo`" + ` is a record name, would encode:
 
-- `+"`null` as `null`"+`;
-- the string `+"`\"a\"` as `{\"string\": \"a\"}`"+`; and
-- a `+"`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`"+` instance.
+- ` + "`null` as `null`" + `;
+- the string ` + "`\"a\"` as `{\"string\": \"a\"}`" + `; and
+- a ` + "`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`" + ` instance.
 
-However, it is possible to instead create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field `+"<<avro_raw_json, `avro_raw_json`>> to `true`"+`.
+However, it is possible to instead create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field ` + "<<avro_raw_json, `avro_raw_json`>> to `true`" + `.
 
 == Protobuf format
 
@@ -152,10 +152,10 @@ map debeziumTimestampToAvroTimestamp {
 }
 root = this.apply("debeziumTimestampToAvroTimestamp")
 `),
+				service.NewStringField("store_schema_metadata").
+					Description("Optionally store the schema used to decode messages as a metadata field under the given name. This field can later be referenced in other components such as a `parquet_encode` processor in order to automatically infer their schema.").
+					Optional(),
 			).Description("Configuration for how to decode schemas that are of type AVRO."),
-			service.NewStringField("store_schema_metadata").
-				Description("Optionally store the schema used to decode messages as a metadata field under the given name. This field can later be referenced in other components such as a `parquet_encode` processor in order to automatically infer their schema.").
-				Optional(),
 		).
 		Fields(
 			service.NewObjectField(

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -47,16 +47,16 @@ Avro, Protobuf and Json schemas are supported, all are capable of expanding from
 
 This processor creates documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
-- if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
+- if its type is `+"`null`, then it is encoded as a JSON `null`"+`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
 
-For example, the union schema ` + "`[\"null\",\"string\",\"Foo\"]`, where `Foo`" + ` is a record name, would encode:
+For example, the union schema `+"`[\"null\",\"string\",\"Foo\"]`, where `Foo`"+` is a record name, would encode:
 
-- ` + "`null` as `null`" + `;
-- the string ` + "`\"a\"` as `{\"string\": \"a\"}`" + `; and
-- a ` + "`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`" + ` instance.
+- `+"`null` as `null`"+`;
+- the string `+"`\"a\"` as `{\"string\": \"a\"}`"+`; and
+- a `+"`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`"+` instance.
 
-However, it is possible to instead create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field ` + "<<avro_raw_json, `avro_raw_json`>> to `true`" + `.
+However, it is possible to instead create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field `+"<<avro_raw_json, `avro_raw_json`>> to `true`"+`.
 
 == Protobuf format
 
@@ -153,6 +153,9 @@ map debeziumTimestampToAvroTimestamp {
 root = this.apply("debeziumTimestampToAvroTimestamp")
 `),
 			).Description("Configuration for how to decode schemas that are of type AVRO."),
+			service.NewStringField("store_schema_metadata").
+				Description("Optionally store the schema used to decode messages as a metadata field under the given name. This field can later be referenced in other components such as a `parquet_encode` processor in order to automatically infer their schema.").
+				Optional(),
 		).
 		Fields(
 			service.NewObjectField(
@@ -201,6 +204,7 @@ type decodingConfig struct {
 		rawUnions                  bool
 		translateKafkaConnectTypes bool
 		mapping                    *bloblang.Executor
+		storeSchemaMeta            string
 	}
 	protobuf struct {
 		useProtoNames     bool
@@ -259,6 +263,11 @@ func newSchemaRegistryDecoderFromConfig(conf *service.ParsedConfig, mgr *service
 	if conf.Contains("avro", "mapping") {
 		cfg.avro.mapping, err = conf.FieldBloblang("avro", "mapping")
 		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.Contains("avro", "store_schema_metadata") {
+		if cfg.avro.storeSchemaMeta, err = conf.FieldString("avro", "store_schema_metadata"); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/impl/confluent/serde_goavro.go
+++ b/internal/impl/confluent/serde_goavro.go
@@ -17,14 +17,12 @@ package confluent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/linkedin/goavro/v2"
 	franz_sr "github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
-	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/impl/confluent/sr"
@@ -123,20 +121,6 @@ func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, schema franz
 	}, nil
 }
 
-func tryExtractCommonSchemaFromAvroBytes(rawUnion bool, specBytes []byte) (any, error) {
-	var as any
-	if err := json.Unmarshal(specBytes, &as); err != nil {
-		return nil, err
-	}
-
-	commonSchema, err := avroAnyToCommonSchema(rawUnion, as)
-	if err != nil {
-		return nil, err
-	}
-
-	return commonSchema.ToAny(), nil
-}
-
 func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, aschema franz_sr.Schema) (schemaDecoder, error) {
 	schemaSpec, err := resolveGoAvroReferences(ctx, s.client, s.cfg.avro.mapping, aschema)
 	if err != nil {
@@ -153,9 +137,11 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, aschema fr
 		return nil, err
 	}
 
-	var commonSchemaAny any
+	var commonSchema any
 	if s.cfg.avro.storeSchemaMeta != "" {
-		if commonSchemaAny, err = tryExtractCommonSchemaFromAvroBytes(s.cfg.avro.rawUnions, []byte(schemaSpec)); err != nil {
+		if commonSchema, err = ecsAvroFromBytes(ecsAvroConfig{
+			rawUnion: s.cfg.avro.rawUnions,
+		}, []byte(schemaSpec)); err != nil {
 			s.logger.With("error", err).Error("Failed to extract common schema for meta storage")
 		}
 	}
@@ -177,224 +163,11 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, aschema fr
 		}
 		m.SetBytes(jb)
 
-		if commonSchemaAny != nil {
-			m.MetaSetMut(s.cfg.avro.storeSchemaMeta, commonSchemaAny)
+		if commonSchema != nil {
+			m.MetaSetMut(s.cfg.avro.storeSchemaMeta, commonSchema)
 		}
 		return nil
 	}
 
 	return decoder, nil
-}
-
-// If the union is actually just a verbose way of defining an optional field
-// then we return the real type and true. E.g. if we see:
-//
-// `"type": [ "null", "string" ]`
-//
-// Then we return string and true.
-func isUnionJustOptional(types []any) (schema.CommonType, bool) {
-	if len(types) != 2 {
-		return schema.CommonType(-1), false
-	}
-
-	firstTypeStr, ok := types[0].(string)
-	if !ok || firstTypeStr != "null" {
-		return schema.CommonType(-1), false
-	}
-
-	secondTypeStr, ok := types[1].(string)
-	if !ok {
-		return schema.CommonType(-1), false
-	}
-
-	return avroTypeToCommonType(secondTypeStr), true
-}
-
-func avroTypeToCommonType(t string) schema.CommonType {
-	switch t {
-	case "record":
-		return schema.Object
-	case "null":
-		return schema.Null
-	case "int":
-		return schema.Int32
-	case "long":
-		return schema.Int64
-	case "float":
-		return schema.Float32
-	case "double":
-		return schema.Float64
-	case "boolean":
-		return schema.Boolean
-	case "bytes":
-		return schema.ByteArray
-	case "string":
-		return schema.String
-	case "enum":
-		return schema.String
-	case "map":
-		return schema.Map
-	case "array":
-		return schema.Array
-	}
-	return schema.CommonType(-1)
-}
-
-func avroAnyToCommonSchema(rawUnion bool, aRoot any) (schema.Common, error) {
-	switch t := aRoot.(type) {
-	case map[string]any:
-		return avroAnyMapToCommonSchema(rawUnion, t)
-	case []any:
-		root := schema.Common{Type: schema.Union}
-		for i, e := range t {
-			eObj, ok := e.(map[string]any)
-			if !ok {
-				return schema.Common{}, fmt.Errorf("expected element %v of root array to be an object, got %T", i, e)
-			}
-
-			cObj, err := avroAnyMapToCommonSchema(rawUnion, eObj)
-			if err != nil {
-				return schema.Common{}, fmt.Errorf("expected element %v: %w", i, err)
-			}
-
-			root.Children = append(root.Children, cObj)
-		}
-		return root, nil
-	}
-	return schema.Common{}, fmt.Errorf("expected either an array or object at root of schema, got %T", aRoot)
-}
-
-func avroHydrateRawUnion(c *schema.Common, types []any) error {
-	if c.Type, c.Optional = isUnionJustOptional(types); !c.Optional {
-		c.Type = schema.Union
-		for i, uObj := range types {
-			switch ut := uObj.(type) {
-			case string:
-				c.Children = append(c.Children, schema.Common{
-					Type: avroTypeToCommonType(ut),
-				})
-			case map[string]any:
-				tmpC, err := avroAnyMapToCommonSchema(true, ut)
-				if err != nil {
-					return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
-				}
-				c.Children = append(c.Children, tmpC)
-			}
-		}
-	}
-	return nil
-}
-
-func avroHydrateLameUnion(c *schema.Common, types []any) error {
-	c.Type = schema.Union
-	for i, uObj := range types {
-		var childT schema.Common
-
-		switch ut := uObj.(type) {
-		case string:
-			childT = schema.Common{
-				Name: ut,
-				Type: avroTypeToCommonType(ut),
-			}
-		case map[string]any:
-			var err error
-			if childT, err = avroAnyMapToCommonSchema(true, ut); err != nil {
-				return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
-			}
-		}
-
-		if childT.Type == schema.Null {
-			// Null is the only type that encodes in its raw form:
-			// https://avro.apache.org/docs/1.10.2/spec.html#json_encoding
-			// It's all very silly.
-			childT.Name = ""
-			c.Children = append(c.Children, childT)
-			continue
-		}
-
-		c.Children = append(c.Children, schema.Common{
-			Type:     schema.Object,
-			Children: []schema.Common{childT},
-		})
-	}
-
-	return nil
-}
-
-func avroAnyMapToCommonSchema(rawUnion bool, as map[string]any) (schema.Common, error) {
-	var c schema.Common
-	c.Name, _ = as["name"].(string)
-
-	switch t := as["type"].(type) {
-	case []any:
-		if rawUnion {
-			if err := avroHydrateRawUnion(&c, t); err != nil {
-				return c, err
-			}
-		} else {
-			if err := avroHydrateLameUnion(&c, t); err != nil {
-				return c, err
-			}
-		}
-	case string:
-		c.Type = avroTypeToCommonType(t)
-	case map[string]any:
-		// This is so ridiculous, I can't believe they've allowed the type field
-		// to be a union of three different types SMDH.
-		if typeStr, ok := t["type"].(string); ok {
-			c.Type = avroTypeToCommonType(typeStr)
-		} else {
-			return schema.Common{}, errors.New("detected an unrecognized `type` field of type object, missing a `type` field")
-		}
-	default:
-		return schema.Common{}, fmt.Errorf("expected `type` field of type string or array, got %T", t)
-	}
-
-	switch c.Type {
-	case schema.Map:
-		valuesType, exists := as["values"].(string)
-		if !exists {
-			return schema.Common{}, fmt.Errorf("expected `values` field of type string, got %T", as["values"])
-		}
-
-		c.Children = []schema.Common{
-			{
-				Type: avroTypeToCommonType(valuesType),
-			},
-		}
-
-	case schema.Array:
-		itemsType, exists := as["items"].(string)
-		if !exists {
-			return schema.Common{}, fmt.Errorf("expected `items` field of type string, got %T", as["items"])
-		}
-
-		c.Children = []schema.Common{
-			{
-				Type: avroTypeToCommonType(itemsType),
-			},
-		}
-
-	case schema.Object:
-		fields, exists := as["fields"].([]any)
-		if !exists {
-			return schema.Common{}, fmt.Errorf("expected `fields` field of type array, got %T", as["fields"])
-		}
-
-		for i, f := range fields {
-			fobj, ok := f.(map[string]any)
-			if !ok {
-				return schema.Common{}, fmt.Errorf("record `%v` field '%v': expected object, got %T", c.Name, i, f)
-			}
-
-			cField, err := avroAnyMapToCommonSchema(rawUnion, fobj)
-			if err != nil {
-				return schema.Common{}, fmt.Errorf("record `%v` field '%v': %w", c.Name, i, err)
-			}
-
-			c.Children = append(c.Children, cField)
-		}
-	}
-
-	return c, nil
 }

--- a/internal/impl/confluent/serde_goavro.go
+++ b/internal/impl/confluent/serde_goavro.go
@@ -224,6 +224,8 @@ func avroTypeToCommonType(t string) schema.CommonType {
 		return schema.Float32
 	case "double":
 		return schema.Float64
+	case "boolean":
+		return schema.Boolean
 	case "bytes":
 		return schema.ByteArray
 	case "string":

--- a/internal/impl/confluent/serde_goavro.go
+++ b/internal/impl/confluent/serde_goavro.go
@@ -17,12 +17,14 @@ package confluent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/linkedin/goavro/v2"
 	franz_sr "github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/impl/confluent/sr"
@@ -121,8 +123,22 @@ func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, schema franz
 	}, nil
 }
 
-func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema franz_sr.Schema) (schemaDecoder, error) {
-	schemaSpec, err := resolveGoAvroReferences(ctx, s.client, s.cfg.avro.mapping, schema)
+func tryExtractCommonSchema(specBytes []byte) (any, error) {
+	var as any
+	if err := json.Unmarshal(specBytes, &as); err != nil {
+		return nil, err
+	}
+
+	commonSchema, err := avroAnyToCommonSchema(as)
+	if err != nil {
+		return nil, err
+	}
+
+	return commonSchema.ToAny(), nil
+}
+
+func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, aschema franz_sr.Schema) (schemaDecoder, error) {
+	schemaSpec, err := resolveGoAvroReferences(ctx, s.client, s.cfg.avro.mapping, aschema)
 	if err != nil {
 		return nil, err
 	}
@@ -135,6 +151,13 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema fra
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	var commonSchemaAny any
+	if s.cfg.avro.storeSchemaMeta != "" {
+		if commonSchemaAny, err = tryExtractCommonSchema([]byte(schemaSpec)); err != nil {
+			s.logger.With("error", err).Error("Failed to extract common schema for meta storage")
+		}
 	}
 
 	decoder := func(m *service.Message) error {
@@ -154,8 +177,175 @@ func (s *schemaRegistryDecoder) getGoAvroDecoder(ctx context.Context, schema fra
 		}
 		m.SetBytes(jb)
 
+		if commonSchemaAny != nil {
+			m.MetaSetMut(s.cfg.avro.storeSchemaMeta, commonSchemaAny)
+		}
 		return nil
 	}
 
 	return decoder, nil
+}
+
+// If the union is actually just a verbose way of defining an optional field
+// then we return the real type and true. E.g. if we see:
+//
+// `"type": [ "null", "string" ]`
+//
+// Then we return string and true.
+func isUnionJustOptional(types []any) (schema.CommonType, bool) {
+	if len(types) != 2 {
+		return schema.CommonType(-1), false
+	}
+
+	firstTypeStr, ok := types[0].(string)
+	if !ok || firstTypeStr != "null" {
+		return schema.CommonType(-1), false
+	}
+
+	secondTypeStr, ok := types[1].(string)
+	if !ok {
+		return schema.CommonType(-1), false
+	}
+
+	return avroTypeToCommonType(secondTypeStr), true
+}
+
+func avroTypeToCommonType(t string) schema.CommonType {
+	switch t {
+	case "record":
+		return schema.Object
+	case "null":
+		return schema.Null
+	case "int":
+		return schema.Int32
+	case "long":
+		return schema.Int64
+	case "float":
+		return schema.Float32
+	case "double":
+		return schema.Float64
+	case "bytes":
+		return schema.ByteArray
+	case "string":
+		return schema.String
+	case "enum":
+		return schema.String
+	case "map":
+		return schema.Map
+	case "array":
+		return schema.Array
+	}
+	return schema.CommonType(-1)
+}
+
+func avroAnyToCommonSchema(aRoot any) (*schema.Common, error) {
+	switch t := aRoot.(type) {
+	case map[string]any:
+		return avroAnyMapToCommonSchema(t)
+	case []any:
+		root := schema.Common{
+			Type: schema.Union,
+		}
+		for i, e := range t {
+			eObj, ok := e.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("expected element %v of root array to be an object, got %T", i, e)
+			}
+
+			cObj, err := avroAnyMapToCommonSchema(eObj)
+			if err != nil {
+				return nil, fmt.Errorf("expected element %v: %w", i, err)
+			}
+
+			root.Children = append(root.Children, cObj)
+		}
+		return &root, nil
+	}
+	return nil, fmt.Errorf("expected either an array or object at root of schema, got %T", aRoot)
+}
+
+func avroAnyMapToCommonSchema(as map[string]any) (*schema.Common, error) {
+	var c schema.Common
+	c.Name, _ = as["name"].(string)
+
+	switch t := as["type"].(type) {
+	case []any:
+		if c.Type, c.Optional = isUnionJustOptional(t); !c.Optional {
+			c.Type = schema.Union
+			for i, uObj := range t {
+				switch ut := uObj.(type) {
+				case string:
+					c.Children = append(c.Children, &schema.Common{
+						Type: avroTypeToCommonType(ut),
+					})
+				case map[string]any:
+					tmpC, err := avroAnyMapToCommonSchema(ut)
+					if err != nil {
+						return nil, fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
+					}
+					c.Children = append(c.Children, tmpC)
+				}
+			}
+		}
+	case string:
+		c.Type = avroTypeToCommonType(t)
+	case map[string]any:
+		// This is so ridiculous, I can't believe they've allowed the type field
+		// to be a union of three different types SMDH.
+		if typeStr, ok := t["type"].(string); ok {
+			c.Type = avroTypeToCommonType(typeStr)
+		} else {
+			return nil, errors.New("detected an unrecognized `type` field of type object, missing a `type` field")
+		}
+	default:
+		return nil, fmt.Errorf("expected `type` field of type string or array, got %T", t)
+	}
+
+	switch c.Type {
+	case schema.Map:
+		valuesType, exists := as["values"].(string)
+		if !exists {
+			return nil, fmt.Errorf("expected `values` field of type string, got %T", as["values"])
+		}
+
+		c.Children = []*schema.Common{
+			{
+				Type: avroTypeToCommonType(valuesType),
+			},
+		}
+
+	case schema.Array:
+		itemsType, exists := as["items"].(string)
+		if !exists {
+			return nil, fmt.Errorf("expected `items` field of type string, got %T", as["items"])
+		}
+
+		c.Children = []*schema.Common{
+			{
+				Type: avroTypeToCommonType(itemsType),
+			},
+		}
+
+	case schema.Object:
+		fields, exists := as["fields"].([]any)
+		if !exists {
+			return nil, fmt.Errorf("expected `fields` field of type array, got %T", as["fields"])
+		}
+
+		for i, f := range fields {
+			fobj, ok := f.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("record `%v` field '%v': expected object, got %T", c.Name, i, f)
+			}
+
+			cField, err := avroAnyMapToCommonSchema(fobj)
+			if err != nil {
+				return nil, fmt.Errorf("record `%v` field '%v': %w", c.Name, i, err)
+			}
+
+			c.Children = append(c.Children, cField)
+		}
+	}
+
+	return &c, nil
 }

--- a/internal/impl/confluent/serde_goavro_test.go
+++ b/internal/impl/confluent/serde_goavro_test.go
@@ -197,7 +197,7 @@ func TestAvroSchemaExtraction(t *testing.T) {
 	]
 }`
 
-	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+	urlStr := runSchemaRegistryServer(t, func(_ string) ([]byte, error) {
 		return mustJBytes(t, map[string]any{
 			"id": 2, "version": 10, "schemaType": "AVRO",
 			"schema": fooSchema,

--- a/internal/impl/confluent/serde_goavro_test.go
+++ b/internal/impl/confluent/serde_goavro_test.go
@@ -112,17 +112,17 @@ func TestAvroReferences(t *testing.T) {
 	}{
 		{
 			name:   "a foo",
-			input:  `{"Woof":"hhnnnnnnroooo"}`,
+			input:  `{ "Woof" : "hhnnnnnnroooo" }`,
 			output: `{"Woof":"hhnnnnnnroooo"}`,
 		},
 		{
 			name:   "a bar",
-			input:  `{"Moo":"mmuuuuuueew"}`,
+			input:  `{ "Moo" : "mmuuuuuueew" }`,
 			output: `{"Moo":"mmuuuuuueew"}`,
 		},
 		{
 			name:   "a baz",
-			input:  `{"Miao":{"Woof":"tsssssssuuuuuuuu"}}`,
+			input:  `{ "Miao" : { "Woof" : "tsssssssuuuuuuuu" } }`,
 			output: `{"Miao":{"Woof":"tsssssssuuuuuuuu"}}`,
 		},
 	}
@@ -181,5 +181,91 @@ func TestAvroReferences(t *testing.T) {
 			require.NoError(t, decodedMsg.GetError())
 			require.JSONEq(t, test.output, string(b))
 		})
+	}
+}
+
+func TestAvroSchemaExtraction(t *testing.T) {
+	tCtx, done := context.WithTimeout(t.Context(), time.Second*10)
+	defer done()
+
+	fooSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "foo",
+	"fields": [
+		{ "name": "Woof", "type": "string"}
+	]
+}`
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		return mustJBytes(t, map[string]any{
+			"id": 2, "version": 10, "schemaType": "AVRO",
+			"schema": fooSchema,
+		}), nil
+	})
+
+	subj, err := service.NewInterpolatedString("root")
+	require.NoError(t, err)
+
+	encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
+	require.NoError(t, err)
+
+	cfg := decodingConfig{}
+	cfg.avro.rawUnions = true
+	cfg.avro.storeSchemaMeta = "testschema"
+	decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, cfg, schemaStaleAfter, service.MockResources())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = encoder.Close(tCtx)
+		_ = decoder.Close(tCtx)
+	})
+
+	inBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{ "Woof" : "woof one" }`)),
+		service.NewMessage([]byte(`{ "Woof" : "woof two" }`)),
+		service.NewMessage([]byte(`{ "Woof" : "woof three" }`)),
+	}
+
+	outBatch := []string{
+		`{"Woof":"woof one"}`,
+		`{"Woof":"woof two"}`,
+		`{"Woof":"woof three"}`,
+	}
+
+	encodedBatches, err := encoder.ProcessBatch(tCtx, inBatch)
+	require.NoError(t, err)
+	require.Len(t, encodedBatches, 1)
+	require.Len(t, encodedBatches[0], 3)
+
+	for i, encodedMsg := range encodedBatches[0] {
+		b, err := encodedMsg.AsBytes()
+		require.NoError(t, err)
+		require.NoError(t, encodedMsg.GetError())
+
+		var n any
+		require.Error(t, json.Unmarshal(b, &n), "message contents should no longer be valid JSON")
+
+		decodedBatch, err := decoder.Process(tCtx, encodedMsg)
+		require.NoError(t, err)
+		require.Len(t, decodedBatch, 1)
+
+		decodedMsg := decodedBatch[0]
+
+		b, err = decodedMsg.AsBytes()
+		require.NoError(t, err)
+
+		require.NoError(t, decodedMsg.GetError())
+		require.JSONEq(t, outBatch[i], string(b))
+
+		schema, exists := decodedMsg.MetaGetMut("testschema")
+		assert.True(t, exists)
+
+		assert.Equal(t, map[string]any{
+			"name": "foo", "type": "OBJECT",
+			"children": []any{
+				map[string]any{"name": "Woof", "type": "STRING"},
+			},
+		}, schema)
 	}
 }

--- a/internal/impl/confluent/serde_goavro_test.go
+++ b/internal/impl/confluent/serde_goavro_test.go
@@ -291,3 +291,116 @@ func TestAvroSchemaExtraction(t *testing.T) {
 		}, schema)
 	}
 }
+
+func TestAvroSchemaExtractionLameUnions(t *testing.T) {
+	tCtx, done := context.WithTimeout(t.Context(), time.Second*10)
+	defer done()
+
+	fooSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "foo",
+	"fields": [
+		{ "name": "A", "type": "string" },
+		{ "name": "B", "type": "null" },
+		{ "name": "C", "type": ["null", "int"] },
+		{ "name": "D", "type": "long", "default": 99 },
+		{ "name": "E", "type": "float" },
+		{ "name": "F", "type": "double" },
+		{ "name": "G", "type": "boolean", "default": true },
+		{ "name": "H", "type": "bytes" },
+		{ "name": "I", "type": "enum", "symbols": [ "MOO", "WOOF" ] },
+		{ "name": "J", "type": "map", "values" : "long" },
+		{ "name": "K", "type": "array", "items": "boolean" }
+	]
+}`
+
+	urlStr := runSchemaRegistryServer(t, func(_ string) ([]byte, error) {
+		return mustJBytes(t, map[string]any{
+			"id": 2, "version": 10, "schemaType": "AVRO",
+			"schema": fooSchema,
+		}), nil
+	})
+
+	subj, err := service.NewInterpolatedString("root")
+	require.NoError(t, err)
+
+	encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
+	require.NoError(t, err)
+
+	cfg := decodingConfig{}
+	cfg.avro.rawUnions = false
+	cfg.avro.storeSchemaMeta = "testschema"
+	decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, cfg, schemaStaleAfter, service.MockResources())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = encoder.Close(tCtx)
+		_ = decoder.Close(tCtx)
+	})
+
+	inBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{ "A" : "woof one", "B": null, "C": 1, "D": 11, "E": 1.1, "F": 11.1, "G": true, "H": "foo", "I": "MOO", "J": { "i": 3 }, "K": [ true, false] }`)),
+		service.NewMessage([]byte(`{ "A" : "woof two", "B": null, "C": 2, "D": 12, "E": 2.1, "F": 12.1, "G": false, "H": "bar", "I": "WOOF", "J": { "i": 4 }, "K": [ true, false] }`)),
+	}
+
+	outBatch := []string{
+		`{"A":"woof one","B":null,"C":{"int":1},"D":11,"E":1.1,"F":11.1,"G":true,"H":"foo","I":"MOO","J":{"i":3},"K":[true,false]}`,
+		`{"A":"woof two","B":null,"C":{"int":2},"D":12,"E":2.1,"F":12.1,"G":false,"H":"bar","I":"WOOF","J":{"i":4},"K":[true,false]}`,
+	}
+
+	encodedBatches, err := encoder.ProcessBatch(tCtx, inBatch)
+	require.NoError(t, err)
+	require.Len(t, encodedBatches, 1)
+	require.Len(t, encodedBatches[0], 2)
+
+	for i, encodedMsg := range encodedBatches[0] {
+		b, err := encodedMsg.AsBytes()
+		require.NoError(t, err)
+		require.NoError(t, encodedMsg.GetError())
+
+		var n any
+		require.Error(t, json.Unmarshal(b, &n), "message contents should no longer be valid JSON")
+
+		decodedBatch, err := decoder.Process(tCtx, encodedMsg)
+		require.NoError(t, err)
+		require.Len(t, decodedBatch, 1)
+
+		decodedMsg := decodedBatch[0]
+
+		b, err = decodedMsg.AsBytes()
+		require.NoError(t, err)
+
+		require.NoError(t, decodedMsg.GetError())
+		require.JSONEq(t, outBatch[i], string(b))
+
+		schema, exists := decodedMsg.MetaGetMut("testschema")
+		assert.True(t, exists)
+
+		assert.Equal(t, map[string]any{
+			"name": "foo", "type": "OBJECT",
+			"children": []any{
+				map[string]any{"name": "A", "type": "STRING"},
+				map[string]any{"name": "B", "type": "NULL"},
+				map[string]any{"name": "C", "type": "UNION", "children": []any{
+					map[string]any{"type": "NULL"},
+					map[string]any{"type": "OBJECT", "children": []any{
+						map[string]any{"name": "int", "type": "INT32"},
+					}},
+				}},
+				map[string]any{"name": "D", "type": "INT64"},
+				map[string]any{"name": "E", "type": "FLOAT32"},
+				map[string]any{"name": "F", "type": "FLOAT64"},
+				map[string]any{"name": "G", "type": "BOOLEAN"},
+				map[string]any{"name": "H", "type": "BYTE_ARRAY"},
+				map[string]any{"name": "I", "type": "STRING"},
+				map[string]any{"name": "J", "type": "MAP", "children": []any{
+					map[string]any{"type": "INT64"},
+				}},
+				map[string]any{"name": "K", "type": "ARRAY", "children": []any{
+					map[string]any{"type": "BOOLEAN"},
+				}},
+			},
+		}, schema)
+	}
+}

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -75,9 +75,11 @@ func (s *schemaRegistryDecoder) getHambaAvroDecoder(ctx context.Context, schema 
 		}
 	}
 
-	var commonSchemaAny any
+	var commonSchema any
 	if s.cfg.avro.storeSchemaMeta != "" {
-		if commonSchemaAny, err = tryExtractCommonSchemaFromAvroBytes(s.cfg.avro.rawUnions, []byte(schema.Schema)); err != nil {
+		if commonSchema, err = ecsAvroFromBytes(ecsAvroConfig{
+			rawUnion: s.cfg.avro.rawUnions,
+		}, []byte(schema.Schema)); err != nil {
 			s.logger.With("error", err).Error("Failed to extract common schema for meta storage")
 		}
 	}
@@ -102,8 +104,8 @@ func (s *schemaRegistryDecoder) getHambaAvroDecoder(ctx context.Context, schema 
 		}
 		m.SetStructuredMut(native)
 
-		if commonSchemaAny != nil {
-			m.MetaSetMut(s.cfg.avro.storeSchemaMeta, commonSchemaAny)
+		if commonSchema != nil {
+			m.MetaSetMut(s.cfg.avro.storeSchemaMeta, commonSchema)
 		}
 		return nil
 	}

--- a/internal/impl/confluent/serde_hamba_avro.go
+++ b/internal/impl/confluent/serde_hamba_avro.go
@@ -77,7 +77,7 @@ func (s *schemaRegistryDecoder) getHambaAvroDecoder(ctx context.Context, schema 
 
 	var commonSchemaAny any
 	if s.cfg.avro.storeSchemaMeta != "" {
-		if commonSchemaAny, err = tryExtractCommonSchema([]byte(schema.Schema)); err != nil {
+		if commonSchemaAny, err = tryExtractCommonSchemaFromAvroBytes(s.cfg.avro.rawUnions, []byte(schema.Schema)); err != nil {
 			s.logger.With("error", err).Error("Failed to extract common schema for meta storage")
 		}
 	}

--- a/internal/impl/confluent/serde_hamba_avro_test.go
+++ b/internal/impl/confluent/serde_hamba_avro_test.go
@@ -545,7 +545,7 @@ func TestHambaAvroSchemaExtraction(t *testing.T) {
 	]
 }`
 
-	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+	urlStr := runSchemaRegistryServer(t, func(_ string) ([]byte, error) {
 		return mustJBytes(t, map[string]any{
 			"id": 2, "version": 10, "schemaType": "AVRO",
 			"schema": fooSchema,

--- a/internal/impl/confluent/serde_hamba_avro_test.go
+++ b/internal/impl/confluent/serde_hamba_avro_test.go
@@ -531,3 +531,90 @@ func TestHambaDecodeKafkaConnectTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestHambaAvroSchemaExtraction(t *testing.T) {
+	tCtx, done := context.WithTimeout(t.Context(), time.Second*10)
+	defer done()
+
+	fooSchema := `{
+	"namespace": "benthos.namespace.com",
+	"type": "record",
+	"name": "foo",
+	"fields": [
+		{ "name": "Woof", "type": "string"}
+	]
+}`
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		return mustJBytes(t, map[string]any{
+			"id": 2, "version": 10, "schemaType": "AVRO",
+			"schema": fooSchema,
+		}), nil
+	})
+
+	subj, err := service.NewInterpolatedString("root")
+	require.NoError(t, err)
+
+	encoder, err := newSchemaRegistryEncoder(urlStr, noopReqSign, nil, subj, true, time.Minute*10, time.Minute, service.MockResources())
+	require.NoError(t, err)
+
+	cfg := decodingConfig{}
+	cfg.avro.rawUnions = true
+	cfg.avro.useHamba = true
+	cfg.avro.storeSchemaMeta = "testschema"
+	decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, cfg, schemaStaleAfter, service.MockResources())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = encoder.Close(tCtx)
+		_ = decoder.Close(tCtx)
+	})
+
+	inBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{ "Woof" : "woof one" }`)),
+		service.NewMessage([]byte(`{ "Woof" : "woof two" }`)),
+		service.NewMessage([]byte(`{ "Woof" : "woof three" }`)),
+	}
+
+	outBatch := []string{
+		`{"Woof":"woof one"}`,
+		`{"Woof":"woof two"}`,
+		`{"Woof":"woof three"}`,
+	}
+
+	encodedBatches, err := encoder.ProcessBatch(tCtx, inBatch)
+	require.NoError(t, err)
+	require.Len(t, encodedBatches, 1)
+	require.Len(t, encodedBatches[0], 3)
+
+	for i, encodedMsg := range encodedBatches[0] {
+		b, err := encodedMsg.AsBytes()
+		require.NoError(t, err)
+		require.NoError(t, encodedMsg.GetError())
+
+		var n any
+		require.Error(t, json.Unmarshal(b, &n), "message contents should no longer be valid JSON")
+
+		decodedBatch, err := decoder.Process(tCtx, encodedMsg)
+		require.NoError(t, err)
+		require.Len(t, decodedBatch, 1)
+
+		decodedMsg := decodedBatch[0]
+
+		b, err = decodedMsg.AsBytes()
+		require.NoError(t, err)
+
+		require.NoError(t, decodedMsg.GetError())
+		require.JSONEq(t, outBatch[i], string(b))
+
+		schema, exists := decodedMsg.MetaGetMut("testschema")
+		assert.True(t, exists)
+
+		assert.Equal(t, map[string]any{
+			"name": "foo", "type": "OBJECT",
+			"children": []any{
+				map[string]any{"name": "Woof", "type": "STRING"},
+			},
+		}, schema)
+	}
+}

--- a/internal/impl/parquet/processor_encode.go
+++ b/internal/impl/parquet/processor_encode.go
@@ -155,7 +155,7 @@ func parquetGroupFromConfig(columnConfs []*service.ParsedConfig, encodingFn enco
 			case "UTF8":
 				n = parquet.String()
 			case "TIMESTAMP":
-				// TODO: add field to specify timestamp unit
+				// TODO: add field to specify timestamp unit (https://github.com/redpanda-data/connect/issues/3570)
 				n = parquet.Timestamp(parquet.Nanosecond)
 			case "BSON":
 				n = parquet.BSON()
@@ -365,7 +365,7 @@ func parquetNodeFromCommonField(field schema.Common) (parquet.Node, error) {
 	case schema.String:
 		n = parquet.String()
 	case schema.Timestamp:
-		// TODO: add field to specify timestamp unit
+		// TODO: add field to specify timestamp unit (https://github.com/redpanda-data/connect/issues/3570)
 		n = parquet.Timestamp(parquet.Nanosecond)
 	case schema.ByteArray:
 		n = parquet.Leaf(parquet.ByteArrayType)

--- a/internal/impl/parquet/processor_encode.go
+++ b/internal/impl/parquet/processor_encode.go
@@ -35,7 +35,7 @@ func parquetEncodeProcessorConfig() *service.ConfigSpec {
 		Fields(
 			parquetSchemaConfig().Optional(),
 			service.NewStringField("schema_metadata").
-				Description("Optionally specify a metadata field containing a schema definition to use for encoding instead of a statically defined schema. For batches of messages the first messages schema will be applied for all subsequent messages of the batch.").
+				Description("Optionally specify a metadata field containing a schema definition to use for encoding instead of a statically defined schema. For batches of messages, the first message's schema will be applied to all subsequent messages of the batch.").
 				Default(""),
 			service.NewStringEnumField("default_compression",
 				"uncompressed", "snappy", "gzip", "brotli", "zstd", "lz4raw",

--- a/internal/impl/parquet/processor_encode_test.go
+++ b/internal/impl/parquet/processor_encode_test.go
@@ -517,7 +517,7 @@ func TestParquetEncodeDynamicSchemaProcessor(t *testing.T) {
 
 	commonSchema := &schema.Common{
 		Type: schema.Object,
-		Children: []*schema.Common{
+		Children: []schema.Common{
 			{
 				Name: "foo",
 				Type: schema.String,
@@ -525,7 +525,7 @@ func TestParquetEncodeDynamicSchemaProcessor(t *testing.T) {
 			{
 				Name: "bar",
 				Type: schema.Object,
-				Children: []*schema.Common{
+				Children: []schema.Common{
 					{
 						Name:     "a",
 						Type:     schema.Int64,
@@ -546,14 +546,14 @@ func TestParquetEncodeDynamicSchemaProcessor(t *testing.T) {
 			{
 				Name: "baz",
 				Type: schema.Array,
-				Children: []*schema.Common{
+				Children: []schema.Common{
 					{
 						Type: schema.Object,
-						Children: []*schema.Common{
+						Children: []schema.Common{
 							{
 								Name: "nested",
 								Type: schema.Array,
-								Children: []*schema.Common{
+								Children: []schema.Common{
 									{
 										Type: schema.Int64,
 									},

--- a/internal/impl/parquet/processor_encode_test.go
+++ b/internal/impl/parquet/processor_encode_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
@@ -333,7 +334,7 @@ func TestParquetEncodeProcessor(t *testing.T) {
 			expectedDataBytes, err := json.Marshal(test.input)
 			require.NoError(t, err)
 
-			reader, err := newParquetEncodeProcessor(nil, testPMSchema(), &parquet.Uncompressed)
+			reader, err := newParquetEncodeProcessor(nil, testPMSchema(), "", &parquet.Uncompressed)
 			require.NoError(t, err)
 
 			readerResBatches, err := reader.ProcessBatch(t.Context(), service.MessageBatch{
@@ -380,7 +381,7 @@ func TestParquetEncodeProcessor(t *testing.T) {
 			inBatch = append(inBatch, service.NewMessage(dataBytes))
 		}
 
-		reader, err := newParquetEncodeProcessor(nil, testPMSchema(), &parquet.Uncompressed)
+		reader, err := newParquetEncodeProcessor(nil, testPMSchema(), "", &parquet.Uncompressed)
 		require.NoError(t, err)
 
 		readerResBatches, err := reader.ProcessBatch(t.Context(), inBatch)
@@ -474,4 +475,147 @@ schema:
 		})
 	}
 	wg.Wait()
+}
+
+func TestParquetEncodeDynamicSchemaProcessor(t *testing.T) {
+	type obj map[string]any
+	type arr []any
+
+	var expected []any
+
+	var inBatch service.MessageBatch
+	for _, inObj := range []any{
+		obj{
+			"foo": "hello world",
+			"bar": obj{"a": 23, "b": true, "c": 0.5},
+			"baz": arr{
+				obj{"nested": arr{1, 2, 3}},
+				obj{"nested": arr{4, 5, 6}},
+			},
+		},
+		obj{
+			"foo": "this is",
+			"bar": obj{"a": nil, "b": true, "c": nil},
+			"baz": arr{
+				obj{"nested": arr{7}},
+				obj{"nested": arr{8, 9}},
+			},
+		},
+		obj{
+			"foo": "my data",
+			"bar": obj{"a": nil, "b": nil, "c": nil},
+			"baz": arr{},
+		},
+	} {
+		expected = append(expected, inObj)
+
+		dataBytes, err := json.Marshal(inObj)
+		require.NoError(t, err)
+
+		inBatch = append(inBatch, service.NewMessage(dataBytes))
+	}
+
+	commonSchema := &schema.Common{
+		Type: schema.Object,
+		Children: []*schema.Common{
+			{
+				Name: "foo",
+				Type: schema.String,
+			},
+			{
+				Name: "bar",
+				Type: schema.Object,
+				Children: []*schema.Common{
+					{
+						Name:     "a",
+						Type:     schema.Int64,
+						Optional: true,
+					},
+					{
+						Name:     "b",
+						Type:     schema.Boolean,
+						Optional: true,
+					},
+					{
+						Name:     "c",
+						Type:     schema.Float64,
+						Optional: true,
+					},
+				},
+			},
+			{
+				Name: "baz",
+				Type: schema.Array,
+				Children: []*schema.Common{
+					{
+						Type: schema.Object,
+						Children: []*schema.Common{
+							{
+								Name: "nested",
+								Type: schema.Array,
+								Children: []*schema.Common{
+									{
+										Type: schema.Int64,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	parquetSchema := parquet.NewSchema("test", parquet.Group{
+		"foo": parquet.String(),
+		"bar": parquet.Group{
+			"a": parquet.Optional(parquet.Int(64)),
+			"b": parquet.Optional(parquet.Leaf(parquet.BooleanType)),
+			"c": parquet.Optional(parquet.Leaf(parquet.DoubleType)),
+		},
+		"baz": parquet.Repeated(parquet.Group{
+			"nested": parquet.Repeated(parquet.Int(64)),
+		}),
+	})
+
+	inBatch[0].MetaSetMut("foobar", commonSchema.ToAny())
+
+	reader, err := newParquetEncodeProcessor(nil, nil, "foobar", &parquet.Uncompressed)
+	require.NoError(t, err)
+
+	readerResBatches, err := reader.ProcessBatch(t.Context(), inBatch)
+	require.NoError(t, err)
+
+	require.Len(t, readerResBatches, 1)
+	require.Len(t, readerResBatches[0], 1)
+
+	pqDataBytes, err := readerResBatches[0][0].AsBytes()
+	require.NoError(t, err)
+
+	pRdr := parquet.NewGenericReader[any](bytes.NewReader(pqDataBytes), parquetSchema)
+	require.NoError(t, err)
+
+	var outRows []any
+	for {
+		outRowsTmp := make([]any, 1)
+		n, err := pRdr.Read(outRowsTmp)
+		if !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+		if n == 0 {
+			if err != nil {
+				require.ErrorIs(t, err, io.EOF)
+			}
+			break
+		}
+		outRows = append(outRows, outRowsTmp[0])
+	}
+	require.NoError(t, pRdr.Close())
+
+	expectedBytes, err := json.Marshal(expected)
+	require.NoError(t, err)
+	actualBytes, err := json.Marshal(outRows)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expectedBytes), string(actualBytes))
 }


### PR DESCRIPTION
This PR uses the new common schema package from benthos in order to create a reusable method for creating parquet files with dynamic schemas extracted during avro decoding.