### PR TITLE
fix(snowflake): url field reference

### DIFF
--- a/internal/impl/snowflake/output_snowflake_streaming.go
+++ b/internal/impl/snowflake/output_snowflake_streaming.go
@@ -391,7 +391,7 @@ func newSnowflakeStreamer(
 	}
 	var url string
 	if conf.Contains(ssoFieldURL) {
-		url, err = conf.FieldString(ssoFieldAccount)
+		url, err = conf.FieldString(ssoFieldURL)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Replaces incorrect reference to `ssoFieldAccount` with `ssoFieldURL` when fetching the SSO URL from configuration in the Snowflake streaming connector.