### PR TITLE
Add component linter in public/schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - (google_cloud_storage) Field `bucket` can now be interpolated (@rockwotj)
 - (output_sns) Field `topic_arn` can now be interpolation (@josephwoodward)
+- (Benthos) Logging: Enable timestamp output by default (@josephwoodward)
 
 ## 4.63.0 - 2025-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added `default_schema_id` field to the `schema_registry_decode` processor. (@mmatczuk)
+- Go API: Component linter added to `public/schema`, including Redpanda build meta fields. (@Jeffail)
 
 ### Changed
 

--- a/docs/modules/components/pages/logger/about.adoc
+++ b/docs/modules/components/pages/logger/about.adoc
@@ -26,7 +26,7 @@ Common::
 logger:
   level: INFO
   format: logfmt
-  add_timestamp: false
+  add_timestamp: true
   static_fields:
     '@service': redpanda-connect
 ```
@@ -41,7 +41,7 @@ Advanced::
 logger:
   level: INFO
   format: logfmt
-  add_timestamp: false
+  add_timestamp: true
   level_name: level
   timestamp_name: time
   message_name: msg
@@ -100,7 +100,7 @@ Whether to include timestamps in logs.
 
 *Type*: `bool`
 
-*Default*: `false`
+*Default*: `true`
 
 === `level_name`
 

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/redis/go-redis/v9 v9.7.3
-	github.com/redpanda-data/benthos/v4 v4.55.0
+	github.com/redpanda-data/benthos/v4 v4.56.0
 	github.com/redpanda-data/common-go/secrets v0.1.4
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.31.0
 	github.com/rs/xid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1810,8 +1810,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
-github.com/redpanda-data/benthos/v4 v4.55.0 h1:zAN0N/xeOZXJbacVUiF9aBUAQ8zOJhiW1PU/oMRDluA=
-github.com/redpanda-data/benthos/v4 v4.55.0/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
+github.com/redpanda-data/benthos/v4 v4.56.0 h1:vuPHR1Pf1sNK2Ng7W6ALeY+m/vCgGH9fLYXanRytNsk=
+github.com/redpanda-data/benthos/v4 v4.56.0/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.31.0 h1:Qiz4Q8ZO17n8797hgDdJ2f1XN7wh6J2hIRgeeSw4F24=

--- a/internal/cli/custom_lint.go
+++ b/internal/cli/custom_lint.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/mcp/repository"
+	"github.com/redpanda-data/connect/v4/public/schema"
 )
 
 var (
@@ -93,7 +94,7 @@ func directoryMode(c *cli.Context, repositoryDir string) error {
 
 	env := service.NewEnvironment()
 
-	cLinter := env.NewComponentConfigLinter()
+	cLinter := schema.ComponentLinter(env)
 	cLinter.SetRejectDeprecated(c.Bool("deprecated"))
 	cLinter.SetRequireLabels(c.Bool("labels"))
 	cLinter.SetSkipEnvVarCheck(c.Bool("skip-env-var-check"))

--- a/public/schema/component_config_linter.go
+++ b/public/schema/component_config_linter.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+const (
+	metaFieldTags        = "tags"
+	mcpFieldSection      = "mcp"
+	mcpFieldEnabled      = "enabled"
+	mcpFieldDescription  = "description"
+	mcpFieldProperties   = "properties"
+	mcpFieldPropName     = "name"
+	mcpFieldPropType     = "type"
+	mcpFieldPropDesc     = "description"
+	mcpFieldPropRequired = "required"
+)
+
+func mcpMetaSchema(disableProps bool) *service.ConfigField {
+	propsField := service.NewObjectListField(mcpFieldProperties,
+		service.NewStringField(mcpFieldPropName),
+		service.NewStringEnumField(mcpFieldPropType, "string", "bool", "boolean", "number"),
+		service.NewStringField(mcpFieldPropDesc).Default(""),
+		service.NewBoolField(mcpFieldPropRequired).Default(false),
+	).Default([]any{})
+	if disableProps {
+		propsField = propsField.LintRule(`if this.type() == "array" && this.length() > 0 { "this component type does not support custom properties" }`)
+	}
+
+	mcpFields := []*service.ConfigField{
+		service.NewBoolField(mcpFieldEnabled).Default(false),
+		service.NewStringField(mcpFieldDescription).Default(""),
+		propsField,
+	}
+
+	return service.NewObjectField(mcpFieldSection, mcpFields...)
+}
+
+// ComponentLinter creates a component config linter that includes mcp specific
+// meta fields.
+func ComponentLinter(env *service.Environment) *service.ComponentConfigLinter {
+	l := env.NewComponentConfigLinter()
+	l.SetRequireLabels(true)
+	l.SetMetaFieldsFn(func(componentType string) []*service.ConfigField {
+		_, disableProps := map[string]struct{}{
+			"cache": {},
+			"input": {},
+		}[componentType]
+
+		return []*service.ConfigField{
+			service.NewStringListField(metaFieldTags).Default([]any{}),
+			mcpMetaSchema(disableProps),
+		}
+	})
+	return l
+}

--- a/public/schema/component_config_linter_test.go
+++ b/public/schema/component_config_linter_test.go
@@ -1,0 +1,150 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/public/schema"
+)
+
+func TestComponentLinter(t *testing.T) {
+	env := service.NewEmptyEnvironment()
+
+	require.NoError(t, env.RegisterInput("testinput", service.NewConfigSpec(),
+		func(*service.ParsedConfig, *service.Resources) (service.Input, error) {
+			return nil, errors.New("nope")
+		}))
+
+	require.NoError(t, env.RegisterProcessor("testprocessor", service.NewConfigSpec(),
+		func(*service.ParsedConfig, *service.Resources) (service.Processor, error) {
+			return nil, errors.New("nope")
+		}))
+
+	require.NoError(t, env.RegisterCache("testcache", service.NewConfigSpec(),
+		func(*service.ParsedConfig, *service.Resources) (service.Cache, error) {
+			return nil, errors.New("nope")
+		}))
+
+	require.NoError(t, env.RegisterOutput("testoutput", service.NewConfigSpec(),
+		func(*service.ParsedConfig, *service.Resources) (out service.Output, maxInFlight int, err error) {
+			err = errors.New("nope")
+			return
+		}))
+
+	tests := []struct {
+		name         string
+		typeStr      string
+		config       string
+		lintContains []string
+		errContains  string
+	}{
+		{
+			name:    "basic config no meta",
+			typeStr: "input",
+			config: `
+label: a
+testinput: {}
+`,
+		},
+		{
+			name:    "meta config no lints",
+			typeStr: "input",
+			config: `
+label: a
+testinput: {}
+meta:
+  tags: [ nah ]
+  mcp:
+    enabled: true
+`,
+		},
+		{
+			name:    "meta config props allowed",
+			typeStr: "processor",
+			config: `
+label: a
+testprocessor: {}
+meta:
+  tags: [ nah ]
+  mcp:
+    enabled: true
+    properties:
+      - name: meow
+        type: string
+`,
+		},
+		{
+			name:    "meta config props not allowed",
+			typeStr: "input",
+			config: `
+label: a
+testinput: {}
+meta:
+  tags: [ nah ]
+  mcp:
+    enabled: true
+    properties:
+      - name: meow
+        type: string
+`,
+			lintContains: []string{
+				"component type does not support custom properties",
+			},
+		},
+		{
+			name:    "meta config props missing type",
+			typeStr: "processor",
+			config: `
+label: a
+testprocessor: {}
+meta:
+  tags: [ nah ]
+  mcp:
+    enabled: true
+    properties:
+      - name: meow
+`,
+			lintContains: []string{
+				"field type is required",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			linter := schema.ComponentLinter(env)
+
+			lints, err := linter.LintYAML(test.typeStr, []byte(test.config))
+			if test.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, lints, len(test.lintContains))
+			for i, lc := range test.lintContains {
+				assert.Contains(t, lints[i].Error(), lc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new component linter to the public/schema package, the purpose of it is to create a component linter that includes the fields we ship within the `meta` section of configs, so that our MCP stuff gets linted. This will allow the cloud team to use this linter in our MCP product.