### PR TITLE
docker: remove setcap on community Docker image

### DIFF
--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -31,7 +31,6 @@ COPY . /go/src/github.com/redpanda-data/connect/
 # Tag timetzdata required for busybox base image:
 # https://github.com/benthosdev/benthos/issues/897
 RUN TAGS="timetzdata" task build:redpanda-connect
-RUN setcap 'cap_sys_chroot=+ep' target/redpanda-connect
 
 # Pack
 FROM busybox AS package


### PR DESCRIPTION
Limit setcap to cloud images as it proves to be problematic with some Kubernetes environments.

Fixes #3583