### PR TITLE
confluent: bump twmb/avro to v1.6.0, generalize avro reference hydration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	github.com/timeplus-io/proton-go-driver/v2 v2.1.4
 	github.com/tmc/langchaingo v0.1.14
 	github.com/trinodb/trino-go-client v0.333.0
-	github.com/twmb/avro v1.3.4
+	github.com/twmb/avro v1.7.1
 	github.com/twmb/franz-go v1.20.7
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/timeplus-io/proton-go-driver/v2 v2.1.4
 	github.com/tmc/langchaingo v0.1.14
 	github.com/trinodb/trino-go-client v0.333.0
-	github.com/twmb/avro v1.3.4
+	github.com/twmb/avro v1.6.0
 	github.com/twmb/franz-go v1.20.7
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1751,8 +1751,8 @@ github.com/trivago/grok v1.0.0/go.mod h1:9t59xLInhrncYq9a3J7488NgiBZi5y5yC7bss+w
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twmb/avro v1.3.4 h1:4tTV207HOUHKTdAMv6fGPyqgwmGfMLUfnFg5R4cfIX0=
-github.com/twmb/avro v1.3.4/go.mod h1:TUQS96Ptl8tDRyK0Jw91FXIVCoPKz4sXxvUSShiG5FA=
+github.com/twmb/avro v1.7.1 h1:eS4n6zGNWXJhDKkGaD9yuCD8Nd1RUI8/svjp0/8IUcE=
+github.com/twmb/avro v1.7.1/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.20.7 h1:P4MGSXJjjAPP3NRGPCks/Lrq+j+twWMVl1qYCVgNmWY=
 github.com/twmb/franz-go v1.20.7/go.mod h1:0bRX9HZVaoueqFWhPZNi2ODnJL7DNa6mK0HeCrC2bNU=
 github.com/twmb/franz-go/pkg/kadm v1.17.2 h1:g5f1sAxnTkYC6G96pV5u715HWhxd66hWaDZUAQ8xHY8=

--- a/go.sum
+++ b/go.sum
@@ -1737,8 +1737,8 @@ github.com/trivago/grok v1.0.0/go.mod h1:9t59xLInhrncYq9a3J7488NgiBZi5y5yC7bss+w
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twmb/avro v1.3.4 h1:4tTV207HOUHKTdAMv6fGPyqgwmGfMLUfnFg5R4cfIX0=
-github.com/twmb/avro v1.3.4/go.mod h1:TUQS96Ptl8tDRyK0Jw91FXIVCoPKz4sXxvUSShiG5FA=
+github.com/twmb/avro v1.6.0 h1:9oUok2HAI+VJ8XpkVppV+e7Pz7AAcuq2r98gGCYUwGM=
+github.com/twmb/avro v1.6.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.20.7 h1:P4MGSXJjjAPP3NRGPCks/Lrq+j+twWMVl1qYCVgNmWY=
 github.com/twmb/franz-go v1.20.7/go.mod h1:0bRX9HZVaoueqFWhPZNi2ODnJL7DNa6mK0HeCrC2bNU=
 github.com/twmb/franz-go/pkg/kadm v1.17.2 h1:g5f1sAxnTkYC6G96pV5u715HWhxd66hWaDZUAQ8xHY8=

--- a/internal/impl/confluent/avro_walker.go
+++ b/internal/impl/confluent/avro_walker.go
@@ -15,6 +15,7 @@
 package confluent
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/twmb/avro"
@@ -52,6 +53,19 @@ func preserveLogicalTypeOpts() []avro.SchemaOpt {
 					return nil, avro.ErrSkipCustomType
 				}
 				return avro.DurationFromBytes(b).String(), nil
+			},
+		},
+		// Decimal: raw type is []byte. Convert to json.Number for the
+		// SetStructuredMut path (json.Marshal can't handle *big.Rat).
+		avro.CustomType{
+			LogicalType: "decimal",
+			Decode: func(v any, node *avro.SchemaNode) (any, error) {
+				b, ok := v.([]byte)
+				if !ok {
+					return nil, avro.ErrSkipCustomType
+				}
+				r := avro.RatFromBytes(b, node.Scale)
+				return json.Number(r.FloatString(node.Scale)), nil
 			},
 		},
 	}

--- a/internal/impl/confluent/serde_avro.go
+++ b/internal/impl/confluent/serde_avro.go
@@ -48,39 +48,117 @@ func resolveAvroReferences(ctx context.Context, client *sr.Client, mapping *blob
 		return mapSchema(schema)
 	}
 
-	refsMap := map[string]string{}
-	if err := client.WalkReferences(ctx, schema.References, func(_ context.Context, name string, schema franz_sr.Schema) error {
-		s, err := mapSchema(schema)
-		refsMap[name] = s
-		return err
+	refsMap := map[string]json.RawMessage{}
+	if err := client.WalkReferences(ctx, schema.References, func(_ context.Context, name string, refSchema franz_sr.Schema) error {
+		s, err := mapSchema(refSchema)
+		if err != nil {
+			return err
+		}
+		refsMap[name] = json.RawMessage(s)
+		return nil
 	}); err != nil {
-		return "", nil
+		return "", fmt.Errorf("walking avro schema references: %w", err)
 	}
 
 	root, err := mapSchema(schema)
 	if err != nil {
 		return "", err
 	}
-	schemaDry := []string{}
-	if err := json.Unmarshal([]byte(root), &schemaDry); err != nil {
-		return "", fmt.Errorf("parsing root schema as enum: %w", err)
+	var rootNode any
+	if err := json.Unmarshal([]byte(root), &rootNode); err != nil {
+		return "", fmt.Errorf("unmarshaling root avro schema: %w", err)
 	}
-
-	schemaHydrated := make([]json.RawMessage, len(schemaDry))
-	for i, name := range schemaDry {
-		def, exists := refsMap[name]
-		if !exists {
-			return "", fmt.Errorf("referenced type '%v' was not found in references", name)
-		}
-		schemaHydrated[i] = []byte(def)
-	}
-
-	schemaHydratedBytes, err := json.Marshal(schemaHydrated)
+	hydrated, err := hydrateAvroRefs(rootNode, refsMap, make(map[string]bool))
 	if err != nil {
-		return "", fmt.Errorf("marshalling hydrated schema: %w", err)
+		return "", fmt.Errorf("hydrating avro references: %w", err)
 	}
+	out, err := json.Marshal(hydrated)
+	if err != nil {
+		return "", fmt.Errorf("marshaling hydrated avro schema: %w", err)
+	}
+	return string(out), nil
+}
 
-	return string(schemaHydratedBytes), nil
+// hydrateAvroRefs recursively replaces named type references with their
+// inlined definitions throughout an Avro schema JSON tree. It walks only
+// type positions — record fields' type values, array items, map values,
+// and union branches — so name/namespace/doc/aliases/symbols strings that
+// happen to match a reference name are left alone.
+//
+// Each named type is inlined at most once per walk; subsequent references
+// to the same name are left as string name references so Avro's
+// one-definition-many-references semantics are preserved. This correctly
+// handles self-referential types, mutually recursive subjects, and shared
+// subgraphs.
+func hydrateAvroRefs(node any, refs map[string]json.RawMessage, inlined map[string]bool) (any, error) {
+	switch v := node.(type) {
+	case string:
+		if inlined[v] {
+			return v, nil
+		}
+		def, ok := refs[v]
+		if !ok {
+			return v, nil
+		}
+		inlined[v] = true
+		var parsed any
+		if err := json.Unmarshal(def, &parsed); err != nil {
+			return nil, fmt.Errorf("unmarshaling avro reference %q: %w", v, err)
+		}
+		return hydrateAvroRefs(parsed, refs, inlined)
+	case []any:
+		for i, item := range v {
+			h, err := hydrateAvroRefs(item, refs, inlined)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = h
+		}
+		return v, nil
+	case map[string]any:
+		typ, _ := v["type"].(string)
+		switch typ {
+		case "record", "error":
+			fields, ok := v["fields"].([]any)
+			if !ok {
+				return v, nil
+			}
+			for i, f := range fields {
+				fm, ok := f.(map[string]any)
+				if !ok {
+					continue
+				}
+				if ft, ok := fm["type"]; ok {
+					h, err := hydrateAvroRefs(ft, refs, inlined)
+					if err != nil {
+						return nil, err
+					}
+					fm["type"] = h
+				}
+				fields[i] = fm
+			}
+			v["fields"] = fields
+		case "array":
+			if items, ok := v["items"]; ok {
+				h, err := hydrateAvroRefs(items, refs, inlined)
+				if err != nil {
+					return nil, err
+				}
+				v["items"] = h
+			}
+		case "map":
+			if values, ok := v["values"]; ok {
+				h, err := hydrateAvroRefs(values, refs, inlined)
+				if err != nil {
+					return nil, err
+				}
+				v["values"] = h
+			}
+		}
+		return v, nil
+	default:
+		return v, nil
+	}
 }
 
 func (s *schemaRegistryEncoder) getAvroEncoder(ctx context.Context, schemaRef franz_sr.Schema) (schemaEncoder, error) {

--- a/internal/impl/confluent/serde_avro_test.go
+++ b/internal/impl/confluent/serde_avro_test.go
@@ -438,3 +438,160 @@ func TestAvroSchemaExtractionLameUnions(t *testing.T) {
 		}, schema)
 	}
 }
+
+func TestHydrateAvroRefs(t *testing.T) {
+	parseRef := func(t *testing.T, s string) json.RawMessage {
+		t.Helper()
+		return json.RawMessage(s)
+	}
+
+	run := func(t *testing.T, root string, refs map[string]json.RawMessage) string {
+		t.Helper()
+		var node any
+		require.NoError(t, json.Unmarshal([]byte(root), &node))
+		hydrated, err := hydrateAvroRefs(node, refs, make(map[string]bool))
+		require.NoError(t, err)
+		out, err := json.Marshal(hydrated)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	t.Run("no references leaves tree untouched", func(t *testing.T) {
+		const schema = `{"type":"record","name":"R","fields":[{"name":"x","type":"int"}]}`
+		got := run(t, schema, nil)
+		assert.JSONEq(t, schema, got)
+	})
+
+	t.Run("union of reference names at root (legacy Confluent pattern)", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Foo": parseRef(t, `{"type":"record","name":"Foo","namespace":"com.example","fields":[{"name":"x","type":"int"}]}`),
+			"com.example.Bar": parseRef(t, `{"type":"record","name":"Bar","namespace":"com.example","fields":[{"name":"y","type":"string"}]}`),
+		}
+		got := run(t, `["com.example.Foo","com.example.Bar"]`, refs)
+		assert.JSONEq(t, `[
+			{"type":"record","name":"Foo","namespace":"com.example","fields":[{"name":"x","type":"int"}]},
+			{"type":"record","name":"Bar","namespace":"com.example","fields":[{"name":"y","type":"string"}]}
+		]`, got)
+	})
+
+	t.Run("record field type is a reference", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Inner": parseRef(t, `{"type":"record","name":"Inner","namespace":"com.example","fields":[{"name":"v","type":"long"}]}`),
+		}
+		got := run(t, `{"type":"record","name":"Outer","fields":[{"name":"inner","type":"com.example.Inner"}]}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"Outer",
+			"fields":[{"name":"inner","type":{"type":"record","name":"Inner","namespace":"com.example","fields":[{"name":"v","type":"long"}]}}]
+		}`, got)
+	})
+
+	t.Run("array items is a reference", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Item": parseRef(t, `{"type":"record","name":"Item","namespace":"com.example","fields":[{"name":"v","type":"int"}]}`),
+		}
+		got := run(t, `{"type":"array","items":"com.example.Item"}`, refs)
+		assert.JSONEq(t, `{"type":"array","items":{"type":"record","name":"Item","namespace":"com.example","fields":[{"name":"v","type":"int"}]}}`, got)
+	})
+
+	t.Run("map values is a reference", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.V": parseRef(t, `{"type":"record","name":"V","namespace":"com.example","fields":[{"name":"x","type":"int"}]}`),
+		}
+		got := run(t, `{"type":"map","values":"com.example.V"}`, refs)
+		assert.JSONEq(t, `{"type":"map","values":{"type":"record","name":"V","namespace":"com.example","fields":[{"name":"x","type":"int"}]}}`, got)
+	})
+
+	t.Run("union branch is a reference", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Some": parseRef(t, `{"type":"record","name":"Some","namespace":"com.example","fields":[{"name":"v","type":"int"}]}`),
+		}
+		got := run(t, `{"type":"record","name":"R","fields":[{"name":"maybe","type":["null","com.example.Some"]}]}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"R",
+			"fields":[{"name":"maybe","type":["null",{"type":"record","name":"Some","namespace":"com.example","fields":[{"name":"v","type":"int"}]}]}]
+		}`, got)
+	})
+
+	t.Run("transitive references are inlined", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Foo": parseRef(t, `{"type":"record","name":"Foo","namespace":"com.example","fields":[{"name":"bar","type":"com.example.Bar"}]}`),
+			"com.example.Bar": parseRef(t, `{"type":"record","name":"Bar","namespace":"com.example","fields":[{"name":"v","type":"int"}]}`),
+		}
+		got := run(t, `{"type":"record","name":"Root","fields":[{"name":"foo","type":"com.example.Foo"}]}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"Root",
+			"fields":[{"name":"foo","type":{
+				"type":"record","name":"Foo","namespace":"com.example",
+				"fields":[{"name":"bar","type":{
+					"type":"record","name":"Bar","namespace":"com.example",
+					"fields":[{"name":"v","type":"int"}]
+				}}]
+			}}]
+		}`, got)
+	})
+
+	t.Run("shared subgraph inlines once then uses name ref", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Shared": parseRef(t, `{"type":"record","name":"Shared","namespace":"com.example","fields":[{"name":"v","type":"int"}]}`),
+		}
+		got := run(t, `{"type":"record","name":"R","fields":[
+			{"name":"a","type":"com.example.Shared"},
+			{"name":"b","type":"com.example.Shared"}
+		]}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"R",
+			"fields":[
+				{"name":"a","type":{"type":"record","name":"Shared","namespace":"com.example","fields":[{"name":"v","type":"int"}]}},
+				{"name":"b","type":"com.example.Shared"}
+			]
+		}`, got)
+	})
+
+	t.Run("self-referential ref leaves inner self as name reference", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"com.example.Node": parseRef(t, `{"type":"record","name":"Node","namespace":"com.example","fields":[{"name":"value","type":"int"},{"name":"next","type":["null","com.example.Node"]}]}`),
+		}
+		got := run(t, `{"type":"record","name":"Root","fields":[{"name":"head","type":"com.example.Node"}]}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"Root",
+			"fields":[{"name":"head","type":{
+				"type":"record","name":"Node","namespace":"com.example",
+				"fields":[
+					{"name":"value","type":"int"},
+					{"name":"next","type":["null","com.example.Node"]}
+				]
+			}}]
+		}`, got)
+	})
+
+	t.Run("enum symbols and record aliases matching ref names are not substituted", func(t *testing.T) {
+		refs := map[string]json.RawMessage{
+			"Foo": parseRef(t, `{"type":"record","name":"Foo","fields":[{"name":"v","type":"int"}]}`),
+		}
+		got := run(t, `{
+			"type":"record","name":"R","aliases":["Foo"],
+			"fields":[
+				{"name":"Foo","type":"int"},
+				{"name":"e","type":{"type":"enum","name":"E","symbols":["Foo","Bar"]}}
+			]
+		}`, refs)
+		assert.JSONEq(t, `{
+			"type":"record","name":"R","aliases":["Foo"],
+			"fields":[
+				{"name":"Foo","type":"int"},
+				{"name":"e","type":{"type":"enum","name":"E","symbols":["Foo","Bar"]}}
+			]
+		}`, got)
+	})
+
+	t.Run("primitive and logical types in field positions are untouched", func(t *testing.T) {
+		got := run(t, `{"type":"record","name":"R","fields":[
+			{"name":"a","type":"int"},
+			{"name":"b","type":{"type":"long","logicalType":"timestamp-micros"}}
+		]}`, nil)
+		assert.JSONEq(t, `{"type":"record","name":"R","fields":[
+			{"name":"a","type":"int"},
+			{"name":"b","type":{"type":"long","logicalType":"timestamp-micros"}}
+		]}`, got)
+	})
+}


### PR DESCRIPTION
## Summary

Three changes:

### 1. Bump `github.com/twmb/avro` to v1.7.1

v1.5.0 decodes decimal logical types to `*big.Rat` instead of
`json.Number` for `*any` targets, matching hamba/avro and linkedin/goavro.
It also exports `RatFromBytes` for CustomType callbacks and fixes
EncodeJSON `json.Number` coercion bugs for int/long schemas.

### 2. Add decimal CustomType for preserve_logical_types path

v1.5.0's `*big.Rat` decimal type can't pass through `SetStructuredMut`
(which uses `json.Marshal`, and `*big.Rat` doesn't implement
`json.Marshaler`). Added a decimal `CustomType` in
`preserveLogicalTypeOpts` that converts the raw `[]byte` to
`json.Number` via `avro.RatFromBytes` at decode time.

### 3. Resolve avro references for arbitrary schema shapes

`resolveAvroReferences` previously only handled one specific schema
shape: a root that parses as a JSON array of reference names
(`["Ref1", "Ref2"]`), the Confluent Schema Registry convention for
"subject is a union of other subjects". Any other shape — a record
whose field type references another subject, an array whose items
reference another subject, etc. — produced the misleading error
`"parsing root schema as enum"`.

It also had two bugs:

- **Swallowed WalkReferences error.** On walk failure, the function
  returned `("", nil)`, silently dropping the error.
- **Transitive references not inlined.** If the root referenced Foo
  and Foo referenced Bar, Bar remained unresolved inside the inlined Foo.

Replaced the hand-rolled hydrator with a recursive walker
`hydrateAvroRefs` that traverses type positions throughout the schema
tree and inlines any reference name it finds. Each named type is
inlined at most once per walk; subsequent references are left as string
name references.

## Test plan

- [x] `go test ./internal/impl/confluent/...` passes
- [x] `go test ./internal/impl/avro/...` passes
- [x] Existing `TestAvroReferences` (legacy shape) still passes
- [x] 11 new `TestHydrateAvroRefs` subtests covering each supported shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)