### PR TITLE
oracledb_cdc: address issue with Oracle stripping leading zeros

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -832,7 +832,8 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		-- Other Data Types
 		bit_col           NUMBER(1),                    -- Boolean-like (0,1,NULL)
 		-- xml_col           XMLTYPE,
-		json_col          CLOB                          -- JSON stored as CLOB
+		json_col          CLOB,                         -- JSON stored as CLOB
+		noleadingzero_col NUMBER                        -- observe Oracle's non-leading zero decimal handling (0.15 -> .15)
 	) LOB(oolvarcharmax_col) STORE AS BASICFILE (DISABLE STORAGE IN ROW NOCACHE LOGGING)`
 	err := db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.all_data_types", q)
 	require.NoError(t, err)
@@ -848,7 +849,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		time_col, datetimeoffset_col, char_col, varchar_col,
 		nchar_col, nvarchar_col, binary_col, varbinary_col,
 		varcharmax_col, oolvarcharmax_col, nvarcharmax_col, varbinarymax_col,
-		bit_col, json_col
+		bit_col, json_col, noleadingzero_col
 	) VALUES (
 		:1, :2, :3, :4,
 		:5, :6, :7, :8,
@@ -856,7 +857,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		:13, :14, :15, :16,
 		:17, :18, :19, :20,
 		:21, :22, :23, :24,
-		:25, :26
+		:25, :26, :27
 	)`
 
 	t.Log("Inserting min values for testing snapshot data...")
@@ -889,6 +890,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 			nil,          // blob (varbinarymax_col)
 			0,            // bit (number)
 			nil,          // json (clob)
+			"0.15",       // noleadingzero_col
 		)
 	}
 
@@ -984,6 +986,7 @@ oracledb_cdc:
 			make([]byte, 255),    // blob (varbinarymax_col)
 			1,                    // bit max (number)
 			`{"max": true}`,      // json (clob)
+			"0.15",               // noleadingzero_col
 		)
 
 		minWant := 2
@@ -1040,7 +1043,8 @@ oracledb_cdc:
 		"VARBINARYMAX_COL": null,
 		"VARCHAR_COL": null,
 		"OOLVARCHARMAX_COL": null,
-		"VARCHARMAX_COL": null
+		"VARCHARMAX_COL": null,
+		"NOLEADINGZERO_COL": 0.15
 		}`, outBatches[0], "Failed to assert min result from snapshot")
 	}
 
@@ -1073,7 +1077,8 @@ oracledb_cdc:
 		"VARBINARYMAX_COL": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		"VARCHAR_COL": "Max varchar value",
 		"OOLVARCHARMAX_COL": "`+largeClob+`",
-		"VARCHARMAX_COL": "Max varchar(max)"
+		"VARCHARMAX_COL": "Max varchar(max)",
+		"NOLEADINGZERO_COL": 0.15
 		}`, outBatches[1], "Failed to assert max result from streaming")
 	}
 }

--- a/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
+++ b/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
@@ -81,7 +81,10 @@ func (c *OracleValueConverter) ConvertValue(value any) any {
 		return n
 	}
 	if f, err := strconv.ParseFloat(str, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-		return json.Number(str)
+		// Oracle can emit bare decimal values without a leading zero (e.g. ".5"
+		// instead of "0.5"). JSON requires a digit before the decimal point, so
+		// we normalise the string before wrapping it in json.Number.
+		return json.Number(normalizeJSONNumber(str))
 	}
 
 	return value
@@ -204,6 +207,20 @@ func (*OracleValueConverter) convertLobValue(value string) any {
 		return []byte{}
 	}
 	return value
+}
+
+// normalizeJSONNumber ensures a numeric string is valid JSON by adding a
+// leading zero when the value starts with a bare decimal point.
+// Oracle SQL_REDO can emit numbers like ".5" or "-.5" (no digit before the
+// decimal), which are not valid JSON. This converts them to "0.5" / "-0.5".
+func normalizeJSONNumber(s string) string {
+	if strings.HasPrefix(s, ".") {
+		return "0" + s
+	}
+	if strings.HasPrefix(s, "-.") {
+		return "-0" + s[1:]
+	}
+	return s
 }
 
 // oracleFormatToGo converts Oracle date/timestamp format to Go format

--- a/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
+++ b/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
@@ -81,10 +81,7 @@ func (c *OracleValueConverter) ConvertValue(value any) any {
 		return n
 	}
 	if f, err := strconv.ParseFloat(str, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-		// Oracle can emit bare decimal values without a leading zero (e.g. ".5"
-		// instead of "0.5"). JSON requires a digit before the decimal point, so
-		// we normalise the string before wrapping it in json.Number.
-		return json.Number(normalizeJSONNumber(str))
+		return json.Number(NormalizeJSONNumber(str))
 	}
 
 	return value
@@ -209,11 +206,11 @@ func (*OracleValueConverter) convertLobValue(value string) any {
 	return value
 }
 
-// normalizeJSONNumber ensures a numeric string is valid JSON by adding a
+// NormalizeJSONNumber ensures a numeric string is valid JSON by adding a
 // leading zero when the value starts with a bare decimal point.
 // Oracle SQL_REDO can emit numbers like ".5" or "-.5" (no digit before the
 // decimal), which are not valid JSON. This converts them to "0.5" / "-0.5".
-func normalizeJSONNumber(s string) string {
+func NormalizeJSONNumber(s string) string {
 	if strings.HasPrefix(s, ".") {
 		return "0" + s
 	}

--- a/internal/impl/oracledb/logminer/sqlredo/valueconverter_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/valueconverter_test.go
@@ -311,6 +311,16 @@ func TestConvertValue(t *testing.T) {
 			wantValue: json.Number("45.67"),
 		},
 		{
+			name:      "bare decimal without leading zero normalised to json.Number",
+			input:     ".5",
+			wantValue: json.Number("0.5"),
+		},
+		{
+			name:      "bare negative decimal without leading zero normalised to json.Number",
+			input:     "-.5",
+			wantValue: json.Number("-0.5"),
+		},
+		{
 			name:      "bare scientific notation converts to json.Number",
 			input:     "1.79E+100",
 			wantValue: json.Number("1.79E+100"),
@@ -352,6 +362,29 @@ func TestConvertValue(t *testing.T) {
 			result := converter.ConvertValue(tt.input)
 			assert.IsType(t, tt.wantValue, result)
 			assert.Equal(t, tt.wantValue, result)
+		})
+	}
+}
+
+func TestConvertValueJSONMarshalRoundtrip(t *testing.T) {
+	// Ensure that all json.Number values produced by ConvertValue are valid JSON
+	// and can be round-tripped through json.Marshal without error.
+	converter := NewOracleValueConverter(time.UTC)
+
+	inputs := []string{
+		".5", "-.5", ".123456", "-.999",
+		"45.67", "-45.67", "0.5", "1.79E+100", "3.3999999E+037",
+		"9223372036854775808",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			result := converter.ConvertValue(input)
+			jn, ok := result.(json.Number)
+			if !ok {
+				return // not a json.Number, skip
+			}
+			_, err := json.Marshal(jn)
+			assert.NoErrorf(t, err, "json.Marshal(json.Number(%q)) should not fail", string(jn))
 		})
 	}
 }

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -301,6 +301,20 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 // Streaming value coercion
 // ---------------------------------------------------------------------------
 
+// normalizeJSONNumber ensures a numeric string is valid JSON by adding a
+// leading zero when the value starts with a bare decimal point.
+// Oracle can emit values like ".5" or "-.5" (no digit before the decimal),
+// which are not accepted by encoding/json as json.Number literals.
+func normalizeJSONNumber(s string) string {
+	if strings.HasPrefix(s, ".") {
+		return "0" + s
+	}
+	if strings.HasPrefix(s, "-.") {
+		return "-0" + s[1:]
+	}
+	return s
+}
+
 // coerceStreamingValues converts string values from LogMiner SQL_REDO parsing
 // to their proper Go types based on schema column metadata. This ensures type
 // consistency between snapshot (which returns native Go types via sql.Scan) and
@@ -361,7 +375,9 @@ func coerceStreamingValues(data map[string]any, info *columnTypeInfo, log *servi
 			// VARCHAR2. Use numericCols to distinguish: only NUMBER-as-String
 			// columns get wrapped as json.Number to match snapshot behavior.
 			if _, isNumeric := info.numericCols[col]; isNumeric {
-				data[col] = json.Number(s)
+				// Oracle may produce values without a leading zero (e.g. ".5").
+				// Normalise to valid JSON before wrapping in json.Number.
+				data[col] = json.Number(normalizeJSONNumber(s))
 			}
 		}
 	}

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/logminer/sqlredo"
 	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
 )
 
@@ -301,20 +302,6 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 // Streaming value coercion
 // ---------------------------------------------------------------------------
 
-// normalizeJSONNumber ensures a numeric string is valid JSON by adding a
-// leading zero when the value starts with a bare decimal point.
-// Oracle can emit values like ".5" or "-.5" (no digit before the decimal),
-// which are not accepted by encoding/json as json.Number literals.
-func normalizeJSONNumber(s string) string {
-	if strings.HasPrefix(s, ".") {
-		return "0" + s
-	}
-	if strings.HasPrefix(s, "-.") {
-		return "-0" + s[1:]
-	}
-	return s
-}
-
 // coerceStreamingValues converts string values from LogMiner SQL_REDO parsing
 // to their proper Go types based on schema column metadata. This ensures type
 // consistency between snapshot (which returns native Go types via sql.Scan) and
@@ -375,9 +362,7 @@ func coerceStreamingValues(data map[string]any, info *columnTypeInfo, log *servi
 			// VARCHAR2. Use numericCols to distinguish: only NUMBER-as-String
 			// columns get wrapped as json.Number to match snapshot behavior.
 			if _, isNumeric := info.numericCols[col]; isNumeric {
-				// Oracle may produce values without a leading zero (e.g. ".5").
-				// Normalise to valid JSON before wrapping in json.Number.
-				data[col] = json.Number(normalizeJSONNumber(s))
+				data[col] = json.Number(sqlredo.NormalizeJSONNumber(s))
 			}
 		}
 	}


### PR DESCRIPTION
OracleDB strips leading zeros on decimals such as 0.15 (storing it as .15) which results in invalid JSON. This change normalises them ensuring they're consistent between snapshot and streaming.

The `go-ora` package already takes care of this (using the same approach) but because we're reading directly from LogMiner, we have to take care of it ourselves.

<img width="1627" height="663" alt="image" src="https://github.com/user-attachments/assets/dfe35c2d-07dc-4beb-b67f-fa29d0b53982" />
