### PR TITLE
(mssqlservercdc): address issue with empty checkpoint cache config

### DIFF
--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -193,10 +193,10 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 				return nil, err
 			}
 		}
-	} else {
-		if cpCacheTableName, err = conf.FieldString(fieldCheckpointCacheTableName); err != nil {
-			return nil, err
-		}
+	}
+
+	if cpCacheTableName, err = conf.FieldString(fieldCheckpointCacheTableName); err != nil {
+		return nil, err
 	}
 
 	// checkpointing

--- a/internal/impl/mssqlserver/integration_test.go
+++ b/internal/impl/mssqlserver/integration_test.go
@@ -66,6 +66,7 @@ func TestIntegration_MicrosoftSQLServerCDC_SnapshotAndStreaming(t *testing.T) {
 microsoft_sql_server_cdc:
   connection_string: %s
   stream_snapshot: true
+  checkpoint_cache: ""
   snapshot_max_batch_size: 10
   include: ["test.foo", "dbo.foo", "dbo.bar"]
   exclude: ["dbo.doesnotexist"]`


### PR DESCRIPTION
This change ensures the SQL Server CDC component treats the `checkpoint_cache` config the same whether it's an empty string or not specified.