### PR TITLE
ci: only trigger docs updates on actual releases

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,9 +1,8 @@
 name: Update Docs
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -13,6 +12,8 @@ jobs:
   update-blobl-playground-modules:
     name: Update Bloblang playground modules
     runs-on: ubuntu-latest
+    # Skip prereleases and drafts
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -32,6 +33,8 @@ jobs:
   update-rpcn-connector-docs:
     name: Generate RPCN connector docs
     runs-on: ubuntu-latest
+    # Skip prereleases and drafts
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v5
         with:


### PR DESCRIPTION
Skip prereleases and drafts by using release event with prerelease and draft filters, matching the pattern used in redpanda repo.

Changes:
- Changed trigger from `push: tags` to `release: types: [published]`
- Added condition to both jobs to skip prereleases and drafts: `if: ${{ !github.event.release.prerelease && !github.event.release.draft }}`

This ensures the workflow only runs for actual GA releases, following the same pattern as the redpanda repository.