### PR TITLE
aws: fixed S3-compatible services base endpoint

### DIFF
--- a/internal/impl/aws/cache_s3.go
+++ b/internal/impl/aws/cache_s3.go
@@ -93,6 +93,11 @@ func newS3CacheFromConfig(conf *service.ParsedConfig) (*s3Cache, error) {
 
 	client := s3.NewFromConfig(sess, func(o *s3.Options) {
 		o.UsePathStyle = forcePathStyleURLs
+
+		// For S3-compatible services, set BaseEndpoint at the client level
+		if sess.BaseEndpoint != nil {
+			o.BaseEndpoint = sess.BaseEndpoint
+		}
 	})
 
 	backOff, err := conf.FieldBackOff("retries")

--- a/internal/impl/aws/input_s3.go
+++ b/internal/impl/aws/input_s3.go
@@ -715,6 +715,11 @@ func (a *awsS3Reader) Connect(ctx context.Context) error {
 
 	a.s3 = s3.NewFromConfig(a.awsConf, func(o *s3.Options) {
 		o.UsePathStyle = a.conf.ForcePathStyleURLs
+
+		// For S3-compatible services, set BaseEndpoint at the client level
+		if a.awsConf.BaseEndpoint != nil {
+			o.BaseEndpoint = a.awsConf.BaseEndpoint
+		}
 	})
 	if a.conf.SQS.URL != "" {
 		sqsConf := a.awsConf.Copy()

--- a/internal/impl/aws/output_s3.go
+++ b/internal/impl/aws/output_s3.go
@@ -366,6 +366,11 @@ func (a *amazonS3Writer) Connect(context.Context) error {
 
 	client := s3.NewFromConfig(a.conf.aconf, func(o *s3.Options) {
 		o.UsePathStyle = a.conf.UsePathStyle
+
+		// For S3-compatible services, set BaseEndpoint at the client level
+		if a.conf.aconf.BaseEndpoint != nil {
+			o.BaseEndpoint = a.conf.aconf.BaseEndpoint
+		}
 	})
 	a.uploader = manager.NewUploader(client)
 	return nil


### PR DESCRIPTION
AWS SDK v2 documentation states that for S3, the BaseEndpoint should be set at the client level for proper endpoint resolution

https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-endpoints.html

Fixes #3864