### PR TITLE
couchbase: add ttl (expiry) support

### DIFF
--- a/docs/modules/components/pages/outputs/couchbase.adoc
+++ b/docs/modules/components/pages/outputs/couchbase.adoc
@@ -74,6 +74,7 @@ output:
     timeout: 15s
     id: ${! json("id") } # No default (required)
     content: "" # No default (optional)
+    ttl: "" # No default (optional)
     operation: upsert
     max_in_flight: 64
     batching:
@@ -209,6 +210,14 @@ id: ${! json("id") }
 === `content`
 
 Document content.
+
+
+*Type*: `string`
+
+
+=== `ttl`
+
+An optional TTL to set for items.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/couchbase.adoc
+++ b/docs/modules/components/pages/processors/couchbase.adoc
@@ -66,6 +66,7 @@ couchbase:
   timeout: 15s
   id: ${! json("id") } # No default (required)
   content: "" # No default (optional)
+  ttl: "" # No default (optional)
   operation: get
 ```
 
@@ -187,6 +188,14 @@ id: ${! json("id") }
 === `content`
 
 Document content.
+
+
+*Type*: `string`
+
+
+=== `ttl`
+
+An optional TTL to set for items.
 
 
 *Type*: `string`

--- a/internal/impl/couchbase/couchbase.go
+++ b/internal/impl/couchbase/couchbase.go
@@ -16,6 +16,7 @@ package couchbase
 
 import (
 	"errors"
+	"time"
 
 	"github.com/couchbase/gocb/v2"
 )
@@ -41,35 +42,53 @@ func valueFromOp(op gocb.BulkOp) (out any, err error) {
 	return nil, errors.New("type not supported")
 }
 
-func get(key string, _ []byte) gocb.BulkOp {
+func get(key string, _ []byte, _ *time.Duration) gocb.BulkOp {
 	return &gocb.GetOp{
 		ID: key,
 	}
 }
 
-func insert(key string, data []byte) gocb.BulkOp {
-	return &gocb.InsertOp{
+func insert(key string, data []byte, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.InsertOp{
 		ID:    key,
 		Value: data,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }
 
-func remove(key string, _ []byte) gocb.BulkOp {
+func remove(key string, _ []byte, _ *time.Duration) gocb.BulkOp {
 	return &gocb.RemoveOp{
 		ID: key,
 	}
 }
 
-func replace(key string, data []byte) gocb.BulkOp {
-	return &gocb.ReplaceOp{
+func replace(key string, data []byte, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.ReplaceOp{
 		ID:    key,
 		Value: data,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }
 
-func upsert(key string, data []byte) gocb.BulkOp {
-	return &gocb.UpsertOp{
+func upsert(key string, data []byte, ttl *time.Duration) gocb.BulkOp {
+	op := &gocb.UpsertOp{
 		ID:    key,
 		Value: data,
 	}
+
+	if ttl != nil {
+		op.Expiry = *ttl
+	}
+
+	return op
 }

--- a/internal/impl/couchbase/processor_test.go
+++ b/internal/impl/couchbase/processor_test.go
@@ -15,6 +15,7 @@
 package couchbase_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -124,7 +125,7 @@ func TestIntegrationCouchbaseProcessor(t *testing.T) {
 	bucket := fmt.Sprintf("testing-processor-%d", time.Now().Unix())
 	require.NoError(t, createBucket(t.Context(), servicePort, bucket))
 	t.Cleanup(func() {
-		require.NoError(t, removeBucket(t.Context(), servicePort, bucket))
+		require.NoError(t, removeBucket(context.Background(), servicePort, bucket))
 	})
 
 	uid := faker.UUIDHyphenated()
@@ -157,6 +158,12 @@ func TestIntegrationCouchbaseProcessor(t *testing.T) {
 	})
 	t.Run("Get", func(t *testing.T) {
 		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
+	})
+	t.Run("TTL", func(t *testing.T) {
+		testCouchbaseProcessorUpsertTTL(payload, bucket, servicePort, t)
+		testCouchbaseProcessorGet(uid, payload, bucket, servicePort, t)
+		time.Sleep(5 * time.Second)
+		testCouchbaseProcessorGetMissing(uid, bucket, servicePort, t)
 	})
 }
 
@@ -329,4 +336,31 @@ operation: 'get'
 	dataOut, err := msgOut[0][0].AsBytes()
 	assert.NoError(t, err)
 	assert.Equal(t, uid, string(dataOut))
+}
+
+func testCouchbaseProcessorUpsertTTL(payload, bucket, port string, t *testing.T) {
+	config := fmt.Sprintf(`
+url: 'couchbase://localhost:%s'
+bucket: %s
+username: %s
+password: %s
+id: '${! json("id") }'
+content: 'root = this'
+operation: 'upsert'
+ttl: 3s
+`, port, bucket, username, password)
+
+	msgOut, err := getProc(t, config).ProcessBatch(t.Context(), service.MessageBatch{
+		service.NewMessage([]byte(payload)),
+	})
+
+	// batch processing should be fine and contain one message.
+	assert.NoError(t, err)
+	assert.Len(t, msgOut, 1)
+	assert.Len(t, msgOut[0], 1)
+
+	// message content should stay the same.
+	dataOut, err := msgOut[0][0].AsBytes()
+	assert.NoError(t, err)
+	assert.JSONEq(t, payload, string(dataOut))
 }


### PR DESCRIPTION
The ttl (called expiry in couchbase) was implemented in couchbase cache implementation but was missing in processor and output.
This PR add a new field ttl to set this value (like it is done in cache implementation).