### PR TITLE
mysql_cdc: Add IAM auth support

### DIFF
--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -74,6 +74,19 @@ input:
     stream_snapshot: false # No default (required)
     auto_replay_nacks: true
     checkpoint_limit: 1024
+    tls:
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+    aws:
+      enabled: false
+      region: "" # No default (optional)
+      endpoint: "" # No default (required)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
+      roles: [] # No default (optional)
     batching:
       count: 0
       byte_size: 0
@@ -196,6 +209,232 @@ The maximum number of messages that can be processed at a given time. Increasing
 *Type*: `int`
 
 *Default*: `1024`
+
+=== `tls`
+
+Using this field overrides the SSL/TLS settings in the environment and DSN.
+
+
+*Type*: `object`
+
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server side certificate verification.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 3.45.0 or newer
+
+=== `tls.root_cas`
+
+An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+A plain text certificate key to use.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+=== `aws`
+
+AWS IAM authentication configuration for MySQL instances. When enabled, IAM credentials are used to generate temporary authentication tokens instead of a static password.
+
+
+*Type*: `object`
+
+
+=== `aws.enabled`
+
+Enable AWS IAM authentication for MySQL. When enabled, an IAM authentication token is generated and used as the password.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `aws.region`
+
+The AWS region where the MySQL instance is located. If no region is specified then the environment default will be used.
+
+
+*Type*: `string`
+
+
+=== `aws.endpoint`
+
+The MySQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com).
+
+
+*Type*: `string`
+
+
+=== `aws.role`
+
+Optional AWS IAM role ARN to assume for authentication. Use this for cross-account access to RDS instances. Deprecated: use `roles` array for multiple roles or roles with external IDs.
+
+
+*Type*: `string`
+
+
+=== `aws.role_external_id`
+
+Optional external ID for the role assumption. Only used with the `role` field. Deprecated: use `roles` array instead.
+
+
+*Type*: `string`
+
+
+=== `aws.roles`
+
+Optional array of AWS IAM roles to assume for authentication. Roles are assumed in sequence, enabling role chaining for cross-account access. Each role can optionally specify an external ID.
+
+
+*Type*: `array`
+
+
+=== `aws.roles[].role`
+
+AWS IAM role ARN to assume.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `aws.roles[].role_external_id`
+
+Optional external ID for the role assumption.
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `batching`
 

--- a/internal/impl/mysql/aws/aws.go
+++ b/internal/impl/mysql/aws/aws.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	mysqlimpl "github.com/redpanda-data/connect/v4/internal/impl/mysql"
+)
+
+type roleConfig struct {
+	arn        string
+	externalID string
+}
+
+func init() {
+	mysqlimpl.AWSOptFn = awsIAMAuth
+}
+
+func awsIAMAuth(ctx context.Context, awsConf *service.ParsedConfig, dbConf *mysql.Config, log *service.Logger) (mysqlimpl.TokenBuilder, error) {
+	if enabled, _ := awsConf.FieldBool(mysqlimpl.FieldAWSIAMAuthEnabled); !enabled {
+		return nil, nil
+	}
+
+	var (
+		err    error
+		awsCfg aws.Config
+
+		endpoint    string
+		region      string
+		roleConfigs []roleConfig
+	)
+	if awsCfg, err = awsconfig.LoadDefaultConfig(ctx); err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	if endpoint, err = awsConf.FieldString("endpoint"); err != nil {
+		return nil, err
+	}
+	if region, err = awsConf.FieldString("region"); err != nil {
+		return nil, err
+	} else if region != "" {
+		awsCfg.Region = region
+	}
+	if awsCfg.Region == "" {
+		return nil, errors.New("aws.region is required for IAM authentication")
+	}
+
+	// parse aws.role and aws.roles[]
+	role, _ := parseRoleConfig(awsConf)
+	roleConfigs = append(roleConfigs, role...)
+
+	if rolesConfs, err := awsConf.FieldObjectList("roles"); err != nil {
+		return nil, err
+	} else {
+		for _, conf := range rolesConfs {
+			if roles, err := parseRoleConfig(conf); err != nil {
+				return nil, err
+			} else {
+				for i, v := range roles {
+					if v.arn == "" {
+						return nil, fmt.Errorf("roles[%d].role is required for IAM authentication", i)
+					}
+				}
+				roleConfigs = append(roleConfigs, roles...)
+			}
+		}
+	}
+
+	// tokenBuilder will be called upon component connection to refresh token/password and reconnect.
+	// Tokens last ~15 minutes and will only need refreshing after a connection is lost.
+	tokenBuilder := func(ctx context.Context) error {
+		if len(roleConfigs) > 0 {
+			if awsCfg, err = assumeRoleChain(ctx, awsCfg, roleConfigs, log); err != nil {
+				return fmt.Errorf("assuming role based on configured roles: %w", err)
+			}
+		}
+		password, err := auth.BuildAuthToken(ctx, endpoint, awsCfg.Region, dbConf.User, awsCfg.Credentials)
+		if err != nil {
+			return fmt.Errorf("building IAM auth token: %w", err)
+		}
+		dbConf.Passwd = password
+
+		log.Debug("IAM authentication token generated successfully")
+		return nil
+	}
+	return tokenBuilder, nil
+}
+
+// assumeRoleChain iterates through one or more roles enabling the user to chain elevation them (ie, from local role, privileged then cross-account).
+// If no roles are set, AWS SDK will check for environment configured roles and automatically assume them.
+func assumeRoleChain(ctx context.Context, awsCfg aws.Config, roles []roleConfig, log *service.Logger) (aws.Config, error) {
+	currentConfig := awsCfg
+	for _, role := range roles {
+		if role.arn == "" {
+			continue
+		}
+
+		// Create credentials provider for this role
+		stsClient := sts.NewFromConfig(currentConfig)
+		provider := stscreds.NewAssumeRoleProvider(stsClient, role.arn, func(opts *stscreds.AssumeRoleOptions) {
+			if role.externalID != "" {
+				opts.ExternalID = &role.externalID
+				log.Debugf("Using external ID for role '%s'", role.arn)
+			}
+		})
+		currentConfig.Credentials = aws.NewCredentialsCache(provider)
+
+		// Verify the role assumption worked
+		identity, err := sts.NewFromConfig(currentConfig).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err != nil {
+			return aws.Config{}, fmt.Errorf("verifying role assumption for '%s': %w", role.arn, err)
+		}
+
+		log.Debugf("Successfully assumed role '%s' with identity '%s'", role.arn, *identity.Arn)
+	}
+
+	return currentConfig, nil
+}
+
+func parseRoleConfig(awsConf *service.ParsedConfig) ([]roleConfig, error) {
+	var roles []roleConfig
+	if role, err := awsConf.FieldString("role"); err != nil {
+		return nil, err
+	} else if externalID, err := awsConf.FieldString("role_external_id"); err != nil {
+		return nil, err
+	} else {
+		roles = append(roles, roleConfig{role, externalID})
+	}
+
+	return roles, nil
+}

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -10,6 +10,7 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -43,9 +44,25 @@ const (
 	fieldCheckpointKey        = "checkpoint_key"
 	fieldCheckpointCache      = "checkpoint_cache"
 	fieldCheckpointLimit      = "checkpoint_limit"
+	fieldAWSIAMAuth           = "aws"
+	// FieldAWSIAMAuthEnabled enabled field.
+	FieldAWSIAMAuthEnabled = "enabled"
 
 	shutdownTimeout = 5 * time.Second
 )
+
+func notImportedAWSOptFn(_ context.Context, awsConf *service.ParsedConfig, _ *mysql.Config, _ *service.Logger) (TokenBuilder, error) {
+	if enabled, _ := awsConf.FieldBool(FieldAWSIAMAuthEnabled); !enabled {
+		return nil, nil
+	}
+	return nil, errors.New("unable to configure AWS authentication as this binary does not import components/aws")
+}
+
+// AWSOptFn is populated with the child `aws` package when imported.
+var AWSOptFn = notImportedAWSOptFn
+
+// TokenBuilder can be used for fetching passwords at runtime during connection (ie. IAM auth tokens)
+type TokenBuilder func(context.Context) error
 
 var mysqlStreamConfigSpec = service.NewConfigSpec().
 	Beta().
@@ -89,6 +106,39 @@ This input adds the following metadata fields to each message:
 		service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given BinLog Position will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
 			Default(1024),
+		service.NewTLSField("tls").
+			Description("Using this field overrides the SSL/TLS settings in the environment and DSN.").
+			Optional(),
+		service.NewObjectField(fieldAWSIAMAuth,
+			service.NewBoolField(FieldAWSIAMAuthEnabled).
+				Description("Enable AWS IAM authentication for MySQL. When enabled, an IAM authentication token is generated and used as the password.").
+				Default(false),
+			service.NewStringField("region").
+				Description("The AWS region where the MySQL instance is located. If no region is specified then the environment default will be used.").
+				Optional(),
+			service.NewStringField("endpoint").
+				Description("The MySQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com)."),
+			service.NewStringField("role").
+				Description("Optional AWS IAM role ARN to assume for authentication. Use this for cross-account access to RDS instances. Deprecated: use `roles` array for multiple roles or roles with external IDs.").
+				Optional(),
+			service.NewStringField("role_external_id").
+				Description("Optional external ID for the role assumption. Only used with the `role` field. Deprecated: use `roles` array instead.").
+				Optional(),
+			service.NewObjectListField("roles",
+				service.NewStringField("role").
+					Default("").
+					Description("AWS IAM role ARN to assume."),
+				service.NewStringField("role_external_id").
+					Description("Optional external ID for the role assumption.").
+					Default("").
+					Optional(),
+			).
+				Description("Optional array of AWS IAM roles to assume for authentication. Roles are assumed in sequence, enabling role chaining for cross-account access. Each role can optionally specify an external ID.").
+				Optional(),
+		).
+			Description("AWS IAM authentication configuration for MySQL instances. When enabled, IAM credentials are used to generate temporary authentication tokens instead of a static password.").
+			Advanced().
+			Optional(),
 		service.NewBatchPolicyField(fieldBatching),
 	)
 
@@ -126,6 +176,13 @@ type mysqlStreamInput struct {
 	cp               *checkpoint.Capped[*position]
 
 	shutSig *shutdown.Signaller
+
+	// TLS configuration
+	tlsConfig *tls.Config
+
+	// IAM authentication fields
+	iamAuthEnabled      bool
+	iamAuthTokenBuilder TokenBuilder
 }
 
 func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s service.BatchInput, err error) {
@@ -158,6 +215,34 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	}
 	// We require this configuration option is enabled.
 	i.mysqlConfig.ParseTime = true
+
+	// Configure TLS if specified
+	if i.tlsConfig, err = conf.FieldTLS("tls"); err != nil {
+		return nil, err
+	}
+	if i.tlsConfig != nil {
+		// Get ServerName from the address, stripping the port if present
+		host := i.mysqlConfig.Addr
+		if idx := strings.Index(host, ":"); idx != -1 {
+			host = host[:idx]
+		}
+		i.tlsConfig.ServerName = host
+
+		tlsConfigKey := "custom-tls"
+		if err := mysql.RegisterTLSConfig(tlsConfigKey, i.tlsConfig); err != nil {
+			return nil, fmt.Errorf("failed to register TLS config: %w", err)
+		}
+		i.mysqlConfig.TLSConfig = tlsConfigKey
+	}
+
+	// Configure AWS IAM authentication if enabled
+	awsConf := conf.Namespace(fieldAWSIAMAuth)
+	i.iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
+
+	if i.iamAuthTokenBuilder, err = AWSOptFn(context.Background(), awsConf, i.mysqlConfig, res.Logger()); err != nil {
+		return nil, err
+	}
+
 	i.dsn = i.mysqlConfig.FormatDSN()
 
 	if i.tables, err = conf.FieldStringList(fieldMySQLTables); err != nil {
@@ -222,6 +307,13 @@ func init() {
 // ---- Redpanda Connect specific methods----
 
 func (i *mysqlStreamInput) Connect(ctx context.Context) error {
+	// If IAM authentication is enabled, generate a new token
+	if i.iamAuthEnabled && i.iamAuthTokenBuilder != nil {
+		if err := i.iamAuthTokenBuilder(ctx); err != nil {
+			return fmt.Errorf("unable to generate IAM auth token: %w", err)
+		}
+	}
+
 	canalConfig := canal.NewDefaultConfig()
 	canalConfig.Flavor = i.flavor
 	canalConfig.Addr = i.mysqlConfig.Addr
@@ -233,8 +325,9 @@ func (i *mysqlStreamInput) Connect(ctx context.Context) error {
 
 	// Parse and set additional parameters
 	canalConfig.Charset = i.mysqlConfig.Collation
-	if i.mysqlConfig.TLS != nil {
-		canalConfig.TLSConfig = i.mysqlConfig.TLS
+	if i.tlsConfig != nil {
+		canalConfig.TLSConfig = i.tlsConfig
+		i.logger.Debugf("Using custom TLS config with ServerName: '%s'", i.tlsConfig.ServerName)
 	}
 	// Parse time values as time.Time values not strings
 	canalConfig.ParseTime = true
@@ -261,7 +354,7 @@ func (i *mysqlStreamInput) Connect(ctx context.Context) error {
 	// create snapshot instance if we were requested and haven't finished it before.
 	var snapshot *Snapshot
 	if i.streamSnapshot && pos == nil {
-		db, err := sql.Open("mysql", i.dsn)
+		db, err := sql.Open("mysql", i.mysqlConfig.FormatDSN())
 		if err != nil {
 			return fmt.Errorf("failed to connect to MySQL server: %s", err)
 		}

--- a/public/components/aws/package.go
+++ b/public/components/aws/package.go
@@ -18,6 +18,7 @@ import (
 	// Bring in the internal plugin definitions.
 	_ "github.com/redpanda-data/connect/v4/internal/impl/aws"
 	_ "github.com/redpanda-data/connect/v4/internal/impl/kafka/aws"
+	_ "github.com/redpanda-data/connect/v4/internal/impl/mysql/aws"
 	_ "github.com/redpanda-data/connect/v4/internal/impl/opensearch/aws"
 	_ "github.com/redpanda-data/connect/v4/internal/impl/postgresql/aws"
 )


### PR DESCRIPTION
This change adds support for IAM authentication for the MySQL CDC component, following the same approach as the recently added [IAM support for PostgreSQL CDC](https://github.com/redpanda-data/connect/pull/3791), however this version has the benefit of being able to support a range of IAM configurations:

- Default (.aws/) configured policies
- Single assumes role operations
- Chained assume role operations (as demonstrated in the screenshot below)

This change also enables the advanced TLS configuration as it's needed for connecting to Aurora.

<img width="2998" height="1662" alt="image" src="https://github.com/user-attachments/assets/c26af0ca-ba68-4990-a91c-c417452e3800" />
