### PR TITLE
redpanda/migrator: improve handling of record values starting with 0-byte

### DIFF
--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -51,6 +51,7 @@ output:
       include_deleted: false
       translate_ids: false
       normalize: false
+      strict: false
     consumer_groups:
       enabled: true
       interval: 1m
@@ -127,6 +128,7 @@ output:
       include_deleted: false
       translate_ids: false
       normalize: false
+      strict: false
     consumer_groups:
       enabled: true
       interval: 1m
@@ -1150,7 +1152,7 @@ Whether schema registry migration is enabled. When disabled, no schema operation
 
 === `schema_registry.interval`
 
-How often to synchronise schema registry subjects. Set to 0s for one-time sync at startup only, with additional syncs triggered when unknown subjects are encountered.
+How often to synchronise schema registry subjects. Set to 0s for one-time sync at startup only.
 
 
 *Type*: `string`
@@ -1251,6 +1253,15 @@ Whether to translate schema IDs during migration.
 === `schema_registry.normalize`
 
 Whether to normalize schemas when creating them in the destination registry.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `schema_registry.strict`
+
+Error on unknown schema IDs. Only relevant when translate_ids is true. When false (default), unknown schema IDs are passed through unchanged, allowing migration of topics with mixed message formats. Note: messages with 0-byte prefixes (e.g., protobuf) cannot be distinguished from schema registry headers and may fail when strict is enabled.
 
 
 *Type*: `bool`

--- a/internal/impl/redpanda/migrator/TESTING.md
+++ b/internal/impl/redpanda/migrator/TESTING.md
@@ -13,6 +13,18 @@ Verifies basic single-partition migration functionality.
 - Validates all messages arrive at destination in correct order
 - Confirms message keys and values match exactly
 
+### `TestIntegrationMigratorSinglePartitionMalformedSchemaID`
+
+Tests graceful handling of messages with malformed schema ID headers.
+- Creates source and destination clusters with Schema Registry enabled
+- Registers a schema in source Schema Registry
+- Produces 100 messages with malformed 5-byte schema ID headers (non-conformant to wire format)
+- Starts migrator and waits for message transfer
+- Validates:
+  - All messages arrive at destination without migration failure
+  - Malformed schema ID headers are preserved unchanged
+  - Message values remain intact
+
 ### `TestIntegrationMigratorMultiPartitionSchemaAwareWithConsumerGroups`
 
 Tests multi-partition migration with Schema Registry and consumer group synchronization.

--- a/internal/impl/redpanda/migrator/migrator.go
+++ b/internal/impl/redpanda/migrator/migrator.go
@@ -534,20 +534,22 @@ func (m *Migrator) onWrite(
 		record.Topic = lastDstTopic
 
 		// Update schema ID
-		schemaID, err := parseSchemaID(record.Value)
-		if err != nil {
-			return fmt.Errorf("parse schema ID: %w", err)
-		}
-		if schemaID != 0 {
-			if schemaID != lastSchemaID {
-				id, err := m.sr.DestinationSchemaID(ctx, schemaID)
-				if err != nil {
-					return fmt.Errorf("resolve destination schema ID: %w", err)
-				}
-				lastSchemaID, lastDstSchemaID = schemaID, id
+		if m.sr.enabled() && m.sr.conf.TranslateIDs {
+			schemaID, err := parseSchemaID(record.Value)
+			if err != nil {
+				return fmt.Errorf("parse schema ID: %w", err)
 			}
-			if err := updateSchemaID(record.Value, lastDstSchemaID); err != nil {
-				return fmt.Errorf("update schema ID: %w", err)
+			if schemaID != 0 {
+				if schemaID != lastSchemaID {
+					id, err := m.sr.DestinationSchemaID(schemaID)
+					if err != nil {
+						return fmt.Errorf("resolve destination schema ID: %w", err)
+					}
+					lastSchemaID, lastDstSchemaID = schemaID, id
+				}
+				if err := updateSchemaID(record.Value, lastDstSchemaID); err != nil {
+					return fmt.Errorf("update schema ID: %w", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We may encounter 0-byte prefixed messages, an example could be protobuf encoded messages. To better serve this use-case we:

- Disable dynamic schema registry resyncing in hot path
- Only parse schema ID if registry is enabled and translate ID is set - otherwise we want to just rewrite the ID
- Don't return error on unknown schema IDs unless strict mode is enabled