### PR TITLE
output/aws_dynamodb: chunk batch writes to 25 item limit

### DIFF
--- a/internal/impl/aws/dynamodb/output.go
+++ b/internal/impl/aws/dynamodb/output.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -38,6 +39,10 @@ import (
 )
 
 const (
+	// dynamoDBMaxBatchItems is the maximum number of items that can be sent in
+	// a single BatchWriteItem request per the AWS API.
+	dynamoDBMaxBatchItems = 25
+
 	// DynamoDB Output Fields
 	ddboField               = "namespace"
 	ddboFieldTable          = "table"
@@ -386,82 +391,137 @@ func (d *dynamoDBWriter) WriteBatch(ctx context.Context, b service.MessageBatch)
 		return err
 	}
 
-	batchResult, err := d.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
-		RequestItems: map[string][]types.WriteRequest{
-			*d.table: writeReqs,
-		},
-	})
-	if err != nil {
-		headlineErr := err
+	// Chunk writeReqs into groups of dynamoDBMaxBatchItems (25) per the
+	// DynamoDB BatchWriteItem API limit.
+	for chunkStart := 0; chunkStart < len(writeReqs); chunkStart += dynamoDBMaxBatchItems {
+		boff.Reset()
+		chunkEnd := min(chunkStart+dynamoDBMaxBatchItems, len(writeReqs))
+		chunk := writeReqs[chunkStart:chunkEnd]
 
-		// None of the messages were successful, attempt to send individually
-	individualRequestsLoop:
-		for err != nil {
-			batchErr := service.NewBatchError(b, headlineErr)
-			for i, req := range writeReqs {
-				if req.PutRequest == nil {
-					continue
-				}
-				if _, iErr := d.client.PutItem(ctx, &dynamodb.PutItemInput{
-					TableName: d.table,
-					Item:      req.PutRequest.Item,
-				}); iErr != nil {
-					d.log.Errorf("Put error: %v\n", iErr)
-					wait := boff.NextBackOff()
-					if wait == backoff.Stop {
-						break individualRequestsLoop
-					}
-					select {
-					case <-time.After(wait):
-					case <-ctx.Done():
-						break individualRequestsLoop
-					}
-					batchErr.Failed(i, iErr)
-				} else {
-					writeReqs[i].PutRequest = nil
-				}
-			}
-			if batchErr.IndexedErrors() == 0 {
-				err = nil
-			} else {
-				err = batchErr
-			}
-		}
-		return err
-	}
-
-	unproc := batchResult.UnprocessedItems[*d.table]
-unprocessedLoop:
-	for len(unproc) > 0 {
-		wait := boff.NextBackOff()
-		if wait == backoff.Stop {
-			break unprocessedLoop
-		}
-
-		select {
-		case <-time.After(wait):
-		case <-ctx.Done():
-			break unprocessedLoop
-		}
-		if batchResult, err = d.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		batchResult, err := d.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
 			RequestItems: map[string][]types.WriteRequest{
-				*d.table: unproc,
+				*d.table: chunk,
 			},
-		}); err != nil {
-			d.log.Errorf("Write multi error: %v\n", err)
-		} else if unproc = batchResult.UnprocessedItems[*d.table]; len(unproc) > 0 {
-			err = fmt.Errorf("setting %v items", len(unproc))
-		} else {
-			unproc = nil
-		}
-	}
+		})
+		if err != nil {
+			headlineErr := err
 
-	if len(unproc) > 0 {
-		if err == nil {
-			err = errors.New("ran out of request retries")
+			// None of the messages were successful, attempt to send individually
+		individualRequestsLoop:
+			for err != nil {
+				batchErr := service.NewBatchError(b, headlineErr)
+				for j, req := range chunk {
+					if req.PutRequest == nil {
+						continue
+					}
+					if _, iErr := d.client.PutItem(ctx, &dynamodb.PutItemInput{
+						TableName: d.table,
+						Item:      req.PutRequest.Item,
+					}); iErr != nil {
+						d.log.Errorf("Put error: %v\n", iErr)
+						wait := boff.NextBackOff()
+						if wait == backoff.Stop {
+							break individualRequestsLoop
+						}
+						select {
+						case <-time.After(wait):
+						case <-ctx.Done():
+							break individualRequestsLoop
+						}
+						batchErr.Failed(chunkStart+j, iErr)
+					} else {
+						chunk[j].PutRequest = nil
+					}
+				}
+				if batchErr.IndexedErrors() == 0 {
+					err = nil
+				} else {
+					// Mark all items in subsequent unattempted chunks as
+					// failed to prevent silent data loss.
+					for k := chunkEnd; k < len(writeReqs); k++ {
+						batchErr.Failed(k, headlineErr)
+					}
+					err = batchErr
+				}
+			}
+			if err != nil {
+				return err
+			}
+			// Individual fallback wrote every item in this chunk; move on.
+			continue
+		}
+
+		unproc := batchResult.UnprocessedItems[*d.table]
+	unprocessedLoop:
+		for len(unproc) > 0 {
+			wait := boff.NextBackOff()
+			if wait == backoff.Stop {
+				break unprocessedLoop
+			}
+
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				break unprocessedLoop
+			}
+			if batchResult, err = d.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]types.WriteRequest{
+					*d.table: unproc,
+				},
+			}); err != nil {
+				d.log.Errorf("Write multi error: %v\n", err)
+			} else if unproc = batchResult.UnprocessedItems[*d.table]; len(unproc) > 0 {
+				err = fmt.Errorf("setting %v items", len(unproc))
+			} else {
+				unproc = nil
+			}
+		}
+
+		if len(unproc) > 0 {
+			if err == nil {
+				err = errors.New("ran out of request retries")
+			}
+			batchErr := service.NewBatchError(b, err)
+			// Map each unprocessed item back to its original index in
+			// this chunk so only the genuinely-unwritten items (and
+			// items in unattempted later chunks) are marked as failed.
+			matched := make([]bool, len(chunk))
+			matches := 0
+			for _, u := range unproc {
+				for j := range chunk {
+					if matched[j] {
+						continue
+					}
+					if reflect.DeepEqual(u, chunk[j]) {
+						matched[j] = true
+						matches++
+						break
+					}
+				}
+			}
+			if matches == len(unproc) {
+				for j, m := range matched {
+					if m {
+						batchErr.Failed(chunkStart+j, err)
+					}
+				}
+			} else {
+				// Some unprocessed items did not match anything in the
+				// chunk — the SDK returned a shape we did not expect. Fall
+				// back to marking the whole chunk failed. Writes are
+				// upserts, so retried items that already landed are
+				// harmless; the alternative is silent data loss.
+				for j := range chunk {
+					batchErr.Failed(chunkStart+j, err)
+				}
+			}
+			for k := chunkEnd; k < len(writeReqs); k++ {
+				batchErr.Failed(k, err)
+			}
+			return batchErr
 		}
 	}
-	return err
+	return nil
 }
 
 func (*dynamoDBWriter) Close(context.Context) error {

--- a/internal/impl/aws/dynamodb/output_integration_test.go
+++ b/internal/impl/aws/dynamodb/output_integration_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamodb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+)
+
+func TestIntegrationDynamoDBOutput(t *testing.T) {
+	integration.CheckSkip(t)
+
+	ctr, err := testcontainers.Run(t.Context(), "amazon/dynamodb-local:latest",
+		testcontainers.WithExposedPorts("8000/tcp"),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("8000/tcp").WithStartupTimeout(30*time.Second),
+		),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	mp, err := ctr.MappedPort(t.Context(), "8000/tcp")
+	require.NoError(t, err)
+	dynamoPort := mp.Port()
+
+	const tableName = "output_batch_table"
+	require.Eventually(t, func() bool {
+		return createTable(t.Context(), t, dynamoPort, tableName) == nil
+	}, 30*time.Second, time.Second)
+
+	endpoint := fmt.Sprintf("http://localhost:%s", dynamoPort)
+
+	pConf, err := ddboOutputSpec().ParseYAML(fmt.Sprintf(`
+table: %s
+string_columns:
+  id: ${! json("id") }
+  content: ${! json("content") }
+region: us-east-1
+endpoint: %s
+credentials:
+  id: xxxxx
+  secret: xxxxx
+  token: xxxxx
+`, tableName, endpoint), nil)
+	require.NoError(t, err)
+
+	dConf, err := ddboConfigFromParsed(pConf)
+	require.NoError(t, err)
+
+	writer, err := newDynamoDBWriter(dConf, service.MockResources())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, writer.Close(context.Background()))
+	})
+
+	require.NoError(t, writer.Connect(t.Context()))
+
+	const numMessages = 60
+	batch := make(service.MessageBatch, numMessages)
+	for i := range numMessages {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d","content":"content-%d"}`, i, i))
+	}
+
+	require.NoError(t, writer.WriteBatch(t.Context(), batch))
+
+	awsCfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("xxxxx", "xxxxx", "xxxxx")),
+	)
+	require.NoError(t, err)
+	awsCfg.BaseEndpoint = &endpoint
+	client := dynamodb.NewFromConfig(awsCfg)
+
+	seenIDs := make(map[string]bool, numMessages)
+	var lastKey map[string]types.AttributeValue
+	for {
+		scanOut, err := client.Scan(t.Context(), &dynamodb.ScanInput{
+			TableName:         aws.String(tableName),
+			ExclusiveStartKey: lastKey,
+		})
+		require.NoError(t, err)
+		for _, item := range scanOut.Items {
+			idAttr, ok := item["id"].(*types.AttributeValueMemberS)
+			require.True(t, ok, "item missing string 'id' attribute")
+			seenIDs[idAttr.Value] = true
+		}
+		if len(scanOut.LastEvaluatedKey) == 0 {
+			break
+		}
+		lastKey = scanOut.LastEvaluatedKey
+	}
+
+	assert.Len(t, seenIDs, numMessages, "expected all %d items to be written", numMessages)
+	for i := range numMessages {
+		expectedID := fmt.Sprintf("id-%d", i)
+		assert.True(t, seenIDs[expectedID], "expected item %q to be present in table", expectedID)
+	}
+}

--- a/internal/impl/aws/dynamodb/output_test.go
+++ b/internal/impl/aws/dynamodb/output_test.go
@@ -17,6 +17,7 @@ package dynamodb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -466,7 +467,9 @@ string_columns:
 		service.NewMessage([]byte(`{"id":"baz","content":"baz stuff"}`)),
 	}
 
-	require.Equal(t, errors.New("setting 1 items"), db.WriteBatch(t.Context(), msg))
+	expErr := service.NewBatchError(msg, errors.New("setting 1 items"))
+	expErr.Failed(1, errors.New("setting 1 items"))
+	require.Equal(t, expErr, db.WriteBatch(t.Context(), msg))
 
 	expected := [][]types.WriteRequest{
 		{
@@ -508,4 +511,225 @@ string_columns:
 	}
 
 	assert.Equal(t, expected, requests)
+}
+
+// TestDynamoDBChunkedBatchWrite verifies that WriteBatch splits batches
+// larger than the 25-item BatchWriteItem limit and sends every chunk.
+func TestDynamoDBChunkedBatchWrite(t *testing.T) {
+	t.Parallel()
+
+	db := testDDBOWriter(t, `
+table: FooTable
+string_columns:
+  id: ${!json("id")}
+`)
+
+	var chunkSizes []int
+	db.client = &mockDynamoDB{
+		fn: func(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+			t.Error("not expected")
+			return nil, errors.New("not implemented")
+		},
+		batchFn: func(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+			chunkSizes = append(chunkSizes, len(input.RequestItems["FooTable"]))
+			return &dynamodb.BatchWriteItemOutput{}, nil
+		},
+	}
+
+	const total = 60
+	batch := make(service.MessageBatch, total)
+	for i := range total {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d"}`, i))
+	}
+
+	require.NoError(t, db.WriteBatch(t.Context(), batch))
+	assert.Equal(t, []int{25, 25, 10}, chunkSizes)
+}
+
+// TestDynamoDBChunkedFallbackContinuesToNextChunk guards against a bug where
+// a BatchWriteItem failure in chunk N that was fully recovered via individual
+// PutItem fallback would cause WriteBatch to return nil without sending
+// chunks N+1..end, silently dropping those items.
+func TestDynamoDBChunkedFallbackContinuesToNextChunk(t *testing.T) {
+	t.Parallel()
+
+	db := testDDBOWriter(t, `
+table: FooTable
+string_columns:
+  id: ${!json("id")}
+`)
+
+	var batchCalls int
+	var putIDs []string
+	db.client = &mockDynamoDB{
+		fn: func(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+			putIDs = append(putIDs, input.Item["id"].(*types.AttributeValueMemberS).Value)
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		batchFn: func(*dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+			batchCalls++
+			if batchCalls == 1 {
+				return &dynamodb.BatchWriteItemOutput{}, errors.New("forced batch failure")
+			}
+			return &dynamodb.BatchWriteItemOutput{}, nil
+		},
+	}
+
+	const total = 30
+	batch := make(service.MessageBatch, total)
+	for i := range total {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d"}`, i))
+	}
+
+	require.NoError(t, db.WriteBatch(t.Context(), batch))
+
+	// Chunk 0 fell back to individual PutItem for all 25 items; chunk 1
+	// must still be sent as a batch after chunk 0 recovers.
+	assert.Len(t, putIDs, 25)
+	assert.Equal(t, 2, batchCalls)
+}
+
+// TestDynamoDBChunkedUnprocessedReturnsBatchError guards against a bug where
+// exhausting the unprocessed-items retry budget returned a plain error,
+// causing the framework to retry the whole original batch (duplicating
+// already-written earlier chunks) and leaving later chunks unreported. The
+// writer must return a BatchError that marks only the genuinely unwritten
+// items, plus items in unattempted later chunks.
+func TestDynamoDBChunkedUnprocessedReturnsBatchError(t *testing.T) {
+	t.Parallel()
+
+	db := testDDBOWriter(t, `
+table: FooTable
+string_columns:
+  id: ${!json("id")}
+backoff:
+  max_elapsed_time: 100ms
+`)
+
+	var batchCalls int
+	db.client = &mockDynamoDB{
+		fn: func(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+			t.Error("not expected")
+			return nil, errors.New("not implemented")
+		},
+		batchFn: func(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+			batchCalls++
+			if batchCalls == 1 {
+				return &dynamodb.BatchWriteItemOutput{}, nil
+			}
+			return &dynamodb.BatchWriteItemOutput{
+				UnprocessedItems: map[string][]types.WriteRequest{
+					"FooTable": input.RequestItems["FooTable"],
+				},
+			}, nil
+		},
+	}
+
+	const total = 40
+	batch := make(service.MessageBatch, total)
+	for i := range total {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d"}`, i))
+	}
+
+	expErr := service.NewBatchError(batch, errors.New("ran out of request retries"))
+	for i := 25; i < total; i++ {
+		expErr.Failed(i, errors.New("ran out of request retries"))
+	}
+	require.Equal(t, expErr, db.WriteBatch(t.Context(), batch))
+}
+
+// TestDynamoDBChunkedUnprocessedUnmatchedFallback guards the pessimistic
+// fallback path: if the SDK returns an unprocessed WriteRequest that we
+// cannot match against any item we sent (an invariant we rely on via
+// reflect.DeepEqual), we must still return a BatchError that marks the
+// whole chunk as failed — never silently drop an unmatched item.
+func TestDynamoDBChunkedUnprocessedUnmatchedFallback(t *testing.T) {
+	t.Parallel()
+
+	db := testDDBOWriter(t, `
+table: FooTable
+string_columns:
+  id: ${!json("id")}
+backoff:
+  max_elapsed_time: 100ms
+`)
+
+	db.client = &mockDynamoDB{
+		fn: func(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+			t.Error("not expected")
+			return nil, errors.New("not implemented")
+		},
+		batchFn: func(*dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+			// Return an unprocessed item that does not match anything we
+			// sent (different id), simulating SDK drift that breaks our
+			// DeepEqual mapping heuristic.
+			return &dynamodb.BatchWriteItemOutput{
+				UnprocessedItems: map[string][]types.WriteRequest{
+					"FooTable": {{PutRequest: &types.PutRequest{
+						Item: map[string]types.AttributeValue{
+							"id": &types.AttributeValueMemberS{Value: "unknown-id"},
+						},
+					}}},
+				},
+			}, nil
+		},
+	}
+
+	const total = 3
+	batch := make(service.MessageBatch, total)
+	for i := range total {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d"}`, i))
+	}
+
+	expErr := service.NewBatchError(batch, errors.New("ran out of request retries"))
+	for i := range total {
+		expErr.Failed(i, errors.New("ran out of request retries"))
+	}
+	require.Equal(t, expErr, db.WriteBatch(t.Context(), batch))
+}
+
+// TestDynamoDBChunkedIndividualFallbackGlobalIndex verifies that when a
+// non-zero chunk falls back to individual PutItem calls and some of those
+// PutItems fail, the returned BatchError marks the failed items at their
+// *global* batch indices (chunkStart+j), not their local chunk indices.
+func TestDynamoDBChunkedIndividualFallbackGlobalIndex(t *testing.T) {
+	t.Parallel()
+
+	db := testDDBOWriter(t, `
+table: FooTable
+string_columns:
+  id: ${!json("id")}
+backoff:
+  initial_interval: 1ms
+  max_interval: 10ms
+  max_elapsed_time: 50ms
+`)
+
+	barErr := errors.New("dont like id-27")
+	db.client = &mockDynamoDB{
+		fn: func(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+			if input.Item["id"].(*types.AttributeValueMemberS).Value == "id-27" {
+				return nil, barErr
+			}
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		batchFn: func(input *dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error) {
+			// Fail chunk 1 (the second chunk) at the batch level so it
+			// drops into the individual fallback with chunkStart=25.
+			if input.RequestItems["FooTable"][0].PutRequest.Item["id"].(*types.AttributeValueMemberS).Value == "id-25" {
+				return &dynamodb.BatchWriteItemOutput{}, errors.New("chunk 1 batch failure")
+			}
+			return &dynamodb.BatchWriteItemOutput{}, nil
+		},
+	}
+
+	const total = 30
+	batch := make(service.MessageBatch, total)
+	for i := range total {
+		batch[i] = service.NewMessage(fmt.Appendf(nil, `{"id":"id-%d"}`, i))
+	}
+
+	expErr := service.NewBatchError(batch, errors.New("chunk 1 batch failure"))
+	expErr.Failed(27, barErr)
+	require.Equal(t, expErr, db.WriteBatch(t.Context(), batch))
 }


### PR DESCRIPTION
## Summary

- Chunks `BatchWriteItem` calls into groups of 25 items per the [DynamoDB API limit](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html), instead of sending all items at once and falling back to expensive one-by-one writes on failure
- Resets backoff between chunks so each chunk gets a fresh retry budget
- Marks items in unattempted chunks as failed in `BatchError` when a chunk fails, preventing silent data loss

## Test plan

- [x] Existing unit tests pass (`go test ./internal/impl/aws/dynamodb/...`)
- [ ] Manual test with batch sizes > 25 against a real DynamoDB table
- [ ] Integration tests (require Docker)

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)