### PR TITLE
fix debugf template to respect each type of the arguments

### DIFF
--- a/internal/impl/elasticsearch/v8/output.go
+++ b/internal/impl/elasticsearch/v8/output.go
@@ -349,7 +349,7 @@ func (e *esOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) e
 	tookDuration := time.Duration(result.Took) * time.Millisecond
 
 	e.log.Debugf(
-		"Successfully dispatched [%s] documents in %s (%s docs/sec)",
+		"Successfully dispatched [%d] documents in %s (%f docs/sec)",
 		len(result.Items),
 		tookDuration,
 		float64(len(result.Items))/tookDuration.Seconds(),

--- a/internal/impl/opensearch/output.go
+++ b/internal/impl/opensearch/output.go
@@ -347,7 +347,7 @@ func (e *Output) WriteBatch(ctx context.Context, msg service.MessageBatch) error
 	dur := time.Since(start)
 
 	e.log.Debugf(
-		"Successfully dispatched [%s] documents in %s (%s docs/sec)",
+		"Successfully dispatched [%d] documents in %s (%f docs/sec)",
 		biStats.NumFlushed,
 		dur.Truncate(time.Millisecond),
 		int64(1000.0/float64(dur/time.Millisecond)*float64(biStats.NumFlushed)),


### PR DESCRIPTION
I note this _ugly_ debug message when I was testing the output component `elasticsearch_v8` (since my [PR to support elasticsearch v9](https://github.com/redpanda-data/connect/pull/3813) was not approved yet):

```console
Successfully dispatched [%!s(int=1)] documents in 0s (%!s(float64=+Inf) docs/sec)
```

the root cause was a template message that uses `%s` for all arguments. I find a identical issue in the `opensearch` output via grep, then I apply the same fix

perhaps we can consider set a better format in the docs/sec instead just `%f` like `%02.2f`

enjoy