### PR TITLE
oracledb: handle LOB_TRIM events to establish LOB locator state

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -64,7 +64,7 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 	if len(userTables) > 0 {
 		opCodes := "6, 7, 36"
 		if cfg.LOBEnabled {
-			opCodes += ", 9, 10"
+			opCodes += ", 9, 10, 11"
 		}
 		buf.WriteString(" AND (OPERATION_CODE IN (" + opCodes + ")")
 		// DML carries the real table name — filter by configured tables.
@@ -274,17 +274,19 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 
 		lm.txnCache.AddEvent(redoEvent.TransactionID, redoEvent.SCN, &event)
 
-	case sqlredo.OpSelectLobLocator:
+	case sqlredo.OpSelectLobLocator, sqlredo.OpLobTrim:
 		if !lm.cfg.LOBEnabled {
 			return nil
 		}
 		if !redoEvent.SQLRedo.Valid || redoEvent.SQLRedo.String == "" {
-			lm.log.Warnf("Skipping SELECT_LOB_LOCATOR with no SQL_REDO (scn=%d, txn=%s)", redoEvent.SCN, redoEvent.TransactionID)
+			lm.log.Warnf("Skipping %s with no SQL_REDO (scn=%d, txn=%s)", redoEvent.Operation, redoEvent.SCN, redoEvent.TransactionID)
 			return nil
 		}
+		// LOB_TRIM SQL has the same SELECT "COL" INTO ... FROM "SCHEMA"."TABLE" WHERE ...
+		// structure as SELECT_LOB_LOCATOR, so the same parser works for both.
 		info, err := sqlredo.ParseSelectLobLocator(redoEvent.SQLRedo.String)
 		if err != nil {
-			lm.log.Warnf("Failed to parse SELECT_LOB_LOCATOR SQL (scn=%d, txn=%s): %v\nSQL: %.500s", redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
+			lm.log.Warnf("Failed to parse %s SQL (scn=%d, txn=%s): %v\nSQL: %.500s", redoEvent.Operation, redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
 			return nil
 		}
 		// Resolve LOB type from the schema cache populated at startup.

--- a/internal/impl/oracledb/logminer/sqlredo/events.go
+++ b/internal/impl/oracledb/logminer/sqlredo/events.go
@@ -38,6 +38,8 @@ const (
 	OpSelectLobLocator Operation = 9
 	// OpLobWrite represents a LOB_WRITE operation (op 10)
 	OpLobWrite Operation = 10
+	// OpLobTrim represents a LOB_TRIM operation (op 11)
+	OpLobTrim Operation = 11
 )
 
 // String converts the operation type to a string equivalent.
@@ -59,6 +61,8 @@ func (op Operation) String() string {
 		return "select_lob_locator"
 	case OpLobWrite:
 		return "lob_write"
+	case OpLobTrim:
+		return "lob_trim"
 	default:
 		return fmt.Sprintf("unknown operation (%d)", int64(op))
 	}
@@ -104,6 +108,8 @@ func operationFromCode(code int64) Operation {
 		return OpSelectLobLocator
 	case 10:
 		return OpLobWrite
+	case 11:
+		return OpLobTrim
 	default:
 		return OpUnknown
 	}


### PR DESCRIPTION
Oracle emits LOB_TRIM (op 11) before LOB_WRITE for certain LOB column
types (e.g. out-of-line VARCHAR MAX). Without processing LOB_TRIM, the
LOB locator state is never established and subsequent LOB_WRITE events
are dropped, causing the column to be silently absent from streaming
records.

Add OpLobTrim to the query filter and handle it alongside
OpSelectLobLocator since both share the same SQL structure.

Fixes CON-408