### PR TITLE
amqp1: fix data race in randomString

### DIFF
--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -390,12 +390,10 @@ const (
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 func randomString(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[seededRand.Intn(len(letterBytes))]
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
Replace package-level `*rand.Rand` (not goroutine-safe) with top-level `rand.Intn` which is safe for concurrent use since Go 1.20+

Fixes CON-398