### PR TITLE
confluent: fix data race on shutSig in schema registry encoder

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -303,12 +303,13 @@ func newSchemaRegistryEncoder(
 		return nil, err
 	}
 
+	shutSig := s.shutSig
 	go func() {
 		for {
 			select {
 			case <-time.After(schemaRefreshTicker):
 				s.refreshEncoders()
-			case <-s.shutSig.SoftStopChan():
+			case <-shutSig.SoftStopChan():
 				return
 			}
 		}


### PR DESCRIPTION
The background goroutine started by newSchemaRegistryEncoder re-reads
s.shutSig on every loop iteration. When newSchemaRegistryEncoderFromConfig
replaces s.shutSig with a new signaller, there is a concurrent read/write
race. Capture shutSig in a local variable before launching the goroutine
so it never re-reads the struct field.

Fixes CON-412