### PR TITLE
chore(resources/docker/profiling): minor improvements

### DIFF
--- a/resources/docker/profiling/config.yaml
+++ b/resources/docker/profiling/config.yaml
@@ -25,6 +25,7 @@ metrics:
     add_process_metrics: true
     add_go_metrics: true
 
+# Also enable jaeger service in docker-compose.yml
 # tracer:
 #   jaeger:
 #     agent_address: 'localhost:6831'

--- a/resources/docker/profiling/docker-compose.yaml
+++ b/resources/docker/profiling/docker-compose.yaml
@@ -3,12 +3,6 @@ volumes:
   grafana_data: {}
 
 services:
-  jaeger:
-    image: jaegertracing/all-in-one
-    ports:
-      - 6831:6831/udp
-      - 16686:16686
-
   prometheus:
     image: prom/prometheus
     volumes:
@@ -22,14 +16,15 @@ services:
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
-      - 9090:9090
+      - "9090:9090"
+    cpus: 0.5
 
   grafana:
     image: grafana/grafana
     depends_on:
       - prometheus
     ports:
-      - 3000:3000
+      - "3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/:/etc/grafana/provisioning/
@@ -39,3 +34,10 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=true
     env_file:
       - ./grafana/config.monitoring
+    cpus: 0.5
+
+# jaeger:
+#   image: jaegertracing/all-in-one
+#   ports:
+#     - "6831:6831/udp"
+#     - "16686:16686"

--- a/resources/docker/profiling/prometheus/prometheus.yml
+++ b/resources/docker/profiling/prometheus/prometheus.yml
@@ -5,13 +5,7 @@ global:
     monitor: 'rpcn-benchmark'
 
 scrape_configs:
-  - job_name: 'prometheus'
-    scrape_interval: 5s
-    static_configs:
-      - targets: ['localhost:9090']
-
   - job_name: 'rpcn'
     scrape_interval: 5s
     static_configs:
       - targets: ['host.docker.internal:4195']
-


### PR DESCRIPTION
- Disable jaeger as tracing is disabled by default in config
- Do not scrape prometheus itself
- Use quotes for port mapping
- Limit CPU usage to 1 core