### PR TITLE
Add batching capabilities to the redpanda output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.75.0 - TBD
+
+### Added
+
+- Field `batching` added to the `redpanda` output. (@Jeffail)
 
 ## 4.74.0 - 2025-12-15
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -142,7 +142,7 @@ output:
 
 == Batching
 
-Records are processed and delivered from each partition in batches as received from brokers. These batch sizes are therefore dynamically sized in order to optimise throughput, but can be tuned with the config fields `fetch_max_partition_bytes` and `fetch_max_bytes`. Batches can be further broken down using the xref:components:processors/split.adoc[`split`] processor.
+Records are processed and delivered from each partition in batches as received from brokers. These batch sizes are therefore dynamically sized in order to optimise throughput, but can be tuned with the config field `max_yield_batch_bytes`, or `unordered_processing.batching` when unordered processing is enabled. Batches can be further broken down using the xref:components:processors/split.adoc[`split`] processor.
 
 == Metrics
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -45,6 +45,11 @@ output:
       include_prefixes: []
       include_patterns: []
     max_in_flight: 256
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
 ```
 
 --
@@ -85,6 +90,12 @@ output:
       include_patterns: []
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
     max_in_flight: 256
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
+      processors: [] # No default (optional)
     partitioner: "" # No default (optional)
     idempotent_write: true
     compression: "" # No default (optional)
@@ -769,6 +780,108 @@ The maximum number of batches to be sending in parallel at any given time.
 *Type*: `int`
 
 *Default*: `256`
+
+=== `batching`
+
+Optional explicit batching policy for the output. Note that when batches are formed at the input level they can be expanded by this policy, but not contracted. When consuming data from a Redpanda input it is recommended to tune batches from the input config via the `max_yield_batch_bytes` field, or the `unordered_processing.batching` field if appropriate.
+
+
+*Type*: `object`
+
+
+```yml
+# Examples
+
+batching:
+  byte_size: 5000
+  count: 0
+  period: 1s
+
+batching:
+  count: 10
+  period: 1s
+
+batching:
+  check: this.contains("END BATCH")
+  count: 0
+  period: 1m
+```
+
+=== `batching.count`
+
+A number of messages at which the batch should be flushed. If `0` disables count based batching.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `batching.byte_size`
+
+An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `batching.period`
+
+A period in which an incomplete batch should be flushed regardless of its size.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+period: 1s
+
+period: 1m
+
+period: 500ms
+```
+
+=== `batching.check`
+
+A xref:guides:bloblang/about.adoc[Bloblang query] that should return a boolean value indicating whether a message should end a batch.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+check: this.type == "end_of_transaction"
+```
+
+=== `batching.processors`
+
+A list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
+
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+processors:
+  - archive:
+      format: concatenate
+
+processors:
+  - archive:
+      format: lines
+
+processors:
+  - archive:
+      format: json_array
+```
 
 === `partitioner`
 

--- a/internal/impl/kafka/input_redpanda.go
+++ b/internal/impl/kafka/input_redpanda.go
@@ -60,7 +60,7 @@ output:
 
 == Batching
 
-Records are processed and delivered from each partition in batches as received from brokers. These batch sizes are therefore dynamically sized in order to optimise throughput, but can be tuned with the config fields ` + "`fetch_max_partition_bytes` and `fetch_max_bytes`" + `. Batches can be further broken down using the ` + "xref:components:processors/split.adoc[`split`] processor" + `.
+Records are processed and delivered from each partition in batches as received from brokers. These batch sizes are therefore dynamically sized in order to optimise throughput, but can be tuned with the config field ` + "`max_yield_batch_bytes`, or `unordered_processing.batching` when unordered processing is enabled" + `. Batches can be further broken down using the ` + "xref:components:processors/split.adoc[`split`] processor" + `.
 
 == Metrics
 

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -154,6 +154,8 @@ output:
     timeout: "5s"
     metadata:
       include_patterns: [ .* ]
+    batching:
+      count: $OUTPUT_BATCH_COUNT
 
 input:
   redpanda:
@@ -169,6 +171,7 @@ input:
 		integration.StreamTestSendBatch(10),
 		integration.StreamTestStreamSequential(1000),
 		integration.StreamTestStreamParallel(1000),
+		integration.StreamTestSendBatchCount(10),
 	)
 
 	suite.Run(
@@ -231,6 +234,8 @@ output:
     partition: "0"
     metadata:
       include_patterns: [ .* ]
+    batching:
+      count: $OUTPUT_BATCH_COUNT
 
 input:
   redpanda:


### PR DESCRIPTION
Note that although there are no ordering issues with using batching at the output level, using batching here when the input is ordered can result in stalling.