### PR TITLE
mssqlservercdc: improve documentation and default `stream_snapshot` to false

### DIFF
--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -40,7 +40,7 @@ input:
   label: ""
   microsoft_sql_server_cdc:
     connection_string: sqlserver://username:password@host/instance?param1=value&param2=value # No default (required)
-    stream_snapshot: false # No default (required)
+    stream_snapshot: false
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     include: [] # No default (required)
@@ -69,7 +69,7 @@ input:
   label: ""
   microsoft_sql_server_cdc:
     connection_string: sqlserver://username:password@host/instance?param1=value&param2=value # No default (required)
-    stream_snapshot: false # No default (required)
+    stream_snapshot: false
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     include: [] # No default (required)
@@ -104,7 +104,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-To use the default Microsoft SQL Server cache, the user must have permissions to create tables and stored procedures. Refer to `checkpoint_cache_table_name` for additional details.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
 		
 
 == Fields
@@ -130,6 +130,13 @@ If set to true, the connector will query all the existing data as a part of snap
 
 *Type*: `bool`
 
+*Default*: `false`
+
+```yml
+# Examples
+
+stream_snapshot: true
+```
 
 === `max_parallel_snapshot_tables`
 
@@ -179,7 +186,7 @@ exclude: dbo.privatetable
 
 === `checkpoint_cache`
 
-A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current Log Sequence Number (LSN) that has been successfully delivered, this allows Redpanda Connect to continue from that Log Sequence Number (LSN) upon restart, rather than consume the entire state of the change table.
+A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current Log Sequence Number (LSN) that has been successfully delivered, this allows Redpanda Connect to continue from that Log Sequence Number (LSN) upon restart, rather than consume the entire state of the change table. If not set the default Microsoft SQL Server based cache will be used, see `checkpoint_cache_table_name` for more information.
 
 
 *Type*: `string`

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -65,14 +65,16 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-To use the default Microsoft SQL Server cache, the user must have permissions to create tables and stored procedures. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for additional details.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").
 		Example("sqlserver://username:password@host/instance?param1=value&param2=value"),
 	).
 	Field(service.NewBoolField(fieldStreamSnapshot).
-		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current Log Sequence Number position."),
+		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current Log Sequence Number position.").
+		Example(true).
+		Default(false),
 	).
 	Field(service.NewIntField(fieldMaxParallelSnapshotTables).
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").
@@ -91,7 +93,7 @@ To use the default Microsoft SQL Server cache, the user must have permissions to
 		Optional(),
 	).
 	Field(service.NewStringField(fieldCheckpointCache).
-		Description("A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current Log Sequence Number (LSN) that has been successfully delivered, this allows Redpanda Connect to continue from that Log Sequence Number (LSN) upon restart, rather than consume the entire state of the change table.").
+		Description("A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current Log Sequence Number (LSN) that has been successfully delivered, this allows Redpanda Connect to continue from that Log Sequence Number (LSN) upon restart, rather than consume the entire state of the change table. If not set the default Microsoft SQL Server based cache will be used, see `" + fieldCheckpointCacheTableName + "` for more information.").
 		Optional(),
 	).
 	Field(service.NewStringField(fieldCheckpointCacheTableName).


### PR DESCRIPTION
Slight tweak on the SQL Server CDC cache to highlight that the `rpcn` schema must exist for the table and stored procedure to be created.

This change also sets the `stream_snapshot` config to `false` by default to align it with the PostgreSQL CDC component (it'd be good to do more work on aligning the CDC components where necessary). Given by default it was not set and a required field it won't be a breaking change to anyone using the component.