### PR TITLE
postgresql: fix data race in Stream.Stop() on pgConn

### DIFF
--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -812,6 +812,12 @@ func (s *Stream) Stop(ctx context.Context) error {
 	stopNowCtx, done := s.shutSig.HardStopCtx(ctx)
 	defer done()
 	wg.Go(func() error {
+		// Wait for streamMessages to finish using pgConn before closing it,
+		// otherwise we race on pgconn internal state (lock field, write buffer).
+		select {
+		case <-s.shutSig.HasStoppedChan():
+		case <-stopNowCtx.Done():
+		}
 		return s.pgConn.Close(stopNowCtx)
 	})
 	wg.Go(func() error {


### PR DESCRIPTION
Stop() was closing pgConn concurrently with streamMessages() still
using it for ReceiveMessage and SendStandbyStatusUpdate. Wait for the
stream goroutine to exit (HasStoppedChan) before closing the connection.

Fixes CON-406