### PR TITLE
Fix mcp lint exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.73.0 - TBD
+
+### Fixed
+
+- The `mcp-server lint` subcommand now exits with status 1 when linting errors are detected.
+
 ## 4.72.0 - 2025-11-28
 
 ### Added

--- a/internal/cli/custom_lint.go
+++ b/internal/cli/custom_lint.go
@@ -156,7 +156,9 @@ func directoryMode(c *cli.Context, repositoryDir string) error {
 		return err
 	}
 
+	hasLintErrors := false
 	for _, pl := range pathLints {
+		hasLintErrors = hasLintErrors || len(pl.lints) > 0 || pl.err != nil
 		for _, lint := range pl.lints {
 			lintText := fmt.Sprintf("%v%v\n", pl.fileName, lint.Error())
 			fmt.Fprint(os.Stderr, yellow(lintText))
@@ -165,6 +167,10 @@ func directoryMode(c *cli.Context, repositoryDir string) error {
 			lintText := fmt.Sprintf("%v%v\n", pl.fileName, pl.err.Error())
 			fmt.Fprint(os.Stderr, red(lintText))
 		}
+	}
+
+	if hasLintErrors {
+		os.Exit(1)
 	}
 
 	return nil


### PR DESCRIPTION
Previously we were always exiting with status 0 regardless of whether lint errors are found.