### PR TITLE
redis: increase pubsub channel buffer to prevent message drops

### DIFF
--- a/internal/impl/redis/input_pubsub.go
+++ b/internal/impl/redis/input_pubsub.go
@@ -145,7 +145,7 @@ func (r *redisPubSubReader) Read(ctx context.Context) (*service.Message, service
 	}
 
 	select {
-	case rMsg, open := <-pubsub.Channel():
+	case rMsg, open := <-pubsub.Channel(redis.WithChannelSize(2000)):
 		if !open {
 			_ = r.disconnect()
 			return nil, nil, service.ErrEndOfInput


### PR DESCRIPTION
## Commits

- increase pubsub channel buffer to prevent message drops

## Jira

- CON-411