### PR TITLE
license: fix metric cardinality panic in expiry metric

### DIFF
--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -149,9 +149,7 @@ func (s *Service) setLicense(res *service.Resources, l *RedpandaLicense) {
 	}
 
 	if s.expiryMetric == nil {
-		s.expiryMetric = res.Metrics().NewGauge("redpanda_cluster_features_enterprise_license_expiry_sec",
-			"Seconds remaining until the enterprise license expires.",
-		)
+		s.expiryMetric = res.Metrics().NewGauge("redpanda_cluster_features_enterprise_license_expiry_sec")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel


### PR DESCRIPTION
The license expiry metric initialization incorrectly passed a description string as the second parameter to NewGauge. The method signature is NewGauge(name string, labelKeys ...string), so the description was interpreted as a label key, causing Prometheus to expect 1 label value. When Set() was called with 0 label values, it panicked with "inconsistent label cardinality: expected 1 label values but got 0".

Remove the erroneous description parameter. Metric descriptions are not supported by the NewGauge API.