### PR TITLE
Change metadata processing for single-byte values of kafka headers

### DIFF
--- a/internal/impl/kafka/franz_headers.go
+++ b/internal/impl/kafka/franz_headers.go
@@ -26,7 +26,7 @@ const kafkaHeaders = "__rpcn_kafka_headers"
 
 // AddHeaders stores Kafka record headers in message metadata. Each header value
 // is stored under its key. Empty values are stored as nil, other values
-// as string. The full original list of headers is stored under the 
+// as string. The full original list of headers is stored under the
 // special key "__rpcn_kafka_headers".
 func AddHeaders(msg *service.Message, headers []kgo.RecordHeader) {
 	if len(headers) == 0 {


### PR DESCRIPTION
The current processing of single-byte values leads to different types and values of metadata. For example integers =< 9 are forwarded with their ascii value and of type number, values above 9 are forwarded as strings. A byte encoded 2 for example is forwarded as 50 because 50 is the ascii code of 2, while a 12 is forwarded as string of "12" like one would expect. We had to check this in the piplines and cast it to the correct value:

```
    mapping: |
      meta ce_e2eekeyversion = if metadata("ce_e2eekeyversion").type()  == "number" {
        "%c".format(metadata("ce_e2eekeyversion"))
      } else {
        metadata("ce_e2eekeyversion")
      }
```

This fix changes the kafka input to propagate every value as string.