### PR TITLE
pulsar: various test fixes

### DIFF
--- a/internal/impl/pulsar/integration_test.go
+++ b/internal/impl/pulsar/integration_test.go
@@ -30,8 +30,8 @@ import (
 func TestIntegrationPulsar(t *testing.T) {
 	integration.CheckSkip(t)
 
-	ctr, err := testcontainers.Run(t.Context(), "apachepulsar/pulsar-standalone:2.8.3",
-		testcontainers.WithImagePlatform("linux/amd64"),
+	ctr, err := testcontainers.Run(t.Context(), "apachepulsar/pulsar:3.3.4",
+		testcontainers.WithCmd("bin/pulsar", "standalone"),
 		testcontainers.WithExposedPorts("6650/tcp", "8080/tcp"),
 		testcontainers.WithWaitStrategyAndDeadline(3*time.Minute,
 			wait.ForHTTP("/admin/v2/brokers/ready").WithPort("8080/tcp").WithStartupTimeout(3*time.Minute),

--- a/internal/impl/pulsar/integration_test.go
+++ b/internal/impl/pulsar/integration_test.go
@@ -95,7 +95,8 @@ input:
 		integration.StreamTestStreamParallel(1000),
 		integration.StreamTestStreamParallelLossy(1000),
 		integration.StreamTestStreamParallelLossyThroughReconnect(1000),
-		integration.StreamTestAtLeastOnceDelivery(),
+		// StreamTestAtLeastOnceDelivery disabled due to upstream data race in
+		// benthos stream_test_definitions.go:571-584 (concurrent map read/write).
 	)
 
 	suite.Run(


### PR DESCRIPTION
## Commits

- use native ARM image to fix container startup timeouts
- disable StreamTestAtLeastOnceDelivery due to upstream data race

## Jira

- CON-387
- CON-415