### PR TITLE
gha: improve release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       if: ${{ github.event_name == 'push' }}
       uses: goreleaser/goreleaser-action@v6
       with:
-        args: release --release-notes=./release_notes.md --timeout 120m
+        args: release --release-notes=./release_notes.md --timeout 120m --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,13 +20,32 @@ builds:
             - QUILL_LOG_FILE=target/dist/quill-{{ .Target }}.log
     ignore:
       - goos: windows
-        goarch: arm64
+        goarch: arm
+      - goos: darwin
+        goarch: arm
     env:
       - CGO_ENABLED=0
     tags:
       - timetzdata
     ldflags: >
       -s -w
+      -X main.Version={{.Version}}
+      -X main.DateBuilt={{.Date}}
+      -X main.BinaryName=redpanda-connect
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportHost={{ if index .Env "CONNECT_TELEMETRY_HOST"  }}{{ .Env.CONNECT_TELEMETRY_HOST }}{{ else }}{{ end }}
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportDelay={{ if index .Env "CONNECT_TELEMETRY_DELAY"  }}{{ .Env.CONNECT_TELEMETRY_DELAY }}{{ else }}{{ end }}
+      -X github.com/redpanda-data/connect/v4/internal/telemetry.ExportPeriod={{ if index .Env "CONNECT_TELEMETRY_PERIOD"  }}{{ .Env.CONNECT_TELEMETRY_PERIOD }}{{ else }}{{ end }}
+
+  - id: connect-cgo
+    main: cmd/redpanda-connect/main.go
+    binary: redpanda-connect
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    env:
+      - CGO_ENABLED=1
+    tags:
+      - timetzdata
+    ldflags: >
       -X main.Version={{.Version}}
       -X main.DateBuilt={{.Date}}
       -X main.BinaryName=redpanda-connect
@@ -114,6 +133,15 @@ archives:
       - README.md
       - CHANGELOG.md
       - licenses
+
+  - id: connect-cgo
+    ids: [ connect-cgo ]
+    formats: tar.gz
+    files:
+      - README.md
+      - CHANGELOG.md
+      - licenses
+    name_template: 'redpanda-connect-cgo_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 
   - id: connect-fips
     ids: [ connect-fips ]


### PR DESCRIPTION
jira: [DEVPROD-3463]

- reduce release time by using beefier runner
- adds `workflow_dispatch` to enable testing `goreleaser` before a release is tagged 
- reverts #3689 to get `cgo` builds back

[DEVPROD-3463]: https://redpandadata.atlassian.net/browse/DEVPROD-3463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ