### PR TITLE
feat(kafka): expose more kafka_franz parameters

### DIFF
--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -100,11 +100,17 @@ output:
       processors: [] # No default (optional)
     partitioner: "" # No default (optional)
     idempotent_write: true
+    acks: all
     compression: "" # No default (optional)
     allow_auto_topic_creation: true
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
+    max_buffered_records: 10000
+    max_buffered_bytes: "0"
+    max_in_flight_requests: 1
+    record_retries: 0
+    record_delivery_timeout: 0s
 ```
 
 --
@@ -878,6 +884,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -945,5 +972,58 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 

--- a/docs/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/outputs/ockam_kafka.adoc
@@ -89,11 +89,17 @@ output:
         processors: [] # No default (optional)
       partitioner: "" # No default (optional)
       idempotent_write: true
+      acks: all
       compression: "" # No default (optional)
       allow_auto_topic_creation: true
       timeout: 10s
       max_message_bytes: 1MiB
       broker_write_max_bytes: 100MiB
+      max_buffered_records: 10000
+      max_buffered_bytes: "0"
+      max_in_flight_requests: 1
+      record_retries: 0
+      record_delivery_timeout: 0s
       topic: "" # No default (required)
       key: "" # No default (optional)
       partition: ${! meta("partition") } # No default (optional)
@@ -448,6 +454,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `kafka.acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `kafka.compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -515,6 +542,59 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `kafka.max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `kafka.max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `kafka.max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `kafka.record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `kafka.record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `kafka.topic`
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -98,11 +98,17 @@ output:
       processors: [] # No default (optional)
     partitioner: "" # No default (optional)
     idempotent_write: true
+    acks: all
     compression: "" # No default (optional)
     allow_auto_topic_creation: true
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
+    max_buffered_records: 10000
+    max_buffered_bytes: "0"
+    max_in_flight_requests: 1
+    record_retries: 0
+    record_delivery_timeout: 0s
 ```
 
 --
@@ -914,6 +920,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -981,5 +1008,58 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -98,11 +98,17 @@ output:
       tcp_user_timeout: 0s
     partitioner: "" # No default (optional)
     idempotent_write: true
+    acks: all
     compression: "" # No default (optional)
     allow_auto_topic_creation: true
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
+    max_buffered_records: 10000
+    max_buffered_bytes: "0"
+    max_in_flight_requests: 1
+    record_retries: 0
+    record_delivery_timeout: 0s
     schema_registry:
       url: http://localhost:8081 # No default (required)
       timeout: 5s
@@ -881,6 +887,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -948,6 +975,59 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `schema_registry`
 

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -67,11 +67,17 @@ redpanda:
   status_topic: ""
   partitioner: "" # No default (optional)
   idempotent_write: true
+  acks: all
   compression: "" # No default (optional)
   allow_auto_topic_creation: true
   timeout: 10s
   max_message_bytes: 1MiB
   broker_write_max_bytes: 100MiB
+  max_buffered_records: 10000
+  max_buffered_bytes: "0"
+  max_in_flight_requests: 1
+  record_retries: 0
+  record_delivery_timeout: 0s
 ```
 --
 ======
@@ -684,6 +690,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -751,4 +778,57 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 

--- a/docs/modules/components/pages/tracers/redpanda.adoc
+++ b/docs/modules/components/pages/tracers/redpanda.adoc
@@ -77,11 +77,17 @@ tracer:
       tcp_user_timeout: 0s
     partitioner: "" # No default (optional)
     idempotent_write: true
+    acks: all
     compression: "" # No default (optional)
     allow_auto_topic_creation: true
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
+    max_buffered_records: 10000
+    max_buffered_bytes: "0"
+    max_in_flight_requests: 1
+    record_retries: 0
+    record_delivery_timeout: 0s
     topic: otel-traces
     format: json
     schema_registry:
@@ -677,6 +683,27 @@ Enable the idempotent write producer option. When enabled, the producer initiali
 
 *Default*: `true`
 
+=== `acks`
+
+The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. When `idempotent_write` is enabled this must be set to `all`.
+
+
+*Type*: `string`
+
+*Default*: `"all"`
+
+|===
+| Option | Summary
+
+| `all`
+| Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.
+| `leader`
+| Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.
+| `none`
+| Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.
+
+|===
+
 === `compression`
 
 Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
@@ -744,6 +771,59 @@ broker_write_max_bytes: 128MB
 
 broker_write_max_bytes: 50mib
 ```
+
+=== `max_buffered_records`
+
+The maximum number of records the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. Increase this value for high-throughput pipelines to avoid back-pressure stalls.
+
+
+*Type*: `int`
+
+*Default*: `10000`
+
+=== `max_buffered_bytes`
+
+The maximum number of bytes the client will buffer in memory before blocking. When this limit is reached, `Produce()` calls will block until buffered records are delivered. Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). This limit is checked after `max_buffered_records`.
+
+
+*Type*: `string`
+
+*Default*: `"0"`
+
+```yml
+# Examples
+
+max_buffered_bytes: 256MB
+
+max_buffered_bytes: 50mib
+```
+
+=== `max_in_flight_requests`
+
+The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `record_retries`
+
+The maximum number of times a record produce is retried on failure before the record is failed. When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. Set to `0` for unlimited retries (the default). With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `record_delivery_timeout`
+
+The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. This is evaluated before writing a request or after a produce response. When a record times out, all records in the same partition are also failed. Set to `0s` for no timeout (the default). With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
 
 === `topic`
 

--- a/internal/impl/kafka/franz_writer.go
+++ b/internal/impl/kafka/franz_writer.go
@@ -37,11 +37,17 @@ const (
 	// Producer fields
 	kfwFieldPartitioner            = "partitioner"
 	kfwFieldIdempotentWrite        = "idempotent_write"
+	kfwFieldAcks                   = "acks"
 	kfwFieldCompression            = "compression"
 	kfwFieldAllowAutoTopicCreation = "allow_auto_topic_creation"
-	kfwFieldTimeout                = "timeout"
-	kfwFieldMaxMessageBytes        = "max_message_bytes"
-	kfwFieldBrokerWriteMaxBytes    = "broker_write_max_bytes"
+	kfwFieldTimeout                     = "timeout"
+	kfwFieldMaxMessageBytes             = "max_message_bytes"
+	kfwFieldBrokerWriteMaxBytes         = "broker_write_max_bytes"
+	kfwFieldMaxBufferedRecords          = "max_buffered_records"
+	kfwFieldMaxBufferedBytes            = "max_buffered_bytes"
+	kfwFieldMaxInFlightRequestsPerBrkr  = "max_in_flight_requests"
+	kfwFieldRecordRetries               = "record_retries"
+	kfwFieldRecordDeliveryTimeout       = "record_delivery_timeout"
 )
 
 // FranzProducerLimitsFields returns a slice of fields specifically for
@@ -68,6 +74,42 @@ func FranzProducerLimitsFields() []*service.ConfigField {
 			Default("100MiB").
 			Example("128MB").
 			Example("50mib"),
+		service.NewIntField(kfwFieldMaxBufferedRecords).
+			Description("The maximum number of records the client will buffer in memory before blocking. " +
+				"When this limit is reached, `Produce()` calls will block until buffered records are delivered and space frees up. " +
+				"Increase this value for high-throughput pipelines to avoid back-pressure stalls.").
+			Advanced().
+			Default(10000),
+		service.NewStringField(kfwFieldMaxBufferedBytes).
+			Description("The maximum number of bytes the client will buffer in memory before blocking. " +
+				"When this limit is reached, `Produce()` calls will block until buffered records are delivered. " +
+				"Set to `0` to disable the byte-level limit (only `max_buffered_records` applies). " +
+				"This limit is checked after `max_buffered_records`.").
+			Advanced().
+			Default("0").
+			Example("256MB").
+			Example("50mib"),
+		service.NewIntField(kfwFieldMaxInFlightRequestsPerBrkr).
+			Description("The maximum number of produce requests in flight per broker connection. " +
+				"When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). " +
+				"When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.").
+			Advanced().
+			Default(1),
+		service.NewIntField(kfwFieldRecordRetries).
+			Description("The maximum number of times a record produce is retried on failure before the record is failed. " +
+				"When a record fails, all records buffered in the same partition are also failed to preserve gapless ordering. " +
+				"Set to `0` for unlimited retries (the default). " +
+				"With `idempotent_write` enabled, retries are only enforced when safe to do so without creating invalid sequence numbers.").
+			Advanced().
+			Default(0),
+		service.NewDurationField(kfwFieldRecordDeliveryTimeout).
+			Description("The maximum time a record can sit in the producer buffer before it is failed, roughly equivalent to Kafka's `delivery.timeout.ms`. " +
+				"This is evaluated before writing a request or after a produce response. " +
+				"When a record times out, all records in the same partition are also failed. " +
+				"Set to `0s` for no timeout (the default). " +
+				"With `idempotent_write` enabled, timeouts are only enforced when safe to do so without creating invalid sequence numbers.").
+			Advanced().
+			Default("0s"),
 	}
 }
 
@@ -84,16 +126,25 @@ func FranzProducerFields() []*service.ConfigField {
 			}).
 				Description("Override the default murmur2 hashing partitioner.").
 				Advanced().Optional(),
-			service.NewBoolField(kfwFieldIdempotentWrite).
-				Description("Enable the idempotent write producer option. " +
-					"When enabled, the producer initializes a producer ID and uses it to guarantee exactly-once semantics per partition (no duplicates on retries). " +
-					"This requires the `IDEMPOTENT_WRITE` permission on the `CLUSTER` resource. " +
-					"If your cluster does not grant this permission or uses ACLs restrictively, disable this option. " +
-					"Note: Idempotent writes are strictly a win for data integrity but may be unavailable in restricted environments " +
-					"(e.g., some managed Kafka services, Redpanda with strict ACLs). " +
-					"Disabling this option is safe and only affects retry behavior—duplicates may occur on producer retries, but the pipeline will continue to function normally.").
-				Default(true).
-				Advanced(),
+		service.NewBoolField(kfwFieldIdempotentWrite).
+			Description("Enable the idempotent write producer option. " +
+				"When enabled, the producer initializes a producer ID and uses it to guarantee exactly-once semantics per partition (no duplicates on retries). " +
+				"This requires the `IDEMPOTENT_WRITE` permission on the `CLUSTER` resource. " +
+				"If your cluster does not grant this permission or uses ACLs restrictively, disable this option. " +
+				"Note: Idempotent writes are strictly a win for data integrity but may be unavailable in restricted environments " +
+				"(e.g., some managed Kafka services, Redpanda with strict ACLs). " +
+				"Disabling this option is safe and only affects retry behavior—duplicates may occur on producer retries, but the pipeline will continue to function normally.").
+			Default(true).
+			Advanced(),
+		service.NewStringAnnotatedEnumField(kfwFieldAcks, map[string]string{
+			"all":    "Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.",
+			"none":   "Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.",
+			"leader": "Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.",
+		}).
+			Description("The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. " +
+				"When `idempotent_write` is enabled this must be set to `all`.").
+			Default("all").
+			Advanced(),
 			service.NewStringEnumField(kfwFieldCompression, "lz4", "snappy", "gzip", "none", "zstd").
 				Description("Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.").
 				Optional().
@@ -143,6 +194,56 @@ func FranzProducerLimitsOptsFromConfig(conf *service.ParsedConfig) ([]kgo.Opt, e
 		return nil, err
 	}
 	opts = append(opts, kgo.ProduceRequestTimeout(timeout))
+
+	maxBufferedRecords, err := conf.FieldInt(kfwFieldMaxBufferedRecords)
+	if err != nil {
+		return nil, err
+	}
+	if maxBufferedRecords < 1 {
+		return nil, fmt.Errorf("invalid max_buffered_records %d, must be at least 1", maxBufferedRecords)
+	}
+	opts = append(opts, kgo.MaxBufferedRecords(maxBufferedRecords))
+
+	maxBufferedBytesStr, err := conf.FieldString(kfwFieldMaxBufferedBytes)
+	if err != nil {
+		return nil, err
+	}
+	var maxBufferedBytes uint64
+	maxBufferedBytes, err = humanize.ParseBytes(maxBufferedBytesStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse max_buffered_bytes: %w", err)
+	}
+	if maxBufferedBytes > uint64(math.MaxInt) {
+		return nil, fmt.Errorf("invalid max_buffered_bytes, must not exceed %v", math.MaxInt)
+	}
+	if maxBufferedBytes > 0 {
+		opts = append(opts, kgo.MaxBufferedBytes(int(maxBufferedBytes)))
+	}
+
+	maxInFlightRequests, err := conf.FieldInt(kfwFieldMaxInFlightRequestsPerBrkr)
+	if err != nil {
+		return nil, err
+	}
+	if maxInFlightRequests < 1 {
+		return nil, fmt.Errorf("invalid max_in_flight_requests %d, must be at least 1", maxInFlightRequests)
+	}
+	opts = append(opts, kgo.MaxProduceRequestsInflightPerBroker(maxInFlightRequests))
+
+	recordRetries, err := conf.FieldInt(kfwFieldRecordRetries)
+	if err != nil {
+		return nil, err
+	}
+	if recordRetries > 0 {
+		opts = append(opts, kgo.RecordRetries(recordRetries))
+	}
+
+	recordDeliveryTimeout, err := conf.FieldDuration(kfwFieldRecordDeliveryTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if recordDeliveryTimeout > 0 {
+		opts = append(opts, kgo.RecordDeliveryTimeout(recordDeliveryTimeout))
+	}
 
 	return opts, nil
 }
@@ -211,8 +312,29 @@ func FranzProducerOptsFromConfig(conf *service.ParsedConfig) ([]kgo.Opt, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	acksStr, err := conf.FieldString(kfwFieldAcks)
+	if err != nil {
+		return nil, err
+	}
+
+	if idempotentWrite && acksStr != "all" {
+		return nil, fmt.Errorf("idempotent_write requires acks to be \"all\", got %q", acksStr)
+	}
+
 	if !idempotentWrite {
 		opts = append(opts, kgo.DisableIdempotentWrite())
+	}
+
+	switch acksStr {
+	case "all":
+		opts = append(opts, kgo.RequiredAcks(kgo.AllISRAcks()))
+	case "leader":
+		opts = append(opts, kgo.RequiredAcks(kgo.LeaderAck()))
+	case "none":
+		opts = append(opts, kgo.RequiredAcks(kgo.NoAck()))
+	default:
+		return nil, fmt.Errorf("unknown acks value: %q", acksStr)
 	}
 
 	allowAutoTopicCreation, err := conf.FieldBool(kfwFieldAllowAutoTopicCreation)
@@ -275,6 +397,7 @@ func FranzWriterConfigLints() string {
   this.partitioner == "manual" && this.partition.or("") == "" => "a partition must be specified when the partitioner is set to manual"
   this.partitioner != "manual" && this.partition.or("") != "" => "a partition cannot be specified unless the partitioner is set to manual"
   this.timestamp.or("") != "" && this.timestamp_ms.or("") != "" => "both timestamp and timestamp_ms cannot be specified simultaneously"
+  this.idempotent_write == true && this.acks.or("all") != "all" => "idempotent_write requires acks to be set to all"
 }`
 }
 

--- a/internal/impl/kafka/franz_writer.go
+++ b/internal/impl/kafka/franz_writer.go
@@ -35,19 +35,19 @@ import (
 
 const (
 	// Producer fields
-	kfwFieldPartitioner            = "partitioner"
-	kfwFieldIdempotentWrite        = "idempotent_write"
-	kfwFieldAcks                   = "acks"
-	kfwFieldCompression            = "compression"
-	kfwFieldAllowAutoTopicCreation = "allow_auto_topic_creation"
-	kfwFieldTimeout                     = "timeout"
-	kfwFieldMaxMessageBytes             = "max_message_bytes"
-	kfwFieldBrokerWriteMaxBytes         = "broker_write_max_bytes"
-	kfwFieldMaxBufferedRecords          = "max_buffered_records"
-	kfwFieldMaxBufferedBytes            = "max_buffered_bytes"
-	kfwFieldMaxInFlightRequestsPerBrkr  = "max_in_flight_requests"
-	kfwFieldRecordRetries               = "record_retries"
-	kfwFieldRecordDeliveryTimeout       = "record_delivery_timeout"
+	kfwFieldPartitioner                = "partitioner"
+	kfwFieldIdempotentWrite            = "idempotent_write"
+	kfwFieldAcks                       = "acks"
+	kfwFieldCompression                = "compression"
+	kfwFieldAllowAutoTopicCreation     = "allow_auto_topic_creation"
+	kfwFieldTimeout                    = "timeout"
+	kfwFieldMaxMessageBytes            = "max_message_bytes"
+	kfwFieldBrokerWriteMaxBytes        = "broker_write_max_bytes"
+	kfwFieldMaxBufferedRecords         = "max_buffered_records"
+	kfwFieldMaxBufferedBytes           = "max_buffered_bytes"
+	kfwFieldMaxInFlightRequestsPerBrkr = "max_in_flight_requests"
+	kfwFieldRecordRetries              = "record_retries"
+	kfwFieldRecordDeliveryTimeout      = "record_delivery_timeout"
 )
 
 // FranzProducerLimitsFields returns a slice of fields specifically for
@@ -126,25 +126,25 @@ func FranzProducerFields() []*service.ConfigField {
 			}).
 				Description("Override the default murmur2 hashing partitioner.").
 				Advanced().Optional(),
-		service.NewBoolField(kfwFieldIdempotentWrite).
-			Description("Enable the idempotent write producer option. " +
-				"When enabled, the producer initializes a producer ID and uses it to guarantee exactly-once semantics per partition (no duplicates on retries). " +
-				"This requires the `IDEMPOTENT_WRITE` permission on the `CLUSTER` resource. " +
-				"If your cluster does not grant this permission or uses ACLs restrictively, disable this option. " +
-				"Note: Idempotent writes are strictly a win for data integrity but may be unavailable in restricted environments " +
-				"(e.g., some managed Kafka services, Redpanda with strict ACLs). " +
-				"Disabling this option is safe and only affects retry behavior—duplicates may occur on producer retries, but the pipeline will continue to function normally.").
-			Default(true).
-			Advanced(),
-		service.NewStringAnnotatedEnumField(kfwFieldAcks, map[string]string{
-			"all":    "Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.",
-			"none":   "Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.",
-			"leader": "Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.",
-		}).
-			Description("The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. " +
-				"When `idempotent_write` is enabled this must be set to `all`.").
-			Default("all").
-			Advanced(),
+			service.NewBoolField(kfwFieldIdempotentWrite).
+				Description("Enable the idempotent write producer option. " +
+					"When enabled, the producer initializes a producer ID and uses it to guarantee exactly-once semantics per partition (no duplicates on retries). " +
+					"This requires the `IDEMPOTENT_WRITE` permission on the `CLUSTER` resource. " +
+					"If your cluster does not grant this permission or uses ACLs restrictively, disable this option. " +
+					"Note: Idempotent writes are strictly a win for data integrity but may be unavailable in restricted environments " +
+					"(e.g., some managed Kafka services, Redpanda with strict ACLs). " +
+					"Disabling this option is safe and only affects retry behavior—duplicates may occur on producer retries, but the pipeline will continue to function normally.").
+				Default(true).
+				Advanced(),
+			service.NewStringAnnotatedEnumField(kfwFieldAcks, map[string]string{
+				"all":    "Wait for all in-sync replicas to acknowledge (acks=-1). Required when idempotent_write is enabled.",
+				"none":   "Do not wait for any acknowledgement (acks=0). Highest throughput but messages may be lost.",
+				"leader": "Wait for the leader broker to acknowledge (acks=1). Messages are lost if the leader fails before replication.",
+			}).
+				Description("The number of acknowledgements the leader broker must receive from ISR brokers before responding to the produce request. " +
+					"When `idempotent_write` is enabled this must be set to `all`.").
+				Default("all").
+				Advanced(),
 			service.NewStringEnumField(kfwFieldCompression, "lz4", "snappy", "gzip", "none", "zstd").
 				Description("Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.").
 				Optional().

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -67,6 +67,72 @@ kafka_franz:
 `,
 			errContains: "a partition cannot be specified unless the partitioner is set to manual",
 		},
+		{
+			name: "idempotent write with acks all",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: true
+  acks: all
+`,
+		},
+		{
+			name: "idempotent write with acks leader",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: true
+  acks: leader
+`,
+			errContains: "idempotent_write requires acks to be set to all",
+		},
+		{
+			name: "idempotent write with acks none",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: true
+  acks: none
+`,
+			errContains: "idempotent_write requires acks to be set to all",
+		},
+		{
+			name: "non-idempotent with acks leader",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: false
+  acks: leader
+`,
+		},
+		{
+			name: "non-idempotent with acks none",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: false
+  acks: none
+`,
+		},
+		{
+			name: "custom producer limits",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: false
+  max_buffered_records: 50000
+  max_buffered_bytes: "128MB"
+  max_in_flight_requests: 5
+  record_retries: 10
+  record_delivery_timeout: "30s"
+`,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Hi, I would like to introduce several changes to kafka_franz output (shared with redpanda output) to expose more go client parameters into redpanda-connect. My main use case is low throughput of kafka output (I tried all, sarama, franz, redpanda). I stopped on kafka_franz for now (I know it is deprecated, but actually redpanda uses franz under the hood) and main issue is default limitation of 10k buffer in kafka_franz which results in limited throughput over latency networks. As well as  minor concurrency bug in redpanda output. Also default values for all new params are same as before (equal to kafka_franz defaults) 

## 1: Add configurable `acks` field to redpanda/kafka_franz output

**File**: `internal/impl/kafka/franz_writer.go`

**Problem**: The `redpanda` and `kafka_franz` outputs hardcode `acks=all` (all ISR replicas) with no way to configure it. When `idempotent_write: false`, users may want `acks=leader` (acks=1) for higher throughput at the cost of durability, or `acks=none` (acks=0) for fire-and-forget scenarios. Previously, the franz-go default of `acks=all` was always used regardless of the `idempotent_write` setting.

**Fix**: Add a new `acks` field to `FranzProducerFields()` with three options:

| Value    | Kafka equivalent | Behavior |
|----------|-----------------|----------|
| `all`    | acks=-1         | Wait for all in-sync replicas (default, required for idempotent writes) |
| `leader` | acks=1          | Wait for leader only (available when `idempotent_write: false`) |
| `none`   | acks=0          | Fire-and-forget (available when `idempotent_write: false`) |

**Validation**: If `idempotent_write: true` and `acks` is set to anything other than `all`, the config fails with an error at both lint time and runtime. This matches the Kafka protocol requirement that idempotent producers must use `acks=all`.

**Config example**:
```yaml
output:
  redpanda:
    seed_brokers: ["localhost:9092"]
    topic: my-topic
    idempotent_write: false
    acks: leader  # only valid when idempotent_write is false
```

**Changes**:
1. Added `kfwFieldAcks` constant and `StringAnnotatedEnumField` with `all`, `leader`, `none` options (default: `all`)
2. Added validation in `FranzProducerOptsFromConfig`: error if `idempotent_write: true && acks != "all"`
3. Maps config values to franz-go options: `kgo.AllISRAcks()`, `kgo.LeaderAck()`, `kgo.NoAck()`
4. Added lint rule: `this.idempotent_write == true && this.acks.or("all") != "all"` for early config validation

**Backward compatible**: Default is `all`, matching the previous implicit behavior.

---

## 2: Expose producer buffer and in-flight tuning fields

**File**: `internal/impl/kafka/franz_writer.go`

**Problem**: The franz-go producer has several critical tuning parameters hardcoded to defaults and not exposed in the `redpanda`/`kafka_franz` output config:

| Parameter | franz-go default | Issue |
|-----------|-----------------|-------|
| `MaxBufferedRecords` | 10,000 | `Produce()` blocks when hit. For high-throughput pipelines, records arrive faster than they drain, causing the caller goroutine to stall. |
| `MaxBufferedBytes` | 0 (unlimited) | No byte-level memory guard. 10k large records could consume gigabytes. |
| `MaxProduceRequestsInflightPerBroker` | 1 | Only one produce request per broker TCP connection at a time. The pipeline idles during the full broker round-trip, wasting the ability to pipeline requests. |
| `RecordRetries` | unlimited | On persistent broker failure (i/o timeout), franz-go retries every record forever. `WriteBatch` hangs because callbacks never fire, the process becomes a zombie — alive but non-functional. |
| `RecordDeliveryTimeout` | unlimited | Same zombie problem as above but time-based. Equivalent to Kafka's `delivery.timeout.ms`. |

**Fix**: Add five new fields to `FranzProducerLimitsFields()`:

```yaml
output:
  redpanda:
    # New fields (shown with defaults):
    max_buffered_records: 10000       # max records buffered before Produce() blocks
    max_buffered_bytes: "0"           # max bytes buffered (0 = unlimited, only record limit applies)
    max_in_flight_requests: 1         # max produce requests per broker TCP connection
    record_retries: 0                 # max retries per record (0 = unlimited)
    record_delivery_timeout: "0s"     # max time a record can sit in buffer (0s = unlimited)
```

**Validation**:
- `max_buffered_records` must be >= 1
- `max_buffered_bytes` accepts human-readable sizes ("256MB", "50mib"), 0 disables
- `max_in_flight_requests` must be >= 1; with `idempotent_write: true`, franz-go internally caps at 5 (Kafka v1+) or 1 (Kafka < v1)
- `record_retries` 0 = unlimited (default), > 0 = fail after N retries
- `record_delivery_timeout` 0s = unlimited (default), > 0 = fail after duration
- With `idempotent_write: true`, both retry/timeout options are only enforced when safe (no invalid sequence numbers)

Thanks