### PR TITLE
Fix gateway input reload bug

### DIFF
--- a/docs/modules/components/pages/inputs/gateway.adoc
+++ b/docs/modules/components/pages/inputs/gateway.adoc
@@ -39,6 +39,13 @@ input:
   gateway:
     path: /
     rate_limit: ""
+    sync_response:
+      status: "200"
+      headers:
+        Content-Type: application/octet-stream
+      metadata_headers:
+        include_prefixes: []
+        include_patterns: []
 ```
 
 --
@@ -60,6 +67,9 @@ input:
       metadata_headers:
         include_prefixes: []
         include_patterns: []
+    tcp:
+      reuse_addr: false
+      reuse_port: false
 ```
 
 --
@@ -112,7 +122,7 @@ An optional xref:components:rate_limits/about.adoc[rate limit] to throttle reque
 
 === `sync_response`
 
-Customize messages returned via xref:guides:sync_responses.adoc[synchronous responses].
+Sorry! This field is missing documentation.
 
 
 *Type*: `object`
@@ -195,5 +205,31 @@ include_patterns:
 include_patterns:
   - _timestamp_unix$
 ```
+
+=== `tcp`
+
+Customize messages returned via xref:guides:sync_responses.adoc[synchronous responses].
+
+
+*Type*: `object`
+
+
+=== `tcp.reuse_addr`
+
+Enable SO_REUSEADDR, allowing binding to ports in TIME_WAIT state. Useful for graceful restarts and config reloads where the server needs to rebind to the same port immediately after shutdown.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tcp.reuse_port`
+
+Enable SO_REUSEPORT, allowing multiple sockets to bind to the same port for load balancing across multiple processes/threads.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 


### PR DESCRIPTION
_Relies on https://github.com/redpanda-data/benthos/pull/306_

### Problem
When using `--watcher` for config reloads with the `gateway` input, the service would often get stuck returning 503 errors and fail to process requests until manually restarted.

This occurred due to a race condition during reload:
1. The old server's TCP port wasn't fully released before the new server tried to bind
2. Port binding happened asynchronously in a goroutine, so `Connect()` returned success even when binding failed
3. Once in this state, the server was marked as "running but not ready" with no recovery mechanism

### Solution
Made these changes to `internal/impl/gateway/input.go`:

1. **Enable SO_REUSEADDR socket option** - This feature is provided by https://github.com/redpanda-data/benthos/pull/306
2. **Synchronous port binding** - `Connect()` now creates the TCP listener before returning, immediately surfacing any binding errors

### Testing
- Added `TestHTTPServerReload` that verifies the server can be closed and recreated on the same port without errors