### PR TITLE
redpanda: add field for topic exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 
 - (Benthos) New `string.repeat(int)` method to repeat a string or byte array N times. (@rockwotj)
 - (Benthos) New `bytes` method to create a 0 initialized byte array. (@rockwotj)
+- Added `regexp_topics_include` and `regexp_topics_exclude` fields to `redpanda`, `redpanda_migrator`, `ockam` inputs. (@mmatczuk)
+
+### Deprecated
+
+- The `regexp_topics` boolean field is now deprecated in favor of `regexp_topics_include`. (@mmatczuk)
 
 ### Changed
 

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -39,8 +39,9 @@ input:
   ockam_kafka:
     kafka:
       seed_brokers: [] # No default (optional)
-      topics: [] # No default (required)
-      regexp_topics: false
+      topics: [] # No default (optional)
+      regexp_topics_include: [] # No default (optional)
+      regexp_topics_exclude: [] # No default (optional)
       transaction_isolation_level: read_uncommitted
       consumer_group: "" # No default (optional)
     disable_content_encryption: false
@@ -73,8 +74,9 @@ input:
         root_cas: ""
         root_cas_file: ""
         client_certs: []
-      topics: [] # No default (required)
-      regexp_topics: false
+      topics: [] # No default (optional)
+      regexp_topics_include: [] # No default (optional)
+      regexp_topics_exclude: [] # No default (optional)
       rack_id: ""
       instance_id: ""
       rebalance_timeout: 45s
@@ -340,14 +342,32 @@ topics:
   - foo:0-5
 ```
 
-=== `kafka.regexp_topics`
+=== `kafka.regexp_topics_include`
 
-Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When enabled, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. When topics are specified with explicit partitions this field must remain set to `false`.
+A list of regular expression patterns for matching topics to consume from. When specified, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. This enables regex mode and cannot be used together with the `topics` field. Use `regexp_topics_exclude` to exclude specific patterns.
 
 
-*Type*: `bool`
+*Type*: `array`
 
-*Default*: `false`
+
+```yml
+# Examples
+
+regexp_topics_include:
+  - logs_.*
+  - metrics_.*
+
+regexp_topics_include:
+  - events_[0-9]+
+```
+
+=== `kafka.regexp_topics_exclude`
+
+A list of regular expression patterns for excluding topics when regex mode is enabled (via `regexp_topics` or `regexp_topics_include`). Topics matching any of these patterns will be excluded from consumption, even if they match include patterns.
+
+
+*Type*: `array`
+
 
 === `kafka.rack_id`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -38,8 +38,9 @@ input:
   label: ""
   redpanda:
     seed_brokers: [] # No default (optional)
-    topics: [] # No default (required)
-    regexp_topics: false
+    topics: [] # No default (optional)
+    regexp_topics_include: [] # No default (optional)
+    regexp_topics_exclude: [] # No default (optional)
     transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     auto_replay_nacks: true
@@ -68,8 +69,9 @@ input:
     metadata_max_age: 5m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
-    topics: [] # No default (required)
-    regexp_topics: false
+    topics: [] # No default (optional)
+    regexp_topics_include: [] # No default (optional)
+    regexp_topics_exclude: [] # No default (optional)
     rack_id: ""
     instance_id: ""
     rebalance_timeout: 45s
@@ -590,14 +592,32 @@ topics:
   - foo:0-5
 ```
 
-=== `regexp_topics`
+=== `regexp_topics_include`
 
-Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When enabled, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. When topics are specified with explicit partitions this field must remain set to `false`.
+A list of regular expression patterns for matching topics to consume from. When specified, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. This enables regex mode and cannot be used together with the `topics` field. Use `regexp_topics_exclude` to exclude specific patterns.
 
 
-*Type*: `bool`
+*Type*: `array`
 
-*Default*: `false`
+
+```yml
+# Examples
+
+regexp_topics_include:
+  - logs_.*
+  - metrics_.*
+
+regexp_topics_include:
+  - events_[0-9]+
+```
+
+=== `regexp_topics_exclude`
+
+A list of regular expression patterns for excluding topics when regex mode is enabled (via `regexp_topics` or `regexp_topics_include`). Topics matching any of these patterns will be excluded from consumption, even if they match include patterns.
+
+
+*Type*: `array`
+
 
 === `rack_id`
 

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -40,8 +40,9 @@ input:
   label: ""
   redpanda_migrator:
     seed_brokers: [] # No default (required)
-    topics: [] # No default (required)
-    regexp_topics: false
+    topics: [] # No default (optional)
+    regexp_topics_include: [] # No default (optional)
+    regexp_topics_exclude: [] # No default (optional)
     transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     schema_registry:
@@ -72,8 +73,9 @@ input:
     metadata_max_age: 5m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
-    topics: [] # No default (required)
-    regexp_topics: false
+    topics: [] # No default (optional)
+    regexp_topics_include: [] # No default (optional)
+    regexp_topics_exclude: [] # No default (optional)
     rack_id: ""
     instance_id: ""
     rebalance_timeout: 45s
@@ -575,14 +577,32 @@ topics:
   - foo:0-5
 ```
 
-=== `regexp_topics`
+=== `regexp_topics_include`
 
-Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When enabled, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. When topics are specified with explicit partitions this field must remain set to `false`.
+A list of regular expression patterns for matching topics to consume from. When specified, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. This enables regex mode and cannot be used together with the `topics` field. Use `regexp_topics_exclude` to exclude specific patterns.
 
 
-*Type*: `bool`
+*Type*: `array`
 
-*Default*: `false`
+
+```yml
+# Examples
+
+regexp_topics_include:
+  - logs_.*
+  - metrics_.*
+
+regexp_topics_include:
+  - events_[0-9]+
+```
+
+=== `regexp_topics_exclude`
+
+A list of regular expression patterns for excluding topics when regex mode is enabled (via `regexp_topics` or `regexp_topics_include`). Topics matching any of these patterns will be excluded from consumption, even if they match include patterns.
+
+
+*Type*: `array`
+
 
 === `rack_id`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -277,9 +277,10 @@ Migrate from Confluent/Kafka to Redpanda Cloud serverless cluster with authentic
 ```yamlinput:
   redpanda_migrator:
     seed_brokers: ["source-kafka:9092"]
-    topics:
-      - '^[^_]'  # All topics not starting with underscore
-    regexp_topics: true
+    regexp_topics_include:
+      - '.'
+    regexp_topics_exclude:
+      - '^_'
     consumer_group: "migrator_cg"
     schema_registry:
       url: "http://source-registry:8081"

--- a/internal/impl/kafka/franz_reader.go
+++ b/internal/impl/kafka/franz_reader.go
@@ -53,6 +53,8 @@ const (
 	kfrFieldRackID                 = "rack_id"
 	kfrFieldTopics                 = "topics"
 	kfrFieldRegexpTopics           = "regexp_topics"
+	kfrFieldRegexpTopicsInclude    = "regexp_topics_include"
+	kfrFieldRegexpTopicsExclude    = "regexp_topics_exclude"
 	kfrFieldStartFromOldest        = "start_from_oldest"
 	kfrFieldStartOffset            = "start_offset"
 	kfrFieldFetchMaxBytes          = "fetch_max_bytes"
@@ -92,6 +94,9 @@ const (
 	// FranzConsumerFieldLintRules contains the lint rules for the consumer fields.
 	FranzConsumerFieldLintRules = `
 let has_topic_partitions = this.topics.any(t -> t.contains(":"))
+let has_topics = this.topics.length() > 0
+let has_regexp_topics_include = this.regexp_topics_include.length() > 0 
+let is_regex_mode = this.regexp_topics || $has_regexp_topics_include
 
 root = [
   if $has_topic_partitions {
@@ -104,6 +109,15 @@ root = [
     if this.consumer_group.or("") == "" {
       "a consumer group is mandatory when not using explicit topic partitions"
     }
+  },
+  if !$has_topics && !$has_regexp_topics_include {
+    "either topics or regexp_topics_include must be specified"
+  },
+  if $has_topics && $has_regexp_topics_include {
+    "cannot specify both topics and regexp_topics_include, use one or the other"
+  },
+  if this.regexp_topics_exclude.length() > 0 && !$is_regex_mode {
+    "regexp_topics_exclude can only be used when regexp_topics is set to true or regexp_topics_include is specified"
   },
   # We don't have any way to distinguish between start_from_oldest set explicitly to true and not set at all, so we
   # assume users will be OK if start_offset overwrites it silently
@@ -130,10 +144,20 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 			Example([]string{"foo,bar"}).
 			Example([]string{"foo:0", "bar:1", "bar:3"}).
 			Example([]string{"foo:0,bar:1,bar:3"}).
-			Example([]string{"foo:0-5"}),
+			Example([]string{"foo:0-5"}).
+			Optional(),
 		service.NewBoolField(kfrFieldRegexpTopics).
-			Description("Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When enabled, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. When topics are specified with explicit partitions this field must remain set to `false`.").
-			Default(false),
+			Description("Whether listed topics should be interpreted as regular expression patterns for matching multiple topics. When enabled, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. When topics are specified with explicit partitions this field must remain set to `false`.\n\nThis field is deprecated, use `regexp_topics_include` instead.").
+			Default(false).
+			Deprecated(),
+		service.NewStringListField(kfrFieldRegexpTopicsInclude).
+			Description("A list of regular expression patterns for matching topics to consume from. When specified, the client will periodically refresh the list of matching topics based on the `metadata_max_age` interval. This enables regex mode and cannot be used together with the `topics` field. Use `regexp_topics_exclude` to exclude specific patterns.").
+			Example([]string{"logs_.*", "metrics_.*"}).
+			Example([]string{"events_[0-9]+"}).
+			Optional(),
+		service.NewStringListField(kfrFieldRegexpTopicsExclude).
+			Description("A list of regular expression patterns for excluding topics when regex mode is enabled (via `regexp_topics` or `regexp_topics_include`). Topics matching any of these patterns will be excluded from consumption, even if they match include patterns.").
+			Optional(),
 		service.NewStringField(kfrFieldRackID).
 			Description("A rack specifies where the client is physically located and changes fetch requests to consume from the closest replica as opposed to the leader replica.").
 			Default("").
@@ -204,6 +228,7 @@ type FranzConsumerDetails struct {
 	Topics                 []string
 	TopicPartitions        map[string]map[int32]kgo.Offset
 	RegexPattern           bool
+	ExcludeTopics          []string
 	FetchMinBytes          int32
 	FetchMaxBytes          int32
 	FetchMaxPartitionBytes int32
@@ -278,6 +303,21 @@ func FranzConsumerDetailsFromConfig(conf *service.ParsedConfig) (*FranzConsumerD
 		return nil, err
 	}
 
+	regexpTopics, err := conf.FieldBool(kfrFieldRegexpTopics)
+	if err != nil {
+		return nil, err
+	}
+	regexpIncludeTopics, err := conf.FieldStringList(kfrFieldRegexpTopicsInclude)
+	if err != nil {
+		return nil, err
+	}
+	d.RegexPattern = regexpTopics || len(regexpIncludeTopics) > 0
+
+	// Update topic list based on regex mode
+	if len(regexpIncludeTopics) != 0 {
+		topicList = regexpIncludeTopics
+	}
+
 	var topicPartitionsInts map[string]map[int32]int64
 	if d.Topics, topicPartitionsInts, err = ParseTopics(topicList, d.StartOffset.EpochOffset().Offset, true); err != nil {
 		return nil, err
@@ -294,7 +334,7 @@ func FranzConsumerDetailsFromConfig(conf *service.ParsedConfig) (*FranzConsumerD
 		}
 	}
 
-	if d.RegexPattern, err = conf.FieldBool(kfrFieldRegexpTopics); err != nil {
+	if d.ExcludeTopics, err = conf.FieldStringList(kfrFieldRegexpTopicsExclude); err != nil {
 		return nil, err
 	}
 
@@ -335,6 +375,9 @@ func (d *FranzConsumerDetails) FranzOpts() []kgo.Opt {
 
 	if d.RegexPattern {
 		opts = append(opts, kgo.ConsumeRegex())
+		if len(d.ExcludeTopics) > 0 {
+			opts = append(opts, kgo.ConsumeExcludeTopics(d.ExcludeTopics...))
+		}
 	}
 
 	if d.InstanceID != "" {

--- a/internal/impl/kafka/franz_reader_test.go
+++ b/internal/impl/kafka/franz_reader_test.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestFranzConsumerDetailsFromConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        string
+		wantTopics    []string
+		wantRegexMode bool
+		wantExclude   []string
+	}{
+		{
+			name: "topics_only",
+			config: `
+topics:
+  - foo
+  - bar
+`,
+			wantTopics:    []string{"foo", "bar"},
+			wantRegexMode: false,
+		},
+		{
+			name: "regexp_topics_include",
+			config: `
+regexp_topics_include:
+  - "logs_.*"
+  - "metrics_.*"
+`,
+			wantTopics:    []string{"logs_.*", "metrics_.*"},
+			wantRegexMode: true,
+		},
+		{
+			name: "regexp_include_with_exclude",
+			config: `
+regexp_topics_include:
+  - "logs_.*"
+regexp_topics_exclude:
+  - "logs_debug_.*"
+`,
+			wantTopics:    []string{"logs_.*"},
+			wantRegexMode: true,
+			wantExclude:   []string{"logs_debug_.*"},
+		},
+		{
+			name: "deprecated_regexp_topics_true",
+			config: `
+topics:
+  - "logs_.*"
+regexp_topics: true
+`,
+			wantTopics:    []string{"logs_.*"},
+			wantRegexMode: true,
+		},
+		{
+			name: "deprecated_regexp_topics_with_exclude",
+			config: `
+topics:
+  - "logs_.*"
+regexp_topics: true
+regexp_topics_exclude:
+  - "logs_debug_.*"
+`,
+			wantTopics:    []string{"logs_.*"},
+			wantRegexMode: true,
+			wantExclude:   []string{"logs_debug_.*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := service.NewEnvironment()
+
+			spec := service.NewConfigSpec().
+				Fields(FranzConsumerFields()...)
+
+			pConf, err := spec.ParseYAML(tc.config, env)
+			require.NoError(t, err)
+
+			got, err := FranzConsumerDetailsFromConfig(pConf)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantTopics, got.Topics)
+			assert.Equal(t, tc.wantRegexMode, got.RegexPattern)
+			if tc.wantExclude != nil {
+				assert.Equal(t, tc.wantExclude, got.ExcludeTopics)
+			}
+		})
+	}
+}

--- a/internal/impl/kafka/input_redpanda_test.go
+++ b/internal/impl/kafka/input_redpanda_test.go
@@ -1,0 +1,180 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestRedpandaInputFranzConsumerFieldLintRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    string
+		lintErr string
+	}{
+		{
+			name: "valid_config_with_topics",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo
+    - bar
+  consumer_group: test
+`,
+			lintErr: "",
+		},
+		{
+			name: "valid_config_with_regexp_topics_include",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  regexp_topics_include:
+    - "logs_.*"
+  consumer_group: test
+`,
+			lintErr: "",
+		},
+		{
+			name: "valid_config_with_topic_partitions",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo:0
+    - bar:1
+`,
+			lintErr: "",
+		},
+		{
+			name: "valid_config_with_regexp_topics_exclude",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  regexp_topics_include:
+    - "logs_.*"
+  regexp_topics_exclude:
+    - "logs_debug_.*"
+  consumer_group: test
+`,
+			lintErr: "",
+		},
+		{
+			name: "both_topics_and_regexp_topics_include",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo
+    - bar
+  regexp_topics_include:
+    - "logs_.*"
+  consumer_group: test
+`,
+			lintErr: "(3,1) cannot specify both topics and regexp_topics_include, use one or the other",
+		},
+		{
+			name: "topic_partitions_with_consumer_group",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo:0
+    - bar:1
+  consumer_group: test
+`,
+			lintErr: "(3,1) this input does not support both a consumer group and explicit topic partitions",
+		},
+		{
+			name: "topic_partitions_with_regexp_topics",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo:0
+    - bar:1
+  regexp_topics: true
+`,
+			lintErr: "(3,1) this input does not support both regular expression topics and explicit topic partitions",
+		},
+		{
+			name: "no_consumer_group_without_topic_partitions",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo
+    - bar
+`,
+			lintErr: "(3,1) a consumer group is mandatory when not using explicit topic partitions",
+		},
+		{
+			name: "neither_topics_nor_regexp_topics_include",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  consumer_group: test
+`,
+			lintErr: "(3,1) either topics or regexp_topics_include must be specified",
+		},
+		{
+			name: "regexp_topics_exclude_without_regex_mode",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo
+  regexp_topics_exclude:
+    - "bar_.*"
+  consumer_group: test
+`,
+			lintErr: "(3,1) regexp_topics_exclude can only be used when regexp_topics is set to true or regexp_topics_include is specified",
+		},
+		{
+			name: "start_from_oldest_false_with_start_offset_earliest",
+			conf: `
+redpanda:
+  seed_brokers: ["localhost:9092"]
+  topics:
+    - foo
+  consumer_group: test
+  start_from_oldest: false
+  start_offset: earliest
+`,
+			lintErr: "(3,1) start_from_oldest cannot be set to false when start_offset is set to earliest",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := service.NewEnvironment()
+			linter := env.NewComponentConfigLinter()
+
+			lints, err := linter.LintInputYAML([]byte(test.conf))
+			require.NoError(t, err)
+			if test.lintErr != "" {
+				assert.Len(t, lints, 1)
+				assert.Equal(t, test.lintErr, lints[0].Error())
+			} else {
+				assert.Empty(t, lints)
+			}
+		})
+	}
+}

--- a/internal/impl/redpanda/migrator/migrator.go
+++ b/internal/impl/redpanda/migrator/migrator.go
@@ -199,9 +199,10 @@ output:
 			`input:
   redpanda_migrator:
     seed_brokers: ["source-kafka:9092"]
-    topics:
-      - '^[^_]'  # All topics not starting with underscore
-    regexp_topics: true
+    regexp_topics_include:
+      - '.'
+    regexp_topics_exclude:
+      - '^_'
     consumer_group: "migrator_cg"
     schema_registry:
       url: "http://source-registry:8081"


### PR DESCRIPTION
Add support for excluding topics when using regex-based consumption in
franz-go based inputs (redpanda, redpanda_migrator). Deprecate `regexp_topics`
field in favor of more explicit include syntax.