### PR TITLE
Fix update-docs workflow not triggering on releases

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,7 +2,7 @@ name: Update Docs
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   id-token: write
@@ -12,8 +12,6 @@ jobs:
   update-blobl-playground-modules:
     name: Update Bloblang playground modules
     runs-on: ubuntu-latest
-    # Skip prereleases and drafts
-    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -33,8 +31,6 @@ jobs:
   update-rpcn-connector-docs:
     name: Generate RPCN connector docs
     runs-on: ubuntu-latest
-    # Skip prereleases and drafts
-    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -50,3 +46,22 @@ jobs:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/rp-connect-docs
           event-type: generate-rpcn-docs
+
+  test-cookbook-examples:
+    name: Test cookbook examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+      - uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/rp-connect-docs
+          event-type: test-cookbook-examples


### PR DESCRIPTION
The update-docs workflow wasn't firing on releases. Turns out we were using `published` which fires for prereleases too, then filtering them out with an `if` condition. But if the release was marked as a prerelease at any point, the job just silently skipped.

Switched to `released` which only fires for actual releases (not prereleases), so we don't need the manual filtering anymore.

Also added a job to trigger the cookbook example tests in rp-connect-docs when we release.

Changes:
- `published` to `released` event type
- Removed the now-redundant prerelease/draft checks
- Added `test-cookbook-examples` job

Tested with `act` - all three jobs run as expected.