### PR TITLE
postgresql_cdc: Support IAM assume role chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.72.0 - TBD
+## 4.72.0 - 2025-11-28
 
 ### Added
 
 - Added Redpanda Cloud service account authentication to all redpanda/kafka based components (@rockwotj)
+- `mysql_cdc`: Support for chained or unchained IAM authentication (@josephwoodward)
+- `postgresql_cdc`: Support for chained or unchained IAM authentication (@josephwoodward)
 
 ## 4.71.0 - 2025-11-21
 

--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -71,6 +71,7 @@ input:
     checkpoint_cache: "" # No default (required)
     checkpoint_key: mysql_binlog_position
     snapshot_max_batch_size: 1000
+    max_reconnect_attempts: 10
     stream_snapshot: false # No default (required)
     auto_replay_nacks: true
     checkpoint_limit: 1024
@@ -84,6 +85,9 @@ input:
       enabled: false
       region: "" # No default (optional)
       endpoint: "" # No default (required)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
       role: "" # No default (optional)
       role_external_id: "" # No default (optional)
       roles: [] # No default (optional)
@@ -183,6 +187,15 @@ The maximum number of rows to be streamed in a single batch when taking a snapsh
 *Type*: `int`
 
 *Default*: `1000`
+
+=== `max_reconnect_attempts`
+
+The maximum number of attempts the MySQL driver will try to re-establish a broken connection before Connect attempts reconnection. A zero or negative number means infinite retry attempts.
+
+
+*Type*: `int`
+
+*Default*: `10`
 
 === `stream_snapshot`
 
@@ -371,7 +384,7 @@ AWS IAM authentication configuration for MySQL instances. When enabled, IAM cred
 
 === `aws.enabled`
 
-Enable AWS IAM authentication for MySQL. When enabled, an IAM authentication token is generated and used as the password.
+Enable AWS IAM authentication for MySQL. When enabled, an IAM authentication token is generated and used as the password. When using IAM authentication ensure `max_reconnect_attempts` is set to a low value to ensure it can refresh credentials.
 
 
 *Type*: `bool`
@@ -394,9 +407,38 @@ The MySQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com).
 *Type*: `string`
 
 
+=== `aws.id`
+
+The ID of credentials to use.
+
+
+*Type*: `string`
+
+
+=== `aws.secret`
+
+The secret for the credentials being used.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+
+=== `aws.token`
+
+The token for the credentials being used, required when using short term credentials.
+
+
+*Type*: `string`
+
+
 === `aws.role`
 
-Optional AWS IAM role ARN to assume for authentication. Use this for cross-account access to RDS instances. Deprecated: use `roles` array for multiple roles or roles with external IDs.
+Optional AWS IAM role ARN to assume for authentication. Alternatively, use `roles` array for role chaining instead.
 
 
 *Type*: `string`
@@ -404,7 +446,7 @@ Optional AWS IAM role ARN to assume for authentication. Use this for cross-accou
 
 === `aws.role_external_id`
 
-Optional external ID for the role assumption. Only used with the `role` field. Deprecated: use `roles` array instead.
+Optional external ID for the role assumption. Only used with the `role` field. Alternatively, use `roles` array for role chaining instead.
 
 
 *Type*: `string`
@@ -412,7 +454,7 @@ Optional external ID for the role assumption. Only used with the `role` field. D
 
 === `aws.roles`
 
-Optional array of AWS IAM roles to assume for authentication. Roles are assumed in sequence, enabling role chaining for cross-account access. Each role can optionally specify an external ID.
+Optional array of AWS IAM roles to assume for authentication. Roles can be assumed in sequence, enabling chaining for purposes such as cross-account access. Each role can optionally specify an external ID.
 
 
 *Type*: `array`

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -93,6 +93,12 @@ input:
       enabled: false
       region: "" # No default (optional)
       endpoint: "" # No default (required)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
+      roles: [] # No default (optional)
     auto_replay_nacks: true
     batching:
       count: 0
@@ -480,6 +486,77 @@ The PostgreSQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com)
 
 *Type*: `string`
 
+
+=== `aws.id`
+
+The ID of credentials to use.
+
+
+*Type*: `string`
+
+
+=== `aws.secret`
+
+The secret for the credentials being used.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+
+=== `aws.token`
+
+The token for the credentials being used, required when using short term credentials.
+
+
+*Type*: `string`
+
+
+=== `aws.role`
+
+Optional AWS IAM role ARN to assume for authentication. Alternatively, use `roles` array for role chaining instead.
+
+
+*Type*: `string`
+
+
+=== `aws.role_external_id`
+
+Optional external ID for the role assumption. Only used with the `role` field. Alternatively, use `roles` array for role chaining instead.
+
+
+*Type*: `string`
+
+
+=== `aws.roles`
+
+Optional array of AWS IAM roles to assume for authentication. Roles can be assumed in sequence, enabling chaining for purposes such as cross-account access. Each role can optionally specify an external ID.
+
+
+*Type*: `array`
+
+
+=== `aws.roles[].role`
+
+AWS IAM role ARN to assume.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `aws.roles[].role_external_id`
+
+Optional external ID for the role assumption.
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `auto_replay_nacks`
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -151,6 +151,32 @@ This input adds the following metadata fields to each message:
 				Optional(),
 			service.NewStringField("endpoint").
 				Description("The PostgreSQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com)."),
+			service.NewStringField("id").
+				Description("The ID of credentials to use.").
+				Optional().Advanced(),
+			service.NewStringField("secret").
+				Description("The secret for the credentials being used.").
+				Optional().Advanced().Secret(),
+			service.NewStringField("token").
+				Description("The token for the credentials being used, required when using short term credentials.").
+				Optional().Advanced(),
+			service.NewStringField("role").
+				Description("Optional AWS IAM role ARN to assume for authentication. Alternatively, use `roles` array for role chaining instead.").
+				Optional(),
+			service.NewStringField("role_external_id").
+				Description("Optional external ID for the role assumption. Only used with the `role` field. Alternatively, use `roles` array for role chaining instead.").
+				Optional(),
+			service.NewObjectListField("roles",
+				service.NewStringField("role").
+					Default("").
+					Description("AWS IAM role ARN to assume."),
+				service.NewStringField("role_external_id").
+					Description("Optional external ID for the role assumption.").
+					Default("").
+					Optional(),
+			).
+				Description("Optional array of AWS IAM roles to assume for authentication. Roles can be assumed in sequence, enabling chaining for purposes such as cross-account access. Each role can optionally specify an external ID.").
+				Optional(),
 		).
 			Description("AWS IAM authentication configuration for PostgreSQL instances. When enabled, IAM credentials are used to generate temporary authentication tokens instead of a static password.").
 			Advanced().


### PR DESCRIPTION
This PR copies the functionality for supporting chained IAM roles from the [recently merged MySQL CDC](https://github.com/redpanda-data/connect/pull/3801) change. It also adds support for specifying access keys in config for both the MySQL and PostgreSQL IAM features.

Once the dust settles on this, I'll look at moving some of this into the `internal/impl/aws` directory where it can be shared between PostgreSQL and MySQL as it's mostly identical.

### Initial Connection

<img width="1512" height="946" alt="image" src="https://github.com/user-attachments/assets/5c16005f-e7d1-4e48-b85e-3a4b391ed5ec" />

### Reconnection:

<img width="1509" height="862" alt="image" src="https://github.com/user-attachments/assets/4a7ae76d-4b72-4bb6-b518-66bc30f0ed63" />


### Integration Tests

<img width="1803" height="1185" alt="image" src="https://github.com/user-attachments/assets/ab172ac2-4121-45eb-b541-bf12015a81b7" />
