### PR TITLE
Add TTL to MongoDB Cache

### DIFF
--- a/docs/modules/components/pages/caches/mongodb.adoc
+++ b/docs/modules/components/pages/caches/mongodb.adoc
@@ -44,6 +44,8 @@ mongodb:
   collection: "" # No default (required)
   key_field: "" # No default (required)
   value_field: "" # No default (required)
+  ttl_field: "" # No default (optional)
+  default_ttl: "" # No default (optional)
 ```
 
 --
@@ -63,6 +65,8 @@ mongodb:
   collection: "" # No default (required)
   key_field: "" # No default (required)
   value_field: "" # No default (required)
+  ttl_field: "" # No default (optional)
+  default_ttl: "" # No default (optional)
 ```
 
 --
@@ -143,6 +147,22 @@ The field in the document that is used as the key.
 === `value_field`
 
 The field in the document that is used as the value.
+
+
+*Type*: `string`
+
+
+=== `ttl_field`
+
+The field in the document that is used as the TTL. A TTL index on that field has to be manually added in MongoDB.
+
+
+*Type*: `string`
+
+
+=== `default_ttl`
+
+The default TTL of each item. After this period an item will be eligible for removal during the next MongoDB cleanup.
 
 
 *Type*: `string`

--- a/internal/impl/mongodb/cache.go
+++ b/internal/impl/mongodb/cache.go
@@ -80,7 +80,7 @@ func newMongodbCacheFromConfig(parsedConf *service.ParsedConfig) (*mongodbCache,
 
 	var ttlField *string
 	if parsedConf.Contains("ttl_field") {
-		var ttlf, err = parsedConf.FieldString("ttl_field")
+		ttlf, err := parsedConf.FieldString("ttl_field")
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func newMongodbCacheFromConfig(parsedConf *service.ParsedConfig) (*mongodbCache,
 
 	var defaultTTL *time.Duration
 	if parsedConf.Contains("default_ttl") {
-		var defTTL, err = parsedConf.FieldDuration("default_ttl")
+		defTTL, err := parsedConf.FieldDuration("default_ttl")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add TTL `ttl_field` and `default_ttl` config values for the MongoDB cache, so values set in it can also be set to expire. 
A manual TTL index on the `ttl_field` still needs to be created in the collection.

Ref Issue: https://github.com/redpanda-data/connect/issues/2959