### PR TITLE
oracledb: use background context for deferred EndSession cleanup

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -145,10 +145,8 @@ func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) (
 
 	defer func() {
 		if lm.sessionMgr.IsActive() {
-			if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
-				if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
-					lm.log.Errorf("ending logminer session on exit: %v", err)
-				}
+			if err := lm.sessionMgr.EndSession(context.Background(), conn); err != nil {
+				lm.log.Errorf("ending logminer session on exit: %v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
The deferred EndSession call in ReadChanges used the parent context
which is already cancelled during shutdown. The go-ora driver's
ExecContext races internally when given a cancelled context:
StartContext spawns a goroutine that writes the session break flag
while the main goroutine reads it.

Fixes CON-421