### PR TITLE
feat(sql): add pgx as alternate postgres driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,6 +208,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -35,7 +35,7 @@ var dsnField = service.NewStringField("dsn").
 
 ==== Drivers
 
-:driver-support: mysql=certified, postgres=certified, clickhouse=community, mssql=community, sqlite=certified, oracle=certified, snowflake=community, trino=community, gocosmos=community, spanner=community
+:driver-support: mysql=certified, postgres=certified, pgx=community, clickhouse=community, mssql=community, sqlite=certified, oracle=certified, snowflake=community, trino=community, gocosmos=community, spanner=community
 
 The following is a list of supported drivers, their placeholder style, and their respective DSN formats:
 
@@ -48,7 +48,7 @@ The following is a list of supported drivers, their placeholder style, and their
 ` + "| `mysql` " + `
 ` + "| `[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]` " + `
 
-` + "| `postgres` " + `
+` + "| `postgres` and `pgx` " + `
 ` + "| `postgres://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]` " + `
 
 ` + "| `mssql` " + `
@@ -73,7 +73,8 @@ The following is a list of supported drivers, their placeholder style, and their
 ` + "| projects/[PROJECT]/instances/[INSTANCE]/databases/[DATABASE] " + `
 |===
 
-Please note that the ` + "`postgres`" + ` driver enforces SSL by default, you can override this with the parameter ` + "`sslmode=disable`" + ` if required.
+Please note that the ` + "`postgres`" + ` and ` + "`pgx`" + ` drivers enforce SSL by default, you can override this with the parameter ` + "`sslmode=disable`" + ` if required.
+The ` + "`pgx`" + ` driver is an alternative to the standard ` + "`postgres`" + ` (pq) driver and comes with extra functionality such as support for array insertion.
 
 The ` + "`snowflake`" + ` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: ` + "`<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`" + `, where the value for the ` + "`privateKey`" + ` parameter can be constructed from an unencrypted RSA private key file ` + "`rsa_key.p8`" + ` using ` + "`openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0`" + ` (you can use ` + "`gbasenc`" + ` insted of ` + "`basenc`" + ` on OSX if you install ` + "`coreutils`" + ` via Homebrew). If you have a password-encrypted private key, you can decrypt it using ` + "`openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`" + `. Also, make sure fields such as the username are URL-encoded.
 
@@ -154,6 +155,7 @@ func rawQueryField() *service.ConfigField {
 ` + "| `clickhouse` | Dollar sign |" + `
 ` + "| `mysql` | Question mark |" + `
 ` + "| `postgres` | Dollar sign |" + `
+` + "| `pgx` | Dollar sign |" + `
 ` + "| `mssql` | Question mark |" + `
 ` + "| `sqlite` | Question mark |" + `
 ` + "| `oracle` | Colon |" + `

--- a/internal/impl/sql/input_sql_select.go
+++ b/internal/impl/sql/input_sql_select.go
@@ -159,7 +159,7 @@ func newSQLSelectInputFromConfig(conf *service.ParsedConfig, mgr *service.Resour
 
 	s.builder = squirrel.Select(columns...).From(tableStr)
 	switch s.driver {
-	case "postgres", "clickhouse":
+	case "postgres", "pgx", "clickhouse":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Dollar)
 	case "oracle", "gocosmos":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Colon)

--- a/internal/impl/sql/integration_test.go
+++ b/internal/impl/sql/integration_test.go
@@ -91,7 +91,7 @@ func testRawProcessors(name string, fn func(t *testing.T, insertProc, selectProc
 		t.Run(name, func(t *testing.T) {
 			valuesStr := `(?, ?, ?)`
 			switch driver {
-			case "postgres", "clickhouse":
+			case "postgres", "pgx", "clickhouse":
 				valuesStr = `($1, $2, $3)`
 			case "oracle":
 				valuesStr = `(:1, :2, :3)`
@@ -106,7 +106,7 @@ exec_only: true
 
 			placeholderStr := "?"
 			switch driver {
-			case "postgres", "clickhouse":
+			case "postgres", "pgx", "clickhouse":
 				placeholderStr = "$1"
 			case "oracle":
 				placeholderStr = ":1"
@@ -148,7 +148,7 @@ func testRawTransactionalProcessors(name string, fn func(t *testing.T, insertPro
 			placeholderStr := "?"
 			valuesStr := `(?, ?, ?)`
 			switch driver {
-			case "postgres", "clickhouse":
+			case "postgres", "pgx", "clickhouse":
 				valuesStr = `($1, $2, $3)`
 				placeholderStr = "$1"
 			case "oracle":
@@ -208,7 +208,7 @@ func testRawDeprecatedProcessors(name string, fn func(t *testing.T, insertProc, 
 		t.Run(name, func(t *testing.T) {
 			valuesStr := `(?, ?, ?)`
 			switch driver {
-			case "postgres", "clickhouse":
+			case "postgres", "pgx", "clickhouse":
 				valuesStr = `($1, $2, $3)`
 			case "oracle":
 				valuesStr = `(:1, :2, :3)`
@@ -222,7 +222,7 @@ args_mapping: 'root = [ this.foo, this.bar.floor(), this.baz ]'
 
 			placeholderStr := "?"
 			switch driver {
-			case "postgres", "clickhouse":
+			case "postgres", "pgx", "clickhouse":
 				placeholderStr = "$1"
 			case "oracle":
 				placeholderStr = ":1"
@@ -494,7 +494,7 @@ func testBatchInputOutputRaw(t *testing.T, driver, dsn, table string) {
 		placeholderStr := "?"
 		valuesStr := `(?, ?, ?)`
 		switch driver {
-		case "postgres", "clickhouse":
+		case "postgres", "pgx", "clickhouse":
 			valuesStr = `($1, $2, $3)`
 			placeholderStr = "$1"
 		case "oracle":

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -165,13 +165,13 @@ func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 
 	s.builder = squirrel.Insert(tableStr).Columns(columns...)
 	switch s.driver {
-	case "postgres", "clickhouse":
+	case "postgres", "pgx", "clickhouse":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Dollar)
 	case "oracle", "gocosmos":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Colon)
 	}
 
-	if s.driver == "postgres" {
+	if s.driver == "postgres" || s.driver == "pgx" {
 		s.argsConverter = bloblValuesToPgSQLValues
 	} else {
 		s.argsConverter = func(v []any) []any { return v }

--- a/internal/impl/sql/processor_sql_insert.go
+++ b/internal/impl/sql/processor_sql_insert.go
@@ -154,13 +154,13 @@ func NewSQLInsertProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 
 	s.builder = squirrel.Insert(tableStr).Columns(columns...)
 	switch driverStr {
-	case "postgres", "clickhouse":
+	case "postgres", "pgx", "clickhouse":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Dollar)
 	case "oracle", "gocosmos":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Colon)
 	}
 
-	if driverStr == "postgres" {
+	if driverStr == "postgres" || driverStr == "pgx" {
 		s.argsConverter = bloblValuesToPgSQLValues
 	} else {
 		s.argsConverter = func(v []any) []any { return v }

--- a/internal/impl/sql/processor_sql_select.go
+++ b/internal/impl/sql/processor_sql_select.go
@@ -156,7 +156,7 @@ func NewSQLSelectProcessorFromConfig(conf *service.ParsedConfig, mgr *service.Re
 
 	s.builder = squirrel.Select(columns...).From(tableStr)
 	switch driverStr {
-	case "postgres", "clickhouse":
+	case "postgres", "pgx", "clickhouse":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Dollar)
 	case "oracle", "gocosmos":
 		s.builder = s.builder.PlaceholderFormat(squirrel.Colon)

--- a/public/components/sql/package.go
+++ b/public/components/sql/package.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/googleapis/go-sql-spanner"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/gocosmos"


### PR DESCRIPTION
Draws on [this issue](https://github.com/redpanda-data/connect/issues/1987) (which I ran into myself), in which `sql_insert` doesn't actually support Postgres array columns. I was left trying to manually escape convoluted strings using regex, and handcraft array literals, which is really brittle.

Thus I am basically just rebasing and updating [this older PR](https://github.com/redpanda-data/connect/pull/2200). It adds **pgx** (which is intended to be a drop-in replacement for **lib/pq**) as an _alternate_ postgres driver.

It doesn't redefine any settings, just reuses everything from the original postgres driver.

---

I've run `go test` on `internal/impl/sql` as @mihaitodor suggested and built a docker image, and everything seems to be fully working.

That being said, I would like to state for the record that I leaned on codex a bit to refactor the two postgres integration tests (though basically all I'm doing is looping over the existing test for the now two driver options—super straightforward), so I would appreciate a proper review from someone who knows what they're doing better than I do.