### PR TITLE
rpcplugin: adjust backoff strategy

### DIFF
--- a/internal/rpcplugin/input.go
+++ b/internal/rpcplugin/input.go
@@ -151,7 +151,7 @@ func startInputPlugin(
 			return false, backoff.Permanent(err)
 		}
 		return resp.AutoReplayNacks, nil
-	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts()...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return false, fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/input.go
+++ b/internal/rpcplugin/input.go
@@ -151,7 +151,7 @@ func startInputPlugin(
 			return false, backoff.Permanent(err)
 		}
 		return resp.AutoReplayNacks, nil
-	}, backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxStartupTime)))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return false, fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/output.go
+++ b/internal/rpcplugin/output.go
@@ -150,7 +150,7 @@ func startOutputPlugin(
 			return nil, backoff.Permanent(err)
 		}
 		return resp, nil
-	}, backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxStartupTime)))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return 0, service.BatchPolicy{}, fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/output.go
+++ b/internal/rpcplugin/output.go
@@ -150,7 +150,7 @@ func startOutputPlugin(
 			return nil, backoff.Permanent(err)
 		}
 		return resp, nil
-	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts()...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return 0, service.BatchPolicy{}, fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/processor.go
+++ b/internal/rpcplugin/processor.go
@@ -146,7 +146,7 @@ func startProcessorPlugin(
 			return err
 		}
 		return runtimepb.ProtoToError(resp.Error)
-	}, backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxStartupTime)))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/processor.go
+++ b/internal/rpcplugin/processor.go
@@ -146,7 +146,7 @@ func startProcessorPlugin(
 			return err
 		}
 		return runtimepb.ProtoToError(resp.Error)
-	}, backoff.NewExponentialBackOff(exponentialBackoffOpts...))
+	}, backoff.NewExponentialBackOff(exponentialBackoffOpts()...))
 	if err != nil {
 		_ = proc.Close(ctx)
 		return fmt.Errorf("unable to initialize plugin: %w", err)

--- a/internal/rpcplugin/util.go
+++ b/internal/rpcplugin/util.go
@@ -19,12 +19,20 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 const (
 	retryCount     = 3
 	maxStartupTime = 30 * time.Second
 )
+
+var exponentialBackoffOpts = []backoff.ExponentialBackOffOpts{
+	backoff.WithInitialInterval(100 * time.Millisecond),
+	backoff.WithMaxInterval(5 * time.Second),
+	backoff.WithMaxElapsedTime(maxStartupTime),
+}
 
 func newUnixSocketAddr() (string, error) {
 	dir, err := os.MkdirTemp(os.TempDir(), "rpcn_plugin_*")

--- a/internal/rpcplugin/util.go
+++ b/internal/rpcplugin/util.go
@@ -23,15 +23,22 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
-const (
+var (
 	retryCount     = 3
 	maxStartupTime = 30 * time.Second
 )
 
-var exponentialBackoffOpts = []backoff.ExponentialBackOffOpts{
-	backoff.WithInitialInterval(100 * time.Millisecond),
-	backoff.WithMaxInterval(5 * time.Second),
-	backoff.WithMaxElapsedTime(maxStartupTime),
+func exponentialBackoffOpts() []backoff.ExponentialBackOffOpts {
+	mst := maxStartupTime
+	if os.Getenv("CI") != "" {
+		mst = 120 * time.Second
+	}
+
+	return []backoff.ExponentialBackOffOpts{
+		backoff.WithInitialInterval(100 * time.Millisecond),
+		backoff.WithMaxInterval(5 * time.Second),
+		backoff.WithMaxElapsedTime(mst),
+	}
 }
 
 func newUnixSocketAddr() (string, error) {


### PR DESCRIPTION
Attempt to fix in CI

```
--- FAIL: TestProcessorCustomCwd (20.87s)
    processor_test.go:68:
        	Error Trace:	/home/runner/work/connect/connect/internal/rpcplugin/processor_test.go:68
        	Error:      	Received unexpected error:
        	            	failed to init processor 'foo' path root.processor_resources: unable to restart plugin: unable to initialize plugin: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /tmp/rpcn_plugin_1893606329/plugin.sock: connect: no such file or directory"
        	Test:       	TestProcessorCustomCwd
internal/rpcplugin: adjust backoff strategy
```

etc