### PR TITLE
postgres_cdc: Improve documentation around replication slot name

### DIFF
--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -222,6 +222,9 @@ If set to true, creates a temporary replication slot that is automatically dropp
 
 The name of the PostgreSQL logical replication slot to use. If not provided, a random name will be generated. You can create this slot manually before starting replication if desired.
 
+Note: To avoid needing to grant the replication user permission to create publications, you can manually create the publications ahead of time.
+This connector uses the naming pattern `pglog_stream_<replication_slot_name>`, so be sure to create them using this convention.
+
 
 *Type*: `string`
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -116,7 +116,11 @@ This input adds the following metadata fields to each message:
 			Description("If set to true, creates a temporary replication slot that is automatically dropped when the connection is closed.").
 			Default(false)).
 		Field(service.NewStringField(fieldSlotName).
-			Description("The name of the PostgreSQL logical replication slot to use. If not provided, a random name will be generated. You can create this slot manually before starting replication if desired.").
+			Description(`The name of the PostgreSQL logical replication slot to use. If not provided, a random name will be generated. You can create this slot manually before starting replication if desired.
+
+Note: To avoid needing to grant the replication user permission to create publications, you can manually create the publications ahead of time.
+This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name>`" + `, so be sure to create them using this convention.
+			`).
 			Example("my_test_slot")).
 		Field(service.NewDurationField(fieldPgStandbyTimeout).
 			Description("Specify the standby timeout before refreshing an idle connection.").


### PR DESCRIPTION
Updates documentation following feedback from a customer who had to go digging through the source code to find this information.