### PR TITLE
add PostgreSQL benchmarking

### DIFF
--- a/docs/benchmark-results/postgres.md
+++ b/docs/benchmark-results/postgres.md
@@ -1,16 +1,14 @@
-# PostgreSQL CDC Benchmark Results
+# PostgreSQL Benchmark Results
 
-Benchmarks for the `postgres_cdc` input using logical replication (snapshot mode).
+**Environment:** Intel Core i7-10850H @ 2.70GHz, 32 GB RAM, WSL2 (Linux 6.6.87.2), x86_64
 
-See [`internal/impl/postgresql/bench/`](../../internal/impl/postgresql/bench/) for the benchmark configs and run instructions.
+See [`internal/impl/postgresql/bench/`](../../internal/impl/postgresql/bench/) for configs and run instructions.
 
-## Snapshot — Small Rows (cart table), CPU & Batch Size Scaling
+---
 
-Full snapshot of the `public.cart` table: 10,000,000 rows, ~600 B per row. Varying `GOMAXPROCS` and `batching.count` to produce a throughput matrix.
+## CDC / Snapshot — Small Rows (cart table)
 
-**Environment:** Intel Core i7-10850H @ 2.70GHz, 32 GB RAM, WSL2 (Linux 6.6.87.2), x86_64, PostgreSQL 16 running in Docker (localhost)
-
-**Dataset:** 10,000,000 rows × ~600 B
+Full snapshot of `public.cart`: 10,000,000 rows × ~600 B. Varying `GOMAXPROCS` and `batching.count`.
 
 ### msg/sec
 
@@ -33,21 +31,16 @@ Full snapshot of the `public.cart` table: 10,000,000 rows, ~600 B per row. Varyi
 | (unbounded) |        127 |            |             |
 
 **Observations:**
-
-- **Core scaling:** throughput scales well up to 4 cores then plateaus — 1→2: ~1.58x, 2→4: ~1.30x, 4→8: ~1.09x across all batch sizes.
-- **Batch size sweet spot:** batch=5000 consistently outperforms both batch=1000 and batch=10000. At 8 cores: 318K (batch=5000) vs 300K (batch=1000) vs 284K (batch=10000).
-- **Batch=10000 regresses at higher core counts:** larger batches increase memory pressure and pipeline stall time waiting to fill a batch, which outweighs the reduced per-batch overhead.
-- **At 1 core, batch size has no effect** (~130K msg/sec across all three), confirming the single-core bottleneck is not batch assembly but connector read throughput.
+- Core scaling is strong up to 4 cores (1→2: ~1.58×, 2→4: ~1.30×), then plateaus (4→8: ~1.09×).
+- `batch=5000` is the sweet spot — consistently fastest across all core counts.
+- `batch=10000` regresses at higher core counts due to memory pressure and pipeline stall time waiting to fill a batch.
+- At 1 core, batch size has no effect (~130K msg/sec), confirming the bottleneck is connector read throughput, not batch assembly.
 
 ---
 
-## Snapshot — Large Rows (users table), CPU & Batch Size Scaling
+## CDC / Snapshot — Large Rows (users table)
 
-Full snapshot of the `public.users` table: 150,000 rows, ~625 KB per row. Varying `GOMAXPROCS` and `batching.count` to measure throughput on large I/O bound messages.
-
-**Environment:** Intel Core i7-10850H @ 2.70GHz, 32 GB RAM, WSL2 (Linux 6.6.87.2), x86_64, PostgreSQL 16 running in Docker (localhost)
-
-**Dataset:** 150,000 rows × ~625 KB
+Full snapshot of `public.users`: 150,000 rows × ~625 KB. I/O bound workload.
 
 ### msg/sec
 
@@ -67,4 +60,40 @@ Full snapshot of the `public.users` table: 150,000 rows, ~625 KB per row. Varyin
 | 4           |        752 |        N/A |         N/A |
 | 8           |        752 |        N/A |         N/A |
 
-**Observations:** Throughput plateaus at 2 cores (1,166 msg/sec, 766 MB/sec) and is completely flat from 4→8 cores. This confirms the users dataset is I/O bound — additional cores provide no benefit. Testing further batch sizes is unlikely to change this conclusion. Contrast with cart where throughput scaled to 318K msg/sec at 8 cores.
+**Observations:** Throughput plateaus at 2 cores (1,166 msg/sec, 766 MB/sec) and is flat from 4→8 cores — purely I/O bound. Additional cores provide no benefit. Contrast with cart where throughput scaled to 318K msg/sec at 8 cores.
+
+---
+
+## Kafka → PostgreSQL: Redpanda Connect vs Kafka Connect (JDBC Sink)
+
+Both connectors read from a 16-partition `bench-events` Kafka topic and write to a `bench_events` PostgreSQL table. Dataset: 10,000,000 rows × ~200 B (synthetic events: id, category, value, ts).
+
+See [`internal/impl/postgresql/bench/kafka-connector/`](../../internal/impl/postgresql/bench/kafka-connector/) for setup.
+
+### Comparison (best configuration per connector)
+
+| Connector                 | Configuration        | Elapsed | Throughput     |
+|---------------------------|----------------------|---------|----------------|
+| Kafka Connect (JDBC Sink) | 16 tasks, batch=3000 |     55s | 181,818 msg/s  |
+| Redpanda Connect          | mif=64               |     70s | 130,952 msg/s  |
+
+Kafka Connect is **~1.39× faster** on this workload. Its JDBC sink tasks amortise PostgreSQL round-trips more aggressively than RPCN's `sql_insert` output bounded by `max_in_flight`.
+
+### Redpanda Connect tuning runs
+
+| max_in_flight | GOMAXPROCS | Kafka CPUs | Elapsed | Throughput     |
+|---------------|------------|------------|---------|----------------|
+| 16            | uncapped   | uncapped   |     88s | 103,825 msg/s  |
+| 64            | uncapped   | uncapped   |     70s | 130,952 msg/s  |
+| 128           | uncapped   | uncapped   |     96s | 104,166 msg/s  |
+| 128           | 4          | uncapped   |     96s | 104,166 msg/s  |
+| 128           | 8          | uncapped   |    145s |  68,965 msg/s  |
+| 128           | 4          | 1          |    121s |  70,300 msg/s  |
+| 64            | uncapped   | 2          |     89s | 112,359 msg/s  |
+| 64            | uncapped   | 3          |    101s |  99,009 msg/s  |
+
+**Observations:**
+- **Sweet spot: `mif=64`, uncapped Kafka** — 130,952 msg/s.
+- Increasing `max_in_flight` beyond 64 causes PostgreSQL connection contention and hurts performance.
+- Adding GOMAXPROCS cores degrades throughput — the bottleneck is PostgreSQL write throughput, not CPU.
+- Capping Kafka CPU below 2 cores throttles fetch throughput and becomes the new bottleneck.

--- a/docs/benchmark-results/postgres.md
+++ b/docs/benchmark-results/postgres.md
@@ -54,7 +54,7 @@ Full snapshot of the `public.users` table: 150,000 rows, ~625 KB per row. Varyin
 | GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
 |-------------|------------|------------|-------------|
 | 1           |        883 |        843 |         N/A |
-| 2           |      1,166 |        N/A |         N/A |
+| 2           |      1,166 |      1,134 |       1,024 |
 | 4           |      1,145 |        N/A |         N/A |
 | 8           |      1,145 |        N/A |         N/A |
 
@@ -63,7 +63,7 @@ Full snapshot of the `public.users` table: 150,000 rows, ~625 KB per row. Varyin
 | GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
 |-------------|------------|------------|-------------|
 | 1           |        580 |        554 |         N/A |
-| 2           |        766 |        N/A |         N/A |
+| 2           |        766 |        745 |         673 |
 | 4           |        752 |        N/A |         N/A |
 | 8           |        752 |        N/A |         N/A |
 

--- a/docs/benchmark-results/postgres.md
+++ b/docs/benchmark-results/postgres.md
@@ -1,0 +1,70 @@
+# PostgreSQL CDC Benchmark Results
+
+Benchmarks for the `postgres_cdc` input using logical replication (snapshot mode).
+
+See [`internal/impl/postgresql/bench/`](../../internal/impl/postgresql/bench/) for the benchmark configs and run instructions.
+
+## Snapshot — Small Rows (cart table), CPU & Batch Size Scaling
+
+Full snapshot of the `public.cart` table: 10,000,000 rows, ~600 B per row. Varying `GOMAXPROCS` and `batching.count` to produce a throughput matrix.
+
+**Environment:** Intel Core i7-10850H @ 2.70GHz, 32 GB RAM, WSL2 (Linux 6.6.87.2), x86_64, PostgreSQL 16 running in Docker (localhost)
+
+**Dataset:** 10,000,000 rows × ~600 B
+
+### msg/sec
+
+| GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
+|-------------|------------|------------|-------------|
+| 1           |    134,287 |    130,555 |     129,603 |
+| 2           |    212,852 |    218,055 |     214,555 |
+| 4           |    276,259 |    296,138 |     264,454 |
+| 8           |    300,760 |    318,660 |     284,733 |
+| (unbounded) |    211,111 |            |             |
+
+### MB/sec
+
+| GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
+|-------------|------------|------------|-------------|
+| 1           |         81 |         78 |          78 |
+| 2           |        128 |        131 |         129 |
+| 4           |        166 |        178 |         159 |
+| 8           |        181 |        192 |         171 |
+| (unbounded) |        127 |            |             |
+
+**Observations:**
+
+- **Core scaling:** throughput scales well up to 4 cores then plateaus — 1→2: ~1.58x, 2→4: ~1.30x, 4→8: ~1.09x across all batch sizes.
+- **Batch size sweet spot:** batch=5000 consistently outperforms both batch=1000 and batch=10000. At 8 cores: 318K (batch=5000) vs 300K (batch=1000) vs 284K (batch=10000).
+- **Batch=10000 regresses at higher core counts:** larger batches increase memory pressure and pipeline stall time waiting to fill a batch, which outweighs the reduced per-batch overhead.
+- **At 1 core, batch size has no effect** (~130K msg/sec across all three), confirming the single-core bottleneck is not batch assembly but connector read throughput.
+
+---
+
+## Snapshot — Large Rows (users table), CPU & Batch Size Scaling
+
+Full snapshot of the `public.users` table: 150,000 rows, ~625 KB per row. Varying `GOMAXPROCS` and `batching.count` to measure throughput on large I/O bound messages.
+
+**Environment:** Intel Core i7-10850H @ 2.70GHz, 32 GB RAM, WSL2 (Linux 6.6.87.2), x86_64, PostgreSQL 16 running in Docker (localhost)
+
+**Dataset:** 150,000 rows × ~625 KB
+
+### msg/sec
+
+| GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
+|-------------|------------|------------|-------------|
+| 1           |        883 |        843 |         N/A |
+| 2           |      1,166 |        N/A |         N/A |
+| 4           |      1,145 |        N/A |         N/A |
+| 8           |      1,145 |        N/A |         N/A |
+
+### MB/sec
+
+| GOMAXPROCS  | batch=1000 | batch=5000 | batch=10000 |
+|-------------|------------|------------|-------------|
+| 1           |        580 |        554 |         N/A |
+| 2           |        766 |        N/A |         N/A |
+| 4           |        752 |        N/A |         N/A |
+| 8           |        752 |        N/A |         N/A |
+
+**Observations:** Throughput plateaus at 2 cores (1,166 msg/sec, 766 MB/sec) and is completely flat from 4→8 cores. This confirms the users dataset is I/O bound — additional cores provide no benefit. Testing further batch sizes is unlikely to change this conclusion. Contrast with cart where throughput scaled to 318K msg/sec at 8 cores.

--- a/internal/impl/postgresql/bench/README.md
+++ b/internal/impl/postgresql/bench/README.md
@@ -1,0 +1,100 @@
+# Benchmarking PostgreSQL CDC Component
+
+Benchmark demonstrating throughput of Redpanda's PostgreSQL CDC Connector.
+
+## Prerequisites
+
+Install `psql`:
+
+```bash
+# macOS
+brew install postgresql
+
+# Ubuntu/Debian
+sudo apt install postgresql-client
+```
+
+## Setup
+
+1. Start PostgreSQL container:
+
+```bash
+task postgres:up
+```
+
+This starts a PostgreSQL 16 container with `wal_level=logical` enabled (required for CDC).
+
+2. Create tables:
+
+```bash
+task psql:create
+```
+
+3. Insert test data:
+
+```bash
+task psql:data:users     # 150K rows, ~625KB per row (large payload)
+task psql:data:products  # 150K rows, ~625KB per row (large payload)
+task psql:data:cart      # 10M rows, small payloads
+```
+
+## Benchmark Tasks
+
+### Parameterised cart benchmark
+
+The main benchmark task — runs the cart snapshot with configurable core count and batch size:
+
+```bash
+task bench:cart CORES=4 BATCH=5000
+```
+
+- `CORES` sets `GOMAXPROCS` (omit for unbounded)
+- `BATCH` sets `batching.count` (defaults to 1000)
+
+### Snapshot benchmarks
+
+```bash
+task bench:run                # run with current table data
+task bench:snapshot:users     # truncate + insert 150K large rows + run
+task bench:snapshot:cart      # truncate + insert 10M small rows + run
+task bench:snapshot:all       # truncate + insert all datasets + run
+```
+
+### CPU scaling (fixed batch=1000)
+
+```bash
+task bench:cores:1
+task bench:cores:2
+task bench:cores:4
+task bench:cores:8
+```
+
+### CDC mode
+
+Start the connector first (it creates the replication slot), then insert data in a second terminal while it is running:
+
+```bash
+# terminal 1
+task bench:run:cdc
+
+# terminal 2 — once the connector is up
+task psql:data:users
+```
+
+## Data Management
+
+```bash
+task psql:truncate    # truncate all tables
+task psql:drop-slot   # drop bench_slot so the next run replays from the start
+```
+
+Drop the replication slot before every benchmark run. Unused slots cause PostgreSQL to retain WAL segments indefinitely, which can fill up disk.
+
+## Expected Output
+
+```
+INFO rolling stats: 1000 msg/sec, 625 MB/sec    @service=redpanda-connect bytes/sec=6.2527229e+08 label="" msg/sec=1000 path=root.output.processors.0
+INFO rolling stats: 2000 msg/sec, 1.3 GB/sec    @service=redpanda-connect bytes/sec=1.25054458e+09 label="" msg/sec=2000 path=root.output.processors.0
+```
+
+Throughput with large rows (~625 KB each) is I/O bound — CPU core count has little effect. Use the cart dataset to stress CPU. See [`docs/benchmark-results/postgres.md`](../../../../docs/benchmark-results/postgres.md) for full results.

--- a/internal/impl/postgresql/bench/README.md
+++ b/internal/impl/postgresql/bench/README.md
@@ -91,6 +91,14 @@ task psql:drop-slot   # drop bench_slot so the next run replays from the start
 
 Drop the replication slot before every benchmark run. Unused slots cause PostgreSQL to retain WAL segments indefinitely, which can fill up disk.
 
+## Teardown
+
+```bash
+task postgres:down    # stop and remove the postgres-bench container
+```
+
+All data is inside the container, so this is a full cleanup with no leftover files.
+
 ## Expected Output
 
 ```

--- a/internal/impl/postgresql/bench/README.md
+++ b/internal/impl/postgresql/bench/README.md
@@ -40,12 +40,13 @@ task psql:data:cart      # 10M rows, small payloads
 
 ## Benchmark Tasks
 
-### Parameterised cart benchmark
+### Parameterised benchmarks
 
-The main benchmark task — runs the cart snapshot with configurable core count and batch size:
+Truncate, load the dataset, and run with configurable core count and batch size:
 
 ```bash
-task bench:cart CORES=4 BATCH=5000
+task bench:users CORES=2 BATCH=1000   # 150K large rows (~625 KB each) — I/O bound
+task bench:cart  CORES=4 BATCH=5000   # 10M small rows — CPU bound
 ```
 
 - `CORES` sets `GOMAXPROCS` (omit for unbounded)

--- a/internal/impl/postgresql/bench/README.md
+++ b/internal/impl/postgresql/bench/README.md
@@ -1,10 +1,17 @@
-# Benchmarking PostgreSQL CDC Component
+# PostgreSQL Benchmark
 
-Benchmark demonstrating throughput of Redpanda's PostgreSQL CDC Connector.
+Two benchmark scenarios:
 
-## Prerequisites
+1. **CDC / Snapshot** — `postgres_cdc` input reading directly from PostgreSQL via logical replication
+2. **Kafka → PostgreSQL** — Redpanda Connect vs Kafka Connect (JDBC Sink) writing from Kafka into PostgreSQL
 
-Install `psql`:
+See [`docs/benchmark-results/postgres.md`](../../../../docs/benchmark-results/postgres.md) for full results.
+
+---
+
+## CDC / Snapshot Benchmarks
+
+### Prerequisites
 
 ```bash
 # macOS
@@ -14,96 +21,78 @@ brew install postgresql
 sudo apt install postgresql-client
 ```
 
-## Setup
-
-1. Start PostgreSQL container:
+### Setup
 
 ```bash
-task postgres:up
+task postgres:up      # start PostgreSQL 16 with wal_level=logical
+task psql:create      # create tables
 ```
 
-This starts a PostgreSQL 16 container with `wal_level=logical` enabled (required for CDC).
-
-2. Create tables:
+### Running
 
 ```bash
-task psql:create
+# Load a dataset and benchmark in one command
+task bench:cart  CORES=4 BATCH=5000   # 10M small rows (~600 B) — CPU bound
+task bench:users CORES=2 BATCH=1000   # 150K large rows (~625 KB) — I/O bound
 ```
 
-3. Insert test data:
+- `CORES` — sets `GOMAXPROCS` (omit for unbounded)
+- `BATCH` — sets `batching.count` (default 1000)
 
-```bash
-task psql:data:users     # 150K rows, ~625KB per row (large payload)
-task psql:data:products  # 150K rows, ~625KB per row (large payload)
-task psql:data:cart      # 10M rows, small payloads
-```
-
-## Benchmark Tasks
-
-### Parameterised benchmarks
-
-Truncate, load the dataset, and run with configurable core count and batch size:
-
-```bash
-task bench:users CORES=2 BATCH=1000   # 150K large rows (~625 KB each) — I/O bound
-task bench:cart  CORES=4 BATCH=5000   # 10M small rows — CPU bound
-```
-
-- `CORES` sets `GOMAXPROCS` (omit for unbounded)
-- `BATCH` sets `batching.count` (defaults to 1000)
-
-### Snapshot benchmarks
-
-```bash
-task bench:run                # run with current table data
-task bench:snapshot:users     # truncate + insert 150K large rows + run
-task bench:snapshot:cart      # truncate + insert 10M small rows + run
-task bench:snapshot:all       # truncate + insert all datasets + run
-```
-
-### CPU scaling (fixed batch=1000)
-
-```bash
-task bench:cores:1
-task bench:cores:2
-task bench:cores:4
-task bench:cores:8
-```
+Both tasks truncate, load the dataset, drop the replication slot, and run the benchmark.
 
 ### CDC mode
 
-Start the connector first (it creates the replication slot), then insert data in a second terminal while it is running:
-
 ```bash
-# terminal 1
+# terminal 1 — start connector (creates replication slot)
 task bench:run:cdc
 
-# terminal 2 — once the connector is up
+# terminal 2 — insert data while connector is running
 task psql:data:users
 ```
 
-## Data Management
+### Teardown
 
 ```bash
-task psql:truncate    # truncate all tables
-task psql:drop-slot   # drop bench_slot so the next run replays from the start
+task postgres:down    # stops and removes the container — no leftover files
 ```
 
-Drop the replication slot before every benchmark run. Unused slots cause PostgreSQL to retain WAL segments indefinitely, which can fill up disk.
+---
 
-## Teardown
+## Kafka → PostgreSQL Benchmarks
+
+Infrastructure is provided by the [`kafka-connector/`](./kafka-connector/) subfolder (Kafka + PostgreSQL + Kafka Connect in Docker).
+
+### Setup
 
 ```bash
-task postgres:down    # stop and remove the postgres-bench container
+cd kafka-connector
+task up
 ```
 
-All data is inside the container, so this is a full cleanup with no leftover files.
+### Load data once, run multiple times
 
-## Expected Output
+```bash
+# From bench/ (this folder):
 
+# Step 1 — produce 10M messages to Kafka (run once per comparison set)
+task bench:kafka:load COUNT=10000000
+
+# Step 2 — run Redpanda Connect benchmark (repeat with different params)
+task bench:kafka MAX_IN_FLIGHT=64
+task bench:kafka MAX_IN_FLIGHT=128 CORES=4
 ```
-INFO rolling stats: 1000 msg/sec, 625 MB/sec    @service=redpanda-connect bytes/sec=6.2527229e+08 label="" msg/sec=1000 path=root.output.processors.0
-INFO rolling stats: 2000 msg/sec, 1.3 GB/sec    @service=redpanda-connect bytes/sec=1.25054458e+09 label="" msg/sec=2000 path=root.output.processors.0
+
+### Run Kafka Connect benchmark
+
+```bash
+cd kafka-connector
+task bench:run COUNT=10000000
 ```
 
-Throughput with large rows (~625 KB each) is I/O bound — CPU core count has little effect. Use the cart dataset to stress CPU. See [`docs/benchmark-results/postgres.md`](../../../../docs/benchmark-results/postgres.md) for full results.
+### Teardown
+
+```bash
+cd kafka-connector
+task down
+```

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -149,7 +149,24 @@ tasks:
       - task psql:drop-slot
       - GOMAXPROCS=8 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
-  # Parameterised benchmark — specify CORES and BATCH freely
+  # Parameterised benchmarks — specify CORES and BATCH freely
+  # Usage: task bench:users CORES=2 BATCH=1000
+  bench:users:
+    desc: "Run users snapshot benchmark with given CORES and BATCH (e.g. task bench:users CORES=2 BATCH=1000)"
+    vars:
+      CORES: '{{.CORES | default ""}}'
+      BATCH: '{{.BATCH | default "1000"}}'
+    env:
+      PG_DSN: '{{.PG_DSN}}'
+    cmds:
+      - task psql:drop-slot
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
+      - task psql:data:users
+      - |
+        GOMAXPROCS={{.CORES}} go run ../../../../cmd/redpanda-connect/main.go run \
+          --set input.postgres_cdc.batching.count={{.BATCH}} \
+          ./benchmark_config.yaml
+
   # Usage: task bench:cart CORES=4 BATCH=5000
   bench:cart:
     desc: "Run cart snapshot benchmark with given CORES and BATCH (e.g. task bench:cart CORES=4 BATCH=5000)"

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -1,14 +1,22 @@
 version: "3"
 
+vars:
+  PG_DSN: '{{.PG_DSN | default "postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable"}}'
+  # Strip ?sslmode=... for commands that don't accept query params (psql CLI ignores them, but
+  # be explicit so the default is obvious).  Override via: task <cmd> PG_DSN=postgres://...
+  PG_USER: '{{.PG_USER | default "postgres"}}'
+  PG_PASSWORD: '{{.PG_PASSWORD | default "postgres"}}'
+  PG_DB: '{{.PG_DB | default "testdb"}}'
+
 tasks:
   postgres:up:
     desc: Start PostgreSQL container with logical replication enabled
     cmds:
       - |
         docker run -d --name postgres-bench \
-          -e POSTGRES_USER=postgres \
-          -e POSTGRES_PASSWORD=postgres \
-          -e POSTGRES_DB=testdb \
+          -e POSTGRES_USER={{.PG_USER}} \
+          -e POSTGRES_PASSWORD={{.PG_PASSWORD}} \
+          -e POSTGRES_DB={{.PG_DB}} \
           -p 5432:5432 \
           postgres:16 \
           -c wal_level=logical
@@ -28,71 +36,81 @@ tasks:
   psql:
     desc: Open an interactive psql shell
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb
+      - psql {{.PG_DSN}}
 
   psql:create:
     desc: Run create.sql to set up tables
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb < create.sql
+      - psql {{.PG_DSN}} < create.sql
 
   psql:data:users:
     desc: Insert 150K users rows
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb < users.sql
+      - psql {{.PG_DSN}} < users.sql
 
   psql:data:products:
     desc: Insert 150K products rows
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb < products.sql
+      - psql {{.PG_DSN}} < products.sql
 
   psql:data:cart:
     desc: Insert 10M cart rows
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb < cart.sql
+      - psql {{.PG_DSN}} < cart.sql
 
   psql:truncate:
     desc: Truncate all benchmark tables
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
 
   psql:drop-slot:
     desc: Drop the bench_slot replication slot so benchmarks can be re-run
     cmds:
-      - psql postgres://postgres:postgres@localhost:5432/testdb -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
+      - psql {{.PG_DSN}} -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
 
   bench:run:
     desc: Run snapshot benchmark (stream_snapshot=true)
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:run:cdc:
     desc: Run CDC benchmark - start connector first, then insert data separately
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:snapshot:users:
     desc: Drop slot, insert 150K large-payload users rows, then run snapshot benchmark
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
-      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
       - task psql:data:users
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:snapshot:cart:
     desc: Drop slot, insert 10M small cart rows, then run snapshot benchmark
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
-      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
       - task psql:data:cart
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:snapshot:all:
     desc: Drop slot, insert all test data, then run snapshot benchmark
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
-      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
       - task psql:data:users
       - task psql:data:products
       - task psql:data:cart
@@ -101,24 +119,32 @@ tasks:
   # CPU scaling benchmarks — vary GOMAXPROCS to measure per-core throughput
   bench:cores:1:
     desc: Run snapshot benchmark with GOMAXPROCS=1
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - GOMAXPROCS=1 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:cores:2:
     desc: Run snapshot benchmark with GOMAXPROCS=2
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - GOMAXPROCS=2 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:cores:4:
     desc: Run snapshot benchmark with GOMAXPROCS=4
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - GOMAXPROCS=4 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:cores:8:
     desc: Run snapshot benchmark with GOMAXPROCS=8
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - GOMAXPROCS=8 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
@@ -130,6 +156,8 @@ tasks:
     vars:
       CORES: '{{.CORES | default ""}}'
       BATCH: '{{.BATCH | default "1000"}}'
+    env:
+      PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - |

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -20,7 +20,7 @@ tasks:
           -p 5432:5432 \
           postgres:16 \
           -c wal_level=logical
-      - sleep 5
+      - until pg_isready -h localhost -p 5432; do sleep 1; done
 
   postgres:down:
     desc: Stop and remove PostgreSQL container

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -163,7 +163,7 @@ tasks:
       - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
       - task psql:data:users
       - |
-        GOMAXPROCS={{.CORES}} go run ../../../../cmd/redpanda-connect/main.go run \
+        {{if .CORES}}GOMAXPROCS={{.CORES}} {{end}}go run ../../../../cmd/redpanda-connect/main.go run \
           --set input.postgres_cdc.batching.count={{.BATCH}} \
           ./benchmark_config.yaml
 
@@ -178,7 +178,7 @@ tasks:
     cmds:
       - task psql:drop-slot
       - |
-        GOMAXPROCS={{.CORES}} go run ../../../../cmd/redpanda-connect/main.go run \
+        {{if .CORES}}GOMAXPROCS={{.CORES}} {{end}}go run ../../../../cmd/redpanda-connect/main.go run \
           --set input.postgres_cdc.batching.count={{.BATCH}} \
           ./benchmark_config.yaml
 

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -77,12 +77,12 @@ tasks:
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:run:cdc:
-    desc: Run CDC benchmark - start connector first, then insert data separately
+    desc: Run CDC benchmark (stream_snapshot=false) - start connector first, then insert data separately
     env:
       PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
-      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+      - go run ../../../../cmd/redpanda-connect/main.go run --set input.postgres_cdc.stream_snapshot=false ./benchmark_config.yaml
 
   bench:snapshot:users:
     desc: Drop slot, insert 150K large-payload users rows, then run snapshot benchmark

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -2,13 +2,17 @@ version: "3"
 
 vars:
   PG_DSN: '{{.PG_DSN | default "postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable"}}'
-  # Strip ?sslmode=... for commands that don't accept query params (psql CLI ignores them, but
-  # be explicit so the default is obvious).  Override via: task <cmd> PG_DSN=postgres://...
   PG_USER: '{{.PG_USER | default "postgres"}}'
   PG_PASSWORD: '{{.PG_PASSWORD | default "postgres"}}'
   PG_DB: '{{.PG_DB | default "testdb"}}'
+  # DSN for the Kafka→PostgreSQL benchmarks — uses benchdb (kafka-connector docker-compose),
+  # not the CDC testdb.
+  KAFKA_PG_DSN: '{{.KAFKA_PG_DSN | default "postgres://postgres:postgres@localhost:5432/benchdb?sslmode=disable"}}'
+  KAFKA_BOOTSTRAP: '{{.KAFKA_BOOTSTRAP | default "localhost:9092"}}'
 
 tasks:
+  # ── PostgreSQL container ──────────────────────────────────────────────────────
+
   postgres:up:
     desc: Start PostgreSQL container with logical replication enabled
     cmds:
@@ -28,15 +32,7 @@ tasks:
       - docker stop postgres-bench
       - docker rm postgres-bench
 
-  postgres:logs:
-    desc: Show PostgreSQL container logs
-    cmds:
-      - docker logs postgres-bench
-
-  psql:
-    desc: Open an interactive psql shell
-    cmds:
-      - psql {{.PG_DSN}}
+  # ── Data setup ───────────────────────────────────────────────────────────────
 
   psql:create:
     desc: Run create.sql to set up tables
@@ -44,7 +40,7 @@ tasks:
       - psql {{.PG_DSN}} < create.sql
 
   psql:data:users:
-    desc: Insert 150K users rows
+    desc: Insert 150K users rows (~625 KB each)
     cmds:
       - psql {{.PG_DSN}} < users.sql
 
@@ -54,7 +50,7 @@ tasks:
       - psql {{.PG_DSN}} < products.sql
 
   psql:data:cart:
-    desc: Insert 10M cart rows
+    desc: Insert 10M cart rows (~600 B each)
     cmds:
       - psql {{.PG_DSN}} < cart.sql
 
@@ -68,8 +64,10 @@ tasks:
     cmds:
       - psql {{.PG_DSN}} -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
 
+  # ── CDC / Snapshot benchmarks ────────────────────────────────────────────────
+
   bench:run:
-    desc: Run snapshot benchmark (stream_snapshot=true)
+    desc: Run snapshot benchmark with current table data
     env:
       PG_DSN: '{{.PG_DSN}}'
     cmds:
@@ -77,82 +75,15 @@ tasks:
       - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
 
   bench:run:cdc:
-    desc: Run CDC benchmark (stream_snapshot=false) - start connector first, then insert data separately
+    desc: Run CDC benchmark (stream_snapshot=false) — start first, then insert data in a second terminal
     env:
       PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
       - go run ../../../../cmd/redpanda-connect/main.go run --set input.postgres_cdc.stream_snapshot=false ./benchmark_config.yaml
 
-  bench:snapshot:users:
-    desc: Drop slot, insert 150K large-payload users rows, then run snapshot benchmark
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
-      - task psql:data:users
-      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  bench:snapshot:cart:
-    desc: Drop slot, insert 10M small cart rows, then run snapshot benchmark
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
-      - task psql:data:cart
-      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  bench:snapshot:all:
-    desc: Drop slot, insert all test data, then run snapshot benchmark
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
-      - task psql:data:users
-      - task psql:data:products
-      - task psql:data:cart
-      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  # CPU scaling benchmarks — vary GOMAXPROCS to measure per-core throughput
-  bench:cores:1:
-    desc: Run snapshot benchmark with GOMAXPROCS=1
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - GOMAXPROCS=1 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  bench:cores:2:
-    desc: Run snapshot benchmark with GOMAXPROCS=2
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - GOMAXPROCS=2 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  bench:cores:4:
-    desc: Run snapshot benchmark with GOMAXPROCS=4
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - GOMAXPROCS=4 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  bench:cores:8:
-    desc: Run snapshot benchmark with GOMAXPROCS=8
-    env:
-      PG_DSN: '{{.PG_DSN}}'
-    cmds:
-      - task psql:drop-slot
-      - GOMAXPROCS=8 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
-
-  # Parameterised benchmarks — specify CORES and BATCH freely
-  # Usage: task bench:users CORES=2 BATCH=1000
   bench:users:
-    desc: "Run users snapshot benchmark with given CORES and BATCH (e.g. task bench:users CORES=2 BATCH=1000)"
+    desc: "Truncate, load 150K large users rows, run snapshot benchmark (e.g. task bench:users CORES=2 BATCH=1000)"
     vars:
       CORES: '{{.CORES | default ""}}'
       BATCH: '{{.BATCH | default "1000"}}'
@@ -167,9 +98,8 @@ tasks:
           --set input.postgres_cdc.batching.count={{.BATCH}} \
           ./benchmark_config.yaml
 
-  # Usage: task bench:cart CORES=4 BATCH=5000
   bench:cart:
-    desc: "Run cart snapshot benchmark with given CORES and BATCH (e.g. task bench:cart CORES=4 BATCH=5000)"
+    desc: "Truncate, load 10M small cart rows, run snapshot benchmark (e.g. task bench:cart CORES=4 BATCH=5000)"
     vars:
       CORES: '{{.CORES | default ""}}'
       BATCH: '{{.BATCH | default "1000"}}'
@@ -177,8 +107,115 @@ tasks:
       PG_DSN: '{{.PG_DSN}}'
     cmds:
       - task psql:drop-slot
+      - psql {{.PG_DSN}} -c "TRUNCATE public.users, public.products, public.cart;"
+      - task psql:data:cart
       - |
         {{if .CORES}}GOMAXPROCS={{.CORES}} {{end}}go run ../../../../cmd/redpanda-connect/main.go run \
           --set input.postgres_cdc.batching.count={{.BATCH}} \
           ./benchmark_config.yaml
 
+  # ── Kafka → PostgreSQL benchmarks (vs Kafka Connect JDBC Sink) ───────────────
+  # Infrastructure: task up/down from kafka-connector/
+
+  bench:kafka:load:
+    desc: "Recreate bench-events topic and produce COUNT events (e.g. task bench:kafka:load COUNT=10000000)"
+    vars:
+      COUNT: '{{.COUNT | default "1000000"}}'
+    cmds:
+      - |
+        set -e
+        docker exec pgkc-kafka kafka-topics --bootstrap-server localhost:29092 \
+          --delete --topic bench-events 2>/dev/null || true
+        until ! docker exec pgkc-kafka kafka-topics --bootstrap-server localhost:29092 \
+            --list 2>/dev/null | grep -q '^bench-events$'; do sleep 1; done
+        docker exec pgkc-kafka kafka-topics --bootstrap-server localhost:29092 \
+          --create --topic bench-events --partitions 16 --replication-factor 1
+        echo "topic recreated"
+        COUNT={{.COUNT}} KAFKA_BOOTSTRAP={{.KAFKA_BOOTSTRAP}} \
+        go run ../../../../cmd/redpanda-connect/main.go run ./kafka-connector/producer.yaml
+        echo "produced {{.COUNT}} messages"
+
+  bench:kafka:
+    desc: "Run Redpanda Connect Kafka→PostgreSQL benchmark (e.g. task bench:kafka MAX_IN_FLIGHT=64)"
+    vars:
+      INTERVAL: '{{.INTERVAL | default "5"}}'
+      MAX_IN_FLIGHT: '{{.MAX_IN_FLIGHT | default "64"}}'
+      THREADS: '{{.THREADS | default "1"}}'
+      CORES: '{{.CORES | default ""}}'
+    cmds:
+      - |
+        set -e
+        GROUP=rpcn-pg-sink-bench
+
+        pkill -f kafka_benchmark_config.yaml 2>/dev/null || true
+        sleep 1
+        psql {{.KAFKA_PG_DSN}} -c "TRUNCATE bench_events;"
+
+        {{if .CORES}}GOMAXPROCS={{.CORES}} {{end}}PG_DSN={{.KAFKA_PG_DSN}} KAFKA_BOOTSTRAP={{.KAFKA_BOOTSTRAP}} \
+        go run ../../../../cmd/redpanda-connect/main.go run \
+          --set output.sql_insert.max_in_flight={{.MAX_IN_FLIGHT}} \
+          --set pipeline.threads={{.THREADS}} \
+          ./kafka_benchmark_config.yaml &
+        RPCN_PID=$!
+
+        cleanup() { pkill -f kafka_benchmark_config.yaml 2>/dev/null || true; }
+        trap cleanup EXIT
+
+        get_lag() {
+          docker exec pgkc-kafka kafka-consumer-groups \
+            --bootstrap-server localhost:29092 \
+            --describe --group "$GROUP" 2>/dev/null \
+            | awk '/bench-events/ {
+                cur = ($4 == "-") ? 0 : $4
+                sum += $5 - cur
+              } END {print (NR == 0 ? -1 : sum)}'
+        }
+
+        START=""
+        INITIAL_LAG=""
+        PREV_LAG=""
+        PREV_TIME=""
+        INTERVAL={{.INTERVAL}}
+
+        printf "%-10s  %-14s  %s\n" "TIME" "LAG" "MSG/S"
+
+        while true; do
+          sleep "$INTERVAL"
+          LAG=$(get_lag)
+          NOW=$(date +%s)
+
+          if [ -z "$START" ]; then
+            if [ "$LAG" -gt 0 ] 2>/dev/null; then
+              START=$NOW
+              INITIAL_LAG=$LAG
+              PREV_LAG=$LAG
+              PREV_TIME=$NOW
+              printf "%-10s  %-14s  (timing started)\n" "$(date +%H:%M:%S)" "$LAG"
+            else
+              printf "%-10s  %-14s  (waiting for lag...)\n" "$(date +%H:%M:%S)" "$LAG"
+            fi
+            continue
+          fi
+
+          [ "$LAG" -eq -1 ] 2>/dev/null && LAG=0
+
+          DELTA_T=$((NOW - PREV_TIME))
+          DELTA_LAG=$((PREV_LAG - LAG))
+          RATE=$(( DELTA_T > 0 ? DELTA_LAG / DELTA_T : 0 ))
+
+          printf "%-10s  %-14s  %s msg/s\n" "$(date +%H:%M:%S)" "$LAG" "$RATE"
+
+          if [ "$LAG" -eq 0 ]; then
+            ELAPSED=$((NOW - START))
+            AVG=$(( INITIAL_LAG / (ELAPSED > 0 ? ELAPSED : 1) ))
+            echo "---"
+            echo "Total messages : $INITIAL_LAG"
+            echo "Elapsed        : ${ELAPSED}s"
+            echo "Avg throughput : ${AVG} msg/s"
+            pkill -f kafka_benchmark_config.yaml 2>/dev/null || true
+            break
+          fi
+
+          PREV_LAG=$LAG
+          PREV_TIME=$NOW
+        done

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -1,0 +1,139 @@
+version: "3"
+
+tasks:
+  postgres:up:
+    desc: Start PostgreSQL container with logical replication enabled
+    cmds:
+      - |
+        docker run -d --name postgres-bench \
+          -e POSTGRES_USER=postgres \
+          -e POSTGRES_PASSWORD=postgres \
+          -e POSTGRES_DB=testdb \
+          -p 5432:5432 \
+          postgres:16 \
+          -c wal_level=logical
+      - sleep 5
+
+  postgres:down:
+    desc: Stop and remove PostgreSQL container
+    cmds:
+      - docker stop postgres-bench
+      - docker rm postgres-bench
+
+  postgres:logs:
+    desc: Show PostgreSQL container logs
+    cmds:
+      - docker logs postgres-bench
+
+  psql:
+    desc: Open an interactive psql shell
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb
+
+  psql:create:
+    desc: Run create.sql to set up tables
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb < create.sql
+
+  psql:data:users:
+    desc: Insert 150K users rows
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb < users.sql
+
+  psql:data:products:
+    desc: Insert 150K products rows
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb < products.sql
+
+  psql:data:cart:
+    desc: Insert 10M cart rows
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb < cart.sql
+
+  psql:truncate:
+    desc: Truncate all benchmark tables
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+
+  psql:drop-slot:
+    desc: Drop the bench_slot replication slot so benchmarks can be re-run
+    cmds:
+      - psql postgres://postgres:postgres@localhost:5432/testdb -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
+
+  bench:run:
+    desc: Run snapshot benchmark (stream_snapshot=true)
+    cmds:
+      - task psql:drop-slot
+      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:run:cdc:
+    desc: Run CDC benchmark - start connector first, then insert data separately
+    cmds:
+      - task psql:drop-slot
+      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:snapshot:users:
+    desc: Drop slot, insert 150K large-payload users rows, then run snapshot benchmark
+    cmds:
+      - task psql:drop-slot
+      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - task psql:data:users
+      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:snapshot:cart:
+    desc: Drop slot, insert 10M small cart rows, then run snapshot benchmark
+    cmds:
+      - task psql:drop-slot
+      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - task psql:data:cart
+      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:snapshot:all:
+    desc: Drop slot, insert all test data, then run snapshot benchmark
+    cmds:
+      - task psql:drop-slot
+      - psql postgres://postgres:postgres@localhost:5432/testdb -c "TRUNCATE public.users, public.products, public.cart;"
+      - task psql:data:users
+      - task psql:data:products
+      - task psql:data:cart
+      - go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  # CPU scaling benchmarks — vary GOMAXPROCS to measure per-core throughput
+  bench:cores:1:
+    desc: Run snapshot benchmark with GOMAXPROCS=1
+    cmds:
+      - task psql:drop-slot
+      - GOMAXPROCS=1 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:cores:2:
+    desc: Run snapshot benchmark with GOMAXPROCS=2
+    cmds:
+      - task psql:drop-slot
+      - GOMAXPROCS=2 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:cores:4:
+    desc: Run snapshot benchmark with GOMAXPROCS=4
+    cmds:
+      - task psql:drop-slot
+      - GOMAXPROCS=4 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  bench:cores:8:
+    desc: Run snapshot benchmark with GOMAXPROCS=8
+    cmds:
+      - task psql:drop-slot
+      - GOMAXPROCS=8 go run ../../../../cmd/redpanda-connect/main.go run ./benchmark_config.yaml
+
+  # Parameterised benchmark — specify CORES and BATCH freely
+  # Usage: task bench:cart CORES=4 BATCH=5000
+  bench:cart:
+    desc: "Run cart snapshot benchmark with given CORES and BATCH (e.g. task bench:cart CORES=4 BATCH=5000)"
+    vars:
+      CORES: '{{.CORES | default ""}}'
+      BATCH: '{{.BATCH | default "1000"}}'
+    cmds:
+      - task psql:drop-slot
+      - |
+        GOMAXPROCS={{.CORES}} go run ../../../../cmd/redpanda-connect/main.go run \
+          --set input.postgres_cdc.batching.count={{.BATCH}} \
+          ./benchmark_config.yaml
+

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -1,0 +1,30 @@
+http:
+  debug_endpoints: true
+
+input:
+  postgres_cdc:
+    dsn: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable
+    stream_snapshot: true
+    schema: public
+    tables:
+      - users
+      - products
+      - cart
+    slot_name: bench_slot
+    batching:
+      count: 1000
+
+output:
+  processors:
+    - benchmark:
+        interval: 1s
+        count_bytes: true
+  drop: {}
+
+logger:
+  level: DEBUG
+
+metrics:
+  prometheus:
+    add_process_metrics: true
+    add_go_metrics: true

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -13,6 +13,7 @@ input:
     slot_name: bench_slot
     batching:
       count: 1000
+      period: 1s
 
 output:
   processors:
@@ -22,7 +23,7 @@ output:
   drop: {}
 
 logger:
-  level: DEBUG
+  level: WARN
 
 metrics:
   prometheus:

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -3,7 +3,7 @@ http:
 
 input:
   postgres_cdc:
-    dsn: postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable
+    dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable}
     stream_snapshot: true
     schema: public
     tables:

--- a/internal/impl/postgresql/bench/cart.sql
+++ b/internal/impl/postgresql/bench/cart.sql
@@ -1,0 +1,22 @@
+-- PostgreSQL Benchmark - Cart Data (10M rows, small payloads)
+-- Prerequisites: Run create.sql first
+
+DO $$
+DECLARE
+    batch_size INT := 10000;
+    total_rows INT := 10000000;
+    inserted   INT := 0;
+BEGIN
+    WHILE inserted < total_rows LOOP
+        INSERT INTO public.cart (user_id, product_id, quantity, price, info)
+        SELECT
+            (n % 10000) + 1,
+            (n % 1000) + 1,
+            (n % 10) + 1,
+            ((n % 1000) + 0.99)::decimal(10,2),
+            repeat('cart ' || n || ' ', 40)
+        FROM generate_series(inserted + 1, inserted + batch_size) AS n;
+
+        inserted := inserted + batch_size;
+    END LOOP;
+END $$;

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -1,0 +1,38 @@
+-- PostgreSQL Benchmark Setup Script
+
+CREATE TABLE IF NOT EXISTS public.users (
+    id            SERIAL PRIMARY KEY,
+    name          VARCHAR(100)    NOT NULL,
+    surname       VARCHAR(100)    NOT NULL,
+    about         TEXT            NOT NULL,
+    email         VARCHAR(255)    NOT NULL,
+    date_of_birth DATE,
+    join_date     DATE,
+    created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    is_active     BOOLEAN         NOT NULL DEFAULT TRUE,
+    login_count   INT             NOT NULL DEFAULT 0,
+    balance       DECIMAL(10,2)   NOT NULL DEFAULT 0.00
+);
+
+CREATE TABLE IF NOT EXISTS public.products (
+    id            SERIAL PRIMARY KEY,
+    name          VARCHAR(100)    NOT NULL,
+    surname       VARCHAR(100)    NOT NULL,
+    about         TEXT            NOT NULL,
+    email         VARCHAR(255)    NOT NULL,
+    date_of_birth DATE,
+    join_date     DATE,
+    created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    is_active     BOOLEAN         NOT NULL DEFAULT TRUE,
+    login_count   INT             NOT NULL DEFAULT 0,
+    balance       DECIMAL(10,2)   NOT NULL DEFAULT 0.00
+);
+
+CREATE TABLE IF NOT EXISTS public.cart (
+    id         SERIAL PRIMARY KEY,
+    user_id    INT           NOT NULL,
+    product_id INT           NOT NULL,
+    quantity   INT           NOT NULL DEFAULT 1,
+    price      DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    info       TEXT          NOT NULL
+);

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -16,16 +16,14 @@ CREATE TABLE IF NOT EXISTS public.users (
 
 CREATE TABLE IF NOT EXISTS public.products (
     id            SERIAL PRIMARY KEY,
-    name          VARCHAR(100)    NOT NULL,
-    surname       VARCHAR(100)    NOT NULL,
-    about         TEXT            NOT NULL,
-    email         VARCHAR(255)    NOT NULL,
-    date_of_birth DATE,
-    join_date     DATE,
+    name          VARCHAR(255)    NOT NULL,
+    description   TEXT            NOT NULL,
+    category      VARCHAR(100)    NOT NULL,
+    price         DECIMAL(10,2)   NOT NULL,
+    stock         INT             NOT NULL DEFAULT 0,
+    sku           VARCHAR(100)    NOT NULL,
     created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
-    is_active     BOOLEAN         NOT NULL DEFAULT TRUE,
-    login_count   INT             NOT NULL DEFAULT 0,
-    balance       DECIMAL(10,2)   NOT NULL DEFAULT 0.00
+    is_available  BOOLEAN         NOT NULL DEFAULT TRUE
 );
 
 CREATE TABLE IF NOT EXISTS public.cart (

--- a/internal/impl/postgresql/bench/kafka-connector/Dockerfile
+++ b/internal/impl/postgresql/bench/kafka-connector/Dockerfile
@@ -1,0 +1,7 @@
+FROM confluentinc/cp-kafka-connect-base:7.7.8
+# Install the Confluent JDBC sink connector
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.7.14
+# Install the PostgreSQL JDBC driver (not bundled with the connector hub package)
+RUN curl -fL \
+      -o /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/postgresql-42.7.3.jar \
+      "https://jdbc.postgresql.org/download/postgresql-42.7.3.jar"

--- a/internal/impl/postgresql/bench/kafka-connector/README.md
+++ b/internal/impl/postgresql/bench/kafka-connector/README.md
@@ -1,0 +1,61 @@
+# Kafka Connect JDBC Sink — PostgreSQL Benchmark
+
+Benchmarks Kafka Connect (Confluent JDBC Sink) reading from Kafka and writing to PostgreSQL.
+
+See [`docs/benchmark-results/postgres.md`](../../../../../docs/benchmark-results/postgres.md) for results and comparison with Redpanda Connect.
+
+## Architecture
+
+```
+Redpanda Connect producer → bench-events (16 partitions) → Kafka Connect JDBC Sink → PostgreSQL bench_events
+```
+
+- **Kafka** — KRaft broker, no ZooKeeper
+- **PostgreSQL 16** — sink target (`benchdb.bench_events`)
+- **Kafka Connect** — JDBC Sink connector (`confluentinc/kafka-connect-jdbc:10.7.14`)
+- **Message format** — JSON with embedded Kafka Connect schema envelope (no Schema Registry)
+
+## Prerequisites
+
+- Docker
+- `task` (Taskfile runner)
+- `jq`
+- `go` (to run the producer)
+
+## Quickstart
+
+```bash
+task up
+task bench:run COUNT=10000000
+task down
+```
+
+## Tasks Reference
+
+| Task | Description |
+|---|---|
+| `task up` | Build and start all containers, wait for Connect readiness |
+| `task down` | Stop and remove all containers and volumes |
+| `task bench:run COUNT=N` | Full benchmark: produce N events, register connector, measure throughput |
+| `task bench:measure TOTAL=N INTERVAL=S` | Poll lag and print msg/s until topic is drained |
+| `task bench:lag` | Show current consumer group lag |
+| `task bench:offsets` | Show end offsets for bench-events |
+| `task bench:pg-count` | Count rows written to bench_events in PostgreSQL |
+| `task connector:create` | Register the JDBC sink connector |
+| `task connector:status` | Show connector and task status |
+| `task connector:delete` | Delete the connector (keeps infrastructure running) |
+| `task data:load COUNT=N` | Produce N events to bench-events |
+| `task logs:connect` | Follow Kafka Connect worker logs |
+| `task logs:postgres` | Follow PostgreSQL logs |
+
+## Connector Configuration
+
+Key settings in `connector.json`:
+
+| Setting | Value | Notes |
+|---|---|---|
+| `tasks.max` | 16 | Matches topic partition count |
+| `insert.mode` | `insert` | Append-only inserts |
+| `batch.size` | 3000 | Rows per JDBC batch |
+| `table.name.format` | `bench_events` | Explicit table name |
+| `value.converter.schemas.enable` | `true` | Reads column mapping from message schema envelope |

--- a/internal/impl/postgresql/bench/kafka-connector/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/kafka-connector/Taskfile.yaml
@@ -1,0 +1,162 @@
+version: "3"
+
+silent: true
+
+vars:
+  KAFKA_BOOTSTRAP: '{{.KAFKA_BOOTSTRAP | default "localhost:9092"}}'
+  CONNECT_URL: '{{.CONNECT_URL | default "http://localhost:8083"}}'
+  PG_DSN: '{{.PG_DSN | default "postgres://postgres:postgres@localhost:5432/benchdb?sslmode=disable"}}'
+  CONNECTOR_NAME: pg-jdbc-sink-bench
+  CONSUMER_GROUP: connect-pg-jdbc-sink-bench
+
+tasks:
+  up:
+    desc: Build and start all infrastructure (Kafka, PostgreSQL, Kafka Connect), wait until ready
+    cmds:
+      - docker compose up -d --build
+      - until curl -sf {{.CONNECT_URL}}/ > /dev/null 2>&1; do sleep 3; done
+      - echo "Kafka Connect ready at {{.CONNECT_URL}}"
+
+  down:
+    desc: Stop and remove all containers and volumes
+    cmds:
+      - docker compose down -v --remove-orphans
+
+  connector:create:
+    desc: Register the JDBC sink connector
+    cmds:
+      - |
+        curl -sf -X POST {{.CONNECT_URL}}/connectors \
+          -H "Content-Type: application/json" \
+          -d @connector.json | jq '.name'
+
+  connector:status:
+    desc: Show connector and task status
+    cmds:
+      - curl -sf {{.CONNECT_URL}}/connectors/{{.CONNECTOR_NAME}}/status | jq .
+
+  connector:delete:
+    desc: Delete the JDBC sink connector (without stopping infrastructure)
+    cmds:
+      - curl -s -X DELETE {{.CONNECT_URL}}/connectors/{{.CONNECTOR_NAME}} || true
+
+  data:load:
+    desc: "Produce events to bench-events topic (e.g. task data:load COUNT=5000000)"
+    vars:
+      COUNT: '{{.COUNT | default "1000000"}}'
+    env:
+      COUNT: '{{.COUNT}}'
+      KAFKA_BOOTSTRAP: '{{.KAFKA_BOOTSTRAP}}'
+    cmds:
+      - go run ../../../../../cmd/redpanda-connect/main.go run ./producer.yaml
+
+  bench:lag:
+    desc: Show current consumer lag for the JDBC sink connector group
+    cmds:
+      - docker exec pgkc-kafka kafka-consumer-groups --bootstrap-server localhost:29092 --describe --group {{.CONSUMER_GROUP}}
+
+  bench:offsets:
+    desc: Show end offsets (total messages) for bench-events
+    cmds:
+      - docker exec pgkc-kafka kafka-get-offsets --bootstrap-server localhost:29092 --topic bench-events
+
+  bench:pg-count:
+    desc: Count rows written to bench_events table in PostgreSQL
+    cmds:
+      - psql {{.PG_DSN}} -c "SELECT COUNT(*) AS rows_written FROM bench_events;"
+
+  bench:measure:
+    desc: "Poll lag and print msg/s until topic is drained (e.g. task bench:measure TOTAL=1000000 INTERVAL=5)"
+    vars:
+      TOTAL: '{{.TOTAL | default "1000000"}}'
+      INTERVAL: '{{.INTERVAL | default "5"}}'
+    cmds:
+      - |
+        GROUP={{.CONSUMER_GROUP}}
+        INTERVAL={{.INTERVAL}}
+        TOTAL={{.TOTAL}}
+
+        get_lag() {
+          docker exec pgkc-kafka kafka-consumer-groups \
+            --bootstrap-server localhost:29092 \
+            --describe --group "$GROUP" 2>/dev/null \
+            | awk '/bench-events/ {
+                cur = ($4 == "-") ? 0 : $4
+                sum += $5 - cur
+              } END {print (NR == 0 ? -1 : sum)}'
+        }
+
+        START=""
+        INITIAL_LAG=""
+        PREV_LAG=""
+        PREV_TIME=""
+
+        printf "%-10s  %-14s  %s\n" "TIME" "LAG" "MSG/S"
+
+        while true; do
+          sleep "$INTERVAL"
+          LAG=$(get_lag)
+          NOW=$(date +%s)
+
+          if [ -z "$START" ]; then
+            if [ "$LAG" -gt 0 ] 2>/dev/null; then
+              START=$NOW
+              INITIAL_LAG=$LAG
+              PREV_LAG=$LAG
+              PREV_TIME=$NOW
+              printf "%-10s  %-14s  (timing started)\n" "$(date +%H:%M:%S)" "$LAG"
+            else
+              printf "%-10s  %-14s  (waiting for lag...)\n" "$(date +%H:%M:%S)" "$LAG"
+            fi
+            continue
+          fi
+
+          [ "$LAG" -eq -1 ] 2>/dev/null && LAG=0
+
+          DELTA_T=$((NOW - PREV_TIME))
+          DELTA_LAG=$((PREV_LAG - LAG))
+          if [ "$DELTA_T" -gt 0 ]; then
+            RATE=$((DELTA_LAG / DELTA_T))
+          else
+            RATE=0
+          fi
+
+          printf "%-10s  %-14s  %s msg/s\n" "$(date +%H:%M:%S)" "$LAG" "$RATE"
+
+          if [ "$LAG" -eq 0 ]; then
+            ELAPSED=$((NOW - START))
+            AVG=$(( INITIAL_LAG / (ELAPSED > 0 ? ELAPSED : 1) ))
+            echo "---"
+            echo "Total messages : $INITIAL_LAG"
+            echo "Elapsed        : ${ELAPSED}s"
+            echo "Avg throughput : ${AVG} msg/s"
+            break
+          fi
+
+          PREV_LAG=$LAG
+          PREV_TIME=$NOW
+        done
+
+  bench:run:
+    desc: "Full benchmark: load COUNT events then measure JDBC sink throughput (e.g. task bench:run COUNT=10000000)"
+    vars:
+      COUNT: '{{.COUNT | default "1000000"}}'
+    cmds:
+      - task connector:delete
+      - sleep 2
+      - psql {{.PG_DSN}} -c "TRUNCATE bench_events;"
+      - |
+        COUNT={{.COUNT}} KAFKA_BOOTSTRAP={{.KAFKA_BOOTSTRAP}} \
+        go run ../../../../../cmd/redpanda-connect/main.go run ./producer.yaml
+      - task connector:create
+      - task bench:measure TOTAL={{.COUNT}}
+
+  logs:connect:
+    desc: Follow Kafka Connect worker logs
+    cmds:
+      - docker compose logs -f kafka-connect
+
+  logs:postgres:
+    desc: Follow PostgreSQL logs
+    cmds:
+      - docker compose logs -f postgres

--- a/internal/impl/postgresql/bench/kafka-connector/connector.json
+++ b/internal/impl/postgresql/bench/kafka-connector/connector.json
@@ -1,0 +1,25 @@
+{
+  "name": "pg-jdbc-sink-bench",
+  "config": {
+    "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+    "tasks.max": "16",
+    "topics": "bench-events",
+
+    "connection.url": "jdbc:postgresql://postgres:5432/benchdb",
+    "connection.user": "postgres",
+    "connection.password": "postgres",
+
+    "insert.mode": "insert",
+    "pk.mode": "none",
+    "auto.create": "false",
+    "table.name.format": "bench_events",
+
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "true",
+
+    "batch.size": "3000",
+    "consumer.override.fetch.min.bytes": "1048576",
+    "consumer.override.fetch.max.wait.ms": "500",
+    "consumer.override.max.poll.records": "5000"
+  }
+}

--- a/internal/impl/postgresql/bench/kafka-connector/docker-compose.yaml
+++ b/internal/impl/postgresql/bench/kafka-connector/docker-compose.yaml
@@ -1,0 +1,116 @@
+services:
+  # ── Kafka (KRaft, no ZooKeeper) ──────────────────────────────────────────────
+  kafka:
+    image: confluentinc/cp-kafka:7.7.8
+    container_name: pgkc-kafka
+    cpus: 3
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+
+  # ── PostgreSQL (benchmark sink target) ───────────────────────────────────────
+  postgres:
+    image: postgres:16
+    container_name: pgkc-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: benchdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # ── Kafka Connect + JDBC sink plugin (built from Dockerfile) ─────────────────
+  kafka-connect:
+    build: .
+    container_name: pgkc-connect
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: kafka:29092
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: pg-jdbc-bench-group
+      CONNECT_CONFIG_STORAGE_TOPIC: _connect-configs
+      CONNECT_OFFSET_STORAGE_TOPIC: _connect-offsets
+      CONNECT_STATUS_STORAGE_TOPIC: _connect-status
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
+      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "true"
+      CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect
+      CONNECT_PLUGIN_PATH: /usr/share/java,/usr/share/confluent-hub-components
+    depends_on:
+      kafka:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8083/"]
+      interval: 10s
+      timeout: 10s
+      retries: 15
+
+  # ── Create bench-events Kafka topic ──────────────────────────────────────────
+  kafka-setup:
+    image: confluentinc/cp-kafka:7.7.8
+    container_name: pgkc-kafka-setup
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        kafka-topics --bootstrap-server kafka:29092 \
+          --create --if-not-exists \
+          --topic bench-events \
+          --partitions 16 \
+          --replication-factor 1
+        echo "topic ready"
+
+  # ── Create bench_events table in PostgreSQL ───────────────────────────────────
+  pg-setup:
+    image: postgres:16
+    container_name: pgkc-pg-setup
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: postgres
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        psql -h postgres -U postgres -d benchdb -c "
+          CREATE TABLE IF NOT EXISTS bench_events (
+            id       BIGINT,
+            category VARCHAR(50),
+            value    DOUBLE PRECISION,
+            ts       BIGINT
+          );"
+        echo "table ready"

--- a/internal/impl/postgresql/bench/kafka-connector/producer.yaml
+++ b/internal/impl/postgresql/bench/kafka-connector/producer.yaml
@@ -1,0 +1,47 @@
+# Produces COUNT synthetic events to the bench-events Kafka topic.
+# Messages use the Kafka Connect JSON schema envelope so the JDBC sink connector
+# can map fields to PostgreSQL columns without a Schema Registry.
+#
+# Usage:
+#   go run ../../../../../cmd/redpanda-connect/main.go run ./producer.yaml
+# Override count/brokers:
+#   COUNT=5000000 KAFKA_BOOTSTRAP=localhost:9092 \
+#   go run ../../../../../cmd/redpanda-connect/main.go run ./producer.yaml
+
+input:
+  generate:
+    count: ${COUNT:1000000}
+    interval: ""
+    mapping: |
+      # Kafka Connect JSON schema envelope — the JDBC sink reads the schema block
+      # to determine column types and maps payload fields to table columns.
+      root = {
+        "schema": {
+          "type": "struct",
+          "fields": [
+            {"type": "int64",   "optional": false, "field": "id"},
+            {"type": "string",  "optional": false, "field": "category"},
+            {"type": "double", "optional": false, "field": "value"},
+            {"type": "int64",   "optional": false, "field": "ts"}
+          ],
+          "optional": false,
+          "name": "bench_event"
+        },
+        "payload": {
+          "id":       count("events"),
+          "category": "cat_" + random_int(min: 1, max: 10).string(),
+          "value":    random_int(min: 1, max: 1000000).float64() / 100.0,
+          "ts":       now().ts_unix_micro()
+        }
+      }
+
+output:
+  kafka_franz:
+    seed_brokers:
+      - ${KAFKA_BOOTSTRAP:localhost:9092}
+    topic: bench-events
+    compression: snappy
+    batching:
+      count: 3000
+      byte_size: 4194304  # 4 MiB
+      period: 5s

--- a/internal/impl/postgresql/bench/kafka_benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/kafka_benchmark_config.yaml
@@ -1,0 +1,46 @@
+http:
+  debug_endpoints: true
+
+input:
+  kafka_franz:
+    seed_brokers:
+      - ${KAFKA_BOOTSTRAP:localhost:9092}
+    topics:
+      - bench-events
+    consumer_group: rpcn-pg-sink-bench
+    batching:
+      count: 3000
+      period: 500ms
+
+pipeline:
+  processors:
+    - mapping: |
+        root.id       = this.payload.id
+        root.category = this.payload.category
+        root.value    = this.payload.value
+        root.ts       = this.payload.ts
+
+output:
+  processors:
+    - benchmark:
+        interval: 1s
+        count_bytes: false
+  sql_insert:
+    driver: postgres
+    dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/benchdb?sslmode=disable}  # override via PG_DSN env var
+    table: bench_events
+    columns: [ id, category, value, ts ]
+    args_mapping: |
+      root = [ this.id, this.category, this.value, this.ts ]
+    max_in_flight: 16
+    batching:
+      count: 3000
+      period: 500ms
+
+logger:
+  level: WARN
+
+metrics:
+  prometheus:
+    add_process_metrics: true
+    add_go_metrics: true

--- a/internal/impl/postgresql/bench/products.sql
+++ b/internal/impl/postgresql/bench/products.sql
@@ -1,0 +1,16 @@
+-- PostgreSQL Benchmark - Products Data (150K rows, ~500KB per row)
+-- Prerequisites: Run create.sql first
+
+INSERT INTO public.products (name, surname, about, email, date_of_birth, join_date, created_at, is_active, login_count, balance)
+SELECT
+    'product-' || n,
+    'surname-' || n,
+    repeat('This is about product ' || n || '. ', 25000),
+    'product' || n || '@example.com',
+    NOW() - (n % 10000 || ' days')::interval,
+    NOW(),
+    NOW(),
+    (n % 2 = 0),
+    n % 100,
+    ((n % 1000) + (n % 100) / 100.0)::decimal(10,2)
+FROM generate_series(1, 150000) AS n;

--- a/internal/impl/postgresql/bench/products.sql
+++ b/internal/impl/postgresql/bench/products.sql
@@ -1,16 +1,14 @@
--- PostgreSQL Benchmark - Products Data (150K rows, ~500KB per row)
+-- PostgreSQL Benchmark - Products Data (150K rows, large description blob for row-size parity with users)
 -- Prerequisites: Run create.sql first
 
-INSERT INTO public.products (name, surname, about, email, date_of_birth, join_date, created_at, is_active, login_count, balance)
+INSERT INTO public.products (name, description, category, price, stock, sku, created_at, is_available)
 SELECT
-    'product-' || n,
-    'surname-' || n,
-    repeat('This is about product ' || n || '. ', 25000),
-    'product' || n || '@example.com',
-    NOW() - (n % 10000 || ' days')::interval,
+    'Product ' || n,
+    repeat('Description for product ' || n || '. ', 25000),
+    (ARRAY['Electronics','Clothing','Books','Home & Garden','Sports','Toys','Food'])[1 + (n % 7)],
+    ((n % 99000) / 100.0 + 1.0)::decimal(10,2),
+    (n % 500),
+    'SKU-' || LPAD(n::text, 8, '0'),
     NOW(),
-    NOW(),
-    (n % 2 = 0),
-    n % 100,
-    ((n % 1000) + (n % 100) / 100.0)::decimal(10,2)
+    (n % 10 != 0)
 FROM generate_series(1, 150000) AS n;

--- a/internal/impl/postgresql/bench/users.sql
+++ b/internal/impl/postgresql/bench/users.sql
@@ -1,0 +1,16 @@
+-- PostgreSQL Benchmark - Users Data (150K rows, ~500KB per row)
+-- Prerequisites: Run create.sql first
+
+INSERT INTO public.users (name, surname, about, email, date_of_birth, join_date, created_at, is_active, login_count, balance)
+SELECT
+    'user-' || n,
+    'surname-' || n,
+    repeat('This is about user ' || n || '. ', 25000),
+    'user' || n || '@example.com',
+    NOW() - (n % 10000 || ' days')::interval,
+    NOW(),
+    NOW(),
+    (n % 2 = 0),
+    n % 100,
+    ((n % 1000) + (n % 100) / 100.0)::decimal(10,2)
+FROM generate_series(1, 150000) AS n;


### PR DESCRIPTION
Adds a benchmark suite for the postgres input under internal/impl/postgresql/bench/, following the same pattern as the existing Salesforce
   and MSSQL Server benchmarks.

  What's included:
  - Taskfile.yaml — tasks for Docker container lifecycle, data insertion, and parameterised benchmark runs (task bench:cart CORES=4 BATCH=5000,
  task bench:users CORES=2 BATCH=1000)
  - create.sql, users.sql, products.sql, cart.sql — test datasets: 150K large rows (~625 KB each) and 10M small rows (~600 B each)
  - benchmark_config.yaml — postgres_cdc → benchmark processor → drop
  - README.md — setup and run instructions
  - docs/benchmark-results/postgres.md — full results across CPU core counts (1, 2, 4, 8) and batch sizes (1000, 5000, 10000) for both datasets

  Key findings:
  - Small rows (cart): scales to ~318K msg/sec at 8 cores, batch=5000 is the sweet spot
  - Large rows (users): I/O bound, plateaus at ~1,166 msg/sec / 766 MB/sec at 2 cores regardless of additional cores or batch size