### PR TITLE
fix parsing of tool names for metrics

### DIFF
--- a/internal/mcp/metrics/metrics.go
+++ b/internal/mcp/metrics/metrics.go
@@ -107,10 +107,17 @@ func (m *Metrics) handleToolCall(ctx context.Context, next mcp.MethodHandler, re
 
 // extractToolName extracts the tool name from a tools/call request.
 func extractToolName(req mcp.Request) string {
-	// Get params and try to type assert to CallToolParams
 	params := req.GetParams()
+
+	// Try CallToolParamsRaw first (server-side)
+	if callToolParams, ok := params.(*mcp.CallToolParamsRaw); ok {
+		return callToolParams.Name
+	}
+
+	// Try CallToolParams (client-side)
 	if callToolParams, ok := params.(*mcp.CallToolParams); ok {
 		return callToolParams.Name
 	}
+
 	return "unknown"
 }


### PR DESCRIPTION
I see all tool names as unknown here in metrics https://vectorizedio.grafana.net/d/mcp-metrics/mcp-metrics?orgId=1&from=now-30m&to=now&timezone=browser&var-datasource=wYEY2h04k&var-redpanda_id=$__all&refresh=5s

claude's explanation:
```
In production, your middleware will ALWAYS see *mcp.CallToolParamsRaw because:
  - Real requests come from external MCP clients over HTTP
  - The MCP SDK server-side uses CallToolParamsRaw to receive these requests
  - Only test code uses CallToolParams (client-side)

  So the fix I made is correct - trying CallToolParamsRaw first will handle 99.9% of cases, and the CallToolParams fallback is just for edge cases or future-proofing.
```