### PR TITLE
kafka: fix data race on msgChan in connectExplicitTopics

### DIFF
--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -217,6 +217,10 @@ func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.
 	msgChan := make(chan asyncMessage)
 	ctx, doneFn := context.WithCancel(context.Background())
 
+	// Assign msgChan before spawning partition consumer goroutines to avoid a
+	// data race: goroutines read k.msgChan immediately upon starting.
+	k.msgChan = msgChan
+
 	for topic, partitions := range k.topicPartitions {
 		for _, partition := range partitions {
 			topic := topic
@@ -301,6 +305,5 @@ func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.
 	k.consumerCloseFn = doneFn
 	k.consumerDoneCtx = doneCtx
 	k.session = offsetTracker
-	k.msgChan = msgChan
 	return nil
 }


### PR DESCRIPTION
Partition consumer goroutines were spawned before k.msgChan was assigned,
causing a data race between the goroutine reads (line 104) and the
subsequent write (line 304). Move the assignment before the spawn loop.

Fixes CON-407