### PR TITLE
mysql_cdc: parallelise snapshot reads across tables

### DIFF
--- a/internal/impl/mysql/config_test.go
+++ b/internal/impl/mysql/config_test.go
@@ -71,6 +71,8 @@ func TestConfig_SnapshotMaxParallelTables_InvalidValuesRejected(t *testing.T) {
 	}{
 		{"zero", 0},
 		{"negative", -5},
+		{"above_upper_bound", maxSnapshotParallelTables + 1},
+		{"absurdly_large", 10000},
 	}
 
 	for _, tc := range tests {
@@ -90,7 +92,10 @@ snapshot_max_parallel_tables: %d
 			// the validation predicate that guards it).
 			got, err := conf.FieldInt(fieldSnapshotMaxParallelTables)
 			require.NoError(t, err)
-			assert.Less(t, got, 1, "configured value should violate the min>=1 rule enforced in newMySQLStreamInput")
+			assert.True(t,
+				got < 1 || got > maxSnapshotParallelTables,
+				"configured value should violate the [1, %d] range enforced in newMySQLStreamInput", maxSnapshotParallelTables,
+			)
 		})
 	}
 }

--- a/internal/impl/mysql/config_test.go
+++ b/internal/impl/mysql/config_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ensures the snapshot_max_parallel_tables field defaults to 1 (preserving
+// the pre-parallel behaviour for configs that don't set it) and that explicit
+// values round-trip through the spec.
+func TestConfig_SnapshotMaxParallelTables_DefaultAndExplicit(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected int
+	}{
+		{
+			name: "default",
+			yaml: `
+dsn: user:password@tcp(localhost:3306)/db
+tables: [a]
+stream_snapshot: true
+checkpoint_cache: foo
+`,
+			expected: 1,
+		},
+		{
+			name: "explicit=8",
+			yaml: `
+dsn: user:password@tcp(localhost:3306)/db
+tables: [a]
+stream_snapshot: true
+checkpoint_cache: foo
+snapshot_max_parallel_tables: 8
+`,
+			expected: 8,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conf, err := mysqlStreamConfigSpec.ParseYAML(tc.yaml, nil)
+			require.NoError(t, err)
+
+			got, err := conf.FieldInt(fieldSnapshotMaxParallelTables)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// Ensures newMySQLStreamInput's post-parse validation rejects non-positive
+// values for snapshot_max_parallel_tables. We exercise the field contract via
+// the spec rather than the full constructor (which requires a license and a
+// cache resource).
+func TestConfig_SnapshotMaxParallelTables_InvalidValuesRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int
+	}{
+		{"zero", 0},
+		{"negative", -5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := fmt.Sprintf(`
+dsn: user:password@tcp(localhost:3306)/db
+tables: [a]
+stream_snapshot: true
+checkpoint_cache: foo
+snapshot_max_parallel_tables: %d
+`, tc.value)
+			conf, err := mysqlStreamConfigSpec.ParseYAML(yaml, nil)
+			require.NoError(t, err, "spec parsing itself should succeed; validation is enforced inside newMySQLStreamInput")
+
+			// Mirror the constructor's validation logic (we can't invoke the
+			// constructor directly without a license/cache, but this asserts
+			// the validation predicate that guards it).
+			got, err := conf.FieldInt(fieldSnapshotMaxParallelTables)
+			require.NoError(t, err)
+			assert.Less(t, got, 1, "configured value should violate the min>=1 rule enforced in newMySQLStreamInput")
+		})
+	}
+}

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -52,6 +52,14 @@ const (
 	FieldAWSIAMAuthEnabled = "enabled"
 
 	shutdownTimeout = 5 * time.Second
+
+	// maxSnapshotParallelTables is an upper bound on the snapshot worker pool.
+	// It guards against accidental denial-of-service from a mis-typed config
+	// value that would otherwise try to open thousands of MySQL connections
+	// at once. Operators with a legitimate need for more parallelism can open
+	// an issue — 256 is already well beyond the point at which the MySQL
+	// server's own connection limits dominate.
+	maxSnapshotParallelTables = 256
 )
 
 func notImportedAWSOptFn(_ context.Context, awsConf *service.ParsedConfig, _ *mysql.Config, _ *service.Logger) (TokenBuilder, error) {
@@ -105,7 +113,7 @@ This input adds the following metadata fields to each message:
 			Description("The maximum number of rows to be streamed in a single batch when taking a snapshot.").
 			Default(1000),
 		service.NewIntField(fieldSnapshotMaxParallelTables).
-			Description("The maximum number of tables that may be snapshotted in parallel. When set to `1` (the default) tables are read sequentially using a single transaction, preserving the previous behaviour. When set higher, multiple `REPEATABLE READ` transactions are opened on separate connections under a single brief `FLUSH TABLES ... WITH READ LOCK` window so every worker observes an identical, globally-consistent snapshot at the same binlog position. A value greater than the number of configured `tables` is effectively capped at the table count. Must be at least `1`.").
+			Description("The maximum number of tables that may be snapshotted in parallel. When set to `1` (the default) tables are read sequentially using a single transaction, preserving the previous behaviour. When set higher, multiple `REPEATABLE READ` transactions are opened on separate connections under a single brief `FLUSH TABLES ... WITH READ LOCK` window so every worker observes an identical, globally-consistent snapshot at the same binlog position. A value greater than the number of configured `tables` is effectively capped at the table count. Must be between `1` and `256`.").
 			Advanced().
 			Default(1),
 		service.NewIntField(fieldMaxReconnectAttempts).
@@ -290,6 +298,9 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	}
 	if i.fieldSnapshotMaxParallelTables < 1 {
 		return nil, fmt.Errorf("field '%s' must be at least 1, got %d", fieldSnapshotMaxParallelTables, i.fieldSnapshotMaxParallelTables)
+	}
+	if i.fieldSnapshotMaxParallelTables > maxSnapshotParallelTables {
+		return nil, fmt.Errorf("field '%s' must be at most %d, got %d", fieldSnapshotMaxParallelTables, maxSnapshotParallelTables, i.fieldSnapshotMaxParallelTables)
 	}
 
 	if i.canalMaxConnAttempts, err = conf.FieldInt(fieldMaxReconnectAttempts); err != nil {

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -36,17 +36,18 @@ import (
 )
 
 const (
-	fieldMySQLFlavor          = "flavor"
-	fieldMySQLDSN             = "dsn"
-	fieldMySQLTables          = "tables"
-	fieldStreamSnapshot       = "stream_snapshot"
-	fieldSnapshotMaxBatchSize = "snapshot_max_batch_size"
-	fieldMaxReconnectAttempts = "max_reconnect_attempts"
-	fieldBatching             = "batching"
-	fieldCheckpointKey        = "checkpoint_key"
-	fieldCheckpointCache      = "checkpoint_cache"
-	fieldCheckpointLimit      = "checkpoint_limit"
-	fieldAWSIAMAuth           = "aws"
+	fieldMySQLFlavor               = "flavor"
+	fieldMySQLDSN                  = "dsn"
+	fieldMySQLTables               = "tables"
+	fieldStreamSnapshot            = "stream_snapshot"
+	fieldSnapshotMaxBatchSize      = "snapshot_max_batch_size"
+	fieldSnapshotMaxParallelTables = "snapshot_max_parallel_tables"
+	fieldMaxReconnectAttempts      = "max_reconnect_attempts"
+	fieldBatching                  = "batching"
+	fieldCheckpointKey             = "checkpoint_key"
+	fieldCheckpointCache           = "checkpoint_cache"
+	fieldCheckpointLimit           = "checkpoint_limit"
+	fieldAWSIAMAuth                = "aws"
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
 
@@ -103,6 +104,10 @@ This input adds the following metadata fields to each message:
 		service.NewIntField(fieldSnapshotMaxBatchSize).
 			Description("The maximum number of rows to be streamed in a single batch when taking a snapshot.").
 			Default(1000),
+		service.NewIntField(fieldSnapshotMaxParallelTables).
+			Description("The maximum number of tables that may be snapshotted in parallel. When set to `1` (the default) tables are read sequentially using a single transaction, preserving the previous behaviour. When set higher, multiple `REPEATABLE READ` transactions are opened on separate connections under a single brief `FLUSH TABLES ... WITH READ LOCK` window so every worker observes an identical, globally-consistent snapshot at the same binlog position. A value greater than the number of configured `tables` is effectively capped at the table count. Must be at least `1`.").
+			Advanced().
+			Default(1),
 		service.NewIntField(fieldMaxReconnectAttempts).
 			Description("The maximum number of attempts the MySQL driver will try to re-establish a broken connection before Connect attempts reconnection. A zero or negative number means infinite retry attempts.").
 			Advanced().
@@ -180,10 +185,11 @@ type mysqlStreamInput struct {
 	tables         []string
 	streamSnapshot bool
 
-	batching                  service.BatchPolicy
-	batchPolicy               *service.Batcher
-	checkPointLimit           int
-	fieldSnapshotMaxBatchSize int
+	batching                       service.BatchPolicy
+	batchPolicy                    *service.Batcher
+	checkPointLimit                int
+	fieldSnapshotMaxBatchSize      int
+	fieldSnapshotMaxParallelTables int
 
 	logger *service.Logger
 	res    *service.Resources
@@ -277,6 +283,13 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 
 	if i.fieldSnapshotMaxBatchSize, err = conf.FieldInt(fieldSnapshotMaxBatchSize); err != nil {
 		return nil, err
+	}
+
+	if i.fieldSnapshotMaxParallelTables, err = conf.FieldInt(fieldSnapshotMaxParallelTables); err != nil {
+		return nil, err
+	}
+	if i.fieldSnapshotMaxParallelTables < 1 {
+		return nil, fmt.Errorf("field '%s' must be at least 1, got %d", fieldSnapshotMaxParallelTables, i.fieldSnapshotMaxParallelTables)
 	}
 
 	if i.canalMaxConnAttempts, err = conf.FieldInt(fieldMaxReconnectAttempts); err != nil {
@@ -418,21 +431,15 @@ func (i *mysqlStreamInput) Connect(ctx context.Context) error {
 func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, snapshot *Snapshot) error {
 	// If we are given a snapshot, then we need to read it.
 	if snapshot != nil {
-		startPos, err := snapshot.prepareSnapshot(ctx, i.tables)
+		var startPos *position
+		var err error
+		if i.fieldSnapshotMaxParallelTables <= 1 {
+			startPos, err = i.runSequentialSnapshot(ctx, snapshot)
+		} else {
+			startPos, err = i.runParallelSnapshot(ctx, snapshot)
+		}
 		if err != nil {
-			_ = snapshot.close()
-			return fmt.Errorf("unable to prepare snapshot: %w", err)
-		}
-		if err = i.readSnapshot(ctx, snapshot); err != nil {
-			_ = snapshot.close()
-			return fmt.Errorf("failed reading snapshot: %w", err)
-		}
-		if err = snapshot.releaseSnapshot(ctx); err != nil {
-			_ = snapshot.close()
-			return fmt.Errorf("unable to release snapshot: %w", err)
-		}
-		if err = snapshot.close(); err != nil {
-			return fmt.Errorf("unable to close snapshot: %w", err)
+			return err
 		}
 		// Signal snapshot completion. readMessages will flush any partial batch
 		// and pre-resolve a checkpoint entry for startPos so the cache is
@@ -459,91 +466,159 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 	return nil
 }
 
+// runSequentialSnapshot executes the original single-transaction snapshot flow:
+// one FLUSH TABLES WITH READ LOCK window, one consistent-snapshot transaction,
+// tables read serially by a single goroutine. Preserves byte-identical
+// behaviour from before parallel-snapshot support was introduced.
+func (i *mysqlStreamInput) runSequentialSnapshot(ctx context.Context, snapshot *Snapshot) (*position, error) {
+	startPos, err := snapshot.prepareSnapshot(ctx, i.tables)
+	if err != nil {
+		_ = snapshot.close()
+		return nil, fmt.Errorf("unable to prepare snapshot: %w", err)
+	}
+	if err = i.readSnapshot(ctx, snapshot); err != nil {
+		_ = snapshot.close()
+		return nil, fmt.Errorf("failed reading snapshot: %w", err)
+	}
+	if err = snapshot.releaseSnapshot(ctx); err != nil {
+		_ = snapshot.close()
+		return nil, fmt.Errorf("unable to release snapshot: %w", err)
+	}
+	if err = snapshot.close(); err != nil {
+		return nil, fmt.Errorf("unable to close snapshot: %w", err)
+	}
+	return startPos, nil
+}
+
+// runParallelSnapshot opens fieldSnapshotMaxParallelTables consistent-snapshot
+// transactions under a single FLUSH TABLES WITH READ LOCK window and reads the
+// configured tables concurrently. All workers share one binlog position so the
+// downstream handoff to the binlog stream is unchanged from the sequential
+// path. The original snapshot argument is used only as a carrier for the
+// already-open *sql.DB; ownership of that db is transferred to the parallel
+// set (which closes it when done) so the caller must not reuse the original
+// Snapshot afterwards.
+func (i *mysqlStreamInput) runParallelSnapshot(ctx context.Context, snapshot *Snapshot) (*position, error) {
+	// Transfer db ownership to the parallel set before doing anything that
+	// might fail: if prepare fails, the set's close will release the db, and
+	// we want snapshot.close() to be a safe no-op in that case.
+	db := snapshot.db
+	snapshot.db = nil
+
+	set, startPos, err := prepareParallelSnapshotSet(ctx, i.logger, db, i.tables, i.fieldSnapshotMaxParallelTables)
+	if err != nil {
+		// prepareParallelSnapshotSet closed db on its own error paths.
+		return nil, fmt.Errorf("unable to prepare parallel snapshot: %w", err)
+	}
+	if err := i.readSnapshotParallel(ctx, set); err != nil {
+		_ = set.close()
+		return nil, fmt.Errorf("failed reading snapshot: %w", err)
+	}
+	if err := set.release(ctx); err != nil {
+		_ = set.close()
+		return nil, fmt.Errorf("unable to release parallel snapshot: %w", err)
+	}
+	if err := set.close(); err != nil {
+		return nil, fmt.Errorf("unable to close parallel snapshot: %w", err)
+	}
+	return startPos, nil
+}
+
 func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot) error {
-	// TODO(cdc): Process tables in parallel
 	for _, table := range i.tables {
-		// Pre-populate schema cache so snapshot messages carry schema metadata.
-		if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
-			if _, err := i.getTableSchema(tbl); err != nil {
-				i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
-			}
-		} else {
-			i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
-		}
-		tablePks, err := snapshot.getTablePrimaryKeys(ctx, table)
-		if err != nil {
+		if err := i.readSnapshotTable(ctx, snapshot, table); err != nil {
 			return err
 		}
-		i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
-		lastSeenPksValues := map[string]any{}
-		for _, pk := range tablePks {
-			lastSeenPksValues[pk] = nil
+	}
+	return nil
+}
+
+// readSnapshotTable snapshots a single table by paging through its rows in
+// primary-key order using the REPEATABLE READ / CONSISTENT SNAPSHOT transaction
+// held by snapshot. Extracted so both the sequential (single-snapshot) and the
+// parallel (per-worker snapshot) paths share identical per-table semantics.
+func (i *mysqlStreamInput) readSnapshotTable(ctx context.Context, snapshot *Snapshot, table string) error {
+	// Pre-populate schema cache so snapshot messages carry schema metadata.
+	if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
+		if _, err := i.getTableSchema(tbl); err != nil {
+			i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
+		}
+	} else {
+		i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
+	}
+	tablePks, err := snapshot.getTablePrimaryKeys(ctx, table)
+	if err != nil {
+		return err
+	}
+	i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
+	lastSeenPksValues := map[string]any{}
+	for _, pk := range tablePks {
+		lastSeenPksValues[pk] = nil
+	}
+
+	var numRowsProcessed int
+	for {
+		var batchRows *sql.Rows
+		if numRowsProcessed == 0 {
+			batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
+		} else {
+			batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
+		}
+		if err != nil {
+			return fmt.Errorf("executing snapshot table query: %s", err)
 		}
 
-		var numRowsProcessed int
-		for {
-			var batchRows *sql.Rows
-			if numRowsProcessed == 0 {
-				batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
-			} else {
-				batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
-			}
-			if err != nil {
-				return fmt.Errorf("executing snapshot table query: %s", err)
-			}
+		types, err := batchRows.ColumnTypes()
+		if err != nil {
+			return fmt.Errorf("fetching column types: %s", err)
+		}
 
-			types, err := batchRows.ColumnTypes()
-			if err != nil {
-				return fmt.Errorf("fetching column types: %s", err)
-			}
+		values, mappers := prepSnapshotScannerAndMappers(types)
 
-			values, mappers := prepSnapshotScannerAndMappers(types)
+		columns, err := batchRows.Columns()
+		if err != nil {
+			return fmt.Errorf("fetching columns: %s", err)
+		}
 
-			columns, err := batchRows.Columns()
-			if err != nil {
-				return fmt.Errorf("fetching columns: %s", err)
+		var batchRowsCount int
+		for batchRows.Next() {
+			numRowsProcessed++
+			batchRowsCount++
+
+			if err := batchRows.Scan(values...); err != nil {
+				return err
 			}
 
-			var batchRowsCount int
-			for batchRows.Next() {
-				numRowsProcessed++
-				batchRowsCount++
-
-				if err := batchRows.Scan(values...); err != nil {
+			row := map[string]any{}
+			for idx, value := range values {
+				v, err := mappers[idx](value)
+				if err != nil {
 					return err
 				}
-
-				row := map[string]any{}
-				for idx, value := range values {
-					v, err := mappers[idx](value)
-					if err != nil {
-						return err
-					}
-					row[columns[idx]] = v
-					if _, ok := lastSeenPksValues[columns[idx]]; ok {
-						lastSeenPksValues[columns[idx]] = value
-					}
-				}
-
-				select {
-				case i.rawMessageEvents <- MessageEvent{
-					Row:       row,
-					Operation: MessageOperationRead,
-					Table:     table,
-					Position:  nil,
-				}:
-				case <-ctx.Done():
-					return ctx.Err()
+				row[columns[idx]] = v
+				if _, ok := lastSeenPksValues[columns[idx]]; ok {
+					lastSeenPksValues[columns[idx]] = value
 				}
 			}
 
-			if err := batchRows.Err(); err != nil {
-				return fmt.Errorf("iterating snapshot table: %s", err)
+			select {
+			case i.rawMessageEvents <- MessageEvent{
+				Row:       row,
+				Operation: MessageOperationRead,
+				Table:     table,
+				Position:  nil,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
+		}
 
-			if batchRowsCount < i.fieldSnapshotMaxBatchSize {
-				break
-			}
+		if err := batchRows.Err(); err != nil {
+			return fmt.Errorf("iterating snapshot table: %s", err)
+		}
+
+		if batchRowsCount < i.fieldSnapshotMaxBatchSize {
+			break
 		}
 	}
 	return nil

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -282,6 +282,122 @@ file:
 	require.NoError(t, streamOut.StopWithin(time.Second*10))
 }
 
+// TestIntegrationMySQLParallelSnapshot verifies that enabling
+// snapshot_max_parallel_tables produces the same total set of snapshot rows
+// across multiple tables as the sequential path, and that the subsequent
+// binlog-stream handoff captures ongoing writes correctly. The parallel path
+// opens N REPEATABLE READ / CONSISTENT SNAPSHOT transactions under one
+// FLUSH TABLES WITH READ LOCK window, so all workers observe identical state.
+func TestIntegrationMySQLParallelSnapshot(t *testing.T) {
+	dsn, db := setupTestWithMySQLVersion(t, "8.0")
+
+	// Create 4 tables and pre-load each with 500 rows so a parallel snapshot
+	// has meaningful per-worker work and the distribution is observable.
+	tableNames := []string{"foo1", "foo2", "foo3", "foo4"}
+	const rowsPerTable = 500
+
+	for _, tbl := range tableNames {
+		db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (a INT PRIMARY KEY)", tbl))
+		for i := range rowsPerTable {
+			db.Exec(fmt.Sprintf("INSERT INTO %s VALUES (?)", tbl), i)
+		}
+	}
+
+	template := fmt.Sprintf(`
+mysql_cdc:
+  dsn: %s
+  stream_snapshot: true
+  snapshot_max_batch_size: 100
+  snapshot_max_parallel_tables: 4
+  checkpoint_cache: parcache
+  tables:
+    - foo1
+    - foo2
+    - foo3
+    - foo4
+`, dsn)
+
+	cacheConf := fmt.Sprintf(`
+label: parcache
+file:
+  directory: %s`, t.TempDir())
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+
+	snapshotCounts := map[string]*atomic.Int64{}
+	cdcCounts := map[string]*atomic.Int64{}
+	for _, tbl := range tableNames {
+		snapshotCounts[tbl] = &atomic.Int64{}
+		cdcCounts[tbl] = &atomic.Int64{}
+	}
+	var totalMsgs atomic.Int64
+
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		for _, msg := range mb {
+			op, _ := msg.MetaGet("operation")
+			tbl, _ := msg.MetaGet("table")
+			if c, ok := snapshotCounts[tbl]; ok && op == "read" {
+				c.Add(1)
+			}
+			if c, ok := cdcCounts[tbl]; ok && (op == "insert" || op == "update" || op == "delete") {
+				c.Add(1)
+			}
+			totalMsgs.Add(1)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+
+	go func() {
+		err = streamOut.Run(t.Context())
+		require.NoError(t, err)
+	}()
+
+	// Wait for the snapshot phase to complete for all tables.
+	assert.Eventually(t, func() bool {
+		for _, tbl := range tableNames {
+			if snapshotCounts[tbl].Load() < int64(rowsPerTable) {
+				return false
+			}
+		}
+		return true
+	}, time.Minute*2, time.Millisecond*100, "parallel snapshot should emit %d rows per table", rowsPerTable)
+
+	// Write additional rows post-snapshot and confirm the binlog-stream
+	// handoff picks them up — this validates that the single shared binlog
+	// position captured under the read-lock window is still a valid starting
+	// point for the binlog consumer.
+	const cdcRowsPerTable = 100
+	for _, tbl := range tableNames {
+		for i := rowsPerTable; i < rowsPerTable+cdcRowsPerTable; i++ {
+			db.Exec(fmt.Sprintf("INSERT INTO %s VALUES (?)", tbl), i)
+		}
+	}
+
+	assert.Eventually(t, func() bool {
+		for _, tbl := range tableNames {
+			if cdcCounts[tbl].Load() < int64(cdcRowsPerTable) {
+				return false
+			}
+		}
+		return true
+	}, time.Minute*2, time.Millisecond*100, "binlog stream should pick up post-snapshot inserts for each table")
+
+	// Sanity check: every snapshot row was emitted exactly once (no
+	// duplicates from overlapping per-worker transactions).
+	for _, tbl := range tableNames {
+		assert.Equal(t, int64(rowsPerTable), snapshotCounts[tbl].Load(), "exactly %d snapshot rows expected for %s", rowsPerTable, tbl)
+	}
+
+	require.NoError(t, streamOut.StopWithin(time.Second*10))
+}
+
 func TestIntegrationMySQLCDCWithCompositePrimaryKeys(t *testing.T) {
 	dsn, db := setupTestWithMySQLVersion(t, "8.0")
 	// Create table

--- a/internal/impl/mysql/parallel_snapshot.go
+++ b/internal/impl/mysql/parallel_snapshot.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"golang.org/x/sync/errgroup"
+)
+
+// parallelSnapshotSet owns the shared *sql.DB and a pool of per-worker Snapshot
+// instances. Every worker in the set holds its own *sql.Conn and its own
+// REPEATABLE READ / CONSISTENT SNAPSHOT transaction, but all transactions were
+// opened within a single FLUSH TABLES ... WITH READ LOCK window so they view
+// identical state at the same binlog position.
+type parallelSnapshotSet struct {
+	db      *sql.DB
+	workers []*Snapshot
+	logger  *service.Logger
+}
+
+// prepareParallelSnapshotSet opens workerCount reader connections that all
+// share a single globally-consistent MySQL snapshot:
+//
+//  1. Acquire a single lock connection and FLUSH TABLES <tables> WITH READ LOCK.
+//  2. Open workerCount snapshot connections, each starting a REPEATABLE READ
+//     transaction followed by START TRANSACTION WITH CONSISTENT SNAPSHOT.
+//  3. Capture the binlog position once (all workers share this position).
+//  4. Release the table locks and return.
+//
+// The returned set's workers can each be read from in parallel without
+// coordination: they are independent connections/transactions observing the
+// same historical state. The caller is responsible for invoking release then
+// close once snapshot reading is finished.
+//
+// Ownership: this function takes ownership of db. On success the returned set
+// closes db when set.close() is called. On error db is closed before the
+// function returns (along with any partially-opened conns/txns) and the
+// caller must not reuse it.
+func prepareParallelSnapshotSet(ctx context.Context, logger *service.Logger, db *sql.DB, tables []string, workerCount int) (*parallelSnapshotSet, *position, error) {
+	if workerCount < 1 {
+		_ = db.Close()
+		return nil, nil, fmt.Errorf("parallel snapshot worker count must be >= 1, got %d", workerCount)
+	}
+	if len(tables) == 0 {
+		_ = db.Close()
+		return nil, nil, errors.New("no tables provided")
+	}
+	// Never open more workers than tables: extra workers would sit idle and
+	// waste a connection for the duration of the snapshot.
+	if workerCount > len(tables) {
+		workerCount = len(tables)
+	}
+
+	set := &parallelSnapshotSet{db: db, logger: logger}
+	// failWith closes the partially-built set (which closes db) and returns
+	// the combined error. Use this on every error path below.
+	failWith := func(errs ...error) (*parallelSnapshotSet, *position, error) {
+		errs = append(errs, set.close())
+		return nil, nil, errors.Join(errs...)
+	}
+
+	lockConn, err := db.Conn(ctx)
+	if err != nil {
+		return failWith(fmt.Errorf("create lock connection: %w", err))
+	}
+	// The lock conn is only needed to bracket the BEGINs below. Always return
+	// it to the pool on exit; the lock itself is released via UNLOCK TABLES.
+	defer func() {
+		_ = lockConn.Close()
+	}()
+
+	lockQuery := buildFlushAndLockTablesQuery(tables)
+	logger.Infof("Acquiring table-level read locks for parallel snapshot (%d workers): %s", workerCount, lockQuery)
+	if _, err := lockConn.ExecContext(ctx, lockQuery); err != nil {
+		return failWith(fmt.Errorf("acquire table-level read locks: %w", err))
+	}
+	unlockTables := func() error {
+		if _, err := lockConn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
+			return fmt.Errorf("release table-level read locks: %w", err)
+		}
+		return nil
+	}
+
+	for idx := 0; idx < workerCount; idx++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			return failWith(fmt.Errorf("open snapshot connection %d: %w", idx, err), unlockTables())
+		}
+		tx, err := conn.BeginTx(ctx, &sql.TxOptions{
+			ReadOnly:  true,
+			Isolation: sql.LevelRepeatableRead,
+		})
+		if err != nil {
+			_ = conn.Close()
+			return failWith(fmt.Errorf("begin snapshot transaction %d: %w", idx, err), unlockTables())
+		}
+		// NOTE: this is a little sneaky because we're actually implicitly
+		// closing the transaction started with BeginTx above and replacing it
+		// with this one. We have to do this because the database/sql driver
+		// does not support WITH CONSISTENT SNAPSHOT directly.
+		if _, err := tx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); err != nil {
+			_ = tx.Rollback()
+			_ = conn.Close()
+			return failWith(fmt.Errorf("start consistent snapshot %d: %w", idx, err), unlockTables())
+		}
+		// Each worker is a "bare" Snapshot: no db (the set owns it), no
+		// lockConn (released at the end of this function). close() on each
+		// worker will rollback its tx and close its conn, which is what we
+		// want.
+		set.workers = append(set.workers, &Snapshot{
+			tx:           tx,
+			snapshotConn: conn,
+			logger:       logger,
+		})
+	}
+
+	// Capture binlog position while still under lock, from any worker. All
+	// workers are at the same snapshot so this single position applies to all
+	// of them.
+	pos, err := set.workers[0].getCurrentBinlogPosition(ctx)
+	if err != nil {
+		return failWith(fmt.Errorf("get binlog position: %w", err), unlockTables())
+	}
+
+	if err := unlockTables(); err != nil {
+		return failWith(err)
+	}
+
+	return set, &pos, nil
+}
+
+// release commits every worker's snapshot transaction. Analogous to
+// Snapshot.releaseSnapshot for the sequential path.
+func (p *parallelSnapshotSet) release(ctx context.Context) error {
+	var errs []error
+	for _, w := range p.workers {
+		if err := w.releaseSnapshot(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// close rolls back any still-open transactions, closes every worker
+// connection, then closes the shared *sql.DB.
+func (p *parallelSnapshotSet) close() error {
+	var errs []error
+	for _, w := range p.workers {
+		if err := w.close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if p.db != nil {
+		if err := p.db.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close db: %w", err))
+		}
+		p.db = nil
+	}
+	return errors.Join(errs...)
+}
+
+// readSnapshotParallel distributes i.tables across set.workers and reads them
+// concurrently using an errgroup. Any worker error cancels siblings and
+// returns from Wait (matching the existing fail-halt semantics of the
+// sequential path).
+func (i *mysqlStreamInput) readSnapshotParallel(ctx context.Context, set *parallelSnapshotSet) error {
+	return distributeTablesToWorkers(ctx, i.tables, len(set.workers), func(gctx context.Context, workerIdx int, table string) error {
+		return i.readSnapshotTable(gctx, set.workers[workerIdx], table)
+	})
+}
+
+// distributeTablesToWorkers fans out tables across workerCount goroutines,
+// calling readFn(ctx, workerIdx, table) exactly once per table. It uses an
+// errgroup: the first error cancels the shared context and is returned from
+// Wait. Exposed for unit-testing the fan-out independently of MySQL.
+func distributeTablesToWorkers(ctx context.Context, tables []string, workerCount int, readFn func(context.Context, int, string) error) error {
+	if workerCount < 1 {
+		return fmt.Errorf("workerCount must be >= 1, got %d", workerCount)
+	}
+	if workerCount > len(tables) {
+		workerCount = len(tables)
+	}
+	if workerCount == 0 {
+		// No tables at all. Nothing to do.
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	tableCh := make(chan string)
+
+	g.Go(func() error {
+		defer close(tableCh)
+		for _, t := range tables {
+			select {
+			case tableCh <- t:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+		}
+		return nil
+	})
+
+	for w := 0; w < workerCount; w++ {
+		workerIdx := w
+		g.Go(func() error {
+			for table := range tableCh {
+				if err := readFn(gctx, workerIdx, table); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
+}

--- a/internal/impl/mysql/parallel_snapshot_test.go
+++ b/internal/impl/mysql/parallel_snapshot_test.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistributeTablesToWorkers_CoversEveryTableExactlyOnce(t *testing.T) {
+	tables := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+
+	for _, workers := range []int{1, 2, 3, 4, 8, 16} {
+		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
+			var mu sync.Mutex
+			var visited []string
+
+			err := distributeTablesToWorkers(t.Context(), tables, workers, func(_ context.Context, _ int, table string) error {
+				mu.Lock()
+				visited = append(visited, table)
+				mu.Unlock()
+				return nil
+			})
+			require.NoError(t, err)
+
+			sort.Strings(visited)
+			expected := append([]string{}, tables...)
+			sort.Strings(expected)
+			assert.Equal(t, expected, visited, "each table must be visited exactly once")
+		})
+	}
+}
+
+func TestDistributeTablesToWorkers_WorkerCountCappedByTableCount(t *testing.T) {
+	tables := []string{"a", "b"}
+
+	var activeWorkers atomic.Int32
+	var maxActive atomic.Int32
+
+	err := distributeTablesToWorkers(t.Context(), tables, 16, func(_ context.Context, _ int, _ string) error {
+		n := activeWorkers.Add(1)
+		for {
+			cur := maxActive.Load()
+			if n <= cur || maxActive.CompareAndSwap(cur, n) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		activeWorkers.Add(-1)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, int(maxActive.Load()), len(tables), "should never exceed table count, even when workerCount is larger")
+}
+
+func TestDistributeTablesToWorkers_SingleWorkerIsSequential(t *testing.T) {
+	tables := []string{"a", "b", "c", "d"}
+
+	var mu sync.Mutex
+	var inFlight int
+	var maxInFlight int
+
+	err := distributeTablesToWorkers(t.Context(), tables, 1, func(_ context.Context, _ int, _ string) error {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, maxInFlight, "workerCount=1 must serialize all reads")
+}
+
+func TestDistributeTablesToWorkers_ErrorPropagatesAndCancelsSiblings(t *testing.T) {
+	tables := make([]string, 50)
+	for i := range tables {
+		tables[i] = fmt.Sprintf("t%d", i)
+	}
+
+	sentinel := errors.New("boom")
+	var calls atomic.Int32
+
+	err := distributeTablesToWorkers(t.Context(), tables, 4, func(ctx context.Context, _ int, table string) error {
+		calls.Add(1)
+		if table == "t5" {
+			return sentinel
+		}
+		// Block until cancelled so we can observe siblings being cancelled
+		// after the sentinel error fires.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+			return nil
+		}
+	})
+	require.ErrorIs(t, err, sentinel)
+	// At most every worker got 1 table before cancellation, plus the sentinel.
+	// We should not have processed all 50 tables.
+	assert.Less(t, int(calls.Load()), len(tables), "error must cancel siblings before all tables are consumed")
+}
+
+func TestDistributeTablesToWorkers_ContextCancellationPropagates(t *testing.T) {
+	tables := make([]string, 100)
+	for i := range tables {
+		tables[i] = fmt.Sprintf("t%d", i)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := distributeTablesToWorkers(ctx, tables, 4, func(ctx context.Context, _ int, _ string) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		}
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDistributeTablesToWorkers_ZeroWorkersRejected(t *testing.T) {
+	err := distributeTablesToWorkers(t.Context(), []string{"a"}, 0, func(context.Context, int, string) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ">= 1")
+}
+
+func TestDistributeTablesToWorkers_EmptyTablesIsNoop(t *testing.T) {
+	var called atomic.Bool
+	err := distributeTablesToWorkers(t.Context(), nil, 4, func(context.Context, int, string) error {
+		called.Store(true)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, called.Load(), "readFn must not be called when table list is empty")
+}
+
+func TestDistributeTablesToWorkers_WorkerIdxWithinBounds(t *testing.T) {
+	tables := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	const workerCount = 3
+
+	var mu sync.Mutex
+	seenIdxs := map[int]struct{}{}
+
+	err := distributeTablesToWorkers(t.Context(), tables, workerCount, func(_ context.Context, idx int, _ string) error {
+		mu.Lock()
+		seenIdxs[idx] = struct{}{}
+		mu.Unlock()
+		assert.GreaterOrEqual(t, idx, 0)
+		assert.Less(t, idx, workerCount)
+		return nil
+	})
+	require.NoError(t, err)
+	// Not all worker idxs are guaranteed to fire (fast paths may let one
+	// worker drain the whole channel), but every idx we observed must be
+	// within [0, workerCount).
+	for idx := range seenIdxs {
+		assert.GreaterOrEqual(t, idx, 0)
+		assert.Less(t, idx, workerCount)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `snapshot_max_parallel_tables` field to the `mysql_cdc` input. When left at its default value (`1`), the snapshot flow is the existing single-transaction, single-goroutine path, bit-for-bit unchanged. When set higher, the input fans out table reads across N workers sharing a single globally-consistent MySQL snapshot.

Addresses the `// TODO(cdc): Process tables in parallel` marker previously at `input_mysql_stream.go:463`.

## Motivation

For pipelines that stream tens or hundreds of tables, the current sequential snapshot is the dominant bottleneck: a single `*sql.Tx` on a single connection iterating `for _, table := range i.tables`. On deployments with an IAM-token TTL (15 min on AWS RDS IAM auth, for example), a sufficiently large snapshot cannot complete within one token window no matter how small `snapshot_max_batch_size` is set. This change lets operators scale the snapshot phase horizontally against MySQL's natural capacity for concurrent read transactions.

## Design

### Consistency model is preserved, not relaxed

The key observation is that MySQL allows multiple `START TRANSACTION WITH CONSISTENT SNAPSHOT` transactions to be opened on different connections **while** a `FLUSH TABLES ... WITH READ LOCK` is held. Every transaction that starts inside that lock window observes the same historical state at the same binlog position. Once the lock is released, those transactions proceed independently and concurrently.

This means we keep exactly the same consistency guarantee the sequential path provides today:

- One global consistent snapshot.
- One binlog position driving the snapshot -> binlog-stream handoff.
- Identical `snapshotComplete` signalling.

Only the number of goroutines reading through that snapshot changes.

### Dispatch

`startMySQLSync` branches on `fieldSnapshotMaxParallelTables`:

| Value | Path | Behaviour |
|---|---|---|
| `<= 1` (default) | `runSequentialSnapshot` | **Byte-identical** to the pre-PR code: `prepareSnapshot` -> `readSnapshot` -> `releaseSnapshot` -> `close`, in that order. |
| `> 1` | `runParallelSnapshot` | `prepareParallelSnapshotSet` -> `readSnapshotParallel` -> `set.release` -> `set.close`. |

### Extracted shared body

The per-table body of the old `readSnapshot` loop is extracted into `readSnapshotTable(ctx, *Snapshot, table)`. Both paths call it with identical arguments — the extracted body is not edited, only moved. The sequential `readSnapshot` is a trivial `for`-loop over this helper, preserving previous semantics.

### Parallel path internals (`internal/impl/mysql/parallel_snapshot.go`)

- `parallelSnapshotSet` owns one `*sql.DB` and N `*Snapshot` workers. Each worker holds its own `*sql.Conn` and its own `*sql.Tx`; the set is responsible for closing all of them plus the shared db.
- `prepareParallelSnapshotSet` orchestrates the lock window:
  1. Open one lock connection; `FLUSH TABLES <tables> WITH READ LOCK`.
  2. Open N snapshot connections; on each, `BeginTx(ReadOnly, RepeatableRead)` followed by `START TRANSACTION WITH CONSISTENT SNAPSHOT`.
  3. Capture the binlog position once (all workers are at the same state).
  4. `UNLOCK TABLES`, return the lock conn to the pool.
- The function takes ownership of the caller's `*sql.DB`: on success the returned set closes it; on error it is closed before the function returns, and the partial state is cleaned up via `errors.Join(...)` so no resource leaks across failure paths.
- `distributeTablesToWorkers` is the pure fan-out helper: an `errgroup`, one producer goroutine feeding table names into an unbuffered channel, N consumer goroutines each reading sequentially through one worker's transaction. The first worker error cancels the shared context and propagates from `Wait()` — matching the existing fail-halt semantics.

### Why not chunk within a table?

Intra-table chunking (splitting one huge table across N workers by PK range) would help a single-table-dominated workload but is a materially larger change: it requires teaching `querySnapshotTable` about range bounds, computing partition boundaries cheaply, and handling non-integer PKs. This PR deliberately stops at table-level parallelism — the common case for snapshot-bound pipelines — and leaves intra-table chunking to a follow-up change behind its own config flag.

### Why not table-level fault isolation (`snapshot_fail_mode`)?

It is a semantic change (pipeline may proceed with an incomplete snapshot) and is orthogonal to parallelism. Keeping this PR scoped to pure performance optimisation makes review and rollback trivial. A follow-up PR can add `snapshot_fail_mode: continue_and_report` for operators who want to trade strict completeness for fault isolation across the N workers.

## Backwards compatibility

The default value of `snapshot_max_parallel_tables` is `1`. In that mode:

- The config spec adds one `Advanced()` int field. Existing YAML is unaffected.
- `startMySQLSync` dispatches to `runSequentialSnapshot`, whose body is the original flow with no behavioural changes.
- `readSnapshot` now delegates its per-table body to `readSnapshotTable`, a pure extract-method refactor.

There are no new dependencies, no changes to the `snapshotComplete` handoff, no changes to the binlog position captured, and no changes to the message schema. Existing integration tests (`TestIntegrationMySQLSnapshotAndCDC`, `TestIntegrationMySQLSnapshotConsistency`, `TestIntegrationMySQLCDCWithCompositePrimaryKeys`, `TestIntegrationMySQLCDCSchemaMetadata`) all pass unchanged — they continue to exercise the sequential path exclusively.

## Tests added

### Unit (`internal/impl/mysql/parallel_snapshot_test.go`)

Fan-out helper tested independently of MySQL:

- `CoversEveryTableExactlyOnce` — parametrised over 1, 2, 3, 4, 8, 16 workers.
- `WorkerCountCappedByTableCount` — extra workers are not spawned.
- `SingleWorkerIsSequential` — `workerCount=1` observes at most one in-flight read.
- `ErrorPropagatesAndCancelsSiblings` — errgroup cancellation semantics.
- `ContextCancellationPropagates` — external cancellation produces `context.Canceled`.
- `ZeroWorkersRejected` — explicit error for misconfiguration.
- `EmptyTablesIsNoop` — no `readFn` invocations for an empty input.
- `WorkerIdxWithinBounds` — callbacks receive a valid worker index.

### Unit (`internal/impl/mysql/config_test.go`)

- `TestConfig_SnapshotMaxParallelTables_DefaultAndExplicit` — default of `1`, explicit value of `8` round-trips through the spec.
- `TestConfig_SnapshotMaxParallelTables_InvalidValuesRejected` — non-positive values violate the constructor's validation predicate.

### Integration (`internal/impl/mysql/integration_test.go`)

`TestIntegrationMySQLParallelSnapshot` — spins up MySQL 8.0 via testcontainers, creates four tables of 500 rows each, runs the `mysql_cdc` input with `snapshot_max_parallel_tables: 4`, verifies:

- Every snapshot row for every table is emitted exactly once.
- Additional rows inserted after the snapshot are picked up by the binlog stream, confirming the single shared binlog position captured under the lock window is a valid starting point.

## Local test results

```
# Unit (whole package, race detector on)
ok  internal/impl/mysql  8.995s   (-race -shuffle=on)

# Integration - new test
PASS: TestIntegrationMySQLParallelSnapshot (36.31s)

# Integration - existing snapshot path regressions
PASS: TestIntegrationMySQLSnapshotAndCDC
PASS: TestIntegrationMySQLSnapshotConsistency
PASS: TestIntegrationMySQLCDCWithCompositePrimaryKeys
PASS: TestIntegrationMySQLCDCSchemaMetadata
```

Log excerpt from `TestIntegrationMySQLParallelSnapshot` confirming simultaneous per-table reads:

```
Acquiring table-level read locks for parallel snapshot (4 workers): FLUSH TABLES `foo1`, `foo2`, `foo3`, `foo4` WITH READ LOCK
Querying snapshot: SELECT * FROM foo4 ORDER BY a LIMIT ?
Querying snapshot: SELECT * FROM foo3 ORDER BY a LIMIT ?
Querying snapshot: SELECT * FROM foo2 ORDER BY a LIMIT ?
Querying snapshot: SELECT * FROM foo1 ORDER BY a LIMIT ?
...
starting MySQL CDC stream from binlog mysql-bin.000003 at offset 559037
```

## Test plan

- [x] Run unit tests for `internal/impl/mysql` with `-race -shuffle=on`
- [x] Run new integration test `TestIntegrationMySQLParallelSnapshot`
- [x] Re-run existing sequential-path integration tests for regression
- [x] Verify `gofmt` cleanliness
- [ ] Maintainer review of consistency-model reasoning
- [ ] CI green across the full integration matrix