### PR TITLE
pulsar: disable StreamTestAtLeastOnceDelivery due to upstream data race

### DIFF
--- a/internal/impl/pulsar/integration_test.go
+++ b/internal/impl/pulsar/integration_test.go
@@ -95,7 +95,8 @@ input:
 		integration.StreamTestStreamParallel(1000),
 		integration.StreamTestStreamParallelLossy(1000),
 		integration.StreamTestStreamParallelLossyThroughReconnect(1000),
-		integration.StreamTestAtLeastOnceDelivery(),
+		// StreamTestAtLeastOnceDelivery disabled due to upstream data race in
+		// benthos stream_test_definitions.go:571-584 (concurrent map read/write).
 	)
 
 	suite.Run(


### PR DESCRIPTION
The benthos StreamTestAtLeastOnceDelivery test helper has an unsynchronized
concurrent map read/write at stream_test_definitions.go:571-584. A goroutine
iterates a shared map while another writes to it. Since this is in upstream
benthos code, disabling the test until the race is fixed upstream.

Fixes CON-415