### PR TITLE
kafka: prevent data loss on cooperative rebalance in unordered reader

### DIFF
--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -187,7 +187,8 @@ type partitionTracker struct {
 	outBatchChan chan<- batchWithAckFn
 	commitFn     func(r *kgo.Record)
 
-	shutSig *shutdown.Signaller
+	closeCtxCh chan context.Context
+	shutSig    *shutdown.Signaller
 }
 
 func newPartitionTracker(batcher *service.Batcher, batchChan chan<- batchWithAckFn, commitFn func(r *kgo.Record)) *partitionTracker {
@@ -196,6 +197,7 @@ func newPartitionTracker(batcher *service.Batcher, batchChan chan<- batchWithAck
 		checkpointer: checkpoint.NewUncapped[*kgo.Record](),
 		outBatchChan: batchChan,
 		commitFn:     commitFn,
+		closeCtxCh:   make(chan context.Context, 1),
 		shutSig:      shutdown.NewSignaller(),
 	}
 	go pt.loop()
@@ -275,6 +277,23 @@ func (p *partitionTracker) loop() {
 				}
 			}
 		case <-p.shutSig.SoftStopChan():
+			if p.batcher != nil {
+				closeCtx := context.Background()
+				select {
+				case ctx := <-p.closeCtxCh:
+					closeCtx = ctx
+				default:
+				}
+				p.batcherLock.Lock()
+				if batch, _ := p.batcher.Flush(closeCtx); len(batch) > 0 {
+					record := p.topBatchRecord
+					p.topBatchRecord = nil
+					p.batcherLock.Unlock()
+					_ = p.sendBatch(closeCtx, batch, record)
+				} else {
+					p.batcherLock.Unlock()
+				}
+			}
 			return
 		}
 	}
@@ -347,6 +366,10 @@ func (p *partitionTracker) pauseFetch(limit int) (pauseFetch bool) {
 }
 
 func (p *partitionTracker) close(ctx context.Context) error {
+	select {
+	case p.closeCtxCh <- ctx:
+	default:
+	}
 	p.shutSig.TriggerSoftStop()
 	select {
 	case <-ctx.Done():
@@ -359,8 +382,9 @@ func (p *partitionTracker) close(ctx context.Context) error {
 //------------------------------------------------------------------------------
 
 type checkpointTracker struct {
-	mut    sync.Mutex
-	topics map[string]map[int32]*partitionTracker
+	mut     sync.Mutex
+	topics  map[string]map[int32]*partitionTracker
+	revoked map[string]map[int32]struct{}
 
 	res       *service.Resources
 	batchChan chan<- batchWithAckFn
@@ -376,6 +400,7 @@ func newCheckpointTracker(
 ) *checkpointTracker {
 	return &checkpointTracker{
 		topics:    map[string]map[int32]*partitionTracker{},
+		revoked:   map[string]map[int32]struct{}{},
 		res:       res,
 		batchChan: batchChan,
 		commitFn:  releaseFn,
@@ -450,12 +475,46 @@ func (c *checkpointTracker) removeTopicPartitions(ctx context.Context, m map[str
 			if trackedPartition, exists := trackedTopic[lostPartition]; exists {
 				_ = trackedPartition.close(ctx)
 			}
+			if c.revoked[topicName] == nil {
+				c.revoked[topicName] = map[int32]struct{}{}
+			}
+			c.revoked[topicName][lostPartition] = struct{}{}
 			delete(trackedTopic, lostPartition)
 		}
 		if len(trackedTopic) == 0 {
 			delete(c.topics, topicName)
 		}
 	}
+}
+
+func (c *checkpointTracker) clearRevoked(m map[string][]int32) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	for topicName, partitions := range m {
+		revokedParts, exists := c.revoked[topicName]
+		if !exists {
+			continue
+		}
+		for _, partition := range partitions {
+			delete(revokedParts, partition)
+		}
+		if len(revokedParts) == 0 {
+			delete(c.revoked, topicName)
+		}
+	}
+}
+
+func (c *checkpointTracker) isRevoked(topic string, partition int32) bool {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	parts, ok := c.revoked[topic]
+	if !ok {
+		return false
+	}
+	_, revoked := parts[partition]
+	return revoked
 }
 
 //------------------------------------------------------------------------------
@@ -496,16 +555,18 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 	batchChan := make(chan batchWithAckFn)
 
 	var cl *kgo.Client
-	commitFn := func(*kgo.Record) {}
+	checkpoints := newCheckpointTracker(f.res, batchChan, func(*kgo.Record) {}, f.batchPolicy)
 	if f.consumerGroup != "" {
-		commitFn = func(r *kgo.Record) {
+		checkpoints.commitFn = func(r *kgo.Record) {
 			if cl == nil {
+				return
+			}
+			if checkpoints.isRevoked(r.Topic, r.Partition) {
 				return
 			}
 			cl.MarkCommitRecords(r)
 		}
 	}
-	checkpoints := newCheckpointTracker(f.res, batchChan, commitFn, f.batchPolicy)
 
 	clientOpts, err := f.clientOpts()
 	if err != nil {
@@ -523,6 +584,9 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 			kgo.OnPartitionsLost(func(rctx context.Context, _ *kgo.Client, m map[string][]int32) {
 				// No point trying to commit our offsets, just clean up our topic map
 				checkpoints.removeTopicPartitions(rctx, m)
+			}),
+			kgo.OnPartitionsAssigned(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
+				checkpoints.clearRevoked(m)
 			}),
 			kgo.ConsumerGroup(f.consumerGroup),
 			kgo.AutoCommitMarks(),

--- a/internal/impl/kafka/franz_reader_unordered_test.go
+++ b/internal/impl/kafka/franz_reader_unordered_test.go
@@ -1,0 +1,187 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestCheckpointTracker_RevokedPartitionBlocksCommit(t *testing.T) {
+	var mu sync.Mutex
+	var committed []*kgo.Record
+
+	batchChan := make(chan batchWithAckFn, 100)
+	ct := newCheckpointTracker(
+		service.MockResources(),
+		batchChan,
+		func(*kgo.Record) {},
+		service.BatchPolicy{},
+	)
+	// Wrap commitFn to check revoked status, same as Connect() does.
+	ct.commitFn = func(r *kgo.Record) {
+		if ct.isRevoked(r.Topic, r.Partition) {
+			return
+		}
+		mu.Lock()
+		committed = append(committed, r)
+		mu.Unlock()
+	}
+
+	ctx := context.Background()
+
+	// Add records to two partitions.
+	for i := range 3 {
+		ct.addRecord(ctx, &msgWithRecord{
+			msg: service.NewMessage(nil),
+			r:   &kgo.Record{Topic: "topic-a", Partition: 0, Offset: int64(i)},
+		}, 1024)
+	}
+	for i := range 3 {
+		ct.addRecord(ctx, &msgWithRecord{
+			msg: service.NewMessage(nil),
+			r:   &kgo.Record{Topic: "topic-a", Partition: 1, Offset: int64(i)},
+		}, 1024)
+	}
+
+	// Drain all batches into a slice so we can ack them after revoke.
+	var batches []batchWithAckFn
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for {
+			select {
+			case b := <-batchChan:
+				batches = append(batches, b)
+			case <-time.After(200 * time.Millisecond):
+				return
+			}
+		}
+	}()
+	<-drainDone
+
+	require.NotEmpty(t, batches, "should have received batches")
+
+	// Simulate rebalance: revoke partition 0 only.
+	ct.removeTopicPartitions(ctx, map[string][]int32{
+		"topic-a": {0},
+	})
+
+	assert.True(t, ct.isRevoked("topic-a", 0), "partition 0 should be revoked")
+	assert.False(t, ct.isRevoked("topic-a", 1), "partition 1 should not be revoked")
+
+	// Now ack all in-flight batches. This simulates the pipeline completing
+	// after the rebalance already revoked partition 0.
+	for _, b := range batches {
+		b.onAck()
+	}
+
+	// Only partition 1's records should have been committed.
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range committed {
+		assert.NotEqual(t, int32(0), r.Partition,
+			"commitFn should not be called for revoked partition 0, but got offset %d", r.Offset)
+	}
+}
+
+func TestCheckpointTracker_ClearRevokedOnReassign(t *testing.T) {
+	batchChan := make(chan batchWithAckFn, 100)
+	ct := newCheckpointTracker(
+		service.MockResources(),
+		batchChan,
+		func(_ *kgo.Record) {},
+		service.BatchPolicy{},
+	)
+
+	ctx := context.Background()
+
+	// Add a record so the partition tracker exists.
+	ct.addRecord(ctx, &msgWithRecord{
+		msg: service.NewMessage(nil),
+		r:   &kgo.Record{Topic: "topic-a", Partition: 0, Offset: 0},
+	}, 1024)
+
+	// Revoke partition 0.
+	ct.removeTopicPartitions(ctx, map[string][]int32{
+		"topic-a": {0},
+	})
+	assert.True(t, ct.isRevoked("topic-a", 0))
+
+	// Simulate re-assignment of the same partition.
+	ct.clearRevoked(map[string][]int32{
+		"topic-a": {0},
+	})
+	assert.False(t, ct.isRevoked("topic-a", 0),
+		"partition 0 should no longer be revoked after re-assignment")
+}
+
+func TestCheckpointTracker_SoftStopFlushesBatcher(t *testing.T) {
+	batchChan := make(chan batchWithAckFn, 100)
+	res := service.MockResources()
+
+	bp, err := service.NewConfigSpec().
+		Field(service.NewBatchPolicyField("test")).
+		ParseYAML(`test: {count: 10}`, service.NewEnvironment())
+	require.NoError(t, err)
+
+	batchPol, err := bp.FieldBatchPolicy("test")
+	require.NoError(t, err)
+
+	ct := newCheckpointTracker(
+		res,
+		batchChan,
+		func(_ *kgo.Record) {},
+		batchPol,
+	)
+
+	ctx := context.Background()
+
+	// Add fewer messages than the batch count threshold so they stay
+	// buffered in the batcher.
+	for i := range 3 {
+		ct.addRecord(ctx, &msgWithRecord{
+			msg: service.NewMessage([]byte("hello")),
+			r:   &kgo.Record{Topic: "topic-a", Partition: 0, Offset: int64(i)},
+		}, 1024)
+	}
+
+	// Close the partition tracker (simulates what removeTopicPartitions does).
+	// Before this fix, close() would trigger SoftStop and loop() would return
+	// without flushing the batcher, losing the 3 buffered messages.
+	ct.mut.Lock()
+	tracker := ct.topics["topic-a"][0]
+	ct.mut.Unlock()
+
+	require.NotNil(t, tracker)
+	require.NoError(t, tracker.close(ctx))
+
+	// The flushed batch should appear on batchChan.
+	select {
+	case b := <-batchChan:
+		assert.Len(t, b.batch, 3, "all buffered messages should be flushed on SoftStop")
+		b.onAck()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for flushed batch after SoftStop")
+	}
+}


### PR DESCRIPTION
Fixes #4010

---

We've been running Vector as our Kafka-to-S3 sink connector, but kept hitting two reliability problems: S3 uploads failing when IRSA tokens expired (Vector doesn't refresh tokens gracefully — it drops the batch), and OOM crashes from the adaptive concurrency controller under bursty load. We started a PoC with Redpanda Connect to replace it.

```
  Kafka ───► Redpanda Connect (unordered_processing) ───► S3
              per-partition input batcher (50MB / 1min)
              deterministic path: topic+partition+offset.jsonl.zst
```

Our pipeline uses input batching with a deterministic S3 path so that reprocessed data overwrites the same file — at-least-once with idempotent writes:

```yaml
input:
  redpanda:
    consumer_group: my-group
    unordered_processing:
      enabled: true
      checkpoint_limit: 1
      batching:
        byte_size: 52428800  # 50 MiB per partition
        period: "1m"

output:
  aws_s3:
    path: '${!meta("kafka_topic")}+${!meta("kafka_partition")}+${!meta("kafka_offset")}.jsonl.zst'
    max_in_flight: 10
```

We tested rebalancing by triggering HPA scale-ups. Redpanda Connect generally handled it better than Vector, but during one cooperative-sticky rebalance we saw that 7 revoked partitions each lost exactly one batcher window of messages (10,433 total). We traced through the source and found the root cause.

## The bug

```
 Timeline          Consumer A                        Kafka broker
 ───────────────────────────────────────────────────────────────────

 T0  normal        sendBatch()
                     Track(r)
                     batchChan ← batch
                     pipeline processing...

 T1  rebalance     OnPartitionsRevoked:
                     CommitMarkedOffsets()    ← in-flight batch NOT marked
                     removeTopicPartitions()
                       close() → SoftStop    ← batcher discards buffered msgs
                       delete from map
                     return                  ───► partition assigned to Consumer B

 T2  pipeline      onAck() → commitFn()
     completes       MarkCommitRecords(r)    ← no ownership check in franz-go
                                                re-inserts into g.uncommitted

 T3  auto-commit   commits offset           ───► broker accepts
                                                  Consumer B starts past the gap
                                                  data LOST
```

Two things go wrong:

1. **`MarkCommitRecords` after revoke**: franz-go doesn't validate partition ownership in `MarkCommitRecords`. After `revoke()` deletes the partition from `g.uncommitted`, a late call re-inserts it, and the next auto-commit cycle commits it.

2. **Batcher silent discard**: `loop()` returns immediately on SoftStop (L277) without flushing buffered messages. One batcher window of data is discarded.

## The fix

**Block MarkCommitRecords for revoked partitions.** `checkpointTracker` gets a `revoked` set. `removeTopicPartitions` marks partitions as revoked before deleting. `commitFn` checks the set and skips `MarkCommitRecords` for revoked partitions. `OnPartitionsAssigned` clears the set on re-assignment.

**Flush batcher on SoftStop.** When the partition tracker's loop receives SoftStop, it flushes remaining buffered messages into the pipeline before returning.

```
 With fix:

 T1  OnPartitionsRevoked:
       SoftStop → batcher.Flush() → sendBatch()    ← buffered msgs delivered
       revoked[partition] = marked

 T2  onAck() → commitFn()
       isRevoked() == true → skip MarkCommitRecords ← offset NOT advanced

 T3  Consumer B starts at last committed offset
       reprocesses same range → same S3 path        ← idempotent, no loss
```

## Test plan

- [x] `TestCheckpointTracker_RevokedPartitionBlocksCommit` — revoke partition, ack in-flight batch, verify commitFn skipped
- [x] `TestCheckpointTracker_ClearRevokedOnReassign` — revoke then re-assign, verify revoked state cleared
- [x] `TestCheckpointTracker_SoftStopFlushesBatcher` — buffer messages below threshold, SoftStop, verify all flushed
- [x] Existing `TestPartitionCacheOrdering` / `TestPartitionCacheBatching` pass (no regression)
