### PR TITLE
Upgrade to ollama v0.12.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/oklog/ulid/v2 v2.1.1
-	github.com/ollama/ollama v0.12.5
+	github.com/ollama/ollama v0.12.6
 	github.com/opensearch-project/opensearch-go/v3 v3.1.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/oschwald/geoip2-golang v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1843,8 +1843,8 @@ github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQ
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/ollama/ollama v0.12.5 h1:pz22TJLvLdtqdH4xYGV2JgXleW2M42xh5AcugxFMP2o=
-github.com/ollama/ollama v0.12.5/go.mod h1:9+1//yWPsDE2u+l1a5mpaKrYw4VdnSsRU3ioq5BvMms=
+github.com/ollama/ollama v0.12.6 h1:bJwDFeFFswOIXkfmSTQReV6Mj3yzPkP2LPb/OjSHQ2M=
+github.com/ollama/ollama v0.12.6/go.mod h1:9+1//yWPsDE2u+l1a5mpaKrYw4VdnSsRU3ioq5BvMms=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=

--- a/internal/impl/ollama/chat_processor_test.go
+++ b/internal/impl/ollama/chat_processor_test.go
@@ -48,7 +48,7 @@ func TestOllamaCompletionIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
 	ctx := t.Context()
-	ollamaContainer, err := ollama.Run(ctx, "ollama/ollama:0.9.0")
+	ollamaContainer, err := ollama.Run(ctx, "ollama/ollama:0.12.6")
 	assert.NoError(t, err)
 	defer func() {
 		if err := ollamaContainer.Terminate(ctx); err != nil {

--- a/internal/impl/ollama/embeddings_processor_test.go
+++ b/internal/impl/ollama/embeddings_processor_test.go
@@ -46,7 +46,7 @@ func TestOllamaEmbeddingsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
 	ctx := t.Context()
-	ollamaContainer, err := ollama.Run(ctx, "ollama/ollama:0.9.0")
+	ollamaContainer, err := ollama.Run(ctx, "ollama/ollama:0.12.6")
 	assert.NoError(t, err)
 	defer func() {
 		if err := ollamaContainer.Terminate(ctx); err != nil {

--- a/internal/impl/ollama/moderation_processor_test.go
+++ b/internal/impl/ollama/moderation_processor_test.go
@@ -52,7 +52,7 @@ func TestOllamaModerationIntegration(t *testing.T) {
 
 	ollamaContainer, err := ollama.Run(
 		ctx,
-		"ollama/ollama:0.9.0",
+		"ollama/ollama:0.12.6",
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/internal/impl/ollama/subprocess_unix.go
+++ b/internal/impl/ollama/subprocess_unix.go
@@ -63,7 +63,7 @@ func (c *runOllamaConfig) lookPath(file string) (string, error) {
 func (c *runOllamaConfig) downloadOllama(ctx context.Context, path string) error {
 	var url string
 	if c.downloadURL == "" {
-		const baseURL string = "https://github.com/ollama/ollama/releases/download/v0.5.4/ollama"
+		const baseURL string = "https://github.com/ollama/ollama/releases/download/v0.12.6/ollama"
 		switch runtime.GOOS {
 		case "darwin":
 			// They ship an universal executable for darwin

--- a/resources/docker/ai.Dockerfile
+++ b/resources/docker/ai.Dockerfile
@@ -18,7 +18,7 @@ RUN setcap 'cap_sys_chroot=+ep' /tmp/redpanda-connect
 
 RUN touch /tmp/keep
 
-FROM ollama/ollama AS package
+FROM ollama/ollama:0.12.6 AS package
 
 # Override the HOST from the ollama dockerfile
 ENV OLLAMA_HOST=127.0.0.1


### PR DESCRIPTION
This upgrades to ollama v0.12.6 across the project, resolving CVE-2024-12886, CVE-2025-0317, CVE-2025-0315, CVE-2024-12055, CVE-2024-8063, CVE-2025-0312, CVE-2025-1975 from the container scan.