### PR TITLE
redpanda_migrator: add client timeout config for schema registry client

### DIFF
--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -47,6 +47,7 @@ input:
     consumer_group: "" # No default (optional)
     schema_registry:
       url: http://localhost:8081 # No default (required)
+      timeout: 5s
     auto_replay_nacks: true
 ```
 
@@ -101,6 +102,7 @@ input:
     max_yield_batch_bytes: 32KB
     schema_registry:
       url: http://localhost:8081 # No default (required)
+      timeout: 5s
       tls:
         enabled: false
         skip_cert_verify: false
@@ -920,6 +922,15 @@ url: http://localhost:8081
 
 url: https://schema-registry.example.com:8081
 ```
+
+=== `schema_registry.timeout`
+
+HTTP client timeout for schema registry requests.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `schema_registry.tls`
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -42,6 +42,7 @@ output:
     seed_brokers: [] # No default (required)
     schema_registry:
       url: http://localhost:8081 # No default (required)
+      timeout: 5s
       enabled: true
       interval: 5m
       include: [] # No default (optional)
@@ -104,6 +105,7 @@ output:
     broker_write_max_bytes: 100MiB
     schema_registry:
       url: http://localhost:8081 # No default (required)
+      timeout: 5s
       tls:
         enabled: false
         skip_cert_verify: false
@@ -970,6 +972,15 @@ url: http://localhost:8081
 
 url: https://schema-registry.example.com:8081
 ```
+
+=== `schema_registry.timeout`
+
+HTTP client timeout for schema registry requests.
+
+
+*Type*: `string`
+
+*Default*: `"5s"`
 
 === `schema_registry.tls`
 


### PR DESCRIPTION
This change adds a timeout configuration for the Schema Registry HTTP Client, ensuring the default behaviour remains the same as Franz's default client (5 second timeout and setting the UA header). https://github.com/twmb/franz-go/blob/master/pkg/sr/client.go#L87-L88 