### PR TITLE
redpanda/migrator: correct docs use of string interpolation

### DIFF
--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -46,7 +46,7 @@ output:
       interval: 5m
       include: [] # No default (optional)
       exclude: [] # No default (optional)
-      subject: '"prod_${! metadata(''schema_registry_subject'') }"' # No default (optional)
+      subject: prod_${! metadata("schema_registry_subject") } # No default (optional)
       versions: all
       include_deleted: false
       translate_ids: false
@@ -130,7 +130,7 @@ output:
       interval: 5m
       include: [] # No default (optional)
       exclude: [] # No default (optional)
-      subject: '"prod_${! metadata(''schema_registry_subject'') }"' # No default (optional)
+      subject: prod_${! metadata("schema_registry_subject") } # No default (optional)
       versions: all
       include_deleted: false
       translate_ids: false
@@ -1347,9 +1347,9 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 ```yml
 # Examples
 
-subject: '"prod_${! metadata(''schema_registry_subject'') }"'
+subject: prod_${! metadata("schema_registry_subject") }
 
-subject: '"${! metadata(''schema_registry_subject'') | replace(''dev_'', ''prod_'') }"'
+subject: ${! metadata("schema_registry_subject") | replace("dev_", "prod_") }
 ```
 
 === `schema_registry.versions`

--- a/internal/impl/redpanda/migrator/migrator_schema_registry.go
+++ b/internal/impl/redpanda/migrator/migrator_schema_registry.go
@@ -125,8 +125,8 @@ func schemaRegistryMigratorFields() []*service.ConfigField {
 			Optional(),
 		service.NewInterpolatedStringField(srFieldSubject).
 			Description("Template for transforming subject names during migration. Use interpolation to rename subjects systematically.").
-			Example(`"prod_${! metadata('schema_registry_subject') }"`).
-			Example(`"${! metadata('schema_registry_subject') | replace('dev_', 'prod_') }"`).
+			Example(`prod_${! metadata("schema_registry_subject") }`).
+			Example(`${! metadata("schema_registry_subject") | replace("dev_", "prod_") }`).
 			Optional(),
 		service.NewStringEnumField(srFieldVersions, VersionsLatest.String(), VersionsAll.String()).
 			Description("Which schema versions to migrate. 'latest' migrates only the current version, 'all' migrates complete version history for better compatibility.").


### PR DESCRIPTION
The change updates the docs to use double quotes as opposed to single quotes for strings passed to the `metadata` function.