### PR TITLE
azure: add blob index tags support for blob storage output

### DIFF
--- a/docs/modules/components/pages/outputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_blob_storage.adoc
@@ -64,6 +64,7 @@ output:
     storage_sas_token: ""
     container: messages-${!timestamp("2006")} # No default (required)
     path: ${!counter()}-${!timestamp_unix_nano()}.txt
+    tags: {}
     blob_type: BLOCK
     public_access_level: PRIVATE
     max_in_flight: 64
@@ -163,6 +164,24 @@ path: ${!counter()}-${!timestamp_unix_nano()}.json
 path: ${!meta("kafka_key")}.json
 
 path: ${!json("doc.namespace")}/${!json("doc.id")}.json
+```
+
+=== `tags`
+
+Key/value pairs to store with the blob as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^]. A maximum of 10 tags are permitted, tag keys must be between 1 and 128 characters, and tag values must be between 0 and 256 characters. Keys and values are case-sensitive and only support string values. Not supported on storage accounts with hierarchical namespace (Data Lake Gen2).
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `object`
+
+*Default*: `{}`
+
+```yml
+# Examples
+
+tags:
+  Environment: production
+  Source: ${!meta("kafka_topic")}
 ```
 
 === `blob_type`

--- a/docs/modules/components/pages/outputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_blob_storage.adoc
@@ -89,6 +89,26 @@ If multiple are set then the `storage_connection_string` is given priority.
 If the `storage_connection_string` does not contain the `AccountName` parameter, please specify it in the
 `storage_account` field.
 
+== Tags
+
+The `tags` field allows you to attach key/value pairs to blobs as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^], where the values support xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]:
+
+```yaml
+output:
+  azure_blob_storage:
+    container: TODO
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
+    tags:
+      Environment: production
+      Source: ${!meta("kafka_topic")}
+```
+
+Only values support interpolation; keys are static and are validated against Azure's limits at startup. Values are resolved per message and so are only rejected once Azure sees them.
+
+If authenticating with `storage_sas_token`, the token must include the `t` (tags) permission.
+
+When `blob_type` is `APPEND` the tags are written separately from the message content, so they are refreshed on each append on a best-effort basis and may briefly lag the most recent append. A failure to write them is logged and does not fail the message, because retrying would append the message content a second time.
+
 == Performance
 
 This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.

--- a/internal/impl/azure/integration_test.go
+++ b/internal/impl/azure/integration_test.go
@@ -230,6 +230,55 @@ input:
 		)
 	})
 
+	t.Run("blob_storage_tags", func(t *testing.T) {
+		u4, err := uuid.NewV4()
+		require.NoError(t, err)
+		containerName := u4.String()
+
+		client, err := azblob.NewClientFromConnectionString(connString, nil)
+		require.NoError(t, err)
+		_, err = client.CreateContainer(t.Context(), containerName, nil)
+		require.NoError(t, err)
+
+		env := service.NewEnvironment()
+		outConf, err := bsoSpec().ParseYAML(fmt.Sprintf(`
+storage_connection_string: %s
+container: %s
+path: tagged-blob.txt
+blob_type: BLOCK
+public_access_level: PRIVATE
+tags:
+  Environment: production
+  Source: test-suite
+`, connString, containerName), env)
+		require.NoError(t, err)
+
+		conf, err := bsoConfigFromParsed(outConf)
+		require.NoError(t, err)
+
+		writer, err := newAzureBlobStorageWriter(conf, service.MockResources().Logger())
+		require.NoError(t, err)
+
+		require.NoError(t, writer.Connect(t.Context()))
+		t.Cleanup(func() { require.NoError(t, writer.Close(context.Background())) })
+
+		msg := service.NewMessage([]byte("hello world"))
+		require.NoError(t, writer.Write(t.Context(), msg))
+
+		resp, err := client.ServiceClient().NewContainerClient(containerName).NewBlobClient("tagged-blob.txt").GetTags(t.Context(), nil)
+		require.NoError(t, err)
+
+		tags := make(map[string]string)
+		for _, tag := range resp.BlobTagSet {
+			tags[*tag.Key] = *tag.Value
+		}
+
+		assert.Equal(t, map[string]string{
+			"Environment": "production",
+			"Source":      "test-suite",
+		}, tags)
+	})
+
 	t.Run("queue_storage", func(t *testing.T) {
 		dummyQueue := "foo"
 

--- a/internal/impl/azure/integration_test.go
+++ b/internal/impl/azure/integration_test.go
@@ -265,7 +265,18 @@ tags:
 		msg := service.NewMessage([]byte("hello world"))
 		require.NoError(t, writer.Write(t.Context(), msg))
 
-		resp, err := client.ServiceClient().NewContainerClient(containerName).NewBlobClient("tagged-blob.txt").GetTags(t.Context(), nil)
+		blobClient := client.ServiceClient().NewContainerClient(containerName).NewBlobClient("tagged-blob.txt")
+
+		// Assert the payload too, so a regression that tags correctly but corrupts
+		// the body cannot pass.
+		dl, err := blobClient.DownloadStream(t.Context(), nil)
+		require.NoError(t, err)
+		body, err := io.ReadAll(dl.Body)
+		require.NoError(t, err)
+		require.NoError(t, dl.Body.Close())
+		assert.Equal(t, "hello world", string(body))
+
+		resp, err := blobClient.GetTags(t.Context(), nil)
 		require.NoError(t, err)
 
 		tags := make(map[string]string)
@@ -277,6 +288,133 @@ tags:
 			"Environment": "production",
 			"Source":      "test-suite",
 		}, tags)
+	})
+
+	t.Run("blob_storage_tags_append", func(t *testing.T) {
+		u4, err := uuid.NewV4()
+		require.NoError(t, err)
+		containerName := u4.String()
+
+		client, err := azblob.NewClientFromConnectionString(connString, nil)
+		require.NoError(t, err)
+		_, err = client.CreateContainer(t.Context(), containerName, nil)
+		require.NoError(t, err)
+
+		env := service.NewEnvironment()
+		outConf, err := bsoSpec().ParseYAML(fmt.Sprintf(`
+storage_connection_string: %s
+container: %s
+path: tagged-append-blob.txt
+blob_type: APPEND
+public_access_level: PRIVATE
+tags:
+  Environment: production
+  Source: ${! content() }
+`, connString, containerName), env)
+		require.NoError(t, err)
+
+		conf, err := bsoConfigFromParsed(outConf)
+		require.NoError(t, err)
+
+		writer, err := newAzureBlobStorageWriter(conf, service.MockResources().Logger())
+		require.NoError(t, err)
+
+		require.NoError(t, writer.Connect(t.Context()))
+		t.Cleanup(func() { require.NoError(t, writer.Close(context.Background())) })
+
+		require.NoError(t, writer.Write(t.Context(), service.NewMessage([]byte("first"))))
+		require.NoError(t, writer.Write(t.Context(), service.NewMessage([]byte("second"))))
+
+		blobClient := client.ServiceClient().NewContainerClient(containerName).NewBlobClient("tagged-append-blob.txt")
+
+		// Each message must be appended exactly once.
+		dl, err := blobClient.DownloadStream(t.Context(), nil)
+		require.NoError(t, err)
+		body, err := io.ReadAll(dl.Body)
+		require.NoError(t, err)
+		require.NoError(t, dl.Body.Close())
+		assert.Equal(t, "firstsecond", string(body))
+
+		// Tags are refreshed on every append, so Source reflects the most recently
+		// written message.
+		resp, err := blobClient.GetTags(t.Context(), nil)
+		require.NoError(t, err)
+
+		tags := make(map[string]string)
+		for _, tag := range resp.BlobTagSet {
+			tags[*tag.Key] = *tag.Value
+		}
+
+		assert.Equal(t, map[string]string{
+			"Environment": "production",
+			"Source":      "second",
+		}, tags)
+	})
+
+	// A blob this output did not create never passes through the creation path, so
+	// it is the case where tags are easiest to silently drop.
+	t.Run("blob_storage_tags_append_preexisting_blob", func(t *testing.T) {
+		u4, err := uuid.NewV4()
+		require.NoError(t, err)
+		containerName := u4.String()
+
+		client, err := azblob.NewClientFromConnectionString(connString, nil)
+		require.NoError(t, err)
+		_, err = client.CreateContainer(t.Context(), containerName, nil)
+		require.NoError(t, err)
+
+		containerClient := client.ServiceClient().NewContainerClient(containerName)
+
+		// Simulate a blob left behind by an earlier run that had no tags configured.
+		_, err = containerClient.NewAppendBlobClient("existing-blob.txt").Create(t.Context(), nil)
+		require.NoError(t, err)
+
+		env := service.NewEnvironment()
+		outConf, err := bsoSpec().ParseYAML(fmt.Sprintf(`
+storage_connection_string: %s
+container: %s
+path: existing-blob.txt
+blob_type: APPEND
+public_access_level: PRIVATE
+tags:
+  Environment: production
+  Source: test-suite
+`, connString, containerName), env)
+		require.NoError(t, err)
+
+		conf, err := bsoConfigFromParsed(outConf)
+		require.NoError(t, err)
+
+		writer, err := newAzureBlobStorageWriter(conf, service.MockResources().Logger())
+		require.NoError(t, err)
+
+		require.NoError(t, writer.Connect(t.Context()))
+		t.Cleanup(func() { require.NoError(t, writer.Close(context.Background())) })
+
+		require.NoError(t, writer.Write(t.Context(), service.NewMessage([]byte("payload"))))
+
+		blobClient := containerClient.NewBlobClient("existing-blob.txt")
+
+		resp, err := blobClient.GetTags(t.Context(), nil)
+		require.NoError(t, err)
+
+		tags := make(map[string]string)
+		for _, tag := range resp.BlobTagSet {
+			tags[*tag.Key] = *tag.Value
+		}
+
+		assert.Equal(t, map[string]string{
+			"Environment": "production",
+			"Source":      "test-suite",
+		}, tags)
+
+		// The pre-existing blob must be appended to, not recreated.
+		dl, err := blobClient.DownloadStream(t.Context(), nil)
+		require.NoError(t, err)
+		body, err := io.ReadAll(dl.Body)
+		require.NoError(t, err)
+		require.NoError(t, dl.Body.Close())
+		assert.Equal(t, "payload", string(body))
 	})
 
 	t.Run("queue_storage", func(t *testing.T) {

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -19,10 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -32,14 +35,21 @@ const (
 	// Blob Storage Output Fields
 	bsoFieldContainer         = "container"
 	bsoFieldPath              = "path"
+	bsoFieldTags              = "tags"
 	bsoFieldBlobType          = "blob_type"
 	bsoFieldPublicAccessLevel = "public_access_level"
 )
+
+type bsoTagPair struct {
+	key   string
+	value *service.InterpolatedString
+}
 
 type bsoConfig struct {
 	client            *azblob.Client
 	Container         *service.InterpolatedString
 	Path              *service.InterpolatedString
+	Tags              []bsoTagPair
 	BlobType          *service.InterpolatedString
 	PublicAccessLevel *service.InterpolatedString
 }
@@ -59,6 +69,23 @@ func bsoConfigFromParsed(pConf *service.ParsedConfig) (conf bsoConfig, err error
 	if conf.Path, err = pConf.FieldInterpolatedString(bsoFieldPath); err != nil {
 		return
 	}
+
+	var tagMap map[string]*service.InterpolatedString
+	if tagMap, err = pConf.FieldInterpolatedStringMap(bsoFieldTags); err != nil {
+		return
+	}
+	if len(tagMap) > 10 {
+		err = fmt.Errorf("at most 10 blob index tags are permitted, got %d", len(tagMap))
+		return
+	}
+	conf.Tags = make([]bsoTagPair, 0, len(tagMap))
+	for k, v := range tagMap {
+		conf.Tags = append(conf.Tags, bsoTagPair{key: k, value: v})
+	}
+	sort.Slice(conf.Tags, func(i, j int) bool {
+		return conf.Tags[i].key < conf.Tags[j].key
+	})
+
 	if conf.BlobType, err = pConf.FieldInterpolatedString(bsoFieldBlobType); err != nil {
 		return
 	}
@@ -99,6 +126,14 @@ If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+
 				Example(`${!meta("kafka_key")}.json`).
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`),
+			service.NewInterpolatedStringMapField(bsoFieldTags).
+				Description("Key/value pairs to store with the blob as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^]. A maximum of 10 tags are permitted, tag keys must be between 1 and 128 characters, and tag values must be between 0 and 256 characters. Keys and values are case-sensitive and only support string values. Not supported on storage accounts with hierarchical namespace (Data Lake Gen2).").
+				Default(map[string]any{}).
+				Example(map[string]any{
+					"Environment": "production",
+					"Source":      `${!meta("kafka_topic")}`,
+				}).
+				Advanced(),
 			service.NewInterpolatedStringEnumField(bsoFieldBlobType, "BLOCK", "APPEND").
 				Description("Block and Append blobs are comprized of blocks, and each blob can support up to 50,000 blocks. The default value is `+\"`BLOCK`\"+`.`").
 				Advanced().
@@ -145,7 +180,7 @@ func (*azureBlobStorageWriter) Connect(context.Context) error {
 	return nil
 }
 
-func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, blobName, blobType string, message []byte) error {
+func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, blobName, blobType string, message []byte, tags map[string]string) error {
 	containerClient := a.conf.client.ServiceClient().NewContainerClient(containerName)
 	var err error
 	if blobType == "APPEND" {
@@ -153,7 +188,11 @@ func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, 
 		_, err = appendBlobClient.AppendBlock(ctx, streaming.NopCloser(bytes.NewReader(message)), nil)
 		if err != nil {
 			if isErrorCode(err, bloberror.BlobNotFound) {
-				_, err := appendBlobClient.Create(ctx, nil)
+				var createOpts *appendblob.CreateOptions
+				if len(tags) > 0 {
+					createOpts = &appendblob.CreateOptions{Tags: tags}
+				}
+				_, err := appendBlobClient.Create(ctx, createOpts)
 				if err != nil && !isErrorCode(err, bloberror.BlobAlreadyExists) {
 					return fmt.Errorf("creating append blob: %w", err)
 				}
@@ -167,8 +206,22 @@ func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, 
 				return fmt.Errorf("appending block to blob: %w", err)
 			}
 		}
+		// Tags must be set separately for append blobs since AppendBlock does not
+		// support tags. On creation they are set via CreateOptions, but when
+		// appending to an existing blob we need an explicit SetTags call to ensure
+		// tags reflect the latest configured values.
+		if len(tags) > 0 {
+			blobClient := containerClient.NewBlobClient(blobName)
+			if _, err = blobClient.SetTags(ctx, tags, nil); err != nil {
+				return fmt.Errorf("setting blob tags: %w", err)
+			}
+		}
 	} else {
-		_, err = containerClient.NewBlockBlobClient(blobName).UploadStream(ctx, bytes.NewReader(message), nil)
+		var uploadOpts *blockblob.UploadStreamOptions
+		if len(tags) > 0 {
+			uploadOpts = &blockblob.UploadStreamOptions{Tags: tags}
+		}
+		_, err = containerClient.NewBlockBlobClient(blobName).UploadStream(ctx, bytes.NewReader(message), uploadOpts)
 		if err != nil {
 			return fmt.Errorf("pushing block to blob: %w", err)
 		}
@@ -211,7 +264,19 @@ func (a *azureBlobStorageWriter) Write(ctx context.Context, msg *service.Message
 		return err
 	}
 
-	if err := a.uploadBlob(ctx, containerName, blobName, blobType, mBytes); err != nil {
+	var blobTags map[string]string
+	if len(a.conf.Tags) > 0 {
+		blobTags = make(map[string]string, len(a.conf.Tags))
+		for _, pair := range a.conf.Tags {
+			tagVal, err := pair.value.TryString(msg)
+			if err != nil {
+				return fmt.Errorf("tag %v interpolation: %w", pair.key, err)
+			}
+			blobTags[pair.key] = tagVal
+		}
+	}
+
+	if err := a.uploadBlob(ctx, containerName, blobName, blobType, mBytes, blobTags); err != nil {
 		if isErrorCode(err, bloberror.ContainerNotFound) {
 			var accessLevel string
 			if accessLevel, err = a.conf.PublicAccessLevel.TryString(msg); err != nil {
@@ -224,7 +289,7 @@ func (a *azureBlobStorageWriter) Write(ctx context.Context, msg *service.Message
 				}
 			}
 
-			if err := a.uploadBlob(ctx, containerName, blobName, blobType, mBytes); err != nil {
+			if err := a.uploadBlob(ctx, containerName, blobName, blobType, mBytes, blobTags); err != nil {
 				return fmt.Errorf("error retrying to upload blob: %s", err)
 			}
 		} else {

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -38,6 +38,11 @@ const (
 	bsoFieldTags              = "tags"
 	bsoFieldBlobType          = "blob_type"
 	bsoFieldPublicAccessLevel = "public_access_level"
+
+	// bsoMaxTagsPermitted is the maximum number of blob index tags a single
+	// blob may carry, a limit imposed by Azure. See
+	// https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs
+	bsoMaxTagsPermitted = 10
 )
 
 type bsoTagPair struct {
@@ -74,8 +79,8 @@ func bsoConfigFromParsed(pConf *service.ParsedConfig) (conf bsoConfig, err error
 	if tagMap, err = pConf.FieldInterpolatedStringMap(bsoFieldTags); err != nil {
 		return
 	}
-	if len(tagMap) > 10 {
-		err = fmt.Errorf("at most 10 blob index tags are permitted, got %d", len(tagMap))
+	if len(tagMap) > bsoMaxTagsPermitted {
+		err = fmt.Errorf("at most %d blob index tags are permitted, got %d", bsoMaxTagsPermitted, len(tagMap))
 		return
 	}
 	conf.Tags = make([]bsoTagPair, 0, len(tagMap))
@@ -127,7 +132,7 @@ If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+
 				Example(`${!json("doc.namespace")}/${!json("doc.id")}.json`).
 				Default(`${!counter()}-${!timestamp_unix_nano()}.txt`),
 			service.NewInterpolatedStringMapField(bsoFieldTags).
-				Description("Key/value pairs to store with the blob as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^]. A maximum of 10 tags are permitted, tag keys must be between 1 and 128 characters, and tag values must be between 0 and 256 characters. Keys and values are case-sensitive and only support string values. Not supported on storage accounts with hierarchical namespace (Data Lake Gen2).").
+				Description(fmt.Sprintf("Key/value pairs to store with the blob as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^]. A maximum of %d tags are permitted, tag keys must be between 1 and 128 characters, and tag values must be between 0 and 256 characters. Keys and values are case-sensitive and only support string values. Not supported on storage accounts with hierarchical namespace (Data Lake Gen2).", bsoMaxTagsPermitted)).
 				Default(map[string]any{}).
 				Example(map[string]any{
 					"Environment": "production",

--- a/internal/impl/azure/output_blob_storage.go
+++ b/internal/impl/azure/output_blob_storage.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -39,11 +40,39 @@ const (
 	bsoFieldBlobType          = "blob_type"
 	bsoFieldPublicAccessLevel = "public_access_level"
 
-	// bsoMaxTagsPermitted is the maximum number of blob index tags a single
-	// blob may carry, a limit imposed by Azure. See
+	// The following blob index tag limits are imposed by Azure. See
 	// https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs
+
+	// bsoMaxTagsPermitted is the maximum number of blob index tags a single
+	// blob may carry.
 	bsoMaxTagsPermitted = 10
+	// bsoMaxTagKeyLength is the maximum length of a blob index tag key.
+	bsoMaxTagKeyLength = 128
+	// bsoTagAllowedSpecialChars are the non-alphanumeric characters permitted
+	// within blob index tag keys and values.
+	bsoTagAllowedSpecialChars = " +-./:=_"
 )
+
+// bsoValidateTagKey checks a blob index tag key against the length and character
+// set limits imposed by Azure. Tag keys are always static, so an invalid one is
+// worth rejecting at config time rather than failing every message. Tag values
+// are interpolated per message and so cannot be checked here.
+func bsoValidateTagKey(key string) error {
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune(bsoTagAllowedSpecialChars, r):
+		default:
+			return fmt.Errorf("blob index tag key %q contains unsupported character %q, only alphanumerics and the characters %q are permitted", key, r, bsoTagAllowedSpecialChars)
+		}
+	}
+	// Only ASCII characters reach here, so byte length matches the character
+	// count Azure counts against the limit.
+	if l := len(key); l < 1 || l > bsoMaxTagKeyLength {
+		return fmt.Errorf("blob index tag key %q must be between 1 and %d characters, got %d", key, bsoMaxTagKeyLength, l)
+	}
+	return nil
+}
 
 type bsoTagPair struct {
 	key   string
@@ -85,6 +114,9 @@ func bsoConfigFromParsed(pConf *service.ParsedConfig) (conf bsoConfig, err error
 	}
 	conf.Tags = make([]bsoTagPair, 0, len(tagMap))
 	for k, v := range tagMap {
+		if err = bsoValidateTagKey(k); err != nil {
+			return
+		}
 		conf.Tags = append(conf.Tags, bsoTagPair{key: k, value: v})
 	}
 	sort.Slice(conf.Tags, func(i, j int) bool {
@@ -120,7 +152,27 @@ Supports multiple authentication methods but only one of the following is requir
 If multiple are set then the `+"`storage_connection_string`"+` is given priority.
 
 If the `+"`storage_connection_string`"+` does not contain the `+"`AccountName`"+` parameter, please specify it in the
-`+"`storage_account`"+` field.`+service.OutputPerformanceDocs(true, false)).
+`+"`storage_account`"+` field.
+
+== Tags
+
+The `+"`tags`"+` field allows you to attach key/value pairs to blobs as https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs[blob index tags^], where the values support xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]:
+
+`+"```yaml"+`
+output:
+  azure_blob_storage:
+    container: TODO
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
+    tags:
+      Environment: production
+      Source: ${!meta("kafka_topic")}
+`+"```"+`
+
+Only values support interpolation; keys are static and are validated against Azure's limits at startup. Values are resolved per message and so are only rejected once Azure sees them.
+
+If authenticating with `+"`storage_sas_token`"+`, the token must include the `+"`t`"+` (tags) permission.
+
+When `+"`blob_type`"+` is `+"`APPEND`"+` the tags are written separately from the message content, so they are refreshed on each append on a best-effort basis and may briefly lag the most recent append. A failure to write them is logged and does not fail the message, because retrying would append the message content a second time.`+service.OutputPerformanceDocs(true, false)).
 		Fields(
 			service.NewInterpolatedStringField(bsoFieldContainer).
 				Description("The container for uploading the messages to.").
@@ -193,6 +245,8 @@ func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, 
 		_, err = appendBlobClient.AppendBlock(ctx, streaming.NopCloser(bytes.NewReader(message)), nil)
 		if err != nil {
 			if isErrorCode(err, bloberror.BlobNotFound) {
+				// Attaching the tags at creation means a newly created blob carries
+				// them even if the refresh below fails.
 				var createOpts *appendblob.CreateOptions
 				if len(tags) > 0 {
 					createOpts = &appendblob.CreateOptions{Tags: tags}
@@ -211,14 +265,18 @@ func (a *azureBlobStorageWriter) uploadBlob(ctx context.Context, containerName, 
 				return fmt.Errorf("appending block to blob: %w", err)
 			}
 		}
-		// Tags must be set separately for append blobs since AppendBlock does not
-		// support tags. On creation they are set via CreateOptions, but when
-		// appending to an existing blob we need an explicit SetTags call to ensure
-		// tags reflect the latest configured values.
+		// AppendBlock does not support tags, so they are written separately. This
+		// also covers blobs this output did not create, which never pass through
+		// the creation path above and would otherwise never be tagged.
+		//
+		// A failure here is logged rather than returned: the message content is
+		// already committed at this point, and AppendBlock is not idempotent, so
+		// nacking would append the same content again on redelivery. Losing a tag
+		// update is preferable to duplicating data.
 		if len(tags) > 0 {
 			blobClient := containerClient.NewBlobClient(blobName)
-			if _, err = blobClient.SetTags(ctx, tags, nil); err != nil {
-				return fmt.Errorf("setting blob tags: %w", err)
+			if _, tagErr := blobClient.SetTags(ctx, tags, nil); tagErr != nil {
+				a.log.Warnf("Failed to set blob index tags on append blob %v: %v", blobName, tagErr)
 			}
 		}
 	} else {

--- a/internal/impl/azure/output_blob_storage_test.go
+++ b/internal/impl/azure/output_blob_storage_test.go
@@ -1,0 +1,146 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+const bsoTestConnString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+
+func bsoParseTagsConf(t *testing.T, tagsYAML string) (bsoConfig, error) {
+	t.Helper()
+
+	conf := fmt.Sprintf(`
+storage_connection_string: %s
+container: test-container
+path: test-blob.txt
+%s`, bsoTestConnString, tagsYAML)
+
+	pConf, err := bsoSpec().ParseYAML(conf, service.NewEnvironment())
+	require.NoError(t, err)
+
+	return bsoConfigFromParsed(pConf)
+}
+
+func TestBlobStorageOutputTagsConfig(t *testing.T) {
+	t.Run("no tags configured", func(t *testing.T) {
+		conf, err := bsoParseTagsConf(t, "")
+		require.NoError(t, err)
+		assert.Empty(t, conf.Tags)
+	})
+
+	t.Run("at the tag limit", func(t *testing.T) {
+		var b strings.Builder
+		b.WriteString("tags:\n")
+		for i := range bsoMaxTagsPermitted {
+			fmt.Fprintf(&b, "  key%02d: value%02d\n", i, i)
+		}
+
+		conf, err := bsoParseTagsConf(t, b.String())
+		require.NoError(t, err)
+		assert.Len(t, conf.Tags, bsoMaxTagsPermitted)
+	})
+
+	t.Run("over the tag limit", func(t *testing.T) {
+		var b strings.Builder
+		b.WriteString("tags:\n")
+		for i := range bsoMaxTagsPermitted + 1 {
+			fmt.Fprintf(&b, "  key%02d: value%02d\n", i, i)
+		}
+
+		_, err := bsoParseTagsConf(t, b.String())
+		require.Error(t, err)
+		assert.EqualError(t, err, fmt.Sprintf("at most %d blob index tags are permitted, got %d", bsoMaxTagsPermitted, bsoMaxTagsPermitted+1))
+	})
+
+	t.Run("keys are sorted deterministically", func(t *testing.T) {
+		// Enough keys that an unsorted implementation is vanishingly unlikely to
+		// produce this order by chance via Go's randomised map iteration.
+		conf, err := bsoParseTagsConf(t, "tags:\n  hotel: h\n  golf: g\n  foxtrot: f\n  echo: e\n  delta: d\n  charlie: c\n  bravo: b\n  alpha: a\n")
+		require.NoError(t, err)
+
+		keys := make([]string, 0, len(conf.Tags))
+		for _, pair := range conf.Tags {
+			keys = append(keys, pair.key)
+		}
+		assert.Equal(t, []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"}, keys)
+	})
+
+	t.Run("invalid keys are rejected at config time", func(t *testing.T) {
+		for _, test := range []struct {
+			name   string
+			key    string
+			errStr string
+		}{
+			{
+				name:   "empty key",
+				key:    `"": value`,
+				errStr: `blob index tag key "" must be between 1 and 128 characters, got 0`,
+			},
+			{
+				name:   "over-long key",
+				key:    strings.Repeat("k", bsoMaxTagKeyLength+1) + ": value",
+				errStr: fmt.Sprintf("blob index tag key %q must be between 1 and 128 characters, got %d", strings.Repeat("k", bsoMaxTagKeyLength+1), bsoMaxTagKeyLength+1),
+			},
+			{
+				name:   "unsupported character",
+				key:    `"bad!key": value`,
+				errStr: `blob index tag key "bad!key" contains unsupported character '!', only alphanumerics and the characters " +-./:=_" are permitted`,
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := bsoParseTagsConf(t, "tags:\n  "+test.key+"\n")
+				require.Error(t, err)
+				assert.EqualError(t, err, test.errStr)
+			})
+		}
+	})
+
+	t.Run("keys at the length limit and using allowed specials are accepted", func(t *testing.T) {
+		maxKey := strings.Repeat("k", bsoMaxTagKeyLength)
+		conf, err := bsoParseTagsConf(t, fmt.Sprintf("tags:\n  %s: a\n  \"with spaces\": b\n  \"a+b-c.d/e:f=g_h\": c\n", maxKey))
+		require.NoError(t, err)
+		assert.Len(t, conf.Tags, 3)
+	})
+
+	t.Run("values are interpolated per message", func(t *testing.T) {
+		conf, err := bsoParseTagsConf(t, "tags:\n  Static: fixed\n  Topic: ${! meta(\"kafka_topic\") }\n")
+		require.NoError(t, err)
+		require.Len(t, conf.Tags, 2)
+
+		msg := service.NewMessage([]byte("hello world"))
+		msg.MetaSetMut("kafka_topic", "orders")
+
+		resolved := make(map[string]string, len(conf.Tags))
+		for _, pair := range conf.Tags {
+			val, err := pair.value.TryString(msg)
+			require.NoError(t, err)
+			resolved[pair.key] = val
+		}
+
+		assert.Equal(t, map[string]string{
+			"Static": "fixed",
+			"Topic":  "orders",
+		}, resolved)
+	})
+}


### PR DESCRIPTION
## Summary 
  - Adds a new `tags` field to the `azure_blob_storage` output, allowing users to set blob index tags as key/value 
  pairs with interpolation support                                                                                   
  - Tags are applied atomically on block blob uploads and via `SetTags` for append blobs
  - Enforces Azure's 10-tag limit at config parse time
  - `review` skill used on this PR                                                              
                  
  Closes #2904                                                                                                       
                                                                                                                     
  ## Test plan
  - [x] `go build ./internal/impl/azure/...` passes
  - [x] `go test ./internal/impl/azure/... -short` passes
  - [x] Integration test `blob_storage_tags` validates tags are set correctly on block blobs via Azurite             
   
  🤖 Generated with [Claude Code](https://claude.com/claude-code)