### PR TITLE
redis: increase pubsub channel buffer to prevent message drops

### DIFF
--- a/internal/impl/redis/input_pubsub.go
+++ b/internal/impl/redis/input_pubsub.go
@@ -145,7 +145,7 @@ func (r *redisPubSubReader) Read(ctx context.Context) (*service.Message, service
 	}
 
 	select {
-	case rMsg, open := <-pubsub.Channel():
+	case rMsg, open := <-pubsub.Channel(redis.WithChannelSize(2000)):
 		if !open {
 			_ = r.disconnect()
 			return nil, nil, service.ErrEndOfInput


### PR DESCRIPTION
The go-redis pubsub.Channel() defaults to a buffer of 100 messages.
Under concurrent writes (e.g. max_in_flight=10 publishing batches of
100), the buffer overflows and messages are silently dropped since
Redis PubSub is fire-and-forget. Increase buffer to 2000.

Fixes CON-411