### PR TITLE
chore: bump to Go 1.25.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25.1
+        go-version: 1.25.2
 
     - name: Install Microsoft Go
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/v4
 
-go 1.25.1
+go 1.25.2
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 


### PR DESCRIPTION
Bump to Go 1.25.2 to include latest security fixes: https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ