### PR TITLE
feat(migrator): streaming batch approach for large schema migrations

### DIFF
--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -53,6 +53,8 @@ output:
       translate_ids: false
       normalize: false
       strict: false
+      workers: 10
+      batch_size: 100
     consumer_groups:
       enabled: true
       interval: 1m
@@ -139,6 +141,8 @@ output:
       translate_ids: false
       normalize: false
       strict: false
+      workers: 10
+      batch_size: 100
     consumer_groups:
       enabled: true
       interval: 1m
@@ -1424,6 +1428,24 @@ Error on unknown schema IDs. Only relevant when translate_ids is true. When fals
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `schema_registry.workers`
+
+Number of parallel workers for schema sync operations. Higher values improve throughput for large schema counts.
+
+
+*Type*: `int`
+
+*Default*: `10`
+
+=== `schema_registry.batch_size`
+
+Number of subjects to fetch and sync per batch. Schemas are streamed in batches rather than fetched all at once, reducing memory usage and providing real-time progress for large migrations.
+
+
+*Type*: `int`
+
+*Default*: `100`
 
 === `consumer_groups`
 


### PR DESCRIPTION
Trying to replicate a large number of schemas with Migrator fails/hangs since it tries to initially get all schemas. This PR allows streaming schemas in batches, keeping order (and schema IDs) in the target cluster the same as the source cluster. Memory utilization does not grow as schemas are produced. This addresses memory, visibility, and ordering issues when migrating large schema counts (40K+).

- Add `batch_size` config to control subjects fetched per batch (default: 100)
- Add `workers` config for parallel sync within batches (default: 10)
- Stream schemas: fetch batch → sync batch → report progress → repeat
- Sample first batch to detect schema references
- Only sort subjects by schema ID when references are detected
- Force sequential processing when references exist to preserve ordering
- Real-time progress logging with synced/skipped counts

Ordering guarantees:
- If references detected: subjects sorted by schema ID, sequential processing
- If no references: parallel processing safe with fixed IDs (translate_ids=false)

Memory optimization:
- Only hold one batch in memory at a time
- Avoid 2x API calls in common case (no references)
- Tracking maps grow with synced schemas (unavoidable for deduplication)