### PR TITLE
protobuf: Add Buf Schema Registry Support

### DIFF
--- a/docs/modules/components/pages/processors/protobuf.adoc
+++ b/docs/modules/components/pages/processors/protobuf.adoc
@@ -37,17 +37,18 @@ protobuf:
   use_proto_names: false
   import_paths: []
   use_enum_numbers: false
+  bsr: []
 ```
 
-The main functionality of this processor is to map to and from JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json[https://developers.google.com/protocol-buffers/docs/proto3#json^]
+The main functionality of this processor is to map to and from JSON documents, you can read more about JSON mapping of protobuf messages here: [https://developers.google.com/protocol-buffers/docs/proto3#json](https://developers.google.com/protocol-buffers/docs/proto3#json)
 
-Using reflection for processing protobuf messages in this way is less performant than generating and using native code. Therefore when performance is critical it is recommended that you use Redpanda Connect plugins instead for processing protobuf messages natively, you can find an example of Redpanda Connect plugins at https://github.com/benthosdev/benthos-plugin-example[https://github.com/benthosdev/benthos-plugin-example^]
+Using reflection for processing protobuf messages in this way is less performant than generating and using native code. Therefore when performance is critical it is recommended that you use Redpanda Connect plugins instead for processing protobuf messages natively, you can find an example of Redpanda Connect plugins at [https://github.com/redpanda-data/redpanda-connect-plugin-example](https://github.com/redpanda-data/redpanda-connect-plugin-example)
 
 == Operators
 
 === `to_json`
 
-Converts protobuf messages into a generic JSON structure. This makes it easier to manipulate the contents of the document within Benthos.
+Converts protobuf messages into a generic JSON structure. This makes it easier to manipulate the contents of the document within Redpanda Connect.
 
 === `from_json`
 
@@ -58,7 +59,7 @@ Attempts to create a target protobuf message from a generic JSON structure.
 
 [tabs]
 ======
-JSON to Protobuf::
+JSON to Protobuf using Schema from Disk::
 +
 --
 
@@ -105,7 +106,7 @@ pipeline:
 ```
 
 --
-Protobuf to JSON::
+Protobuf to JSON using Schema from Disk::
 +
 --
 
@@ -152,13 +153,110 @@ pipeline:
 ```
 
 --
+JSON to Protobuf using Buf Schema Registry::
++
+--
+
+
+If we have the following protobuf definition within a BSR module hosted at `buf.build/exampleco/mymodule`:
+
+```protobuf
+syntax = "proto3";
+package testing;
+
+import "google/protobuf/timestamp.proto";
+
+message Person {
+  string first_name = 1;
+  string last_name = 2;
+  string full_name = 3;
+  int32 age = 4;
+  int32 id = 5; // Unique ID number for this person.
+  string email = 6;
+
+  google.protobuf.Timestamp last_updated = 7;
+}
+```
+
+And a stream of JSON documents of the form:
+
+```json
+{
+	"firstName": "caleb",
+	"lastName": "quaye",
+	"email": "caleb@myspace.com"
+}
+```
+
+We can convert the documents into protobuf messages with the following config:
+
+```yaml
+pipeline:
+  processors:
+    - protobuf:
+        operator: from_json
+        message: testing.Person
+        bsr:
+          - module: buf.build/exampleco/mymodule
+            api_key: xxx
+```
+
+--
+Protobuf to JSON using Buf Schema Registry::
++
+--
+
+
+If we have the following protobuf definition within a BSR module hosted at `buf.build/exampleco/mymodule`:
+```protobuf
+syntax = "proto3";
+package testing;
+
+import "google/protobuf/timestamp.proto";
+
+message Person {
+  string first_name = 1;
+  string last_name = 2;
+  string full_name = 3;
+  int32 age = 4;
+  int32 id = 5; // Unique ID number for this person.
+  string email = 6;
+
+  google.protobuf.Timestamp last_updated = 7;
+}
+```
+
+And a stream of protobuf messages of the type `Person`, we could convert them into JSON documents of the format:
+
+```json
+{
+	"firstName": "caleb",
+	"lastName": "quaye",
+	"email": "caleb@myspace.com"
+}
+```
+
+With the following config:
+
+```yaml
+pipeline:
+  processors:
+    - protobuf:
+        operator: to_json
+        message: testing.Person
+        bsr:
+          - module: buf.build/exampleco/mymodule
+            api_key: xxxx
+```
+
+--
 ======
 
 == Fields
 
 === `operator`
 
-The <<operators, operator>> to execute
+The [operator](#operators) to execute
 
 
 *Type*: `string`
@@ -197,7 +295,7 @@ If `true`, the `to_json` operator deserializes fields exactly as named in schema
 
 === `import_paths`
 
-A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported.
+A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported. Either this field or `bsr` must be populated.
 
 
 *Type*: `array`
@@ -212,5 +310,54 @@ If `true`, the `to_json` operator deserializes enums as numerical values instead
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `bsr`
+
+Buf Schema Registry configuration. Either this field or `import_paths` must be populated. Note that this field is an array, and multiple BSR configurations can be provided.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+=== `bsr[].module`
+
+Module to fetch from a Buf Schema Registry e.g. 'buf.build/exampleco/mymodule'.
+
+
+*Type*: `string`
+
+
+=== `bsr[].url`
+
+Buf Schema Registry URL, leave blank to extract from module.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `bsr[].api_key`
+
+Buf Schema Registry server API key, can be left blank for a public registry.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `bsr[].version`
+
+Version to retrieve from the Buf Schema Registry, leave blank for latest.
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 
 require (
 	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.18.1-20240117202343-bf8f65e8876c.1
+	buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.36.2-20240117202343-bf8f65e8876c.1
 	cloud.google.com/go/aiplatform v1.85.0
 	cloud.google.com/go/bigquery v1.67.0
 	cloud.google.com/go/pubsub v1.49.0
@@ -173,7 +174,6 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.36.2-20240117202343-bf8f65e8876c.1 // indirect
 	cel.dev/expr v0.23.1 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ toolchain go1.24.2
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 
 require (
+	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.18.1-20240117202343-bf8f65e8876c.1
 	cloud.google.com/go/aiplatform v1.85.0
 	cloud.google.com/go/bigquery v1.67.0
 	cloud.google.com/go/pubsub v1.49.0
 	cloud.google.com/go/spanner v1.82.0
 	cloud.google.com/go/storage v1.53.0
 	cloud.google.com/go/vertexai v0.12.0
+	connectrpc.com/connect v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.3.0
@@ -55,6 +57,7 @@ require (
 	github.com/benhoyt/goawk v1.29.1
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/bradfitz/gomemcache v0.0.0-20230124162541-5f7a7d875746
+	github.com/bufbuild/prototransform v0.4.0
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -170,6 +173,7 @@ require (
 )
 
 require (
+	buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.36.2-20240117202343-bf8f65e8876c.1 // indirect
 	cel.dev/expr v0.23.1 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.18.1-20240117202343-bf8f65e8876c.1 h1:tHI0A2R8edX+Prm22Jb08kCtSy5dB6HvE/0AlaqDFEY=
+buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.18.1-20240117202343-bf8f65e8876c.1/go.mod h1:tM/OH72d+hwRXLM6xJwGPhmStju+bA2dLNi19sVLed8=
+buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.36.2-20240117202343-bf8f65e8876c.1 h1:JKrlFWFhpJDBl41n4ApGdHVVYHUxUL/KwWPxixTc6so=
+buf.build/gen/go/bufbuild/reflect/protocolbuffers/go v1.36.2-20240117202343-bf8f65e8876c.1/go.mod h1:6Papc3twYJvx/6kBz9THFiGCeW6lG/uP0awNqQsBHQc=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -630,6 +634,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
+connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
+connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 cuelabs.dev/go/oci/ociregistry v0.0.0-20250304105642-27e071d2c9b1 h1:Dmbd5Q+ENb2C6carvwrMsrOUwJ9X9qfL5JdW32gYAHo=
 cuelabs.dev/go/oci/ociregistry v0.0.0-20250304105642-27e071d2c9b1/go.mod h1:dqrnoZx62xbOZr11giMPrWbhlaV8euHwciXZEy3baT8=
 cuelang.org/go v0.13.2 h1:SagzeEASX4E2FQnRbItsqa33sSelrJjQByLqH9uZCE8=
@@ -931,6 +937,8 @@ github.com/btnguyen2k/consu/semver v0.2.1 h1:le0FzrM7u0IOR4MnOyBySHpZ/p3vV4JjofA
 github.com/btnguyen2k/consu/semver v0.2.1/go.mod h1:jxK/nwIWTXcWlcWcfkhPfLWq9b5dVzAtJLycySBFHTc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/bufbuild/prototransform v0.4.0 h1:XqKyJiughXy7PKSHgaLI8O7xQLkhNL+gnyke4wr/daI=
+github.com/bufbuild/prototransform v0.4.0/go.mod h1:M8jLwHlEZCGTLBWu4YxwkOjAUQSOjk0RtkbF0EWRZ2w=
 github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
 github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=

--- a/internal/impl/protobuf/multimodule_watcher.go
+++ b/internal/impl/protobuf/multimodule_watcher.go
@@ -53,6 +53,8 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
+const watcherTimeout = 10 * time.Second
+
 type multiModuleWatcher struct {
 	bsrClients map[string]*prototransform.SchemaWatcher
 }
@@ -127,7 +129,7 @@ func newSchemaWatcher(ctx context.Context, bsrURL string, bsrAPIKey string, modu
 		return nil, fmt.Errorf("failed to create schema watcher: %w", err)
 	}
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, watcherTimeout)
 	defer cancel()
 	if err = watcher.AwaitReady(ctxWithTimeout); err != nil {
 		return nil, fmt.Errorf("schema watcher never became ready: %w", err)

--- a/internal/impl/protobuf/multimodule_watcher.go
+++ b/internal/impl/protobuf/multimodule_watcher.go
@@ -101,7 +101,7 @@ func newMultiModuleWatcher(bsrModules []*service.ParsedConfig) (*multiModuleWatc
 	return multiModuleWatcher, nil
 }
 
-func newSchemaWatcher(ctx context.Context, bsrURL string, bsrAPIKey string, module string, version string) (*prototransform.SchemaWatcher, error) {
+func newSchemaWatcher(ctx context.Context, bsrURL, bsrAPIKey, module, version string) (*prototransform.SchemaWatcher, error) {
 	// If no BSR URL provided, extract from module
 	if bsrURL == "" {
 		segments := strings.Split(module, "/")
@@ -113,7 +113,8 @@ func newSchemaWatcher(ctx context.Context, bsrURL string, bsrAPIKey string, modu
 
 	opts := []connectrpc.ClientOption{
 		connectrpc.WithHTTPGet(),
-		connectrpc.WithHTTPGetMaxURLSize(8192, true)}
+		connectrpc.WithHTTPGetMaxURLSize(8192, true),
+	}
 
 	if bsrAPIKey != "" {
 		opts = append(opts, connectrpc.WithInterceptors(prototransform.NewAuthInterceptor(bsrAPIKey)))

--- a/internal/impl/protobuf/multimodule_watcher.go
+++ b/internal/impl/protobuf/multimodule_watcher.go
@@ -1,0 +1,171 @@
+package protobuf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"buf.build/gen/go/bufbuild/reflect/connectrpc/go/buf/reflect/v1beta1/reflectv1beta1connect"
+	connectrpc "connectrpc.com/connect"
+	"github.com/bufbuild/prototransform"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+type multiModuleWatcher struct {
+	bsrClients map[string]*prototransform.SchemaWatcher
+}
+
+var _ prototransform.Resolver = &multiModuleWatcher{}
+
+func newMultiModuleWatcher(bsrModules []*service.ParsedConfig) (*multiModuleWatcher, error) {
+	if len(bsrModules) == 0 {
+		return nil, errors.New("no modules provided")
+	}
+	multiModuleWatcher := &multiModuleWatcher{}
+
+	// Initialise one client for each module
+	multiModuleWatcher.bsrClients = make(map[string]*prototransform.SchemaWatcher)
+	for _, bsrModule := range bsrModules {
+		var bsrURL string
+		bsrURL, err := bsrModule.FieldString(fieldBSRUrl)
+		if err != nil {
+			return nil, err
+		}
+
+		var bsrAPIKey string
+		if bsrAPIKey, err = bsrModule.FieldString(fieldBSRAPIKey); err != nil {
+			return nil, err
+		}
+
+		var module string
+		if module, err = bsrModule.FieldString(fieldBSRModule); err != nil {
+			return nil, err
+		}
+
+		var version string
+		if version, err = bsrModule.FieldString(fieldBSRVersion); err != nil {
+			return nil, err
+		}
+
+		watcher, err := newSchemaWatcher(context.Background(), bsrURL, bsrAPIKey, module, version)
+		if err != nil {
+			return nil, err
+		}
+		multiModuleWatcher.bsrClients[module] = watcher
+	}
+
+	return multiModuleWatcher, nil
+}
+
+func newSchemaWatcher(ctx context.Context, bsrURL string, bsrAPIKey string, module string, version string) (*prototransform.SchemaWatcher, error) {
+	// If no BSR URL provided, extract from module
+	if bsrURL == "" {
+		segments := strings.Split(module, "/")
+		if len(segments) != 3 {
+			return nil, fmt.Errorf("could not parse module %s, expected three segments e.g. 'buf.build/exampleco/mymodule'", module)
+		}
+		bsrURL = "https://" + segments[0]
+	}
+
+	opts := []connectrpc.ClientOption{
+		connectrpc.WithHTTPGet(),
+		connectrpc.WithHTTPGetMaxURLSize(8192, true)}
+
+	if bsrAPIKey != "" {
+		opts = append(opts, connectrpc.WithInterceptors(prototransform.NewAuthInterceptor(bsrAPIKey)))
+	}
+	client := reflectv1beta1connect.NewFileDescriptorSetServiceClient(http.DefaultClient, bsrURL, opts...)
+
+	cfg := &prototransform.SchemaWatcherConfig{
+		SchemaPoller: prototransform.NewSchemaPoller(client, module, version),
+		Jitter:       0.2,
+	}
+	watcher, err := prototransform.NewSchemaWatcher(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create schema watcher: %w", err)
+	}
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err = watcher.AwaitReady(ctxWithTimeout); err != nil {
+		return nil, fmt.Errorf("schema watcher never became ready: %w", err)
+	}
+
+	return watcher, nil
+}
+
+func (w *multiModuleWatcher) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	for _, schemaWatcher := range w.bsrClients {
+		extensionType, err := schemaWatcher.FindExtensionByName(field)
+		if err != nil {
+			if errors.Is(err, protoregistry.NotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return extensionType, nil
+	}
+	return nil, fmt.Errorf("could not find %s in any loaded modules", field)
+}
+
+func (w *multiModuleWatcher) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	for _, schemaWatcher := range w.bsrClients {
+		extensionType, err := schemaWatcher.FindExtensionByNumber(message, field)
+		if err != nil {
+			if errors.Is(err, protoregistry.NotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return extensionType, nil
+	}
+	return nil, fmt.Errorf("could not find %s in any loaded modules", message)
+}
+
+func (w *multiModuleWatcher) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	for _, schemaWatcher := range w.bsrClients {
+		messageType, err := schemaWatcher.FindMessageByName(message)
+		if err != nil {
+			if errors.Is(err, protoregistry.NotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return messageType, nil
+	}
+	return nil, fmt.Errorf("could not find %s in any loaded modules", message)
+}
+
+func (w *multiModuleWatcher) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	for _, schemaWatcher := range w.bsrClients {
+		messageType, err := schemaWatcher.FindMessageByURL(url)
+		if err != nil {
+			if errors.Is(err, protoregistry.NotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return messageType, nil
+	}
+	return nil, fmt.Errorf("could not find %s in any loaded modules", url)
+}
+
+func (w *multiModuleWatcher) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+	for _, schemaWatcher := range w.bsrClients {
+		enumType, err := schemaWatcher.FindEnumByName(enum)
+		if err != nil {
+			if errors.Is(err, protoregistry.NotFound) {
+				continue
+			}
+			return nil, err
+		}
+		return enumType, nil
+	}
+	return nil, fmt.Errorf("could not find %s in any loaded modules", enum)
+}

--- a/internal/impl/protobuf/multimodule_watcher.go
+++ b/internal/impl/protobuf/multimodule_watcher.go
@@ -1,3 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains code originally licensed under the MIT License:
+
+// Copyright (c) 2024-present Bento contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package protobuf
 
 import (

--- a/internal/impl/protobuf/processor_protobuf.go
+++ b/internal/impl/protobuf/processor_protobuf.go
@@ -12,6 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This file contains code originally licensed under the MIT License:
+
+// Copyright (c) 2024-present Bento contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package protobuf
 
 import (

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -12,6 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This file contains code originally licensed under the MIT License:
+
+// Copyright (c) 2024-present Bento contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package protobuf
 
 import (

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -167,7 +167,7 @@ discard_unknown: %t
 			proc, err := newProtobuf(conf, service.MockResources())
 			require.NoError(t, err)
 
-			msgs, res := proc.Process(context.Background(), service.NewMessage([]byte(test.input)))
+			msgs, res := proc.Process(t.Context(), service.NewMessage([]byte(test.input)))
 			require.NoError(t, res)
 			require.Len(t, msgs, 1)
 
@@ -310,7 +310,7 @@ use_enum_numbers: %t
 			proc, err := newProtobuf(conf, service.MockResources())
 			require.NoError(t, err)
 
-			msgs, res := proc.Process(context.Background(), service.NewMessage(test.input))
+			msgs, res := proc.Process(t.Context(), service.NewMessage(test.input))
 			require.NoError(t, res)
 			require.Len(t, msgs, 1)
 
@@ -380,14 +380,13 @@ import_paths: [ %v ]
 }
 
 func TestProcessorConfigLinting(t *testing.T) {
-
 	type testCase struct {
 		name        string
 		input       string
 		errContains string
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			name: "valid import_paths config",
 			input: `
@@ -431,7 +430,7 @@ protobuf:
 	}
 	env := service.NewEnvironment()
 	for _, test := range testCases {
-		t.Run(test.name, func(tt *testing.T) {
+		t.Run(test.name, func(_ *testing.T) {
 			strm := env.NewStreamBuilder()
 			err := strm.AddProcessorYAML(test.input)
 			if test.errContains == "" {


### PR DESCRIPTION
This change adds support for Buf Schema Registry based off of [this pull request](https://github.com/warpstreamlabs/bento/pull/278).
