### PR TITLE
SNS Output: Topic ARN string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - (google_cloud_storage) Field `bucket` can now be interpolated (@rockwotj)
+- (output_sns) Field `topic_arn` can now be interpolation (@josephwoodward)
 
 ## 4.63.0 - 2025-08-27
 

--- a/docs/modules/components/pages/outputs/aws_sns.adoc
+++ b/docs/modules/components/pages/outputs/aws_sns.adoc
@@ -92,6 +92,7 @@ This output benefits from sending multiple messages in flight in parallel for im
 === `topic_arn`
 
 The topic to publish to.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`

--- a/internal/impl/aws/output_sns.go
+++ b/internal/impl/aws/output_sns.go
@@ -207,7 +207,7 @@ func (a *snsWriter) getSNSAttributes(msg *service.Message) (snsAttributes, error
 	}, nil
 }
 
-func (a *snsWriter) parseTopicARN(msg *service.Message) (*string, error) {
+func (a *snsWriter) resolveTopicARN(msg *service.Message) (*string, error) {
 	var topicARN *string
 	if a.conf.TopicArn != nil {
 		topicARNStr, err := a.conf.TopicArn.TryString(msg)
@@ -232,7 +232,7 @@ func (a *snsWriter) Write(wctx context.Context, msg *service.Message) error {
 		return err
 	}
 
-	topicARN, err := a.parseTopicARN(msg)
+	topicARN, err := a.resolveTopicARN(msg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change updates the `topic_arn` field for the SNS output to support string interpolation.