### PR TITLE
oracledb: increase integration test timeout from 10m to 30m

### DIFF
--- a/cmd/tools/integration/packages.json
+++ b/cmd/tools/integration/packages.json
@@ -31,7 +31,7 @@
   {"path": "./internal/impl/nats"},
   {"path": "./internal/impl/nsq"},
   {"path": "./internal/impl/opensearch"},
-  {"path": "./internal/impl/oracledb", "timeout": "10m"},
+  {"path": "./internal/impl/oracledb", "timeout": "30m"},
   {"path": "./internal/impl/postgresql"},
   {"path": "./internal/impl/pulsar", "timeout": "10m"},
   {"path": "./internal/impl/qdrant"},


### PR DESCRIPTION
The 14 integration tests each start a fresh Oracle Free container (~40s
startup each). With shuffled test ordering, earlier tests consumed ~9.9
of the 10-minute budget, leaving only ~6 seconds for
TestIntegrationOracleDBCDCSnapshotSchema which was killed immediately.

Bump to 30m to provide sufficient headroom for the full test suite.

Fixes CON-405