### PR TITLE
docs: update copyright year to 2026

### DIFF
--- a/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
+++ b/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
@@ -18,7 +18,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/buffers/memory.adoc
+++ b/docs/modules/components/pages/buffers/memory.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/buffers/none.adoc
+++ b/docs/modules/components/pages/buffers/none.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/buffers/sqlite.adoc
+++ b/docs/modules/components/pages/buffers/sqlite.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/buffers/system_window.adoc
+++ b/docs/modules/components/pages/buffers/system_window.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/caches/aws_dynamodb.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/aws_s3.adoc
+++ b/docs/modules/components/pages/caches/aws_s3.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/couchbase.adoc
+++ b/docs/modules/components/pages/caches/couchbase.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/file.adoc
+++ b/docs/modules/components/pages/caches/file.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/caches/gcp_cloud_storage.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/lru.adoc
+++ b/docs/modules/components/pages/caches/lru.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/memcached.adoc
+++ b/docs/modules/components/pages/caches/memcached.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/memory.adoc
+++ b/docs/modules/components/pages/caches/memory.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/mongodb.adoc
+++ b/docs/modules/components/pages/caches/mongodb.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/multilevel.adoc
+++ b/docs/modules/components/pages/caches/multilevel.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/nats_kv.adoc
+++ b/docs/modules/components/pages/caches/nats_kv.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/noop.adoc
+++ b/docs/modules/components/pages/caches/noop.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/redis.adoc
+++ b/docs/modules/components/pages/caches/redis.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/redpanda.adoc
+++ b/docs/modules/components/pages/caches/redpanda.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/ristretto.adoc
+++ b/docs/modules/components/pages/caches/ristretto.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/sql.adoc
+++ b/docs/modules/components/pages/caches/sql.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/caches/ttlru.adoc
+++ b/docs/modules/components/pages/caches/ttlru.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/amqp_0_9.adoc
+++ b/docs/modules/components/pages/inputs/amqp_0_9.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/amqp_1.adoc
+++ b/docs/modules/components/pages/inputs/amqp_1.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/aws_cloudwatch_logs.adoc
+++ b/docs/modules/components/pages/inputs/aws_cloudwatch_logs.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/aws_s3.adoc
+++ b/docs/modules/components/pages/inputs/aws_s3.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/inputs/aws_sqs.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/inputs/azure_blob_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/azure_cosmosdb.adoc
+++ b/docs/modules/components/pages/inputs/azure_cosmosdb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/azure_queue_storage.adoc
+++ b/docs/modules/components/pages/inputs/azure_queue_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/azure_table_storage.adoc
+++ b/docs/modules/components/pages/inputs/azure_table_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/batched.adoc
+++ b/docs/modules/components/pages/inputs/batched.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/beanstalkd.adoc
+++ b/docs/modules/components/pages/inputs/beanstalkd.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/broker.adoc
+++ b/docs/modules/components/pages/inputs/broker.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/cassandra.adoc
+++ b/docs/modules/components/pages/inputs/cassandra.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/cockroachdb_changefeed.adoc
+++ b/docs/modules/components/pages/inputs/cockroachdb_changefeed.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/csv.adoc
+++ b/docs/modules/components/pages/inputs/csv.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/discord.adoc
+++ b/docs/modules/components/pages/inputs/discord.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/dynamic.adoc
+++ b/docs/modules/components/pages/inputs/dynamic.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/file.adoc
+++ b/docs/modules/components/pages/inputs/file.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/gateway.adoc
+++ b/docs/modules/components/pages/inputs/gateway.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/gcp_bigquery_select.adoc
+++ b/docs/modules/components/pages/inputs/gcp_bigquery_select.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/inputs/gcp_pubsub.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/gcp_spanner_cdc.adoc
+++ b/docs/modules/components/pages/inputs/gcp_spanner_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/generate.adoc
+++ b/docs/modules/components/pages/inputs/generate.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/git.adoc
+++ b/docs/modules/components/pages/inputs/git.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/hdfs.adoc
+++ b/docs/modules/components/pages/inputs/hdfs.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/http_client.adoc
+++ b/docs/modules/components/pages/inputs/http_client.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/http_server.adoc
+++ b/docs/modules/components/pages/inputs/http_server.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/inproc.adoc
+++ b/docs/modules/components/pages/inputs/inproc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/mongodb.adoc
+++ b/docs/modules/components/pages/inputs/mongodb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/mqtt.adoc
+++ b/docs/modules/components/pages/inputs/mqtt.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nanomsg.adoc
+++ b/docs/modules/components/pages/inputs/nanomsg.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nats.adoc
+++ b/docs/modules/components/pages/inputs/nats.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/inputs/nats_jetstream.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nats_kv.adoc
+++ b/docs/modules/components/pages/inputs/nats_kv.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nats_stream.adoc
+++ b/docs/modules/components/pages/inputs/nats_stream.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/nsq.adoc
+++ b/docs/modules/components/pages/inputs/nsq.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/inputs/ockam_kafka.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/otlp_grpc.adoc
+++ b/docs/modules/components/pages/inputs/otlp_grpc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/otlp_http.adoc
+++ b/docs/modules/components/pages/inputs/otlp_http.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/parquet.adoc
+++ b/docs/modules/components/pages/inputs/parquet.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/pulsar.adoc
+++ b/docs/modules/components/pages/inputs/pulsar.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/read_until.adoc
+++ b/docs/modules/components/pages/inputs/read_until.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redis_list.adoc
+++ b/docs/modules/components/pages/inputs/redis_list.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redis_pubsub.adoc
+++ b/docs/modules/components/pages/inputs/redis_pubsub.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redis_scan.adoc
+++ b/docs/modules/components/pages/inputs/redis_scan.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redis_streams.adoc
+++ b/docs/modules/components/pages/inputs/redis_streams.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/resource.adoc
+++ b/docs/modules/components/pages/inputs/resource.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/schema_registry.adoc
+++ b/docs/modules/components/pages/inputs/schema_registry.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/sequence.adoc
+++ b/docs/modules/components/pages/inputs/sequence.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/sftp.adoc
+++ b/docs/modules/components/pages/inputs/sftp.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/slack.adoc
+++ b/docs/modules/components/pages/inputs/slack.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/slack_users.adoc
+++ b/docs/modules/components/pages/inputs/slack_users.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/socket.adoc
+++ b/docs/modules/components/pages/inputs/socket.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/socket_server.adoc
+++ b/docs/modules/components/pages/inputs/socket_server.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/spicedb_watch.adoc
+++ b/docs/modules/components/pages/inputs/spicedb_watch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/splunk.adoc
+++ b/docs/modules/components/pages/inputs/splunk.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/sql_raw.adoc
+++ b/docs/modules/components/pages/inputs/sql_raw.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/sql_select.adoc
+++ b/docs/modules/components/pages/inputs/sql_select.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/stdin.adoc
+++ b/docs/modules/components/pages/inputs/stdin.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/subprocess.adoc
+++ b/docs/modules/components/pages/inputs/subprocess.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/tigerbeetle_cdc.adoc
+++ b/docs/modules/components/pages/inputs/tigerbeetle_cdc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/timeplus.adoc
+++ b/docs/modules/components/pages/inputs/timeplus.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/twitter_search.adoc
+++ b/docs/modules/components/pages/inputs/twitter_search.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/websocket.adoc
+++ b/docs/modules/components/pages/inputs/websocket.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/inputs/zmq4.adoc
+++ b/docs/modules/components/pages/inputs/zmq4.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
+++ b/docs/modules/components/pages/metrics/aws_cloudwatch.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/influxdb.adoc
+++ b/docs/modules/components/pages/metrics/influxdb.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/json_api.adoc
+++ b/docs/modules/components/pages/metrics/json_api.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/logger.adoc
+++ b/docs/modules/components/pages/metrics/logger.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/none.adoc
+++ b/docs/modules/components/pages/metrics/none.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/prometheus.adoc
+++ b/docs/modules/components/pages/metrics/prometheus.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/metrics/statsd.adoc
+++ b/docs/modules/components/pages/metrics/statsd.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/docs/modules/components/pages/outputs/amqp_0_9.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/amqp_1.adoc
+++ b/docs/modules/components/pages/outputs/amqp_1.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_dynamodb.adoc
+++ b/docs/modules/components/pages/outputs/aws_dynamodb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
+++ b/docs/modules/components/pages/outputs/aws_kinesis_firehose.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_s3.adoc
+++ b/docs/modules/components/pages/outputs/aws_s3.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_sns.adoc
+++ b/docs/modules/components/pages/outputs/aws_sns.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/aws_sqs.adoc
+++ b/docs/modules/components/pages/outputs/aws_sqs.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/azure_blob_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_blob_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/azure_cosmosdb.adoc
+++ b/docs/modules/components/pages/outputs/azure_cosmosdb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/docs/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/azure_queue_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_queue_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/azure_table_storage.adoc
+++ b/docs/modules/components/pages/outputs/azure_table_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/beanstalkd.adoc
+++ b/docs/modules/components/pages/outputs/beanstalkd.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/broker.adoc
+++ b/docs/modules/components/pages/outputs/broker.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/cache.adoc
+++ b/docs/modules/components/pages/outputs/cache.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/cassandra.adoc
+++ b/docs/modules/components/pages/outputs/cassandra.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/couchbase.adoc
+++ b/docs/modules/components/pages/outputs/couchbase.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/cyborgdb.adoc
+++ b/docs/modules/components/pages/outputs/cyborgdb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/cypher.adoc
+++ b/docs/modules/components/pages/outputs/cypher.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/discord.adoc
+++ b/docs/modules/components/pages/outputs/discord.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/drop.adoc
+++ b/docs/modules/components/pages/outputs/drop.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/drop_on.adoc
+++ b/docs/modules/components/pages/outputs/drop_on.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/dynamic.adoc
+++ b/docs/modules/components/pages/outputs/dynamic.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/elasticsearch_v8.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch_v8.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/elasticsearch_v9.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch_v9.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/fallback.adoc
+++ b/docs/modules/components/pages/outputs/fallback.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/file.adoc
+++ b/docs/modules/components/pages/outputs/file.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/outputs/gcp_cloud_storage.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/outputs/gcp_pubsub.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/hdfs.adoc
+++ b/docs/modules/components/pages/outputs/hdfs.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/http_client.adoc
+++ b/docs/modules/components/pages/outputs/http_client.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/http_server.adoc
+++ b/docs/modules/components/pages/outputs/http_server.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/inproc.adoc
+++ b/docs/modules/components/pages/outputs/inproc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/kafka.adoc
+++ b/docs/modules/components/pages/outputs/kafka.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/mongodb.adoc
+++ b/docs/modules/components/pages/outputs/mongodb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/mqtt.adoc
+++ b/docs/modules/components/pages/outputs/mqtt.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nanomsg.adoc
+++ b/docs/modules/components/pages/outputs/nanomsg.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nats.adoc
+++ b/docs/modules/components/pages/outputs/nats.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nats_jetstream.adoc
+++ b/docs/modules/components/pages/outputs/nats_jetstream.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nats_kv.adoc
+++ b/docs/modules/components/pages/outputs/nats_kv.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nats_stream.adoc
+++ b/docs/modules/components/pages/outputs/nats_stream.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/nsq.adoc
+++ b/docs/modules/components/pages/outputs/nsq.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/outputs/ockam_kafka.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/opensearch.adoc
+++ b/docs/modules/components/pages/outputs/opensearch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/otlp_grpc.adoc
+++ b/docs/modules/components/pages/outputs/otlp_grpc.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/otlp_http.adoc
+++ b/docs/modules/components/pages/outputs/otlp_http.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/pinecone.adoc
+++ b/docs/modules/components/pages/outputs/pinecone.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/pulsar.adoc
+++ b/docs/modules/components/pages/outputs/pulsar.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/pusher.adoc
+++ b/docs/modules/components/pages/outputs/pusher.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/qdrant.adoc
+++ b/docs/modules/components/pages/outputs/qdrant.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/questdb.adoc
+++ b/docs/modules/components/pages/outputs/questdb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redis_hash.adoc
+++ b/docs/modules/components/pages/outputs/redis_hash.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redis_list.adoc
+++ b/docs/modules/components/pages/outputs/redis_list.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redis_pubsub.adoc
+++ b/docs/modules/components/pages/outputs/redis_pubsub.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redis_streams.adoc
+++ b/docs/modules/components/pages/outputs/redis_streams.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/reject.adoc
+++ b/docs/modules/components/pages/outputs/reject.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/reject_errored.adoc
+++ b/docs/modules/components/pages/outputs/reject_errored.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/resource.adoc
+++ b/docs/modules/components/pages/outputs/resource.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/retry.adoc
+++ b/docs/modules/components/pages/outputs/retry.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/salesforce_sink.adoc
+++ b/docs/modules/components/pages/outputs/salesforce_sink.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/schema_registry.adoc
+++ b/docs/modules/components/pages/outputs/schema_registry.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/sftp.adoc
+++ b/docs/modules/components/pages/outputs/sftp.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/slack_post.adoc
+++ b/docs/modules/components/pages/outputs/slack_post.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/slack_reaction.adoc
+++ b/docs/modules/components/pages/outputs/slack_reaction.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/snowflake_put.adoc
+++ b/docs/modules/components/pages/outputs/snowflake_put.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/docs/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/socket.adoc
+++ b/docs/modules/components/pages/outputs/socket.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/splunk_hec.adoc
+++ b/docs/modules/components/pages/outputs/splunk_hec.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/sql_insert.adoc
+++ b/docs/modules/components/pages/outputs/sql_insert.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/sql_raw.adoc
+++ b/docs/modules/components/pages/outputs/sql_raw.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/stdout.adoc
+++ b/docs/modules/components/pages/outputs/stdout.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/subprocess.adoc
+++ b/docs/modules/components/pages/outputs/subprocess.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/switch.adoc
+++ b/docs/modules/components/pages/outputs/switch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/sync_response.adoc
+++ b/docs/modules/components/pages/outputs/sync_response.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/websocket.adoc
+++ b/docs/modules/components/pages/outputs/websocket.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/outputs/zmq4.adoc
+++ b/docs/modules/components/pages/outputs/zmq4.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/archive.adoc
+++ b/docs/modules/components/pages/processors/archive.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/avro.adoc
+++ b/docs/modules/components/pages/processors/avro.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/awk.adoc
+++ b/docs/modules/components/pages/processors/awk.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_chat.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
+++ b/docs/modules/components/pages/processors/aws_bedrock_embeddings.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
+++ b/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/aws_lambda.adoc
+++ b/docs/modules/components/pages/processors/aws_lambda.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/azure_cosmosdb.adoc
+++ b/docs/modules/components/pages/processors/azure_cosmosdb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/benchmark.adoc
+++ b/docs/modules/components/pages/processors/benchmark.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/bloblang.adoc
+++ b/docs/modules/components/pages/processors/bloblang.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/bounds_check.adoc
+++ b/docs/modules/components/pages/processors/bounds_check.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/branch.adoc
+++ b/docs/modules/components/pages/processors/branch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/cache.adoc
+++ b/docs/modules/components/pages/processors/cache.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/cached.adoc
+++ b/docs/modules/components/pages/processors/cached.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/catch.adoc
+++ b/docs/modules/components/pages/processors/catch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/cohere_chat.adoc
+++ b/docs/modules/components/pages/processors/cohere_chat.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/cohere_embeddings.adoc
+++ b/docs/modules/components/pages/processors/cohere_embeddings.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/cohere_rerank.adoc
+++ b/docs/modules/components/pages/processors/cohere_rerank.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/command.adoc
+++ b/docs/modules/components/pages/processors/command.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/compress.adoc
+++ b/docs/modules/components/pages/processors/compress.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/couchbase.adoc
+++ b/docs/modules/components/pages/processors/couchbase.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/crash.adoc
+++ b/docs/modules/components/pages/processors/crash.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/decompress.adoc
+++ b/docs/modules/components/pages/processors/decompress.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/dedupe.adoc
+++ b/docs/modules/components/pages/processors/dedupe.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/ffi.adoc
+++ b/docs/modules/components/pages/processors/ffi.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/for_each.adoc
+++ b/docs/modules/components/pages/processors/for_each.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/gcp_bigquery_select.adoc
+++ b/docs/modules/components/pages/processors/gcp_bigquery_select.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/gcp_vertex_ai_chat.adoc
+++ b/docs/modules/components/pages/processors/gcp_vertex_ai_chat.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/gcp_vertex_ai_embeddings.adoc
+++ b/docs/modules/components/pages/processors/gcp_vertex_ai_embeddings.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/google_drive_download.adoc
+++ b/docs/modules/components/pages/processors/google_drive_download.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/google_drive_list_labels.adoc
+++ b/docs/modules/components/pages/processors/google_drive_list_labels.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/google_drive_search.adoc
+++ b/docs/modules/components/pages/processors/google_drive_search.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/grok.adoc
+++ b/docs/modules/components/pages/processors/grok.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/group_by.adoc
+++ b/docs/modules/components/pages/processors/group_by.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/group_by_value.adoc
+++ b/docs/modules/components/pages/processors/group_by_value.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/http.adoc
+++ b/docs/modules/components/pages/processors/http.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/insert_part.adoc
+++ b/docs/modules/components/pages/processors/insert_part.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/javascript.adoc
+++ b/docs/modules/components/pages/processors/javascript.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/jira.adoc
+++ b/docs/modules/components/pages/processors/jira.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/jmespath.adoc
+++ b/docs/modules/components/pages/processors/jmespath.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/jq.adoc
+++ b/docs/modules/components/pages/processors/jq.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/json_schema.adoc
+++ b/docs/modules/components/pages/processors/json_schema.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/log.adoc
+++ b/docs/modules/components/pages/processors/log.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/mapping.adoc
+++ b/docs/modules/components/pages/processors/mapping.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/metric.adoc
+++ b/docs/modules/components/pages/processors/metric.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/mongodb.adoc
+++ b/docs/modules/components/pages/processors/mongodb.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/msgpack.adoc
+++ b/docs/modules/components/pages/processors/msgpack.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/mutation.adoc
+++ b/docs/modules/components/pages/processors/mutation.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/nats_kv.adoc
+++ b/docs/modules/components/pages/processors/nats_kv.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/nats_request_reply.adoc
+++ b/docs/modules/components/pages/processors/nats_request_reply.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/noop.adoc
+++ b/docs/modules/components/pages/processors/noop.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/ollama_chat.adoc
+++ b/docs/modules/components/pages/processors/ollama_chat.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/ollama_embeddings.adoc
+++ b/docs/modules/components/pages/processors/ollama_embeddings.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/ollama_moderation.adoc
+++ b/docs/modules/components/pages/processors/ollama_moderation.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/docs/modules/components/pages/processors/openai_chat_completion.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_embeddings.adoc
+++ b/docs/modules/components/pages/processors/openai_embeddings.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_image_generation.adoc
+++ b/docs/modules/components/pages/processors/openai_image_generation.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_speech.adoc
+++ b/docs/modules/components/pages/processors/openai_speech.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_transcription.adoc
+++ b/docs/modules/components/pages/processors/openai_transcription.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/openai_translation.adoc
+++ b/docs/modules/components/pages/processors/openai_translation.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/parallel.adoc
+++ b/docs/modules/components/pages/processors/parallel.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/parquet_decode.adoc
+++ b/docs/modules/components/pages/processors/parquet_decode.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/parquet_encode.adoc
+++ b/docs/modules/components/pages/processors/parquet_encode.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/parse_log.adoc
+++ b/docs/modules/components/pages/processors/parse_log.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/processors.adoc
+++ b/docs/modules/components/pages/processors/processors.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/protobuf.adoc
+++ b/docs/modules/components/pages/processors/protobuf.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/qdrant.adoc
+++ b/docs/modules/components/pages/processors/qdrant.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/rate_limit.adoc
+++ b/docs/modules/components/pages/processors/rate_limit.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/redis.adoc
+++ b/docs/modules/components/pages/processors/redis.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/redis_script.adoc
+++ b/docs/modules/components/pages/processors/redis_script.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/redpanda_data_transform.adoc
+++ b/docs/modules/components/pages/processors/redpanda_data_transform.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/resource.adoc
+++ b/docs/modules/components/pages/processors/resource.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/retry.adoc
+++ b/docs/modules/components/pages/processors/retry.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/salesforce.adoc
+++ b/docs/modules/components/pages/processors/salesforce.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_encode.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/select_parts.adoc
+++ b/docs/modules/components/pages/processors/select_parts.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sentry_capture.adoc
+++ b/docs/modules/components/pages/processors/sentry_capture.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/slack_thread.adoc
+++ b/docs/modules/components/pages/processors/slack_thread.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sleep.adoc
+++ b/docs/modules/components/pages/processors/sleep.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/split.adoc
+++ b/docs/modules/components/pages/processors/split.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sql_insert.adoc
+++ b/docs/modules/components/pages/processors/sql_insert.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sql_raw.adoc
+++ b/docs/modules/components/pages/processors/sql_raw.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sql_select.adoc
+++ b/docs/modules/components/pages/processors/sql_select.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/string_split.adoc
+++ b/docs/modules/components/pages/processors/string_split.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/subprocess.adoc
+++ b/docs/modules/components/pages/processors/subprocess.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/switch.adoc
+++ b/docs/modules/components/pages/processors/switch.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/sync_response.adoc
+++ b/docs/modules/components/pages/processors/sync_response.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/text_chunker.adoc
+++ b/docs/modules/components/pages/processors/text_chunker.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/try.adoc
+++ b/docs/modules/components/pages/processors/try.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/unarchive.adoc
+++ b/docs/modules/components/pages/processors/unarchive.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/wasm.adoc
+++ b/docs/modules/components/pages/processors/wasm.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/while.adoc
+++ b/docs/modules/components/pages/processors/while.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/workflow.adoc
+++ b/docs/modules/components/pages/processors/workflow.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/processors/xml.adoc
+++ b/docs/modules/components/pages/processors/xml.adoc
@@ -17,7 +17,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/rate_limits/local.adoc
+++ b/docs/modules/components/pages/rate_limits/local.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/rate_limits/redis.adoc
+++ b/docs/modules/components/pages/rate_limits/redis.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/avro.adoc
+++ b/docs/modules/components/pages/scanners/avro.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/chunker.adoc
+++ b/docs/modules/components/pages/scanners/chunker.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/csv.adoc
+++ b/docs/modules/components/pages/scanners/csv.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/decompress.adoc
+++ b/docs/modules/components/pages/scanners/decompress.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/json_array.adoc
+++ b/docs/modules/components/pages/scanners/json_array.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/json_documents.adoc
+++ b/docs/modules/components/pages/scanners/json_documents.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/lines.adoc
+++ b/docs/modules/components/pages/scanners/lines.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/re_match.adoc
+++ b/docs/modules/components/pages/scanners/re_match.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/skip_bom.adoc
+++ b/docs/modules/components/pages/scanners/skip_bom.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/switch.adoc
+++ b/docs/modules/components/pages/scanners/switch.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/tar.adoc
+++ b/docs/modules/components/pages/scanners/tar.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/scanners/to_the_end.adoc
+++ b/docs/modules/components/pages/scanners/to_the_end.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/tracers/gcp_cloudtrace.adoc
+++ b/docs/modules/components/pages/tracers/gcp_cloudtrace.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/tracers/jaeger.adoc
+++ b/docs/modules/components/pages/tracers/jaeger.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/tracers/none.adoc
+++ b/docs/modules/components/pages/tracers/none.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/tracers/open_telemetry_collector.adoc
+++ b/docs/modules/components/pages/tracers/open_telemetry_collector.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]

--- a/docs/modules/components/pages/tracers/redpanda.adoc
+++ b/docs/modules/components/pages/tracers/redpanda.adoc
@@ -16,7 +16,7 @@
      https://github.com/redpanda-data/connect/tree/main/cmd/tools/docs_gen/templates/plugin.adoc.tmpl
 ////
 
-// © 2024 Redpanda Data Inc.
+// © 2026 Redpanda Data Inc.
 
 
 component_type_dropdown::[]


### PR DESCRIPTION
Update the doc generation template and regenerate all component documentation to reflect the current year.