### PR TITLE
AMQP 1.0 Output - New Configuration Options

### DIFF
--- a/docs/modules/components/pages/outputs/amqp_1.adoc
+++ b/docs/modules/components/pages/outputs/amqp_1.adoc
@@ -72,6 +72,9 @@ output:
     metadata:
       exclude_prefixes: []
     content_type: opaque_binary
+    persistent: false
+    target_capabilities: [] # No default (optional)
+    message_properties_to: amqp://localhost:5672/ # No default (optional)
 ```
 
 --
@@ -399,5 +402,50 @@ Options:
 `opaque_binary`
 , `string`
 .
+
+=== `persistent`
+
+If set to true, the message will be marked as persistent, ensuring it is stored durably and not lost if an intermediary (such as a broker) restarts. By default, messages are not durable.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `target_capabilities`
+
+Lists the extension capabilities the sender desires from the target, such as support for queues, topics, durability, sharing, or temporary destinations.
+
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+target_capabilities:
+  - queue
+
+target_capabilities:
+  - topic
+
+target_capabilities:
+  - queue
+  - topic
+```
+
+=== `message_properties_to`
+
+The field specifies the node that is the intended destination of the message, which may differ from the node currently receiving the transfer.
+
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+message_properties_to: amqp://localhost:5672/
+```
 
 

--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -43,6 +43,9 @@ const (
 	appPropsMapField = "application_properties_map"
 	metaFilterField  = "metadata"
 	contentTypeField = "content_type"
+	persistentField  = "persistent"
+	targetCapsField  = "target_capabilities"
+	messagePropsTo   = "message_properties_to"
 )
 
 // ErrSASLMechanismNotSupported is returned if a SASL mechanism was not recognised.

--- a/internal/impl/amqp1/output_test.go
+++ b/internal/impl/amqp1/output_test.go
@@ -1,0 +1,55 @@
+package amqp1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestAMQP1ConfigParsing(t *testing.T) {
+	spec := amqp1OutputSpec()
+	env := service.NewEnvironment()
+
+	t.Run("All options omitted (backward compatible)", func(t *testing.T) {
+		inputConfig := `urls:
+  - "amqp://localhost:5672"
+target_address: "/queue"`
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+		w, err := amqp1WriterFromParsed(conf, service.MockResources())
+		require.False(t, w.persistent)
+		require.Empty(t, w.msgTo)
+		require.Empty(t, w.senderOpts.TargetCapabilities)
+		require.NoError(t, err)
+	})
+
+	t.Run("All new options set", func(t *testing.T) {
+		inputConfig := `urls:
+  - "amqp://localhost:5672"
+target_address: "/queue"
+target_capabilities:
+  - "queue"
+  - "topic"
+message_properties_to: "amqp://otherhost:5672/otherqueue"
+persistent: true`
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+		w, wErr := amqp1WriterFromParsed(conf, service.MockResources())
+		require.NoError(t, wErr)
+		require.True(t, w.persistent)
+		require.Equal(t, []string{"queue", "topic"}, w.senderOpts.TargetCapabilities)
+		require.Equal(t, "amqp://otherhost:5672/otherqueue", w.msgTo)
+		require.True(t, w.persistent)
+	})
+
+	t.Run("Invalid type for persistent", func(t *testing.T) {
+		inputConfig := `urls:
+  - "amqp://localhost:5672"
+target_address: "/queue"
+persistent: "notabool"`
+		_, err := spec.ParseYAML(inputConfig, env)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
This pull request adds three new configuration options to the AMQP 1.0 output, giving users more control.

All new configuration options are optional and do not affect existing setups. If not specified, the output will continue to function as before.

1. **persistent**
   - Type: `bool`
   - Description: When enabled, this option marks outgoing messages as persistent. Persistent messages should be are stored by the broker and survive restarts or crashes, ensuring that important data is not lost.
   - Default: `false`

In ActiveMQ this is easy visible (persistent: true):
<img width="383" height="324" alt="activemq_persistent_true" src="https://github.com/user-attachments/assets/1e69aad4-9d3b-4109-a7cd-13e10b642df7" />

persistent: false
<img width="385" height="329" alt="activemq_persistent_false" src="https://github.com/user-attachments/assets/3174e37d-5d83-4bb1-a67d-91acf6293048" />


2. **target_capabilities**
   - Type: `[]string`
   - Description: This option allows you to specify which advanced features or capabilities you expect from the AMQP broker for the target address. Capabilities can include support for queues, topics, durability, sharing, or temporary destinations. Some AMQP brokers ignore this like ActiveMQ, so it really depends on the AMQP broker implementation.
   - Example use case: Requesting a durable queue for reliable event processing, or a shared topic for pub/sub scenarios.
   - Example: `["queue"]`

3. **message_props_to**
   - Type: `string`
   - Description: This option sets the 'To' property on outgoing AMQP messages, which can be used to direct messages to a specific node or endpoint, even if the transfer is handled by an intermediary. This option is dependent on the AMQP broker implementation to properly function.
   - Example use case: Routing messages to a specific microservice or partition in a multi-tenant architecture.
   - Example: `"amqp://analytics-service/ingest"`

In ActiveMQ you can see this in the binary message details, example `message_properties_to: amqp://xx:5672/`:
<img width="568" height="96" alt="activemq_message_properties_to" src="https://github.com/user-attachments/assets/29217d4b-ae1d-451c-a17f-141f80e04fa1" />

