### PR TITLE
Use absolute tools dir

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,7 @@ dotenv:
 
 vars:
   TARGET_DIR: target
-  TOOLS_BIN_DIR: bin
+  TOOLS_BIN_DIR: '{{.USER_WORKING_DIR}}/bin'
   VERSION:
     sh: git describe --tags 2>/dev/null | sed 's/^v//' || echo "0.0.0"
 

--- a/taskfiles/tools.yml
+++ b/taskfiles/tools.yml
@@ -10,17 +10,20 @@ tasks:
     desc: Install golangci-lint
     required:
       vars:
+        - TOOLS_BIN_DIR
         - GOLANGCI_LINT_VERSION
-    run: once
     silent: true
     sources:
       - .versions
     cmds:
-      - GOBIN={{.GOBIN}} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v{{.GOLANGCI_LINT_VERSION}}
+      - GOBIN={{.TOOLS_BIN_DIR}} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v{{.GOLANGCI_LINT_VERSION}}
 
   install-govulncheck:
     desc: Install govulncheck
+    required:
+      vars:
+        - TOOLS_BIN_DIR
     run: always
     silent: true
     cmds:
-      - GOBIN={{.GOBIN}} go install golang.org/x/vuln/cmd/govulncheck@latest
+      - GOBIN={{.TOOLS_BIN_DIR}} go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
Updates the tools install tasks to use TOOLS_BIN_DIR, it needed to be made absolute in order to satisfy GOBIN.