### PR TITLE
redpanda/migrator: reduce log verbosity in consumer group Sync()

### DIFF
--- a/internal/impl/redpanda/migrator/migrator_groups.go
+++ b/internal/impl/redpanda/migrator/migrator_groups.go
@@ -328,14 +328,14 @@ func (m *groupsMigrator) Sync(ctx context.Context, getTopics func() []TopicMappi
 		return nil
 	}
 
-	m.log.Info("Consumer group migration: syncing consumer groups")
+	m.log.Debug("Consumer group migration: syncing consumer groups")
 
 	mappings := getTopics()
 
 	// Filter out topics
 	topics := m.filterTopics(mappings)
 	if len(topics) == 0 {
-		m.log.Infof("Consumer group migration: no topics to sync")
+		m.log.Debug("Consumer group migration: no topics to sync")
 		return nil
 	}
 
@@ -373,7 +373,7 @@ func (m *groupsMigrator) Sync(ctx context.Context, getTopics func() []TopicMappi
 		return false
 	})
 	if len(gcos) == 0 {
-		m.log.Infof("Consumer group migration: nothing to do")
+		m.log.Debug("Consumer group migration: nothing to do")
 		return nil
 	}
 	topics = extractTopics(gcos)
@@ -511,7 +511,7 @@ func (m *groupsMigrator) Sync(ctx context.Context, getTopics func() []TopicMappi
 		offsetsToCommitCount += 1
 	}
 	if len(offsetsToCommit) == 0 {
-		m.log.Infof("Consumer group migration: no offsets to commit")
+		m.log.Debug("Consumer group migration: no offsets to commit")
 		return nil
 	}
 


### PR DESCRIPTION
Change most log statements from Info to Debug level in Sync() to reduce log noise when running with sub-second sync intervals. The final summary log remains at Info level for visibility.