### PR TITLE
integration: fix --unit flag skipping integration tests

### DIFF
--- a/cmd/tools/integration/run.go
+++ b/cmd/tools/integration/run.go
@@ -212,7 +212,7 @@ func runPackageTest(pkg TestPackage, short, outFile string, cached PackageCache,
 	skipRegex := completedTestSkipRegex(cached.Tests)
 	runRegex := "^Test.*Integration"
 	if runArgs.unit {
-		runRegex = ""
+		runRegex = "^Test"
 	}
 	timeout := pkg.TimeoutStr()
 


### PR DESCRIPTION
Benthos CheckSkip guard requires test.run to be non-empty and match
the test name. With --unit we were omitting -run entirely, causing
all integration tests to skip. Use -run ^Test instead to match all
test functions while satisfying the guard.