### PR TITLE
redpanda: fix data race on TestingOnSetSubjectMode callback

### DIFF
--- a/internal/impl/redpanda/migrator/migrator_schema_registry.go
+++ b/internal/impl/redpanda/migrator/migrator_schema_registry.go
@@ -947,8 +947,9 @@ type importModeManager struct {
 	*schemaRegistryMigrator
 	active bool
 
-	mu       sync.RWMutex
-	prevMode map[string]sr.Mode // destination subject -> previous mode (or noMode if not set)
+	mu         sync.RWMutex
+	prevMode   map[string]sr.Mode // destination subject -> previous mode (or noMode if not set)
+	callbackMu sync.Mutex         // serializes TestingOnSetSubjectMode calls from concurrent goroutines
 }
 
 func (m *schemaRegistryMigrator) newImportModeManager(ctx context.Context) (*importModeManager, error) {
@@ -1125,7 +1126,9 @@ func (c *importModeManager) setSubjectMode(ctx context.Context, subject string, 
 	}
 
 	if c.conf.TestingOnSetSubjectMode != nil {
+		c.callbackMu.Lock()
 		c.conf.TestingOnSetSubjectMode(subject, mode)
+		c.callbackMu.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
importModeManager.Close() restores subject modes concurrently via
errgroup. Each goroutine calls setSubjectMode() which invokes the
TestingOnSetSubjectMode callback. Serialize callback invocations
with a dedicated mutex to prevent data races in test callbacks
that write to shared state.

Fixes CON-410