### PR TITLE
postgresql: filter context.Canceled from streamOut.Run in test goroutine

### DIFF
--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -655,7 +655,9 @@ pg_stream:
 			license.InjectTestService(streamOut.Resources())
 
 			go func() {
-				assert.NoError(t, streamOut.Run(t.Context()))
+				if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
 			}()
 
 			time.Sleep(time.Second * 5)


### PR DESCRIPTION
streamOut.Run correctly returns context.Canceled when the test context
is cancelled at shutdown. Use the same filtered error check pattern
already used elsewhere in the file.

Fixes CON-422