### PR TITLE
Fix `schema_registry` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Added `host_selection_policy` for `cassandra` input and output. (@jonny7)
 - Fields `normalize`, `remove_metadata` and `remove_rule_set` added to `schema_registry` output. (@mihaitodor)
 
+### Fixed
+
+- Fixed an issue with the `schema_registry` output where schemas with the same ID weren't successfully associated with multiple subjects when `translate_ids` was set to `false`. (@mihaitodor)
+
 ## 4.60.2 - 2025-07-14
 
 ### Added
@@ -21,7 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed using a `credentials_json` with `gcp_vertex_ai_chat`
+- Fixed using a `credentials_json` with `gcp_vertex_ai_chat`. (@rockwotj)
 
 ## 4.60.0 - 2025-07-10
 

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -947,19 +947,19 @@ message SampleRecord {
 		if ruleSet != "" {
 			inputSS.SchemaRuleSet = nil
 		}
-		assert.True(t, kafka.SchemasEqual(inputSS, returnedSS))
+		assert.True(t, kafka.SchemasEqual(inputSS.Schema, returnedSS.Schema))
 	}
 
 	const dummySubject = "foo"
 
-	deleteSubject := func() {
+	deleteDummySubject := func() {
 		// Clean up the subject at the end of each subtest.
 		deleteSubject(t, sr.SchemaRegistryURL, dummySubject, false)
 		deleteSubject(t, sr.SchemaRegistryURL, dummySubject, true)
 	}
 
 	t.Run("allows creating the same schema twice", func(t *testing.T) {
-		defer deleteSubject()
+		defer deleteDummySubject()
 
 		for range 2 {
 			testFn(t, dummySubject, false, "", "")
@@ -967,13 +967,13 @@ message SampleRecord {
 	})
 
 	t.Run("normalises schemas", func(t *testing.T) {
-		defer deleteSubject()
+		defer deleteDummySubject()
 
 		testFn(t, dummySubject, true, "", "")
 	})
 
 	t.Run("removes metadata", func(t *testing.T) {
-		defer deleteSubject()
+		defer deleteDummySubject()
 
 		const metadata = `{
   "properties": {
@@ -984,7 +984,7 @@ message SampleRecord {
 	})
 
 	t.Run("removes rule sets", func(t *testing.T) {
-		defer deleteSubject()
+		defer deleteDummySubject()
 
 		const ruleSet = `{
   "domainRules": [
@@ -998,6 +998,17 @@ message SampleRecord {
   ]
 }`
 		testFn(t, dummySubject, true, "", ruleSet)
+	})
+
+	t.Run("", func(t *testing.T) {
+		extraSubject := "bar"
+
+		testFn(t, dummySubject, false, "", "")
+		testFn(t, extraSubject, false, "", "")
+
+		// Cleanup the extra subject.
+		deleteSubject(t, sr.SchemaRegistryURL, extraSubject, false)
+		deleteSubject(t, sr.SchemaRegistryURL, extraSubject, true)
 	})
 }
 

--- a/internal/impl/kafka/schema_registry.go
+++ b/internal/impl/kafka/schema_registry.go
@@ -26,12 +26,12 @@ import (
 type srResourceKey string
 
 // SchemasEqual compares two schema objects for equality, ignoring newlines and leading/trailing spaces in the schema string.
-func SchemasEqual(lhs, rhs franz_sr.SubjectSchema) bool {
+func SchemasEqual(lhs, rhs franz_sr.Schema) bool {
 	// TODO: Remove this utility after https://github.com/redpanda-data/redpanda/issues/26331 is resolved.
 
 	// Remove newlines and leading/trailing spaces from the schemas before comparison.
-	lhsSchema := strings.TrimSpace(strings.ReplaceAll(lhs.Schema.Schema, "\n", ""))
-	rhsSchema := strings.TrimSpace(strings.ReplaceAll(rhs.Schema.Schema, "\n", ""))
+	lhsSchema := strings.TrimSpace(strings.ReplaceAll(lhs.Schema, "\n", ""))
+	rhsSchema := strings.TrimSpace(strings.ReplaceAll(rhs.Schema, "\n", ""))
 
 	if lhsSchema != rhsSchema {
 		return false


### PR DESCRIPTION
Fixed an issue with the `schema_registry` output where schemas with the same ID weren't successfully associated with multiple subjects when `translate_ids` was set to `false`.