### PR TITLE
mysql_cdc: ensure snapshot primary key order is consistent for composite primary keys

### DIFF
--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -196,8 +196,12 @@ func (s *Snapshot) querySnapshotTable(ctx context.Context, table string, pk []st
 
 	var lastSeenPkVals []any
 	var placeholders []string
-	for _, pkCol := range *lastSeenPkVal {
-		lastSeenPkVals = append(lastSeenPkVals, pkCol)
+	for _, pkCol := range pk {
+		val, ok := (*lastSeenPkVal)[pkCol]
+		if !ok {
+			return nil, fmt.Errorf("primary key column '%s' not found in last seen values", pkCol)
+		}
+		lastSeenPkVals = append(lastSeenPkVals, val)
 		placeholders = append(placeholders, "?")
 	}
 


### PR DESCRIPTION
Go's map do not guarantee ordering (the Go team even intentionally built randomisation into it to dissuade people from depending on its order), so switch to iterating ordered pk slice instead.

<img width="1283" height="628" alt="image" src="https://github.com/user-attachments/assets/b52aacc8-466b-4935-9571-5f0a156daeaa" />

Closes: https://github.com/redpanda-data/connect/issues/4256
