### PR TITLE
Fix: address migrator integration tests that were failing due to new Redpanda version

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install Task
         uses: ./.github/actions/setup-task
 
+      - name: Pull Latest Redpanda Image 
+        run: task docker:pull-redpanda
+
       - name: Run Integration Tests for ${{ matrix.package }}
         run: task test:integration-package PKG=${{ matrix.package }}
         timeout-minutes: 30

--- a/internal/impl/redpanda/migrator/integration_test.go
+++ b/internal/impl/redpanda/migrator/integration_test.go
@@ -219,6 +219,14 @@ func TestIntegrationMigratorSinglePartitionMalformedSchemaID(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	t.Log("And: Destination schema registry subject is set to import mode")
+	{
+		srDst, err := sr.NewClient(sr.URLs(dst.SchemaRegistryURL))
+		require.NoError(t, err)
+		modeRes := srDst.SetMode(t.Context(), sr.ModeImport, subj)
+		require.NoError(t, modeRes[0].Err)
+	}
+
 	pfx := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
 
 	t.Log("When: Messages with malformed schema ID headers are written to source cluster")
@@ -259,6 +267,14 @@ func TestIntegrationMigratorMultiPartitionSchemaAwareWithConsumerGroups(t *testi
 	require.NoError(t, err)
 	ss, err := srScr.CreateSchema(t.Context(), subj, sr.Schema{Schema: schema})
 	require.NoError(t, err)
+
+	t.Log("And: Destination schema registry subject is set to import mode")
+	{
+		srDst, err := sr.NewClient(sr.URLs(dst.SchemaRegistryURL))
+		require.NoError(t, err)
+		modeRes := srDst.SetMode(t.Context(), sr.ModeImport, subj)
+		require.NoError(t, modeRes[0].Err)
+	}
 
 	t.Log("When: Messages are written to the source cluster")
 	{
@@ -986,6 +1002,14 @@ func TestIntegrationMigratorJiraCON229(t *testing.T) {
 	ss, err := srSrc.CreateSchema(t.Context(), schemaSubject, sr.Schema{Schema: schema})
 	require.NoError(t, err)
 	t.Logf("Created schema with ID: %d", ss.ID)
+
+	t.Log("And: Destination schema registry subject is set to import mode")
+	{
+		srDst, err := sr.NewClient(sr.URLs(dst.SchemaRegistryURL))
+		require.NoError(t, err)
+		modeRes := srDst.SetMode(t.Context(), sr.ModeImport, schemaSubject)
+		require.NoError(t, modeRes[0].Err)
+	}
 
 	t.Log("And: Multiple topics created with multiple partitions")
 	for _, topic := range []string{topicA, topicB, topicC, topicD} {

--- a/internal/impl/redpanda/migrator/migrator_groups_integration_test.go
+++ b/internal/impl/redpanda/migrator/migrator_groups_integration_test.go
@@ -169,6 +169,12 @@ func TestIntegrationReadRecordTimestamp(t *testing.T) {
 
 	src, _ := startRedpandaSourceAndDestination(t)
 
+	// Get the topic ID for migratorTestTopic, Kafka Fetch v13 (KIP-516)
+	topicDetails, err := src.Admin.ListTopics(t.Context(), migratorTestTopic)
+	require.NoError(t, err)
+	topicDetail, exists := topicDetails[migratorTestTopic]
+	require.True(t, exists, "topic should exist")
+
 	secs := func(n int) time.Time {
 		return time.Unix(int64(n), 0)
 	}
@@ -203,7 +209,7 @@ func TestIntegrationReadRecordTimestamp(t *testing.T) {
 		t.Parallel()
 		for _, rec := range records {
 			ts, err := migrator.ReadRecordTimestamp(t.Context(), src.Client,
-				migratorTestTopic, kadm.TopicID{},
+				migratorTestTopic, topicDetail.ID,
 				rec.partition, rec.offset, redpandaTestOpTimeout)
 			require.NoError(t, err)
 			assert.Equal(t, rec.timestamp, ts)

--- a/internal/impl/redpanda/migrator/migrator_topic_integration_test.go
+++ b/internal/impl/redpanda/migrator/migrator_topic_integration_test.go
@@ -42,7 +42,10 @@ func TestIntegrationTopicMigratorSyncACLs(t *testing.T) {
 
 	hasACL := func(t *testing.T, cluster EmbeddedRedpandaCluster, topic, principal string, perm kmsg.ACLPermissionType, op kmsg.ACLOperation) bool {
 		acls, err := cluster.DescribeTopicACLs(topic)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("Failed to describe ACLs (treating as not found): %v", err)
+			return false
+		}
 		for _, a := range acls {
 			t.Logf("Found ACL: %v", a)
 

--- a/taskfiles/docker.yml
+++ b/taskfiles/docker.yml
@@ -41,3 +41,13 @@ tasks:
       .dockers_v2[0].platforms = ["linux/{{.GOARCH}}"] |
       .checksum.disable = true'
       {{.CONFIG_FILE}})
+
+  pull-redpanda:
+    desc: Pull latest version of Redpanda for local development/testing
+    vars:
+      IMAGE_BASE: 'docker.redpanda.com/redpandadata/redpanda'
+      IMAGE_TAG: '{{.IMAGE_TAG | default "latest"}}'
+    cmds:
+      - echo "Pulling latest Redpanda version..."
+      - docker pull {{.IMAGE_BASE }}:{{ .IMAGE_TAG }}
+      - docker inspect {{.IMAGE_BASE }}:{{ .IMAGE_TAG }} | jq '[.[].RepoTags[]]'


### PR DESCRIPTION
Fixes the migrator integration tests that were failing due to either a new version of Redpanda or/and that it was caching the `latest` tagged container.

<img width="2621" height="1524" alt="image" src="https://github.com/user-attachments/assets/fad6f9d5-b77c-4b7e-8a42-0798f92a829c" />
