### PR TITLE
goreleaser: fix docker latest tag for connect image

### DIFF
--- a/.goreleaser/connect.yaml
+++ b/.goreleaser/connect.yaml
@@ -75,7 +75,7 @@ dockers_v2:
       - "{{ if not .IsSnapshot }}{{ .Version }}{{ end }}"
       - "{{ if and (not .IsSnapshot) (eq .Prerelease ``) }}{{ .Major }}.{{.Minor}}{{ end }}"
       - "{{ if and (not .IsSnapshot) (eq .Prerelease ``) }}{{ .Major }}{{ end }}"
-      - "{{ if and (not .IsSnapshot) (eq .Prerelease ``) }}latest-cloud{{ end }}"
+      - "{{ if and (not .IsSnapshot) (eq .Prerelease ``) }}latest{{ end }}"
       - "{{ if or .IsSnapshot (ne .Prerelease ``) }}edge{{ end }}"
     platforms:
       - linux/amd64


### PR DESCRIPTION
The connect goreleaser config incorrectly tagged the main image as `latest-cloud` instead of `latest`, colliding with the cloud variant and leaving the `latest` tag stale across releases.

Fixes #4253
Fixes #4254