### PR TITLE
mongodb: fix data race on ChangeStream between TryNext and ResumeToken

### DIFF
--- a/internal/impl/mongodb/cdc/input.go
+++ b/internal/impl/mongodb/cdc/input.go
@@ -917,7 +917,7 @@ func (m *mongoCDC) readFromStream(ctx context.Context, cp *checkpoint.Capped[bso
 				}
 				m.resumeTokenMu.Lock()
 				defer m.resumeTokenMu.Unlock()
-				m.resumeToken = stream.ResumeToken()
+				m.resumeToken = *resumeToken
 				if m.checkpointFlusher == nil {
 					return m.checkpoint.Store(ctx, m.resumeToken)
 				}


### PR DESCRIPTION
The ack callback called stream.ResumeToken() from a different goroutine
than the one running stream.TryNext(), racing on the ChangeStream's
internal resume token field. Use the value already resolved by the
checkpoint system instead, which is both race-free and semantically
correct.

Fixes CON-418