### PR TITLE
pulsar: use native ARM image to fix container startup timeouts

### DIFF
--- a/internal/impl/pulsar/integration_test.go
+++ b/internal/impl/pulsar/integration_test.go
@@ -30,8 +30,8 @@ import (
 func TestIntegrationPulsar(t *testing.T) {
 	integration.CheckSkip(t)
 
-	ctr, err := testcontainers.Run(t.Context(), "apachepulsar/pulsar-standalone:2.8.3",
-		testcontainers.WithImagePlatform("linux/amd64"),
+	ctr, err := testcontainers.Run(t.Context(), "apachepulsar/pulsar:3.3.4",
+		testcontainers.WithCmd("bin/pulsar", "standalone"),
 		testcontainers.WithExposedPorts("6650/tcp", "8080/tcp"),
 		testcontainers.WithWaitStrategyAndDeadline(3*time.Minute,
 			wait.ForHTTP("/admin/v2/brokers/ready").WithPort("8080/tcp").WithStartupTimeout(3*time.Minute),


### PR DESCRIPTION
Switch from apachepulsar/pulsar-standalone:2.8.3 (amd64-only) to
apachepulsar/pulsar:3.3.4 (multi-arch) so the container runs natively
on ARM instead of under x86 emulation. This eliminates the slow
startup that caused context deadline exceeded errors.

Fixes CON-387