### PR TITLE
gh: restore build task binary due to arduino rate limits

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -19,11 +19,21 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v5
+        id: setup-go
         with:
           go-version: stable
 
-      - name: Setup Task
-        uses: arduino/setup-task@v2
+      - name: Cache Task binary
+        id: cache-task
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/task
+          key: ${{ runner.os }}-go-task-binary-${{ steps.setup-go.outputs.go-version }}
+
+      - name: Install Task
+        if: steps.cache-task.outputs.cache-hit != 'true'
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@latest
 
       - name: Run Integration Tests
         run: task test:integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,17 @@ jobs:
         sudo apt update -y
         sudo apt install -y --no-install-recommends libzmq3-dev
 
-    - name: Setup Task
-      uses: arduino/setup-task@v2
+    - name: Cache Task binary
+      id: cache-task
+      uses: actions/cache@v4
+      with:
+        path: ~/go/bin/task
+        key: ${{ runner.os }}-go-task-binary-${{ steps.setup-go.outputs.go-version }}
+
+    - name: Install Task
+      if: steps.cache-task.outputs.cache-hit != 'true'
+      run: |
+        go install github.com/go-task/task/v3/cmd/task@latest
 
     - name: Deps
       run: task deps && git diff-index --quiet HEAD || { >&2 echo "Stale go.{mod,sum} detected. This can be fixed with 'task deps'."; exit 1; }


### PR DESCRIPTION
Fix

```
Run arduino/setup-task@v2
Error: API rate limit exceeded for 104.209.5.144. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```