### PR TITLE
kafka: various test fixes

### DIFF
--- a/cmd/tools/integration/packages.json
+++ b/cmd/tools/integration/packages.json
@@ -19,7 +19,7 @@
   {"path": "./internal/impl/gcp/enterprise/changestreams/metadata"},
   {"path": "./internal/impl/hdfs"},
   {"path": "./internal/impl/influxdb"},
-  {"path": "./internal/impl/kafka"},
+  {"path": "./internal/impl/kafka", "timeout": "10m"},
   {"path": "./internal/impl/kafka/enterprise"},
   {"path": "./internal/impl/memcached"},
   {"path": "./internal/impl/mssqlserver", "timeout": "10m"},

--- a/internal/impl/kafka/franz_reader_ordered_test.go
+++ b/internal/impl/kafka/franz_reader_ordered_test.go
@@ -33,7 +33,7 @@ func TestPartitionCacheOrdering(t *testing.T) {
 		atomic.StoreInt64(&commitOffset, r.Offset)
 	})
 
-	batches, batchSize := 1000000, 10
+	batches, batchSize := 100000, 10
 
 	go func() {
 		for bid := range batches {

--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -217,6 +217,10 @@ func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.
 	msgChan := make(chan asyncMessage)
 	ctx, doneFn := context.WithCancel(context.Background())
 
+	// Assign msgChan before spawning partition consumer goroutines to avoid a
+	// data race: goroutines read k.msgChan immediately upon starting.
+	k.msgChan = msgChan
+
 	for topic, partitions := range k.topicPartitions {
 		for _, partition := range partitions {
 			topic := topic
@@ -301,6 +305,5 @@ func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.
 	k.consumerCloseFn = doneFn
 	k.consumerDoneCtx = doneCtx
 	k.session = offsetTracker
-	k.msgChan = msgChan
 	return nil
 }

--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -162,6 +162,9 @@ func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.
 			if client != nil {
 				client.Close()
 			}
+			// Reset k.msgChan so a subsequent Connect retry doesn't observe
+			// a stale, orphaned channel and short-circuit as already-connected.
+			k.msgChan = nil
 		}
 	}()
 

--- a/internal/impl/kafka/integration_cache_test.go
+++ b/internal/impl/kafka/integration_cache_test.go
@@ -130,7 +130,7 @@ func TestIntegrationCacheStandardized(t *testing.T) {
 cache_resources:
   - label: testcache
     redpanda:
-      seed_brokers: ["localhost:$PORT"]
+      seed_brokers: ["127.0.0.1:$PORT"]
       topic: "topic-$ID"
 `
 	t.Run("single partition", func(t *testing.T) {

--- a/internal/impl/kafka/integration_ordered_test.go
+++ b/internal/impl/kafka/integration_ordered_test.go
@@ -194,7 +194,7 @@ func TestRedpandaRecordOrderSoakTest(t *testing.T) {
 	const (
 		setupTeardownBudget = 2 * time.Minute
 		minSoakDuration     = 30 * time.Second
-		defaultSoakDuration = 3 * time.Minute
+		defaultSoakDuration = 1 * time.Minute
 	)
 
 	soakDuration := defaultSoakDuration

--- a/internal/impl/kafka/integration_ordered_test.go
+++ b/internal/impl/kafka/integration_ordered_test.go
@@ -188,7 +188,26 @@ func TestRedpandaRecordOrderSoakTest(t *testing.T) {
 	//   nohup go test -timeout 0 -v -count 1000 -run ^TestRedpandaRecordOrderSoakTest$ ./internal/impl/kafka/ > soak.log 2>&1 &
 	integration.CheckSkip(t)
 
-	const soakDuration = 3 * time.Minute
+	// Derive soak duration from the test deadline so the test doesn't get
+	// killed by a timeout when other tests in the package run first. Reserve
+	// time for container setup and teardown. If not enough time remains, skip.
+	const (
+		setupTeardownBudget = 2 * time.Minute
+		minSoakDuration     = 30 * time.Second
+		defaultSoakDuration = 3 * time.Minute
+	)
+
+	soakDuration := defaultSoakDuration
+	if dl, ok := t.Deadline(); ok {
+		remaining := time.Until(dl) - setupTeardownBudget
+		if remaining < minSoakDuration {
+			t.Skipf("not enough time for soak test: %s remaining after reserving %s for setup/teardown (need at least %s)", time.Until(dl).Round(time.Second), setupTeardownBudget, minSoakDuration)
+		}
+		if remaining < soakDuration {
+			soakDuration = remaining
+			t.Logf("Adjusted soak duration to %s based on test deadline", soakDuration.Round(time.Second))
+		}
+	}
 
 	// --- infrastructure ---
 

--- a/internal/impl/kafka/integration_sarama_test.go
+++ b/internal/impl/kafka/integration_sarama_test.go
@@ -55,7 +55,7 @@ func TestIntegrationSaramaCheckpointOneLockUp(t *testing.T) {
 	inBuilder := service.NewStreamBuilder()
 	require.NoError(t, inBuilder.AddOutputYAML(fmt.Sprintf(`
 kafka:
-  addresses: [ "localhost:%v" ]
+  addresses: [ "127.0.0.1:%v" ]
   topic: topic-wcotesttopic
   max_in_flight: 1
 `, kafkaPortStr)))
@@ -75,7 +75,7 @@ kafka:
 
 	outBuilderConf := fmt.Sprintf(`
 kafka:
-  addresses: [ "localhost:%v" ]
+  addresses: [ "127.0.0.1:%v" ]
   topics: [ topic-wcotesttopic ]
   consumer_group: wcotestgroup
   checkpoint_limit: 1
@@ -170,7 +170,7 @@ func TestIntegrationSaramaRedpanda(t *testing.T) {
 	template := `
 output:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: $MAX_IN_FLIGHT
     retry_as_batch: $VAR3
@@ -181,7 +181,7 @@ output:
 
 input:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID$VAR1 ]
     consumer_group: "$VAR4"
     checkpoint_limit: $VAR2
@@ -338,7 +338,7 @@ input:
 	templateManualPartitioner := `
 output:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: $MAX_IN_FLIGHT
     retry_as_batch: $VAR3
@@ -351,7 +351,7 @@ output:
 
 input:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID$VAR1 ]
     consumer_group: "$VAR4"
     checkpoint_limit: $VAR2
@@ -388,13 +388,13 @@ func TestIntegrationSaramaOutputFixedTimestamp(t *testing.T) {
 	template := `
 output:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     timestamp_ms: 1000000000000
 
 input:
   kafka:
-    addresses: [ localhost:$PORT ]
+    addresses: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID ]
     consumer_group: "blobfish"
   processors:

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -173,6 +173,18 @@ input:
 		integration.StreamTestSendBatchCount(10),
 	)
 
+	// Lighter suite for partition-specific groups that only need to validate
+	// routing correctness, not throughput. Keeps total runtime well within
+	// the parent test deadline so later groups don't get starved.
+	partitionSuite := integration.StreamTests(
+		integration.StreamTestOpenClose(),
+		integration.StreamTestMetadata(),
+		integration.StreamTestSendBatch(10),
+		integration.StreamTestStreamSequential(100),
+		integration.StreamTestStreamParallel(100),
+		integration.StreamTestSendBatchCount(10),
+	)
+
 	suite.Run(
 		t, template,
 		integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
@@ -184,7 +196,7 @@ input:
 	)
 
 	t.Run("only one partition", func(t *testing.T) {
-		suite.Run(
+		partitionSuite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 				vars.General["VAR4"] = "group" + vars.ID
@@ -196,7 +208,7 @@ input:
 	})
 
 	t.Run("explicit partitions", func(t *testing.T) {
-		suite.Run(
+		partitionSuite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 				topicName := "topic-" + vars.ID
@@ -210,7 +222,7 @@ input:
 	})
 
 	t.Run("range of partitions", func(t *testing.T) {
-		suite.Run(
+		partitionSuite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 				require.NoError(t, createKafkaTopic(ctx, brokerAddr, vars.ID, 4))
@@ -244,7 +256,7 @@ input:
     commit_period: "1s"
 `
 	t.Run("manual_partitioner", func(t *testing.T) {
-		suite.Run(
+		partitionSuite.Run(
 			t, manualPartitionTemplate,
 			integration.StreamTestOptPreTest(func(t testing.TB, _ context.Context, vars *integration.StreamTestConfigVars) {
 				vars.General["VAR4"] = "group" + vars.ID

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -207,19 +207,19 @@ input:
 			integration.StreamTestOptSleepAfterInput(time.Second*3),
 			integration.StreamTestOptVarSet("VAR4", ""),
 		)
+	})
 
-		t.Run("range of partitions", func(t *testing.T) {
-			suite.Run(
-				t, template,
-				integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
-					require.NoError(t, createKafkaTopic(ctx, brokerAddr, vars.ID, 4))
-				}),
-				integration.StreamTestOptPort(kafkaPortStr),
-				integration.StreamTestOptSleepAfterInput(time.Second*3),
-				integration.StreamTestOptVarSet("VAR1", ":0-3"),
-				integration.StreamTestOptVarSet("VAR4", ""),
-			)
-		})
+	t.Run("range of partitions", func(t *testing.T) {
+		suite.Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
+				require.NoError(t, createKafkaTopic(ctx, brokerAddr, vars.ID, 4))
+			}),
+			integration.StreamTestOptPort(kafkaPortStr),
+			integration.StreamTestOptSleepAfterInput(time.Second*3),
+			integration.StreamTestOptVarSet("VAR1", ":0-3"),
+			integration.StreamTestOptVarSet("VAR4", ""),
+		)
 	})
 
 	manualPartitionTemplate := `

--- a/internal/impl/kafka/integration_unordered_test.go
+++ b/internal/impl/kafka/integration_unordered_test.go
@@ -67,10 +67,21 @@ input:
 		integration.StreamTestStreamSaturatedUnacked(200),
 	)
 
+	// Lighter suite for partition-specific groups that only need to validate
+	// routing correctness, not throughput. Keeps total runtime well within
+	// the parent test deadline so later groups don't get starved.
+	partitionSuite := integration.StreamTests(
+		integration.StreamTestOpenClose(),
+		integration.StreamTestMetadata(),
+		integration.StreamTestSendBatch(10),
+		integration.StreamTestStreamSequential(100),
+		integration.StreamTestStreamParallel(100),
+	)
+
 	// In some modes include testing input level batching
-	var suiteExt integration.StreamTestList
-	suiteExt = append(suiteExt, suite...)
-	suiteExt = append(suiteExt, integration.StreamTestReceiveBatchCount(10))
+	var partitionSuiteExt integration.StreamTestList
+	partitionSuiteExt = append(partitionSuiteExt, partitionSuite...)
+	partitionSuiteExt = append(partitionSuiteExt, integration.StreamTestReceiveBatchCount(10))
 
 	suite.Run(
 		t, template,
@@ -84,7 +95,7 @@ input:
 
 	t.Run("only one partition", func(t *testing.T) {
 		t.Parallel()
-		suiteExt.Run(
+		partitionSuiteExt.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 				vars.General["VAR4"] = "group" + vars.ID
@@ -97,7 +108,7 @@ input:
 
 	t.Run("explicit partitions", func(t *testing.T) {
 		t.Parallel()
-		suite.Run(
+		partitionSuite.Run(
 			t, template,
 			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 				topicName := "topic-" + vars.ID
@@ -111,7 +122,7 @@ input:
 
 		t.Run("range of partitions", func(t *testing.T) {
 			t.Parallel()
-			suite.Run(
+			partitionSuite.Run(
 				t, template,
 				integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, vars *integration.StreamTestConfigVars) {
 					require.NoError(t, createKafkaTopic(ctx, brokerAddr, vars.ID, 4))
@@ -147,7 +158,7 @@ input:
     commit_period: "1s"
 `
 	t.Run("manual_partitioner", func(t *testing.T) {
-		suite.Run(
+		partitionSuite.Run(
 			t, manualPartitionTemplate,
 			integration.StreamTestOptPreTest(func(t testing.TB, _ context.Context, vars *integration.StreamTestConfigVars) {
 				vars.General["VAR4"] = "group" + vars.ID

--- a/internal/impl/kafka/integration_unordered_test.go
+++ b/internal/impl/kafka/integration_unordered_test.go
@@ -210,9 +210,9 @@ input:
 		integration.StreamTestOpenClose(),
 		integration.StreamTestMetadata(),
 		integration.StreamTestSendBatch(10),
-		integration.StreamTestStreamSequential(1000),
-		integration.StreamTestStreamParallel(1000),
-		integration.StreamTestStreamParallelLossy(1000),
+		integration.StreamTestStreamSequential(100),
+		integration.StreamTestStreamParallel(100),
+		integration.StreamTestStreamParallelLossy(100),
 	)
 
 	suite.Run(

--- a/internal/impl/kafka/integration_unordered_test.go
+++ b/internal/impl/kafka/integration_unordered_test.go
@@ -158,6 +158,7 @@ input:
     commit_period: "1s"
 `
 	t.Run("manual_partitioner", func(t *testing.T) {
+		t.Parallel()
 		partitionSuite.Run(
 			t, manualPartitionTemplate,
 			integration.StreamTestOptPreTest(func(t testing.TB, _ context.Context, vars *integration.StreamTestConfigVars) {

--- a/internal/impl/kafka/integration_unordered_test.go
+++ b/internal/impl/kafka/integration_unordered_test.go
@@ -37,7 +37,7 @@ func TestIntegrationUnordered(t *testing.T) {
 	template := `
 output:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: $MAX_IN_FLIGHT
     timeout: "5s"
@@ -46,7 +46,7 @@ output:
 
 input:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID$VAR1 ]
     consumer_group: "$VAR4"
     commit_period: "1s"
@@ -138,7 +138,7 @@ input:
 	manualPartitionTemplate := `
 output:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: $MAX_IN_FLIGHT
     timeout: "5s"
@@ -149,7 +149,7 @@ output:
 
 input:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID$VAR1 ]
     consumer_group: "$VAR4"
     unordered_processing:
@@ -183,7 +183,7 @@ func TestIntegrationUnorderedSasl(t *testing.T) {
 	template := `
 output:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: $MAX_IN_FLIGHT
     metadata:
@@ -195,7 +195,7 @@ output:
 
 input:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID$VAR1 ]
     consumer_group: "$VAR4"
     sasl:
@@ -240,7 +240,7 @@ func BenchmarkIntegrationUnordered(b *testing.B) {
 		template := `
 output:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topic: topic-$ID
     max_in_flight: 128
     timeout: "5s"
@@ -249,7 +249,7 @@ output:
 
 input:
   redpanda:
-    seed_brokers: [ localhost:$PORT ]
+    seed_brokers: [ 127.0.0.1:$PORT ]
     topics: [ topic-$ID ]
     consumer_group: "$VAR3"
     checkpoint_limit: 100

--- a/internal/impl/kafka/testcontainers_test.go
+++ b/internal/impl/kafka/testcontainers_test.go
@@ -39,10 +39,7 @@ func startRedpanda(t testing.TB) (brokerAddr, port string) {
 	brokerAddr, err = ctr.KafkaSeedBroker(t.Context())
 	require.NoError(t, err)
 
-	// Extract port from "host:port"
-	parts := strings.Split(brokerAddr, ":")
-	port = parts[len(parts)-1]
-
+	brokerAddr, port = brokerAddrPort(brokerAddr)
 	return brokerAddr, port
 }
 
@@ -75,8 +72,15 @@ func startRedpandaWithSASL(t testing.TB) (brokerAddr, port string) {
 	brokerAddr, err = ctr.KafkaSeedBroker(t.Context())
 	require.NoError(t, err)
 
-	parts := strings.Split(brokerAddr, ":")
-	port = parts[len(parts)-1]
-
+	brokerAddr, port = brokerAddrPort(brokerAddr)
 	return brokerAddr, port
+}
+
+// brokerAddrPort normalises a broker address returned by testcontainers,
+// replacing "localhost" with "127.0.0.1" to avoid DNS resolution failures
+// in environments where the system resolver cannot resolve "localhost".
+func brokerAddrPort(addr string) (brokerAddr, port string) {
+	addr = strings.Replace(addr, "localhost", "127.0.0.1", 1)
+	parts := strings.Split(addr, ":")
+	return addr, parts[len(parts)-1]
 }


### PR DESCRIPTION
## Commits

- fix data race on msgChan in connectExplicitTopics
- adapt soak test duration to test deadline
- use 127.0.0.1 instead of localhost in test broker address
- unnest range_of_partitions from explicit_partitions test group
- use lighter suite for partition-specific test groups
- reduce partition cache ordering test batch count
- use lighter suite for unordered partition-specific test groups
- parallelize manual_partitioner subtest and raise package timeout
- use lighter suite for unordered SASL test
- shorten soak test default duration to 1 minute

## Jira

- CON-407
- CON-413
- CON-425
- CON-426
- CON-427
- CON-431
- CON-439
- CON-440
- CON-443
- CON-448