### PR TITLE
adding tcp_user_timeout setting for aws components

### DIFF
--- a/docs/modules/components/pages/caches/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/caches/aws_dynamodb.adoc
@@ -64,6 +64,7 @@ aws_dynamodb:
     max_elapsed_time: 30s
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -207,6 +208,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/caches/aws_s3.adoc
+++ b/docs/modules/components/pages/caches/aws_s3.adoc
@@ -59,6 +59,7 @@ aws_s3:
     max_elapsed_time: 30s
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -176,6 +177,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/caches/redpanda.adoc
+++ b/docs/modules/components/pages/caches/redpanda.adoc
@@ -379,6 +379,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -74,6 +74,7 @@ input:
       write_capacity_units: 0
       region: "" # No default (optional)
       endpoint: "" # No default (optional)
+      tcp_user_timeout: 0s
       credentials:
         profile: "" # No default (optional)
         id: "" # No default (optional)
@@ -91,6 +92,7 @@ input:
     start_from_oldest: true
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -218,6 +220,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `dynamodb.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `dynamodb.credentials`
 
@@ -367,6 +378,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/inputs/aws_s3.adoc
+++ b/docs/modules/components/pages/inputs/aws_s3.adoc
@@ -62,6 +62,7 @@ input:
     prefix: ""
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -156,6 +157,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/inputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/inputs/aws_sqs.adoc
@@ -60,6 +60,7 @@ input:
     message_timeout: 30s
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -172,6 +173,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -422,6 +422,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -447,6 +447,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -424,6 +424,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -394,6 +394,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
+++ b/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
@@ -54,6 +54,7 @@ metrics:
     flush_period: 100ms
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -123,6 +124,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/outputs/aws_dynamodb.adoc
@@ -74,6 +74,7 @@ output:
       processors: [] # No default (optional)
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -324,6 +325,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis.adoc
@@ -71,6 +71,7 @@ output:
       processors: [] # No default (optional)
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -263,6 +264,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
@@ -68,6 +68,7 @@ output:
       processors: [] # No default (optional)
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -233,6 +234,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_s3.adoc
+++ b/docs/modules/components/pages/outputs/aws_s3.adoc
@@ -91,6 +91,7 @@ output:
       processors: [] # No default (optional)
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -520,6 +521,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_sns.adoc
+++ b/docs/modules/components/pages/outputs/aws_sns.adoc
@@ -66,6 +66,7 @@ output:
     timeout: 5s
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -169,6 +170,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/outputs/aws_sqs.adoc
@@ -79,6 +79,7 @@ output:
     max_records_per_request: 10
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
+    tcp_user_timeout: 0s
     credentials:
       profile: "" # No default (optional)
       id: "" # No default (optional)
@@ -301,6 +302,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -408,6 +408,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/outputs/opensearch.adoc
+++ b/docs/modules/components/pages/outputs/opensearch.adoc
@@ -87,6 +87,7 @@ output:
       enabled: false
       region: "" # No default (optional)
       endpoint: "" # No default (optional)
+      tcp_user_timeout: 0s
       credentials:
         profile: "" # No default (optional)
         id: "" # No default (optional)
@@ -547,6 +548,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `aws.credentials`
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -393,6 +393,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -441,6 +441,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -393,6 +393,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
@@ -56,6 +56,7 @@ label: ""
 aws_bedrock_chat:
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -96,6 +97,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
@@ -53,6 +53,7 @@ label: ""
 aws_bedrock_embeddings:
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -125,6 +126,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
+++ b/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
@@ -56,6 +56,7 @@ aws_dynamodb_partiql:
   args_mapping: ""
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -140,6 +141,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/processors/aws_lambda.adoc
+++ b/docs/modules/components/pages/processors/aws_lambda.adoc
@@ -56,6 +56,7 @@ aws_lambda:
   rate_limit: ""
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
+  tcp_user_timeout: 0s
   credentials:
     profile: "" # No default (optional)
     id: "" # No default (optional)
@@ -176,6 +177,15 @@ Allows you to specify a custom endpoint for the AWS API.
 
 *Type*: `string`
 
+
+=== `tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `credentials`
 

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -370,6 +370,15 @@ Allows you to specify a custom endpoint for the AWS API.
 *Type*: `string`
 
 
+=== `sasl[].aws.tcp_user_timeout`
+
+Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
 === `sasl[].aws.credentials`
 
 Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redpanda-data/connect/v4
 
-go 1.24.1
-
-toolchain go1.24.2
+go 1.25.1
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 

--- a/go.sum
+++ b/go.sum
@@ -1962,8 +1962,6 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
 github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
-github.com/redpanda-data/benthos/v4 v4.57.0 h1:oxhKhB/Ha5MJQEDhITs5yE8vvofvjW5aU/+yhClgAWU=
-github.com/redpanda-data/benthos/v4 v4.57.0/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.62.0 h1:gy32d4y7AAnHlUHeaphostHpo2TKwGaFzSF9D4pr64Y=

--- a/internal/impl/aws/config/config.go
+++ b/internal/impl/aws/config/config.go
@@ -14,7 +14,10 @@
 
 package config
 
-import "github.com/redpanda-data/benthos/v4/public/service"
+import (
+	"github.com/redpanda-data/benthos/v4/public/netclient"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
 
 // SessionFields defines a re-usable set of config fields for an AWS session
 // that is compatible with the public service APIs and avoids importing the full
@@ -29,6 +32,12 @@ func SessionFields() []*service.ConfigField {
 			Description("Allows you to specify a custom endpoint for the AWS API.").
 			Optional().
 			Advanced(),
+		netclient.ConfigSpec(),
+		// service.NewDurationField("tcp_user_timeout").
+		// 	Description("Linux-specific TCP_USER_TIMEOUT for more fine grained connection stalling detection. How long to wait for acknowledgment of transmitted data on an established conenction before killing the connection. Only applies to connections in ESTAB state. Set to 0 (default) to disable.").
+		// 	Default("0s").
+		// 	Optional().
+		// 	Advanced(),
 		service.NewObjectField("credentials",
 			service.NewStringField("profile").
 				Description("A profile from `~/.aws/credentials` to use.").
@@ -52,7 +61,6 @@ func SessionFields() []*service.ConfigField {
 				Description("An external ID to provide when assuming a role.").
 				Optional().Advanced()).
 			Advanced().
-			Optional().
 			Description("Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[]."),
 	}
 }


### PR DESCRIPTION
In certain situations it is possible where a connection is ESTABLISHED, but for some reason, such as a network disconnect, the data is still sending to an aws service such as `sqs` or `dynamodb`, but those services are not responding back. Typically in this case, it will continue to retry sending the data up to the number set by the kernel setting for `tcp_retries2`, typically 15, which means it takes ~ 15-16mins before the connection is terminated.

This can cause the `input`, such as consumers to stop consuming from a topic/partition from Redpanda until that connection is killed and redpanda connect re-establishes a new connection.

Instead of modifying a systemwide kernel setting, it is possible to pass a value on the application level using `TCP_USER_TIMEOUT`. This will take president over the `tcp_retries2`.  This will make sure users don't have to modify a systemwide kernel setting and have more control specifically for redpanda connect in these cases.