### PR TITLE
Bump questdb go client version to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/pusher/pusher-http-go v4.0.1+incompatible
 	github.com/qdrant/go-client v1.11.1
-	github.com/questdb/go-questdb-client/v3 v3.2.0
+	github.com/questdb/go-questdb-client/v4 v4.0.0
 	github.com/r3labs/diff/v3 v3.0.1
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475

--- a/go.sum
+++ b/go.sum
@@ -1798,8 +1798,8 @@ github.com/pusher/pusher-http-go v4.0.1+incompatible h1:4u6tomPG1WhHaST7Wi9mw83Y
 github.com/pusher/pusher-http-go v4.0.1+incompatible/go.mod h1:XAv1fxRmVTI++2xsfofDhg7whapsLRG/gH/DXbF3a18=
 github.com/qdrant/go-client v1.11.1 h1:kla7n21wSEWWZLrvpttTOnCppDm6jluYDZEFe2kJ8zs=
 github.com/qdrant/go-client v1.11.1/go.mod h1:zFa6t5Y3Oqecoa0aSsGWhMqQWq3x3kTPvm0sMf5qplw=
-github.com/questdb/go-questdb-client/v3 v3.2.0 h1:rFlkc3tD+vNucd4dkNv2xN5xqcFJGwqxt3F5p2H8zrg=
-github.com/questdb/go-questdb-client/v3 v3.2.0/go.mod h1:kXoftTVQZlksdJ9tsHQRWfdWO5Kyl4bZuKotyyeWa3c=
+github.com/questdb/go-questdb-client/v4 v4.0.0 h1:TrftS7zNbzEbKjJ97l7MejEjhE/s8jU3ebSFYyPHIwU=
+github.com/questdb/go-questdb-client/v4 v4.0.0/go.mod h1:Q749HQ2rJg6pZGCeMLEczL3+E90P47lybx5vI6Si8kA=
 github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc h1:hK577yxEJ2f5s8w2iy2KimZmgrdAUZUNftE1ESmg2/Q=
 github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc/go.mod h1:OQt6Zo5B3Zs+C49xul8kcHo+fZ1mCLPvd0LFxiZ2DHc=
 github.com/r3labs/diff/v3 v3.0.1 h1:CBKqf3XmNRHXKmdU7mZP1w7TV0pDyVCis1AUHtA4Xtg=

--- a/internal/impl/questdb/integration_test.go
+++ b/internal/impl/questdb/integration_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
-	qdb "github.com/questdb/go-questdb-client/v3"
+	qdb "github.com/questdb/go-questdb-client/v4"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"

--- a/internal/impl/questdb/output.go
+++ b/internal/impl/questdb/output.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"time"
 
-	qdb "github.com/questdb/go-questdb-client/v3"
+	qdb "github.com/questdb/go-questdb-client/v4"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -278,7 +278,7 @@
 | github.com/prometheus/procfs | Apache-2.0 |
 | github.com/pusher/pusher-http-go | MIT |
 | github.com/qdrant/go-client/qdrant | Apache-2.0 |
-| github.com/questdb/go-questdb-client/v3 | Apache-2.0 |
+| github.com/questdb/go-questdb-client/v4 | Apache-2.0 |
 | github.com/quipo/dependencysolver | MIT |
 | github.com/r3labs/diff/v3 | MPL-2.0 |
 | github.com/rabbitmq/amqp091-go | BSD-2-Clause |

--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -305,7 +305,7 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/pusher/pusher-http-go v4.0.1+incompatible // indirect
 	github.com/qdrant/go-client v1.15.2 // indirect
-	github.com/questdb/go-questdb-client/v3 v3.2.0 // indirect
+	github.com/questdb/go-questdb-client/v4 v4.0.0 // indirect
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc // indirect
 	github.com/r3labs/diff/v3 v3.0.2 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -297,7 +297,7 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/pusher/pusher-http-go v4.0.1+incompatible // indirect
 	github.com/qdrant/go-client v1.15.2 // indirect
-	github.com/questdb/go-questdb-client/v3 v3.2.0 // indirect
+	github.com/questdb/go-questdb-client/v4 v4.0.0 // indirect
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc // indirect
 	github.com/r3labs/diff/v3 v3.0.2 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect


### PR DESCRIPTION
QuestDB has updated its golang client to add array support and improve QuestDB 9.0.0+ compatibility.

This PR bumps the version of the included questdb ingestion client.

See https://github.com/questdb/go-questdb-client/releases/tag/v4.0.0 for more details on the release.