### PR TITLE
postgresqlcdc: make `unchanged_toast_value` optional

### DIFF
--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -133,6 +133,7 @@ This input adds the following metadata fields to each message:
 			Description("The value to emit when there are unchanged TOAST values in the stream. This occurs for updates and deletes where REPLICA IDENTITY is not FULL.").
 			Default(nil).
 			Example("__redpanda_connect_unchanged_toast_value__").
+			Optional().
 			Advanced()).
 		Field(service.NewDurationField(fieldHeartbeatInterval).
 			Description("The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.").


### PR DESCRIPTION
Currently `unchanged_toast_value` is implicitly optional (it uses `NewAnyField`) but doesn't show as optional in the schema which is causing issues for linting in the cloud UI. This change makes it explicitly optional so it shows as such in the schema.

See before (left) and after (right) below.

<img width="1460" height="867" alt="image" src="https://github.com/user-attachments/assets/e6be0b8a-e88a-433f-b0fd-e1920a3419c3" />
