### PR TITLE
.goreleaser.local: use fixed dev tags

### DIFF
--- a/.goreleaser.local/connect-ai.yaml
+++ b/.goreleaser.local/connect-ai.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}-ai"
+      - dev-ai
     platforms:
       - linux/arm64
     extra_files:

--- a/.goreleaser.local/connect-cloud.yaml
+++ b/.goreleaser.local/connect-cloud.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}-cloud"
+      - dev-cloud
     platforms:
       - linux/arm64
     extra_files:

--- a/.goreleaser.local/connect.yaml
+++ b/.goreleaser.local/connect.yaml
@@ -25,8 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}"
-      - latest
+      - dev
     platforms:
       - linux/arm64
     extra_files:


### PR DESCRIPTION
This is more convenient and works around bundle tags being incompatible with docker tags.

For example after tagging bundles we get version like public/bundle/enterprise/v4.66.1-SNAPSHOT-255ed50c4