### PR TITLE
mongodb: fix ResumeWithSnapshot test expecting error on clean shutdown

### DIFF
--- a/internal/impl/mongodb/cdc/integration_test.go
+++ b/internal/impl/mongodb/cdc/integration_test.go
@@ -58,15 +58,6 @@ func (s *streamHelper) RunAsync(t *testing.T) func() {
 	return wg.Wait
 }
 
-func (s *streamHelper) RunAsyncWithErrors(t *testing.T) func() {
-	stream := s.makeStream(t)
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		require.Error(t, stream.Run(t.Context()))
-	})
-	return wg.Wait
-}
-
 func (s *streamHelper) Stop(t *testing.T) {
 	stream := s.getStream(t)
 	require.NoError(t, stream.Stop(t.Context()))
@@ -569,12 +560,7 @@ mongodb_cdc:
 	db.CreateCollection(t, "foo")
 	db.InsertOne(t, "foo", bson.M{"_id": 1, "data": "hello"})
 	output.NackAll()
-	// For some reason the stream's Run doesn't exit until the context is cancelled.
-	// I'm not sure why that doesn't work, but for this test we can just cancel and
-	// let the cancellation happen after the test is done.
-	//
-	// Ideally wait would return immediately after StopNow is called...
-	wait := stream.RunAsyncWithErrors(t)
+	wait := stream.RunAsync(t)
 	t.Cleanup(wait)
 	time.Sleep(time.Second)
 	stream.StopNow(t)


### PR DESCRIPTION
stream.Run() returns nil on forced shutdown (benthos logs a warning
instead of returning an error). Changed RunAsyncWithErrors to RunAsync
and removed the unused helper method.

Fixes CON-419