### PR TITLE
oracledb_cdc: add multi-tenancy support

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -58,6 +58,7 @@ input:
     checkpoint_cache_table_name: RPCN.CDC_CHECKPOINT_CACHE
     checkpoint_cache_key: oracledb_cdc
     checkpoint_limit: 1024
+    pdb_name: "" # No default (optional)
     auto_replay_nacks: true
     batching:
       count: 0
@@ -95,6 +96,7 @@ input:
     checkpoint_cache_table_name: RPCN.CDC_CHECKPOINT_CACHE
     checkpoint_cache_key: oracledb_cdc
     checkpoint_limit: 1024
+    pdb_name: "" # No default (optional)
     auto_replay_nacks: true
     batching:
       count: 0
@@ -349,6 +351,14 @@ The maximum number of messages that can be processed at a given time. Increasing
 *Type*: `int`
 
 *Default*: `1024`
+
+=== `pdb_name`
+
+The name of the pluggable database (PDB) to monitor. When connecting to a CDB root, LogMiner output is scoped to this PDB via SRC_CON_NAME filtering and catalog queries use ALTER SESSION SET CONTAINER to switch context. Requires GRANT SET CONTAINER TO <user> CONTAINER=ALL.
+
+
+*Type*: `string`
+
 
 === `auto_replay_nacks`
 

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -10,7 +10,6 @@ package oracledb
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -33,7 +32,6 @@ type batchPublisher struct {
 	msgChan    chan asyncMessage
 	cacheSCN   func(ctx context.Context, scn replication.SCN) error
 	schemas    *schemaCache
-	db         *sql.DB
 
 	log     *service.Logger
 	shutSig *shutdown.Signaller
@@ -140,7 +138,7 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 			b.schemas.seedFromColumnMeta(table, m.ColumnMeta)
 		}
 		eventKeys := mapKeys(m.Data)
-		s, typeInfo, sErr := b.schemas.schemaForEvent(ctx, b.db, table, eventKeys)
+		s, typeInfo, sErr := b.schemas.schemaForEvent(ctx, table, eventKeys)
 		if sErr != nil {
 			b.log.Warnf("Failed to refresh schema for %s.%s: %v", m.Schema, m.Table, sErr)
 		}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -57,11 +57,6 @@ const (
 	ociFieldLOBEnabled           = "lob_enabled"
 )
 
-// validOracleIdentifier matches a valid unquoted Oracle identifier: starts with a
-// letter, followed by letters, digits, _, $, or #. Used to validate pdb_name at
-// parse time before it reaches SQL construction sites.
-var validOracleIdentifier = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_$#]*$`)
-
 func init() {
 	service.MustRegisterBatchInput("oracledb_cdc", oracleDBStreamConfigSpec, newOracleDBCDCInput)
 }
@@ -361,6 +356,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		userTables []replication.UserTable
 		cachedSCN  replication.SCN
 		err        error
+		isCDB      bool
 	)
 	if o.db != nil {
 		_ = o.db.Close()
@@ -371,7 +367,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		return fmt.Errorf("connecting to oracle database: %w", err)
 	}
 	defer func() {
-		if err != nil {
+		if resErr != nil {
 			_ = o.db.Close()
 		}
 	}()
@@ -380,21 +376,8 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		return fmt.Errorf("validating connection to oracle database: %w", err)
 	}
 
-	// isCDB tracks whether we're connected at the CDB root (vs. directly in the PDB).
-	// Used to decide whether ALTER SESSION SET CONTAINER is needed for catalog queries.
-	var isCDB bool
-	if o.cfg.PDBName != "" {
-		var conName string
-		if err = o.db.QueryRowContext(ctx, `SELECT SYS_CONTEXT('USERENV', 'CON_NAME') FROM DUAL`).Scan(&conName); err != nil {
-			return fmt.Errorf("detecting Oracle container context: %w", err)
-		}
-		o.log.Infof("Connected to Oracle container: %s", conName)
-		if strings.EqualFold(conName, "CDB$ROOT") {
-			isCDB = true
-			o.log.Infof("CDB-mode: will use ALTER SESSION SET CONTAINER = %s for catalog queries", o.cfg.PDBName)
-		} else {
-			o.log.Infof("PDB-mode: connected directly to container %s; pdb_name will be ignored for container switching", conName)
-		}
+	if isCDB, err = o.detectContainerContext(ctx); err != nil {
+		return fmt.Errorf("detecting current container context: %w", err)
 	}
 
 	// If pdb_name is set but we are not at CDB$ROOT (PDB-direct or non-CDB), clear it from
@@ -407,8 +390,8 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 	// In CDB mode the auto-derived checkpoint table uses the common-user prefix C##RPCN.
 	// At parse time we don't yet know if we're in CDB mode, so fix up the name here.
 	cpCacheTable := o.cfg.CpCacheTableName
-	if isCDB && strings.HasPrefix(cpCacheTable, "RPCN.CDC_CHECKPOINT_") {
-		cpCacheTable = "C##" + cpCacheTable
+	if isCDB {
+		cpCacheTable = cdbCheckpointTable(cpCacheTable)
 	}
 
 	// no cache specified so use default, internal oracle based cache
@@ -422,8 +405,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 	// For CDB mode, run VerifyUserTables on a dedicated connection switched to the PDB
 	// (ALTER SESSION SET CONTAINER + ALL_* views, no CDB_* view privileges needed).
-	switch {
-	case isCDB:
+	if isCDB {
 		if err = func() error {
 			conn, err := o.db.Conn(ctx)
 			if err != nil {
@@ -451,7 +433,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		}(); err != nil {
 			return err
 		}
-	default:
+	} else {
 		if userTables, err = replication.VerifyUserTables(ctx, o.db, o.cfg.TablesFilter, o.log); err != nil {
 			return fmt.Errorf("verifying user defined tables: %w", err)
 		}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -42,6 +43,7 @@ const (
 	ociFieldCheckpointCacheKey        = "checkpoint_cache_key"
 	ociFieldCheckpointCacheTableName  = "checkpoint_cache_table_name"
 	ociFieldBatching                  = "batching"
+	ociFieldPDBName                   = "pdb_name"
 
 	shutdownTimeout = 5 * time.Second
 
@@ -54,6 +56,11 @@ const (
 	ociFieldMaxTransactionEvents = "max_transaction_events"
 	ociFieldLOBEnabled           = "lob_enabled"
 )
+
+// validOracleIdentifier matches a valid unquoted Oracle identifier: starts with a
+// letter, followed by letters, digits, _, $, or #. Used to validate pdb_name at
+// parse time before it reaches SQL construction sites.
+var validOracleIdentifier = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_$#]*$`)
 
 func init() {
 	service.MustRegisterBatchInput("oracledb_cdc", oracleDBStreamConfigSpec, newOracleDBCDCInput)
@@ -159,6 +166,10 @@ When using the default Oracle based cache, the Connect user requires permission 
 		Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given System Change Number (SCN) will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
 		Default(1024),
 	).
+	Field(service.NewStringField(ociFieldPDBName).
+		Description("The name of the pluggable database (PDB) to monitor. When connecting to a CDB root, LogMiner output is scoped to this PDB via SRC_CON_NAME filtering and catalog queries use ALTER SESSION SET CONTAINER to switch context. Requires GRANT SET CONTAINER TO <user> CONTAINER=ALL.").
+		Optional(),
+	).
 	Field(service.NewAutoRetryNacksToggleField()).
 	Field(service.NewBatchPolicyField(ociFieldBatching))
 
@@ -177,6 +188,7 @@ type Config struct {
 	SCNCache             string
 	SCNCacheKey          string
 	CpCacheTableName     string
+	PDBName              string
 }
 
 type oracleDBCDCInput struct {
@@ -259,6 +271,20 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 		return nil, err
 	}
 
+	var pdbName string
+	if conf.Contains(ociFieldPDBName) {
+		if pdbName, err = conf.FieldString(ociFieldPDBName); err != nil {
+			return nil, err
+		}
+		if pdbName != "" && !validOracleIdentifier.MatchString(pdbName) {
+			return nil, fmt.Errorf("invalid pdb_name %q: must be a valid Oracle identifier (letters, digits, _ $ # — starting with a letter)", pdbName)
+		}
+		if pdbName != "" && cpCacheTableName == defaultCheckpointCache {
+			cpCacheTableName = "RPCN.CDC_CHECKPOINT_" + strings.ToUpper(pdbName)
+		}
+		lmCfg.PDBName = pdbName
+	}
+
 	// checkpointing
 	var checkpointLimit int
 	if checkpointLimit, err = conf.FieldInt(ociFieldCheckpointLimit); err != nil {
@@ -296,6 +322,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 			SCNCache:             scnCache,
 			SCNCacheKey:          scnCacheKey,
 			CpCacheTableName:     cpCacheTableName,
+			PDBName:              pdbName,
 			TablesFilter: &confx.RegexpFilter{
 				Include: tableIncludes,
 				Exclude: tableExcludes,
@@ -329,10 +356,11 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	return conf.WrapBatchInputExtractTracingSpanMapping("oracledb_cdc", batchInput)
 }
 
-func (o *oracleDBCDCInput) Connect(ctx context.Context) (err error) {
+func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 	var (
 		userTables []replication.UserTable
 		cachedSCN  replication.SCN
+		err        error
 	)
 	if o.db != nil {
 		_ = o.db.Close()
@@ -352,29 +380,97 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (err error) {
 		return fmt.Errorf("validating connection to oracle database: %w", err)
 	}
 
+	// isCDB tracks whether we're connected at the CDB root (vs. directly in the PDB).
+	// Used to decide whether ALTER SESSION SET CONTAINER is needed for catalog queries.
+	var isCDB bool
+	if o.cfg.PDBName != "" {
+		var conName string
+		if err = o.db.QueryRowContext(ctx, `SELECT SYS_CONTEXT('USERENV', 'CON_NAME') FROM DUAL`).Scan(&conName); err != nil {
+			return fmt.Errorf("detecting Oracle container context: %w", err)
+		}
+		o.log.Infof("Connected to Oracle container: %s", conName)
+		if strings.EqualFold(conName, "CDB$ROOT") {
+			isCDB = true
+			o.log.Infof("CDB-mode: will use ALTER SESSION SET CONTAINER = %s for catalog queries", o.cfg.PDBName)
+		} else {
+			o.log.Infof("PDB-mode: connected directly to container %s; pdb_name will be ignored for container switching", conName)
+		}
+	}
+
+	// If pdb_name is set but we are not at CDB$ROOT (PDB-direct or non-CDB), clear it from
+	// the logminer config so that no ALTER SESSION SET CONTAINER calls are attempted downstream.
+	// On non-CDB databases (CDB=NO) those calls would fail with ORA-65090.
+	if !isCDB {
+		o.lmCfg.PDBName = ""
+	}
+
+	// In CDB mode the auto-derived checkpoint table uses the common-user prefix C##RPCN.
+	// At parse time we don't yet know if we're in CDB mode, so fix up the name here.
+	cpCacheTable := o.cfg.CpCacheTableName
+	if isCDB && strings.HasPrefix(cpCacheTable, "RPCN.CDC_CHECKPOINT_") {
+		cpCacheTable = "C##" + cpCacheTable
+	}
+
 	// no cache specified so use default, internal oracle based cache
 	if o.cfg.SCNCache == "" && o.cpCache == nil {
-		c, err := newCheckpointCache(ctx, o.cfg.ConnectionString, o.cfg.CpCacheTableName, o.log)
+		c, err := newCheckpointCache(ctx, o.cfg.ConnectionString, cpCacheTable, o.log)
 		if err != nil {
 			return fmt.Errorf("initialising oracle based checkpoint cache: %w", err)
 		}
 		o.cpCache = c
 	}
 
-	if userTables, err = replication.VerifyUserTables(ctx, o.db, o.cfg.TablesFilter, o.log); err != nil {
-		return fmt.Errorf("verifying user defined tables: %w", err)
+	// For CDB mode, run VerifyUserTables on a dedicated connection switched to the PDB
+	// (ALTER SESSION SET CONTAINER + ALL_* views, no CDB_* view privileges needed).
+	switch {
+	case isCDB:
+		if err = func() error {
+			conn, err := o.db.Conn(ctx)
+			if err != nil {
+				return fmt.Errorf("getting connection for PDB '%s': %w", o.cfg.PDBName, err)
+			}
+			defer func() {
+				if err := conn.Close(); err != nil {
+					o.log.Errorf("Closing connection following table verification: %v", err)
+				}
+			}()
+
+			if _, err = conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER = "+o.cfg.PDBName); err != nil {
+				return fmt.Errorf("switching session to PDB '%s' for user table verification: %w", o.cfg.PDBName, err)
+			}
+			defer func() {
+				if _, resetErr := conn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); resetErr != nil {
+					o.log.Errorf("Failed to reset session to root container after user table verification: %v", resetErr)
+				}
+			}()
+
+			if userTables, err = replication.VerifyUserTables(ctx, conn, o.cfg.TablesFilter, o.log); err != nil {
+				return fmt.Errorf("verifying user defined tables: %w", err)
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+	default:
+		if userTables, err = replication.VerifyUserTables(ctx, o.db, o.cfg.TablesFilter, o.log); err != nil {
+			return fmt.Errorf("verifying user defined tables: %w", err)
+		}
 	}
 
-	// Pre-fetch schemas for all monitored tables. A fresh cache is created on
-	// every Connect() so reconnections always reflect the current catalog state.
-	schemas := newSchemaCache(o.log)
+	// Pre-fetch schemas for all monitored tables. A fresh cache is created on every Connect()
+	// so reconnections always reflect the current catalog state. The schemaCache handles its
+	// own container switching internally for CDB mode cache misses.
+	var pdbNameForCache string
+	if isCDB {
+		pdbNameForCache = o.cfg.PDBName
+	}
+	schemas := newSchemaCache(o.db, pdbNameForCache, o.log)
 	for _, t := range userTables {
-		if _, _, fetchErr := schemas.schemaForEvent(ctx, o.db, t, nil); fetchErr != nil {
-			o.log.Warnf("Failed to pre-fetch schema for %s.%s: %v", t.Schema, t.Name, fetchErr)
+		if _, _, err := schemas.schemaForEvent(ctx, t, nil); err != nil {
+			o.log.Warnf("Failed to pre-fetch schema for %s.%s: %v", t.Schema, t.Name, err)
 		}
 	}
 	o.publisher.schemas = schemas
-	o.publisher.db = o.db
 
 	if cachedSCN, err = o.getCachedSCN(ctx); err != nil {
 		if errors.Is(err, service.ErrKeyNotFound) {
@@ -407,7 +503,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (err error) {
 
 	// no cached SCN means we're not recovering from a restart
 	if o.cfg.StreamSnapshot && cachedSCN == replication.InvalidSCN {
-		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.publisher, o.lmCfg.LOBEnabled, o.log, o.metrics); err != nil {
+		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.publisher, o.lmCfg.LOBEnabled, pdbNameForCache, o.log, o.metrics); err != nil {
 			return fmt.Errorf("creating database snapshotter: %w", err)
 		}
 		defer func() {
@@ -438,10 +534,10 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (err error) {
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {
 			if maxSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
-				if o.stopSig.IsHardStopSignalled() {
-					o.log.Errorf("Shutting down snapshotting process: %s", err)
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					o.log.Infof("Snapshotting stopped: %s", err)
 				} else {
-					o.log.Infof("Gracefully shutting down snapshotting process: %s", err)
+					o.log.Errorf("Snapshotting failed: %s", err)
 				}
 				o.stopSig.TriggerHasStopped()
 				return

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -380,13 +380,6 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		return fmt.Errorf("detecting current container context: %w", err)
 	}
 
-	// If pdb_name is set but we are not at CDB$ROOT (PDB-direct or non-CDB), clear it from
-	// the logminer config so that no ALTER SESSION SET CONTAINER calls are attempted downstream.
-	// On non-CDB databases (CDB=NO) those calls would fail with ORA-65090.
-	if !isCDB {
-		o.lmCfg.PDBName = ""
-	}
-
 	// In CDB mode the auto-derived checkpoint table uses the common-user prefix C##RPCN.
 	// At parse time we don't yet know if we're in CDB mode, so fix up the name here.
 	cpCacheTable := o.cfg.CpCacheTableName

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -35,29 +35,135 @@ import (
 func TestIntegrationOracleDBCDCSnapshotAndStreaming(t *testing.T) {
 	integration.CheckSkip(t)
 
-	// Create tables
-	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
-	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo", "CREATE TABLE testdb.foo (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
-	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo2", "CREATE TABLE testdb.foo2 (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
-	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb2.bar", "CREATE TABLE testdb2.bar (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+	// multi-tenanted mode, allowing users access to logs across various PDBs
+	t.Run("CDB Mode", func(t *testing.T) {
+		// SetupCDBTestWithPDB starts Oracle Free, connects to CDB$ROOT for the
+		// connector, and returns a FREEPDB1 connection for test data setup.
+		cdbConnStr, pdbDB, pdbName := oracledbtest.SetupCDBTestWithPDB(t)
 
-	// Insert 3000 rows across tables for initial snapshot streaming
-	want := 3000
-	for range 1000 {
-		db.MustExec("INSERT INTO testdb.foo (id) VALUES (DEFAULT)")
-		db.MustExec("INSERT INTO testdb.foo2 (id) VALUES (DEFAULT)")
-		db.MustExec("INSERT INTO testdb2.bar (id) VALUES (DEFAULT)")
-	}
+		require.NoError(t, pdbDB.CreatePDBTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.mtfoo", "CREATE TABLE testdb.mtfoo (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+		require.NoError(t, pdbDB.CreatePDBTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb2.mtbar", "CREATE TABLE testdb2.mtbar (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
 
-	var (
-		outBatches   []string
-		outBatchesMu sync.Mutex
-		stream       *service.Stream
-		err          error
-	)
-	t.Log("Launching component...")
-	{
-		cfg := `
+		// Insert 1000 rows into each table for snapshot verification (2000 total).
+		want := 2000
+		for range 1000 {
+			pdbDB.MustExec("INSERT INTO testdb.mtfoo (id) VALUES (DEFAULT)")
+			pdbDB.MustExec("INSERT INTO testdb2.mtbar (id) VALUES (DEFAULT)")
+		}
+
+		var (
+			outBatches   []string
+			outBatchesMu sync.Mutex
+			stream       *service.Stream
+			err          error
+		)
+		t.Log("Launching component in CDB mode...")
+		{
+			cfg := `
+oracledb_cdc:
+  connection_string: %s
+  pdb_name: %s
+  stream_snapshot: true
+  max_parallel_snapshot_tables: 2
+  snapshot_max_batch_size: 10
+  logminer:
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.MTFOO", "TESTDB2.MTBAR"]
+  batching:
+    count: 500`
+
+			streamBuilder := service.NewStreamBuilder()
+			require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, cdbConnStr, pdbName)))
+			require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+
+			require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				for _, msg := range mb {
+					msgBytes, err := msg.AsBytes()
+					assert.NoError(t, err)
+					outBatches = append(outBatches, string(msgBytes))
+				}
+				return nil
+			}))
+
+			stream, err = streamBuilder.Build()
+			require.NoError(t, err)
+			license.InjectTestService(stream.Resources())
+
+			go func() {
+				if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
+			}()
+
+			t.Log("Verifying snapshot changes from FREEPDB1...")
+			var got int
+			assert.Eventually(t, func() bool {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				got = len(outBatches)
+				return got >= want
+			}, time.Minute*5, time.Second*1)
+			assert.Equalf(t, want, got, "Wanted %d snapshot messages but got %d", want, got)
+		}
+
+		t.Log("Verifying streaming changes from FREEPDB1...")
+		{
+			want := 2000
+			_, err = pdbDB.Exec(`
+BEGIN
+	FOR i IN 1..1000 LOOP
+		INSERT INTO testdb.mtfoo (id) VALUES (DEFAULT);
+		INSERT INTO testdb2.mtbar (id) VALUES (DEFAULT);
+	END LOOP;
+	COMMIT;
+END;`)
+			require.NoError(t, err)
+
+			outBatchesMu.Lock()
+			outBatches = nil
+			outBatchesMu.Unlock()
+
+			var got int
+			assert.Eventually(t, func() bool {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				got = len(outBatches)
+				return got >= want
+			}, time.Minute*5, time.Second*1)
+			assert.Equalf(t, want, got, "Wanted %d streaming messages but got %d", want, got)
+		}
+
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
+
+	// single tenant mode
+	t.Run("Non-CDB Mode", func(t *testing.T) {
+		// Create tables
+		connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo", "CREATE TABLE testdb.foo (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo2", "CREATE TABLE testdb.foo2 (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb2.bar", "CREATE TABLE testdb2.bar (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+
+		// Insert 3000 rows across tables for initial snapshot streaming
+		want := 3000
+		for range 1000 {
+			db.MustExec("INSERT INTO testdb.foo (id) VALUES (DEFAULT)")
+			db.MustExec("INSERT INTO testdb.foo2 (id) VALUES (DEFAULT)")
+			db.MustExec("INSERT INTO testdb2.bar (id) VALUES (DEFAULT)")
+		}
+
+		var (
+			outBatches   []string
+			outBatchesMu sync.Mutex
+			stream       *service.Stream
+			err          error
+		)
+		t.Log("Launching component...")
+		{
+			cfg := `
 oracledb_cdc:
   connection_string: %s
   stream_snapshot: true
@@ -71,47 +177,47 @@ oracledb_cdc:
   batching:
     count: 500`
 
-		streamBuilder := service.NewStreamBuilder()
-		require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
-		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+			streamBuilder := service.NewStreamBuilder()
+			require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
+			require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
 
-		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
-			outBatchesMu.Lock()
-			defer outBatchesMu.Unlock()
-			for _, msg := range mb {
-				msgBytes, err := msg.AsBytes()
-				assert.NoError(t, err)
-				outBatches = append(outBatches, string(msgBytes))
-			}
-			return nil
-		}))
+			require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				for _, msg := range mb {
+					msgBytes, err := msg.AsBytes()
+					assert.NoError(t, err)
+					outBatches = append(outBatches, string(msgBytes))
+				}
+				return nil
+			}))
 
-		stream, err = streamBuilder.Build()
-		require.NoError(t, err)
-		license.InjectTestService(stream.Resources())
+			stream, err = streamBuilder.Build()
+			require.NoError(t, err)
+			license.InjectTestService(stream.Resources())
 
-		go func() {
-			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-				t.Error(err)
-			}
-		}()
+			go func() {
+				if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
+			}()
 
-		t.Log("Verifying snapshot changes...")
-		var got int
-		assert.Eventually(t, func() bool {
-			outBatchesMu.Lock()
-			defer outBatchesMu.Unlock()
-			got = len(outBatches)
-			return got >= want
-		}, time.Minute*5, time.Second*1)
-		assert.Truef(t, (got == want), "Wanted %d snapshot messages but got %d", want, got)
-	}
+			t.Log("Verifying snapshot changes...")
+			var got int
+			assert.Eventually(t, func() bool {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				got = len(outBatches)
+				return got >= want
+			}, time.Minute*5, time.Second*1)
+			assert.Truef(t, (got == want), "Wanted %d snapshot messages but got %d", want, got)
+		}
 
-	t.Log("Verifying streaming changes...")
-	{
-		// Insert 3000 rows across tables for initial streaming
-		want := 3000
-		_, err := db.Exec(`
+		t.Log("Verifying streaming changes...")
+		{
+			// Insert 3000 rows across tables for initial streaming
+			want := 3000
+			_, err := db.Exec(`
 	BEGIN
 		FOR i IN 1..1000 LOOP
 			INSERT INTO testdb.foo (id) VALUES (DEFAULT);
@@ -120,23 +226,24 @@ oracledb_cdc:
 		END LOOP;
 		COMMIT;
 	END;`)
-		require.NoError(t, err)
+			require.NoError(t, err)
 
-		outBatchesMu.Lock()
-		outBatches = nil
-		outBatchesMu.Unlock()
-
-		var got int
-		assert.Eventually(t, func() bool {
 			outBatchesMu.Lock()
-			defer outBatchesMu.Unlock()
-			got = len(outBatches)
-			return got >= want
-		}, time.Minute*5, time.Second*1)
-		assert.Truef(t, (got == want), "Wanted %d streaming messages but got %d", want, got)
-	}
+			outBatches = nil
+			outBatchesMu.Unlock()
 
-	require.NoError(t, stream.StopWithin(time.Second*10))
+			var got int
+			assert.Eventually(t, func() bool {
+				outBatchesMu.Lock()
+				defer outBatchesMu.Unlock()
+				got = len(outBatches)
+				return got >= want
+			}, time.Minute*5, time.Second*1)
+			assert.Truef(t, (got == want), "Wanted %d streaming messages but got %d", want, got)
+		}
+
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
 }
 
 func TestIntegrationOracleDBCDCConcurrentSnapshot(t *testing.T) {
@@ -798,7 +905,7 @@ oracledb_cdc:
 
 		streamBuilder := service.NewStreamBuilder()
 		require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
-		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: DEBUG`))
 
 		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 			outBatchesMu.Lock()
@@ -831,7 +938,7 @@ oracledb_cdc:
 			t.Logf("Snapshot progress: %d/1 records", got)
 
 			return got == 1
-		}, time.Second*30, time.Millisecond*500)
+		}, time.Second*60, time.Millisecond*500)
 
 		require.Len(t, outBatches, 1, "Expected 1 snapshot record")
 		t.Logf("Snapshot record received: %s", outBatches[0])
@@ -985,7 +1092,7 @@ oracledb_cdc:
 
 	streamBuilder := service.NewStreamBuilder()
 	require.NoError(t, streamBuilder.AddInputYAML(cfg))
-	require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+	require.NoError(t, streamBuilder.SetLoggerYAML(`level: DEBUG`))
 	require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 		for _, msg := range mb {
 			msgChan <- msg

--- a/internal/impl/oracledb/logminer/config.go
+++ b/internal/impl/oracledb/logminer/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	MiningStrategy        MiningStrategy
 	MaxTransactionEvents  int
 	LOBEnabled            bool
+	PDBName               string
 }
 
 // NewDefaultConfig returns a Config with default values

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -663,7 +663,7 @@ func (*LogFileCollector) GetLogs(ctx context.Context, conn *sql.Conn, startSCN, 
 			WHERE A.NAME IS NOT NULL
 			AND A.ARCHIVED = 'YES'
 			AND A.STATUS = 'A'
-			AND A.NEXT_CHANGE# > :1
+			AND A.NEXT_CHANGE# >= :1
 			AND A.FIRST_CHANGE# <= :2
 			AND A.DEST_ID IN (
 				SELECT DEST_ID
@@ -671,8 +671,7 @@ func (*LogFileCollector) GetLogs(ctx context.Context, conn *sql.Conn, startSCN, 
 				WHERE STATUS='VALID' AND TYPE='LOCAL' AND ROWNUM=1
 			)
 		)
-		ORDER BY SEQ
-	`
+		ORDER BY SEQ`
 
 	rows, err := conn.QueryContext(ctx, query, startSCN, endSCN)
 	if err != nil {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -77,6 +77,10 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 		}
 		buf.WriteString(")))")
 	}
+	if cfg.PDBName != "" {
+		fmt.Fprintf(&buf, " AND SRC_CON_NAME = '%s'", strings.ReplaceAll(cfg.PDBName, "'", "''"))
+	}
+
 	logMinerQuery := fmt.Sprintf(`
 		SELECT
 			SCN,
@@ -110,25 +114,29 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 	return lm
 }
 
-// ReadChanges streams the change events from the configured SQL Server change tables.
-func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) error {
+// ReadChanges streams the change events from LogMiner via a mining cycle.
+func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) (resErr error) {
 	// Acquire a dedicated connection so that all LogMiner session operations
 	// (NLS settings, ADD_LOGFILE, START_LOGMNR, V$LOGMNR_CONTENTS queries) execute
 	// on the same underlying Oracle session. Using lm.db directly risks different
 	// calls being routed to different pool connections, breaking session-scoped state.
 	conn, err := lm.db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("acquiring dedicated LogMiner connection: %w", err)
+		return fmt.Errorf("acquiring dedicated logminer connection: %w", err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil && resErr == nil {
+			resErr = fmt.Errorf("closing connection: %w", err)
+		}
+	}()
 
 	if err := replication.ApplyNLSSettings(ctx, conn); err != nil {
-		return fmt.Errorf("applying NLS settings for LogMiner: %w", err)
+		return fmt.Errorf("applying NLS settings for logminer: %w", err)
 	}
 
 	// always find all lob columns on start up as redo logs don't include column data types.
 	// this also prevents inline lob rows being emitted as events.
-	if err := lm.loadLOBColumnTypes(ctx, conn); err != nil {
+	if err := lm.loadLOBColumnTypes(ctx); err != nil {
 		return fmt.Errorf("discovering LOB column types: %w", err)
 	}
 
@@ -139,7 +147,7 @@ func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) e
 		if lm.sessionMgr.IsActive() {
 			if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
 				if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
-					lm.log.Errorf("ending LogMiner session on exit: %v", err)
+					lm.log.Errorf("ending logminer session on exit: %v", err)
 				}
 			}
 		}
@@ -424,13 +432,41 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 	return nil
 }
 
-func (lm *LogMiner) loadLOBColumnTypes(ctx context.Context, conn *sql.Conn) error {
+func (lm *LogMiner) loadLOBColumnTypes(ctx context.Context) (resErr error) {
 	lm.lobColTypes = make(map[string]string)
 	if len(lm.tables) == 0 {
 		return nil
 	}
 
-	var qb strings.Builder
+	// ALL_TAB_COLUMNS must run in PDB context in CDB mode — the LogMiner conn is
+	// pinned to CDB$ROOT where PDB tables are not visible via ALL_TAB_COLUMNS.
+	// Use a separate connection and switch context if needed.
+	catalogConn, err := lm.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring connection for LOB column discovery: %w", err)
+	}
+	defer func() {
+		if err := catalogConn.Close(); err != nil && resErr == nil {
+			resErr = fmt.Errorf("closing catalog connection: %w", err)
+		}
+	}()
+
+	if lm.cfg.PDBName != "" {
+		// can't use parameterized queries here but we've validated on input.
+		if _, err := catalogConn.ExecContext(ctx, "ALTER SESSION SET CONTAINER = "+lm.cfg.PDBName); err != nil {
+			return fmt.Errorf("switching session to PDB %s for LOB column discovery: %w", lm.cfg.PDBName, err)
+		}
+		defer func() {
+			if _, err := catalogConn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); err != nil && resErr == nil {
+				resErr = fmt.Errorf("switching session back to root container: %w", err)
+			}
+		}()
+	}
+
+	var (
+		qb     strings.Builder
+		qbArgs []any
+	)
 	qb.WriteString(`SELECT OWNER, TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM ALL_TAB_COLUMNS WHERE DATA_TYPE IN ('CLOB', 'BLOB', 'NCLOB') AND (`)
 	for i, t := range lm.tables {
 		if i > 0 {
@@ -442,11 +478,15 @@ func (lm *LogMiner) loadLOBColumnTypes(ctx context.Context, conn *sql.Conn) erro
 	}
 	qb.WriteString(")")
 
-	rows, err := conn.QueryContext(ctx, qb.String())
+	rows, err := catalogConn.QueryContext(ctx, qb.String(), qbArgs...)
 	if err != nil {
 		return fmt.Errorf("querying LOB column types: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			lm.log.Errorf("closing rows: %v", err)
+		}
+	}()
 
 	for rows.Next() {
 		var owner, tableName, columnName, dataType string
@@ -457,6 +497,7 @@ func (lm *LogMiner) loadLOBColumnTypes(ctx context.Context, conn *sql.Conn) erro
 		k := fmt.Sprintf("%s.%s.%s", owner, tableName, columnName)
 		lm.lobColTypes[k] = dataType
 	}
+
 	return rows.Err()
 }
 
@@ -622,7 +663,7 @@ func (*LogFileCollector) GetLogs(ctx context.Context, conn *sql.Conn, startSCN, 
 			WHERE A.NAME IS NOT NULL
 			AND A.ARCHIVED = 'YES'
 			AND A.STATUS = 'A'
-			AND A.NEXT_CHANGE# >= :1
+			AND A.NEXT_CHANGE# > :1
 			AND A.FIRST_CHANGE# <= :2
 			AND A.DEST_ID IN (
 				SELECT DEST_ID

--- a/internal/impl/oracledb/multitenancy.go
+++ b/internal/impl/oracledb/multitenancy.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package oracledb
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validOracleIdentifier matches a valid unquoted Oracle identifier: starts with a
+// letter, followed by letters, digits, _, $, or #. Used to validate pdb_name at
+// parse time before it reaches SQL construction sites.
+var validOracleIdentifier = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_$#]*$`)
+
+// detectContainerContext queries Oracle to determine which container the connection
+// landed in. Returns true if connected to CDB$ROOT (CDB mode), false if connected
+// directly to a PDB or a non-CDB database. When false, pdb_name is cleared from the
+// logminer config to prevent ALTER SESSION SET CONTAINER calls that would fail with
+// ORA-65090 on non-CDB databases.
+func (o *oracleDBCDCInput) detectContainerContext(ctx context.Context) (bool, error) {
+	if o.cfg.PDBName == "" {
+		return false, nil
+	}
+
+	var conName string
+	if err := o.db.QueryRowContext(ctx, `SELECT SYS_CONTEXT('USERENV', 'CON_NAME') FROM DUAL`).Scan(&conName); err != nil {
+		return false, fmt.Errorf("detecting oracle container context: %w", err)
+	}
+	o.log.Infof("Connected to Oracle container: %s", conName)
+
+	if strings.EqualFold(conName, "CDB$ROOT") {
+		o.log.Infof("CDB-mode: will use ALTER SESSION SET CONTAINER = %s for catalog queries", o.cfg.PDBName)
+		return true, nil
+	}
+
+	o.log.Infof("PDB-mode: connected directly to container '%s'; pdb_name will be ignored for container switching", conName)
+	return false, nil
+}
+
+// cdbCheckpointTable returns the checkpoint cache table name to use in CDB mode.
+// When connected at CDB$ROOT the checkpoint table lives under the common user C##RPCN,
+// so the auto-derived name (which uses the plain RPCN prefix) needs a C## prefix.
+// At parse time we don't yet know whether the connection is CDB or PDB-direct, so this
+// fixup is applied after detectContainerContext confirms CDB mode.
+func cdbCheckpointTable(tableName string) string {
+	if strings.HasPrefix(tableName, "RPCN.CDC_CHECKPOINT_") {
+		return "C##" + tableName
+	}
+	return tableName
+}

--- a/internal/impl/oracledb/multitenancy.go
+++ b/internal/impl/oracledb/multitenancy.go
@@ -21,10 +21,9 @@ import (
 var validOracleIdentifier = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_$#]*$`)
 
 // detectContainerContext queries Oracle to determine which container the connection
-// landed in. Returns true if connected to CDB$ROOT (CDB mode), false if connected
-// directly to a PDB or a non-CDB database. When false, pdb_name is cleared from the
-// logminer config to prevent ALTER SESSION SET CONTAINER calls that would fail with
-// ORA-65090 on non-CDB databases.
+// landed in. Returns true if connected to CDB$ROOT (CDB mode). If pdb_name is set
+// but the connection is not at CDB$ROOT, an error is returned — pdb_name requires
+// connecting via the CDB root service.
 func (o *oracleDBCDCInput) detectContainerContext(ctx context.Context) (bool, error) {
 	if o.cfg.PDBName == "" {
 		return false, nil
@@ -41,8 +40,7 @@ func (o *oracleDBCDCInput) detectContainerContext(ctx context.Context) (bool, er
 		return true, nil
 	}
 
-	o.log.Infof("PDB-mode: connected directly to container '%s'; pdb_name will be ignored for container switching", conName)
-	return false, nil
+	return false, fmt.Errorf("pdb_name is set but connected to container '%s' instead of CDB$ROOT; connect via the CDB root service or remove pdb_name", conName)
 }
 
 // cdbCheckpointTable returns the checkpoint cache table name to use in CDB mode.

--- a/internal/impl/oracledb/oracledbtest/oracledbtest.go
+++ b/internal/impl/oracledb/oracledbtest/oracledbtest.go
@@ -18,15 +18,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	_ "github.com/sijms/go-ora/v2"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // Batch represents the expected test output.
@@ -183,46 +184,17 @@ func (db *TestDB) CreateTableWithSupplementalLoggingIfNotExists(ctx context.Cont
 // The container is automatically cleaned up when the test completes.
 func SetupTestWithOracleDBVersion(t *testing.T) (string, *TestDB) {
 	ctx := t.Context()
+	cfg := startContainer(t, ctx)
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "container-registry.oracle.com/database/free:latest-lite",
-			ExposedPorts: []string{"1521/tcp"},
-			Env: map[string]string{
-				"ORACLE_PWD": "YourPassword123",
-			},
-			WaitingFor: wait.ForLog("DATABASE IS READY TO USE!").WithStartupTimeout(3 * time.Minute),
-		},
-		Started: true,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(context.Background()))
-	})
-
-	port, err := container.MappedPort(ctx, "1521/tcp")
-	require.NoError(t, err)
-	host, err := container.Host(ctx)
-	require.NoError(t, err)
-
-	pdbConnectionString := fmt.Sprintf("oracle://system:YourPassword123@%s:%s/FREE", host, port.Port())
-
-	db, err := sql.Open("oracle", pdbConnectionString)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(time.Minute * 5)
-	require.NoError(t, db.PingContext(ctx))
-
-	_, err = db.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA")
+	_, err := cfg.dbConn.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA")
 	assert.NoError(t, err)
 
 	// Enable minimal supplemental logging for primary keys at CDB level
-	_, err = db.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (PRIMARY KEY) COLUMNS")
+	_, err = cfg.dbConn.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (PRIMARY KEY) COLUMNS")
 	assert.NoError(t, err)
 
 	// Enable creation of local users in CDB root (required to avoid ORA-65096)
-	_, err = db.ExecContext(ctx, "ALTER SESSION SET \"_ORACLE_SCRIPT\"=TRUE")
+	_, err = cfg.dbConn.ExecContext(ctx, "ALTER SESSION SET \"_ORACLE_SCRIPT\"=TRUE")
 	require.NoError(t, err, "Failed to enable _ORACLE_SCRIPT session parameter")
 
 	sql := `
@@ -237,7 +209,7 @@ func SetupTestWithOracleDBVersion(t *testing.T) (string, *TestDB) {
 		END IF;
 	END;`
 
-	_, err = db.ExecContext(t.Context(), sql)
+	_, err = cfg.dbConn.ExecContext(t.Context(), sql)
 	assert.NoError(t, err, "Creating 'testdb' schema for testing across multiple schemas")
 
 	sql = `
@@ -252,13 +224,10 @@ func SetupTestWithOracleDBVersion(t *testing.T) (string, *TestDB) {
 		END IF;
 	END;`
 
-	_, err = db.ExecContext(t.Context(), sql)
+	_, err = cfg.dbConn.ExecContext(t.Context(), sql)
 	assert.NoError(t, err, "Creating 'testdb2' schema for testing across multiple schemas")
 
-	t.Cleanup(func() {
-		assert.NoError(t, db.Close())
-	})
-	return pdbConnectionString, &TestDB{db, t}
+	return cfg.connStr, &TestDB{cfg.dbConn, t}
 }
 
 // ---------------------------------------------------------------------------
@@ -315,4 +284,149 @@ func ChildByName(t *testing.T, c schema.Common, name string) schema.Common {
 	}
 	t.Fatalf("child %q not found in schema %q", name, c.Name)
 	return schema.Common{}
+}
+
+// SetupCDBTestWithPDB starts an Oracle Free container and configures it for CDB
+// mode testing. It connects to CDB$ROOT (FREE service) to enable supplemental
+// logging and create the rpcn checkpoint user, then connects to FREEPDB1 to
+// create the testdb and testdb2 schema users.
+//
+// Returns:
+//   - cdbConnStr: connection string targeting CDB$ROOT (use as connection_string in the connector config with pdb_name set)
+//   - pdbDB: TestDB connected to FREEPDB1 for creating tables and inserting test data
+//   - pdbName: "FREEPDB1"
+func SetupCDBTestWithPDB(t *testing.T) (string, *TestDB, string) {
+	ctx := t.Context()
+	cfg := startContainer(t, ctx)
+
+	// Enable CDB-level supplemental logging.
+	_, err := cfg.dbConn.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA")
+	require.NoError(t, err)
+	_, err = cfg.dbConn.ExecContext(ctx, "ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (PRIMARY KEY) COLUMNS")
+	require.NoError(t, err)
+
+	// In CDB mode the connector auto-derives the checkpoint cache table as
+	// C##RPCN.CDC_CHECKPOINT_<PDBNAME>, so the common user must exist as C##RPCN.
+	// Common users require the C## prefix but do not need _ORACLE_SCRIPT workaround.
+	_, err = cfg.dbConn.ExecContext(ctx, `
+	DECLARE
+		user_exists NUMBER;
+	BEGIN
+		SELECT COUNT(*) INTO user_exists FROM dba_users WHERE username = 'C##RPCN';
+		IF user_exists = 0 THEN
+			EXECUTE IMMEDIATE 'CREATE USER "C##RPCN" IDENTIFIED BY rpcn123';
+			EXECUTE IMMEDIATE 'GRANT CONNECT, RESOURCE TO "C##RPCN"';
+			EXECUTE IMMEDIATE 'GRANT UNLIMITED TABLESPACE TO "C##RPCN"';
+		END IF;
+	END;`)
+	require.NoError(t, err)
+
+	// FREEPDB1 connection for creating PDB-local schema users and test tables.
+	// PDB-local users do not require the C## prefix or _ORACLE_SCRIPT workaround.
+	pdbName := "FREEPDB1"
+	pdbConnStr := fmt.Sprintf("oracle://system:YourPassword123@%s:%s/%s", cfg.host, cfg.port.Port(), pdbName)
+	rawPDBDB, err := sql.Open("oracle", pdbConnStr)
+	require.NoError(t, err)
+	rawPDBDB.SetMaxOpenConns(10)
+	rawPDBDB.SetMaxIdleConns(5)
+	rawPDBDB.SetConnMaxLifetime(time.Minute * 5)
+	require.NoError(t, rawPDBDB.PingContext(ctx))
+	t.Cleanup(func() { assert.NoError(t, rawPDBDB.Close()) })
+
+	for _, username := range []string{"TESTDB", "TESTDB2"} {
+		_, err = rawPDBDB.ExecContext(ctx, fmt.Sprintf(`
+		DECLARE
+			user_exists NUMBER;
+		BEGIN
+			SELECT COUNT(*) INTO user_exists FROM dba_users WHERE username = '%s';
+			IF user_exists = 0 THEN
+				EXECUTE IMMEDIATE 'CREATE USER %s IDENTIFIED BY %s123';
+				EXECUTE IMMEDIATE 'GRANT CONNECT, RESOURCE, DBA TO %s';
+				EXECUTE IMMEDIATE 'GRANT UNLIMITED TABLESPACE TO %s';
+			END IF;
+		END;`, username, strings.ToLower(username), strings.ToLower(username), username, username))
+		require.NoError(t, err, "creating %s in FREEPDB1", username)
+	}
+
+	return cfg.connStr, &TestDB{rawPDBDB, t}, pdbName
+}
+
+// CreatePDBTableWithSupplementalLoggingIfNotExists creates a table in a PDB and
+// enables supplemental logging on it. Unlike CreateTableWithSupplementalLoggingIfNotExists,
+// it skips the _ORACLE_SCRIPT workaround and rpcn user creation — those are only
+// needed in CDB$ROOT context and are handled by SetupCDBTestWithPDB.
+func (db *TestDB) CreatePDBTableWithSupplementalLoggingIfNotExists(ctx context.Context, fullTableName, createTableQuery string) error {
+	parts := strings.SplitN(fullTableName, ".", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("fullTableName must be schema.table, got %q", fullTableName)
+	}
+	schemaName := strings.ToUpper(parts[0])
+	tableName := strings.ToUpper(parts[1])
+
+	var count int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM all_tables WHERE owner = :1 AND table_name = :2",
+		schemaName, tableName).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	if _, err := db.ExecContext(ctx, createTableQuery); err != nil {
+		return err
+	}
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE %s.%s ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS",
+		schemaName, tableName))
+	return err
+}
+
+type containerCfg struct {
+	dbConn  *sql.DB
+	host    string
+	connStr string
+	port    nat.Port
+}
+
+func startContainer(t *testing.T, ctx context.Context) containerCfg {
+	t.Helper()
+
+	container, err := testcontainers.Run(ctx, "container-registry.oracle.com/database/free:latest-lite",
+		testcontainers.WithExposedPorts("1521/tcp"),
+		testcontainers.WithEnv(map[string]string{
+			"ORACLE_PWD": "YourPassword123",
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("DATABASE IS READY TO USE!").WithStartupTimeout(3*time.Minute),
+		),
+	)
+	testcontainers.CleanupContainer(t, container)
+	require.NoError(t, err)
+
+	port, err := container.MappedPort(ctx, "1521/tcp")
+	require.NoError(t, err)
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	// CDB$ROOT connection string — the connector uses this with pdb_name set.
+	connStr := fmt.Sprintf("oracle://system:YourPassword123@%s:%s/FREE", host, port.Port())
+	dbConn, err := sql.Open("oracle", connStr)
+	require.NoError(t, err)
+
+	dbConn.SetMaxOpenConns(10)
+	dbConn.SetMaxIdleConns(5)
+	dbConn.SetConnMaxLifetime(time.Minute * 5)
+	require.NoError(t, dbConn.PingContext(ctx))
+	t.Cleanup(func() {
+		assert.NoError(t, dbConn.Close())
+	})
+
+	return containerCfg{
+		dbConn:  dbConn,
+		host:    host,
+		connStr: connStr,
+		port:    port,
+	}
 }

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -25,13 +25,14 @@ import (
 // Snapshot is responsible for creating snapshots of existing tables based on the Tables
 // configuration value.
 type Snapshot struct {
-	db                      *sql.DB
+	dbPool                  *sql.DB
 	tables                  []UserTable
 	publisher               ChangePublisher
 	log                     *service.Logger
 	snapshotStatusMetric    *service.MetricGauge
 	snapshotRowsTotalMetric *service.MetricCounter
 	lobEnabled              bool
+	pdbName                 string
 }
 
 // NewSnapshot creates a new instance of Snapshot capable of snapshotting provided tables.
@@ -42,6 +43,7 @@ func NewSnapshot(ctx context.Context,
 	tables []UserTable,
 	publisher ChangePublisher,
 	lobEnabled bool,
+	pdbName string,
 	logger *service.Logger,
 	metrics *service.Metrics,
 ) (*Snapshot, error) {
@@ -56,13 +58,14 @@ func NewSnapshot(ctx context.Context,
 	}
 
 	s := &Snapshot{
-		db:                      db,
+		dbPool:                  db,
 		tables:                  tables,
 		publisher:               publisher,
-		log:                     logger,
+		lobEnabled:              lobEnabled,
+		pdbName:                 pdbName,
 		snapshotStatusMetric:    metrics.NewGauge("oracledb_cdc_snapshot_status", "table"),
 		snapshotRowsTotalMetric: metrics.NewCounter("oracledb_cdc_snapshot_rows_total", "table"),
-		lobEnabled:              lobEnabled,
+		log:                     logger,
 	}
 	return s, nil
 }
@@ -76,7 +79,7 @@ func (s *Snapshot) Prepare(ctx context.Context) (SCN, error) {
 
 	var currentSCN SCN
 	sql := `SELECT CURRENT_SCN FROM V$DATABASE`
-	if err := s.db.QueryRowContext(ctx, sql).Scan(&currentSCN); err != nil {
+	if err := s.dbPool.QueryRowContext(ctx, sql).Scan(&currentSCN); err != nil {
 		return InvalidSCN, fmt.Errorf("getting current SCN for snapshot: %w", err)
 	}
 
@@ -120,13 +123,38 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 		l := s.log.With("src_table", tableName)
 		l.Infof("Launching snapshot of table '%s'", tableName)
 
-		// BeginTx opens/reuses a dedicated connection for the given table-based transaction
-		// Oracle drivers don't support TxOptions, so we use default and set properties explicitly
-		if tx, err = s.db.BeginTx(ctx, nil); err != nil {
-			return fmt.Errorf("snapshot transaction: %w", err)
+		switch {
+		case s.pdbName != "":
+			var conn *sql.Conn
+			if conn, err = s.dbPool.Conn(ctx); err != nil {
+				return fmt.Errorf("acquiring snapshot connection: %w", err)
+			}
+			defer func() {
+				if err := conn.Close(); err != nil {
+					// snapshot has completed at this point so logging the error is sufficient.
+					s.log.Errorf("Closing snapshot connection: %v", err)
+				}
+			}()
+
+			if _, err = conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER = "+s.pdbName); err != nil {
+				return fmt.Errorf("switching session to PDB '%s' for snapshot: %w", s.pdbName, err)
+			}
+			defer func() {
+				if _, err := conn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); err != nil {
+					// logging the error is sufficient here, connection will be closed in defer call above.
+					s.log.Errorf("Switching session back to root container: %v", err)
+				}
+			}()
+			if tx, err = conn.BeginTx(ctx, nil); err != nil {
+				return fmt.Errorf("beginning snapshot transaction: %w", err)
+			}
+		default:
+			// Non-CDB mode: use db.BeginTx directly — no *Conn needed.
+			if tx, err = s.dbPool.BeginTx(ctx, nil); err != nil {
+				return fmt.Errorf("beginning snapshot transaction: %w", err)
+			}
 		}
 
-		// Set transaction to read-only mode
 		// In Oracle, READ ONLY transactions automatically provide serializable isolation
 		if _, err = tx.ExecContext(ctx, "SET TRANSACTION READ ONLY"); err != nil {
 			_ = tx.Rollback()
@@ -134,12 +162,8 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 		}
 		defer func() {
 			if err != nil {
-				// sql package automatically rolls back transaction if context is cancelled
-				if !errors.Is(err, context.Canceled) {
-					if rbErr := tx.Rollback(); rbErr != nil {
-						l.Errorf("Failed to rollback snapshot transaction: %v", rbErr)
-					}
-					return
+				if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+					l.Errorf("Failed to rollback snapshot transaction: %v", rbErr)
 				}
 			}
 		}()
@@ -155,15 +179,18 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 			lastSeenPksValues[pk] = nil
 		}
 
-		var numRowsProcessed int
+		var (
+			numRowsProcessed int
+			batchCount       int
+		)
 		for {
 			var pksForQuery map[string]any
 			if numRowsProcessed > 0 {
 				pksForQuery = lastSeenPksValues
 			}
-			batchCount, err := s.processBatch(ctx, tx, table, tablePks, pksForQuery, lastSeenPksValues, maxBatchSize, tableName)
+			batchCount, err = s.processBatch(ctx, tx, table, tablePks, pksForQuery, lastSeenPksValues, maxBatchSize, tableName)
 			if err != nil {
-				return fmt.Errorf("prcessing snapshot batch: %w", err)
+				return fmt.Errorf("processing snapshot batch: %w", err)
 			}
 
 			numRowsProcessed += batchCount
@@ -257,20 +284,20 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 }
 
 func getTablePrimaryKeys(ctx context.Context, tx *sql.Tx, table UserTable) ([]string, error) {
-	// Oracle data dictionary query for primary key columns
-	// Note: Oracle stores identifiers in uppercase by default unless created with quotes
+	// ALL_CONSTRAINTS/ALL_CONS_COLUMNS work in any container context after ALTER SESSION SET CONTAINER.
 	pkSQL := `
-		SELECT acc.column_name
-		FROM all_constraints ac
-		JOIN all_cons_columns acc
-			ON ac.constraint_name = acc.constraint_name
-			AND ac.owner = acc.owner
-		WHERE ac.constraint_type = 'P'
-			AND UPPER(ac.table_name) = UPPER(:1)
-			AND UPPER(ac.owner) = UPPER(:2)
-		ORDER BY acc.position`
+	SELECT acc.column_name
+	FROM all_constraints ac
+	JOIN all_cons_columns acc
+		ON ac.constraint_name = acc.constraint_name
+		AND ac.owner = acc.owner
+	WHERE ac.constraint_type = 'P'
+		AND UPPER(ac.table_name) = UPPER(:1)
+		AND UPPER(ac.owner) = UPPER(:2)
+	ORDER BY acc.position`
+	pkArgs := []any{table.Name, table.Schema}
 
-	rows, err := tx.QueryContext(ctx, pkSQL, table.Name, table.Schema)
+	rows, err := tx.QueryContext(ctx, pkSQL, pkArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("get primary key: %w", err)
 	}
@@ -353,8 +380,8 @@ func querySnapshotTable(ctx context.Context, tx *sql.Tx, table UserTable, pk []s
 // Close safely closes all open connections opened for the snapshotting process.
 // It should be called after a non-recoverale error or once the snapshot process has completed.
 func (s *Snapshot) Close() error {
-	if s.db != nil {
-		if err := s.db.Close(); err != nil {
+	if s.dbPool != nil {
+		if err := s.dbPool.Close(); err != nil {
 			return fmt.Errorf("closing database connection: %w", err)
 		}
 	}

--- a/internal/impl/oracledb/replication/snapshot_test.go
+++ b/internal/impl/oracledb/replication/snapshot_test.go
@@ -70,7 +70,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "SINGLE_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 
@@ -99,7 +99,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "COMPOSITE_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 
@@ -130,7 +130,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "THREE_COL_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 

--- a/internal/impl/oracledb/replication/stream.go
+++ b/internal/impl/oracledb/replication/stream.go
@@ -46,7 +46,12 @@ func (t *UserTable) FullName() string {
 // validating supplemental logging is enabled. The caller is responsible for switching the session
 // to the correct container before calling (e.g. ALTER SESSION SET CONTAINER = <pdb>) when in
 // CDB mode; this function uses ALL_TABLES and ALL_LOG_GROUPS which work in any container context.
-func VerifyUserTables(ctx context.Context, db DBQuerier, tableFilter *confx.RegexpFilter, log *service.Logger) ([]UserTable, error) {
+func VerifyUserTables(
+	ctx context.Context,
+	db DBQuerier,
+	tableFilter *confx.RegexpFilter,
+	log *service.Logger,
+) ([]UserTable, error) {
 	tableQuery := `
 		SELECT OWNER AS SchemeName, TABLE_NAME AS TableName
 		FROM ALL_TABLES

--- a/internal/impl/oracledb/replication/stream.go
+++ b/internal/impl/oracledb/replication/stream.go
@@ -18,6 +18,13 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/confx"
 )
 
+// DBQuerier is satisfied by both *sql.DB and *sql.Conn, allowing catalog
+// queries to run on either a pool or a dedicated container-switched connection.
+type DBQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 // ChangePublisher is responsible for handling and processing of a replication.MessageEvent.
 type ChangePublisher interface {
 	Publish(ctx context.Context, msg *MessageEvent) error
@@ -35,17 +42,21 @@ func (t *UserTable) FullName() string {
 	return fmt.Sprintf("%s.%s", t.Schema, t.Name)
 }
 
-// VerifyUserTables verifies underlying user tables based on supplied
-// include and exclude filters, validating change tracking is enabled.
-func VerifyUserTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, log *service.Logger) ([]UserTable, error) {
-	sql := `
-	SELECT OWNER AS SchemeName, TABLE_NAME AS TableName
-	FROM DBA_TABLES
-	WHERE OWNER NOT IN ('SYS', 'SYSTEM', 'OUTLN', 'DBSNMP', 'APPQOSSYS', 'DBSFWUSER', 'GGSYS', 'ANONYMOUS', 'CTXSYS', 'DVSYS', 'DVF', 'GSMADMIN_INTERNAL', 'LBACSYS', 'MDSYS', 'OJVMSYS', 'OLAPSYS', 'ORDDATA', 'ORDSYS', 'WMSYS', 'XDB')
-	ORDER BY OWNER, TABLE_NAME`
-	rows, err := db.QueryContext(ctx, sql)
+// VerifyUserTables verifies underlying user tables based on supplied include and exclude filters,
+// validating supplemental logging is enabled. The caller is responsible for switching the session
+// to the correct container before calling (e.g. ALTER SESSION SET CONTAINER = <pdb>) when in
+// CDB mode; this function uses ALL_TABLES and ALL_LOG_GROUPS which work in any container context.
+func VerifyUserTables(ctx context.Context, db DBQuerier, tableFilter *confx.RegexpFilter, log *service.Logger) ([]UserTable, error) {
+	tableQuery := `
+		SELECT OWNER AS SchemeName, TABLE_NAME AS TableName
+		FROM ALL_TABLES
+		WHERE OWNER NOT IN ('SYS', 'SYSTEM', 'OUTLN', 'DBSNMP', 'APPQOSSYS', 'DBSFWUSER', 'GGSYS', 'ANONYMOUS', 'CTXSYS', 'DVSYS', 'DVF', 'GSMADMIN_INTERNAL', 'LBACSYS', 'MDSYS', 'OJVMSYS', 'OLAPSYS', 'ORDDATA', 'ORDSYS', 'WMSYS', 'XDB')
+		AND OWNER NOT LIKE 'C##%'
+		ORDER BY OWNER, TABLE_NAME`
+
+	rows, err := db.QueryContext(ctx, tableQuery)
 	if err != nil {
-		return nil, fmt.Errorf("listing all user tables from 'DBA_TABLES' for verification: %w", err)
+		return nil, fmt.Errorf("listing all user tables from 'ALL_TABLES' for verification: %w", err)
 	}
 	defer rows.Close()
 
@@ -53,14 +64,14 @@ func VerifyUserTables(ctx context.Context, db *sql.DB, tableFilter *confx.Regexp
 	for rows.Next() {
 		var ut UserTable
 		if err := rows.Scan(&ut.Schema, &ut.Name); err != nil {
-			return nil, fmt.Errorf("scanning 'DBA_TABLES' row for user tables: %w", err)
+			return nil, fmt.Errorf("scanning 'ALL_TABLES' row for user tables: %w", err)
 		}
 		if tableFilter.Matches(fmt.Sprintf("%s.%s", ut.Schema, ut.Name)) {
 			userTables = append(userTables, ut)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating through 'DBA_TABLES' for user tables: %w", err)
+		return nil, fmt.Errorf("iterating through 'ALL_TABLES' for user tables: %w", err)
 	}
 
 	if len(userTables) == 0 {
@@ -70,7 +81,7 @@ func VerifyUserTables(ctx context.Context, db *sql.DB, tableFilter *confx.Regexp
 	// perform a simple check that the tables are tracked, we could verify what columns are tracked but a simple check feels sufficient.
 	for i, tbl := range userTables {
 		var logGroupsCnt int
-		if err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ALL_LOG_GROUPS WHERE OWNER = :1 AND TABLE_NAME = :2`, tbl.Schema, tbl.Name).Scan(&logGroupsCnt); err != nil {
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ALL_LOG_GROUPS WHERE OWNER = :1 AND TABLE_NAME = :2`, tbl.Schema, tbl.Name).Scan(&logGroupsCnt); err != nil {
 			return nil, fmt.Errorf("querying log groups for table '%s': %w", tbl.FullName(), err)
 		}
 		if logGroupsCnt == 0 {

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -75,9 +75,16 @@ func isNumberType(dataType string) bool {
 // schemaCache holds per-table schema entries and performs addition-only drift
 // detection: if an event references a column not in the cached schema, the
 // cache is refreshed from ALL_TAB_COLUMNS.
+//
+// In CDB mode (pdbName != ""), each cache-miss refresh switches a dedicated
+// *sql.Conn to the PDB context (ALTER SESSION SET CONTAINER) before running the
+// catalog query, then switches back. Avoids both CDB_* view privilege issues and
+// separate-connection login issues.
 type schemaCache struct {
 	mu      sync.Mutex
 	schemas map[string]*cachedSchema
+	db      *sql.DB
+	pdbName string // non-empty in CDB mode; triggers ALTER SESSION SET CONTAINER per refresh
 	log     *service.Logger
 }
 
@@ -88,24 +95,32 @@ type cachedSchema struct {
 	numericCols map[string]struct{}          // NUMBER columns that map to String (need json.Number coercion)
 }
 
-func newSchemaCache(log *service.Logger) *schemaCache {
+// newSchemaCache creates a schemaCache. db is used for on-demand cache-miss refreshes.
+// pdbName is non-empty when connected to CDB$ROOT and monitoring a specific PDB; the cache
+// will switch the session to that PDB for each catalog query.
+func newSchemaCache(db *sql.DB, pdbName string, log *service.Logger) *schemaCache {
 	return &schemaCache{
 		schemas: make(map[string]*cachedSchema),
+		db:      db,
+		pdbName: pdbName,
 		log:     log,
 	}
 }
 
-// fetchTableSchema queries ALL_TAB_COLUMNS for the given table and returns a
-// cachedSchema with the column metadata encoded as a schema.Common.
-func fetchTableSchema(ctx context.Context, db *sql.DB, table replication.UserTable) (*cachedSchema, error) {
-	const query = `SELECT COLUMN_NAME, DATA_TYPE, DATA_PRECISION, DATA_SCALE
+// fetchTableSchema queries ALL_TAB_COLUMNS for the given table.
+// The caller is responsible for ensuring the db/conn is in the correct container context.
+func fetchTableSchema(ctx context.Context, db interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}, table replication.UserTable,
+) (*cachedSchema, error) {
+	query := `SELECT COLUMN_NAME, DATA_TYPE, DATA_PRECISION, DATA_SCALE
 FROM ALL_TAB_COLUMNS
 WHERE OWNER = :1 AND TABLE_NAME = :2
 ORDER BY COLUMN_ID`
 
 	rows, err := db.QueryContext(ctx, query, table.Schema, table.Name)
 	if err != nil {
-		return nil, fmt.Errorf("querying ALL_TAB_COLUMNS for %s.%s: %w", table.Schema, table.Name, err)
+		return nil, fmt.Errorf("querying column metadata for %s.%s: %w", table.Schema, table.Name, err)
 	}
 	defer rows.Close()
 
@@ -176,7 +191,7 @@ type columnTypeInfo struct {
 	numericCols map[string]struct{}
 }
 
-func (sc *schemaCache) schemaForEvent(ctx context.Context, db *sql.DB, table replication.UserTable, eventKeys []string) (any, *columnTypeInfo, error) {
+func (sc *schemaCache) schemaForEvent(ctx context.Context, table replication.UserTable, eventKeys []string) (any, *columnTypeInfo, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
@@ -196,7 +211,36 @@ func (sc *schemaCache) schemaForEvent(ctx context.Context, db *sql.DB, table rep
 		sc.log.Debugf("Schema drift detected for %s: refreshing after unknown column in event", tableKey)
 	}
 
-	fresh, err := fetchTableSchema(ctx, db, table)
+	var fresh *cachedSchema
+	var err error
+	if sc.pdbName != "" {
+		// CDB mode: get a dedicated connection and switch to the PDB container
+		// before querying ALL_TAB_COLUMNS.
+		conn, connErr := sc.db.Conn(ctx)
+		if connErr != nil {
+			if existing, exists := sc.schemas[tableKey]; exists {
+				sc.log.Warnf("Failed to get connection for schema refresh of %s, using cached version: %v", tableKey, connErr)
+				return existing.schema, &columnTypeInfo{existing.colTypes, existing.numericCols}, connErr
+			}
+			return nil, nil, connErr
+		}
+		defer conn.Close()
+		if _, execErr := conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER = "+sc.pdbName); execErr != nil {
+			if existing, exists := sc.schemas[tableKey]; exists {
+				sc.log.Warnf("Failed to switch to PDB %s for schema refresh of %s, using cached version: %v", sc.pdbName, tableKey, execErr)
+				return existing.schema, &columnTypeInfo{existing.colTypes, existing.numericCols}, execErr
+			}
+			return nil, nil, execErr
+		}
+		fresh, err = fetchTableSchema(ctx, conn, table)
+		// Must reset to CDB$ROOT before the connection returns to the pool — leaving it
+		// in PDB context would cause subsequent pool users to run in the wrong container.
+		if _, resetErr := conn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); resetErr != nil {
+			return nil, nil, fmt.Errorf("switching session back to root container: %w", resetErr)
+		}
+	} else {
+		fresh, err = fetchTableSchema(ctx, sc.db, table)
+	}
 	if err != nil {
 		if existing, exists := sc.schemas[tableKey]; exists {
 			sc.log.Warnf("Failed to refresh schema for %s, using cached version: %v", tableKey, err)

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -211,8 +211,10 @@ func (sc *schemaCache) schemaForEvent(ctx context.Context, table replication.Use
 		sc.log.Debugf("Schema drift detected for %s: refreshing after unknown column in event", tableKey)
 	}
 
-	var fresh *cachedSchema
-	var err error
+	var (
+		fresh *cachedSchema
+		err   error
+	)
 	if sc.pdbName != "" {
 		// CDB mode: get a dedicated connection and switch to the PDB container
 		// before querying ALL_TAB_COLUMNS.
@@ -232,12 +234,12 @@ func (sc *schemaCache) schemaForEvent(ctx context.Context, table replication.Use
 			}
 			return nil, nil, execErr
 		}
+		defer func() {
+			if _, resetErr := conn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); resetErr != nil {
+				sc.log.Errorf("Failed to reset session back to CDB$ROOT after schema refresh: %v", resetErr)
+			}
+		}()
 		fresh, err = fetchTableSchema(ctx, conn, table)
-		// Must reset to CDB$ROOT before the connection returns to the pool — leaving it
-		// in PDB context would cause subsequent pool users to run in the wrong container.
-		if _, resetErr := conn.ExecContext(context.Background(), "ALTER SESSION SET CONTAINER = CDB$ROOT"); resetErr != nil {
-			return nil, nil, fmt.Errorf("switching session back to root container: %w", resetErr)
-		}
 	} else {
 		fresh, err = fetchTableSchema(ctx, sc.db, table)
 	}

--- a/internal/impl/oracledb/schema_test.go
+++ b/internal/impl/oracledb/schema_test.go
@@ -28,7 +28,7 @@ import (
 
 func testSchemaCache(t *testing.T) *schemaCache {
 	t.Helper()
-	return newSchemaCache(service.NewLoggerFromSlog(slog.Default()))
+	return newSchemaCache(nil, "", service.NewLoggerFromSlog(slog.Default()))
 }
 
 func parseSchema(t *testing.T, s any) schema.Common {
@@ -54,7 +54,7 @@ func childByName(t *testing.T, c schema.Common, name string) schema.Common {
 func seedCache(t *testing.T, sc *schemaCache, schemaName, tableName string, meta []replication.ColumnMeta) any {
 	t.Helper()
 	sc.seedFromColumnMeta(replication.UserTable{Schema: schemaName, Name: tableName}, meta)
-	s, _, err := sc.schemaForEvent(context.Background(), nil, replication.UserTable{Schema: schemaName, Name: tableName}, nil)
+	s, _, err := sc.schemaForEvent(context.Background(), replication.UserTable{Schema: schemaName, Name: tableName}, nil)
 	require.NoError(t, err)
 	return s
 }
@@ -183,7 +183,7 @@ func TestSchemaCacheHit(t *testing.T) {
 
 	// All known subsets are cache hits.
 	for _, keys := range [][]string{{"A", "B", "C"}, {"A", "B"}, {"A"}, {}, nil} {
-		got, _, err := sc.schemaForEvent(ctx, nil, tbl, keys)
+		got, _, err := sc.schemaForEvent(ctx, tbl, keys)
 		require.NoError(t, err)
 		assert.Equal(t, s, got, "expected cache hit for keys %v", keys)
 	}
@@ -201,7 +201,7 @@ func TestSchemaCacheSubsetKeysNoRefresh(t *testing.T) {
 
 	// [A, B] is a subset of [A, B, C] — should not trigger a re-fetch.
 	// Passing nil db proves no DB call is made (would panic on nil).
-	got, _, err := sc.schemaForEvent(context.Background(), nil, tbl, []string{"A", "B"})
+	got, _, err := sc.schemaForEvent(context.Background(), tbl, []string{"A", "B"})
 	require.NoError(t, err)
 	require.NotNil(t, got)
 }
@@ -213,7 +213,7 @@ func TestSchemaCacheEmptyKeysNoRefresh(t *testing.T) {
 	})
 
 	// Empty keys (DELETE event) — always a cache hit.
-	got, _, err := sc.schemaForEvent(context.Background(), nil, replication.UserTable{Schema: "S", Name: "T"}, nil)
+	got, _, err := sc.schemaForEvent(context.Background(), replication.UserTable{Schema: "S", Name: "T"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 }
@@ -253,7 +253,7 @@ func TestSchemaCacheSeedFromColumnMetaOverride(t *testing.T) {
 		{Name: "A", TypeName: "VARCHAR2"},
 		{Name: "B", TypeName: "NUMBER", Precision: 5, Scale: 0, HasDecimalSize: true},
 	})
-	s1, _, err := sc.schemaForEvent(context.Background(), nil, tbl, nil)
+	s1, _, err := sc.schemaForEvent(context.Background(), tbl, nil)
 	require.NoError(t, err)
 	c1 := parseSchema(t, s1)
 	require.Len(t, c1.Children, 2)
@@ -264,7 +264,7 @@ func TestSchemaCacheSeedFromColumnMetaOverride(t *testing.T) {
 		{Name: "B", TypeName: "NUMBER", Precision: 5, Scale: 0, HasDecimalSize: true},
 		{Name: "C", TypeName: "DATE"},
 	})
-	s2, _, err := sc.schemaForEvent(context.Background(), nil, tbl, nil)
+	s2, _, err := sc.schemaForEvent(context.Background(), tbl, nil)
 	require.NoError(t, err)
 	c2 := parseSchema(t, s2)
 	require.Len(t, c2.Children, 3)
@@ -445,7 +445,7 @@ func TestCoerceStreamingValuesColumnTypeInfoFromCache(t *testing.T) {
 		{Name: "SCORE", TypeName: "BINARY_FLOAT"},
 	})
 
-	_, typeInfo, err := sc.schemaForEvent(t.Context(), nil, tbl, nil)
+	_, typeInfo, err := sc.schemaForEvent(t.Context(), tbl, nil)
 	require.NoError(t, err)
 	require.NotNil(t, typeInfo)
 


### PR DESCRIPTION
This change adds CDB mode, allowing the connector to connect to the CDB root container (CDB$ROOT) and monitor change events for a specific pluggable database (PDB) via the new `pdb_name` config field. Connecting at the CDB root is required because Oracle's LogMiner runs at the CDB level and reads redo logs across all containers (tenants).

Includes a test that verifies snapshot/streaming in multi-tenant mode.

<img width="1412" height="584" alt="image" src="https://github.com/user-attachments/assets/8a3196c6-4343-42d9-b733-14bf251801fa" />
