### PR TITLE
fix: docker tags when building the images locally

### DIFF
--- a/.goreleaser.local/connect-ai.yaml
+++ b/.goreleaser.local/connect-ai.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}-ai"
+      - "{{ replace .Version \"/\" \"-\" }}-ai"
     platforms:
       - linux/arm64
     extra_files:

--- a/.goreleaser.local/connect-cloud.yaml
+++ b/.goreleaser.local/connect-cloud.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}-cloud"
+      - "{{ replace .Version \"/\" \"-\" }}-cloud"
     platforms:
       - linux/arm64
     extra_files:

--- a/.goreleaser.local/connect.yaml
+++ b/.goreleaser.local/connect.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     images:
       - redpandadata/connect
     tags:
-      - "{{ .Version }}"
+      - "{{ replace .Version \"/\" \"-\" }}"
       - latest
     platforms:
       - linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PATHINSTBIN        = $(DEST_DIR)/bin
 DOCKER_IMAGE       ?= docker.redpanda.com/redpandadata/connect
 
 VERSION   := $(shell git describe --tags 2> /dev/null || echo "v0.0.0")
-VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
+VER_CUT   := $(shell echo $(VERSION) | sed 's/^v//' | tr '/' '-')
 VER_MAJOR := $(shell echo $(VER_CUT) | cut -f1 -d.)
 VER_MINOR := $(shell echo $(VER_CUT) | cut -f2 -d.)
 VER_PATCH := $(shell echo $(VER_CUT) | cut -f3 -d.)


### PR DESCRIPTION
When running `make docker` on MacOS, I get the following error:

```
make docker
Makefile:9: DEPRECATED: This Makefile is deprecated. Please use https://taskfile.dev instead.
[+] Building 0.0s (0/0)                                                                          docker:desktop-linux
ERROR: invalid tag "docker.redpanda.com/redpandadata/connect:ublic/bundle/enterprise/v4.66.1-5-gd2313045d": invalid reference format
make: *** [docker] Error 1
```

Similarly for `task docker:redpanda-connect`

```
task docker:redpanda-connect
task: [docker:redpanda-connect] goreleaser release --snapshot --clean --skip=archive,publish --config=.goreleaser.local/connect.yaml
...
 ⨯ release failed after 6s                          error=exit status 1 args=docker buildx build --platform linux/arm64 -t redpandadata/connect:latest-arm64 -t redpandadata/connect:public/bundle/enterprise/v4.66.1-SNAPSHOT-d2313045d-arm64 --load --iidfile=id.txt . id=connect
    output=
    │ ERROR: invalid tag "redpandadata/connect:public/bundle/enterprise/v4.66.1-SNAPSHOT-d2313045d-arm64": invalid reference format
task: Failed to run task "docker:redpanda-connect": exit status 1
```

