### PR TITLE
postgres_cdc: continuous table discovery with mid-stream snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - parquet_encode: Added `default_timestamp_unit` field (values `NANOSECOND`, `MICROSECOND`, `MILLISECOND`) controlling the precision of TIMESTAMP logical types. Default remains `NANOSECOND` for backwards compatibility. Use `MICROSECOND` when writing files for Apache Spark/Databricks, AWS Athena or DuckDB, which do not support `TIMESTAMP(NANOS)`. ([#3570](https://github.com/redpanda-data/connect/issues/3570))
+- postgres_cdc: Added `auto_discover_tables` and `discovery_interval` fields to enable continuous mid-stream discovery of new tables. When enabled, newly-created tables in the configured schema are added to the publication, snapshotted, and included in CDC without restarting the replication slot. Per-table snapshot LSN watermarks deduplicate WAL events that overlap with the snapshot window.
 
 ## 4.88.0 - 2026-04-16
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -43,6 +43,8 @@ const (
 	fieldMaxParallelSnapshotTables = "max_parallel_snapshot_tables"
 	fieldUnchangedToastValue       = "unchanged_toast_value"
 	fieldHeartbeatInterval         = "heartbeat_interval"
+	fieldAutoDiscoverTables        = "auto_discover_tables"
+	fieldDiscoveryInterval         = "discovery_interval"
 	fieldAWSIAMAuth                = "aws"
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
@@ -108,8 +110,18 @@ This input adds the following metadata fields to each message:
 			Examples("public", `"MyCaseSensitiveSchemaNeedingQuotes"`),
 		).
 		Field(service.NewStringListField(fieldTables).
-			Description("A list of table names to include in the logical replication. Each table should be specified as a separate item.").
+			Description("A list of table names to include in the logical replication. Each table should be specified as a separate item. May be empty when `"+fieldAutoDiscoverTables+"` is true.").
+			Default([]any{}).
 			Example([]string{"my_table_1", `"MyCaseSensitiveTableNeedingQuotes"`})).
+		Field(service.NewBoolField(fieldAutoDiscoverTables).
+			Description("When true, the input periodically polls `schema` for new tables. Each newly-discovered table is added to the publication, snapshotted mid-stream, and then included in ongoing CDC. The main replication slot is never restarted. Tables listed in `"+fieldTables+"` are still included; discovery is purely additive. Tables without a primary key are skipped (a warning is logged) because the snapshotter requires a primary key.").
+			Default(false).
+			Advanced()).
+		Field(service.NewDurationField(fieldDiscoveryInterval).
+			Description("How often to poll for newly-created tables. Only used when `"+fieldAutoDiscoverTables+"` is true.").
+			Default("60s").
+			Example("30s").
+			Advanced()).
 		Field(service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given LSN will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
 			Default(1024)).
@@ -208,6 +220,8 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		batching                  service.BatchPolicy
 		unchangedToastValue       any
 		heartbeatInterval         time.Duration
+		autoDiscoverTables        bool
+		discoveryInterval         time.Duration
 		iamAuthEnabled            bool
 		iamAuthTokenBuilder       TokenBuilder
 	)
@@ -284,6 +298,23 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		return nil, err
 	}
 
+	if autoDiscoverTables, err = conf.FieldBool(fieldAutoDiscoverTables); err != nil {
+		return nil, err
+	}
+
+	if discoveryInterval, err = conf.FieldDuration(fieldDiscoveryInterval); err != nil {
+		return nil, err
+	}
+
+	if autoDiscoverTables {
+		if schema == "" {
+			return nil, fmt.Errorf("`%s` requires `%s` to be set", fieldAutoDiscoverTables, fieldSchema)
+		}
+		if discoveryInterval <= 0 {
+			return nil, fmt.Errorf("`%s` must be greater than zero when `%s` is true", fieldDiscoveryInterval, fieldAutoDiscoverTables)
+		}
+	}
+
 	awsConf := conf.Namespace(fieldAWSIAMAuth)
 	iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
 
@@ -333,6 +364,8 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 			Logger:                   logger,
 			UnchangedToastValue:      unchangedToastValue,
 			HeartbeatInterval:        heartbeatInterval,
+			AutoDiscoverTables:       autoDiscoverTables,
+			DiscoveryInterval:        discoveryInterval,
 		},
 		batching:        batching,
 		checkpointLimit: checkpointLimit,

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -1423,3 +1423,138 @@ postgres_cdc:
 	}
 	assert.Equal(t, "STRING", byName["extra"], "new 'extra' column should have type STRING")
 }
+
+// TestIntegrationPostgresAutoDiscoverTables verifies that, with
+// auto_discover_tables enabled, a table created mid-stream is discovered,
+// snapshotted, and continues to receive CDC events without restarting the
+// pipeline. It also validates the per-table watermark dedup: WAL events that
+// overlap with the snapshot window are not emitted as duplicates.
+func TestIntegrationPostgresAutoDiscoverTables(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	// Seed flights so initial snapshot has work to do, exercising the path
+	// where the originally-configured table is unaffected by discovery.
+	for i := range 5 {
+		f := GetFakeFlightRecord()
+		_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ($1, $2);`,
+			f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		require.NoError(t, err)
+		_ = i
+	}
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_auto_discover
+    stream_snapshot: true
+    snapshot_batch_size: 5
+    schema: public
+    tables:
+       - flights
+    auto_discover_tables: true
+    discovery_interval: 2s
+`, databaseURL)
+
+	type collected struct {
+		table     string
+		operation string
+	}
+	var (
+		mu       sync.Mutex
+		messages []collected
+	)
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML(`level: WARN`))
+	require.NoError(t, sb.AddInputYAML(template))
+	require.NoError(t, sb.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, m := range mb {
+			tbl, _ := m.MetaGet("table")
+			op, _ := m.MetaGet("operation")
+			messages = append(messages, collected{table: tbl, operation: op})
+		}
+		return nil
+	}))
+
+	streamOut, err := sb.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+
+	go func() { _ = streamOut.Run(t.Context()) }()
+	t.Cleanup(func() { _ = streamOut.StopWithin(time.Second * 10) })
+
+	// Wait for the initial snapshot of `flights` to land.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		count := 0
+		for _, m := range messages {
+			if m.table == "flights" && m.operation == "read" {
+				count++
+			}
+		}
+		assert.GreaterOrEqual(c, count, 5, "initial snapshot reads for flights")
+	}, time.Second*30, time.Millisecond*100)
+
+	// Create a brand-new table after the stream is running. This must be
+	// picked up by the discoverer within ~1 discovery interval.
+	_, err = db.Exec(`CREATE TABLE auto_discovered_orders (id SERIAL PRIMARY KEY, sku TEXT)`)
+	require.NoError(t, err)
+
+	// Seed it before discovery, so its rows must come through the snapshot
+	// path (NOT the WAL path — these inserts happened before the table was
+	// in the publication and therefore are not in the WAL stream).
+	for i := range 4 {
+		_, err = db.Exec(`INSERT INTO auto_discovered_orders (sku) VALUES ($1)`, fmt.Sprintf("sku-%d", i))
+		require.NoError(t, err)
+	}
+
+	// After discovery completes (which adds the table to the publication and
+	// snapshots it), the four pre-discovery rows arrive as 'read' messages.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		readCount := 0
+		for _, m := range messages {
+			if m.table == "auto_discovered_orders" && m.operation == "read" {
+				readCount++
+			}
+		}
+		assert.Equal(c, 4, readCount, "four snapshot reads for auto-discovered table")
+	}, time.Second*30, time.Millisecond*100)
+
+	// Now insert *post*-discovery. These come through the WAL stream as
+	// 'insert' operations. They must arrive exactly once — the watermark
+	// dedup should not eat them (their LSN > snapshot watermark).
+	for i := 4; i < 7; i++ {
+		_, err = db.Exec(`INSERT INTO auto_discovered_orders (sku) VALUES ($1)`, fmt.Sprintf("sku-%d", i))
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		insertCount := 0
+		for _, m := range messages {
+			if m.table == "auto_discovered_orders" && m.operation == "insert" {
+				insertCount++
+			}
+		}
+		assert.Equal(c, 3, insertCount, "three CDC inserts for auto-discovered table after discovery")
+	}, time.Second*30, time.Millisecond*100)
+
+	// Sanity: no duplicate snapshot reads (would indicate dedup failure).
+	mu.Lock()
+	defer mu.Unlock()
+	readCount := 0
+	for _, m := range messages {
+		if m.table == "auto_discovered_orders" && m.operation == "read" {
+			readCount++
+		}
+	}
+	assert.Equal(t, 4, readCount, "snapshot reads must not duplicate")
+}

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -50,4 +50,13 @@ type Config struct {
 	UnchangedToastValue any
 	// The interval to send logical messages
 	HeartbeatInterval time.Duration
+	// AutoDiscoverTables enables periodic discovery of new tables in DBSchema.
+	// When true, newly-created tables are added to the publication and snapshotted
+	// mid-stream without requiring a pipeline restart. WAL events for the new
+	// table that overlap with the snapshot are deduplicated by per-table LSN
+	// watermark, so each row is emitted exactly once.
+	AutoDiscoverTables bool
+	// DiscoveryInterval is the polling interval for table discovery.
+	// Only used when AutoDiscoverTables is true.
+	DiscoveryInterval time.Duration
 }

--- a/internal/impl/postgresql/pglogicalstream/discovery.go
+++ b/internal/impl/postgresql/pglogicalstream/discovery.go
@@ -258,7 +258,7 @@ func (d *discoverer) snapshotTableAt(ctx context.Context, table TableFQN, snapsh
 		return fmt.Errorf("preparing snapshotter: %w", err)
 	}
 
-	pkColumns, err := d.stream.getPrimaryKeyColumn(ctx, table)
+	pkColumns, err := d.primaryKeyColumns(ctx, table)
 	if err != nil {
 		// Tables without a primary key cannot be snapshotted by the existing
 		// scanner. Roll back the publication change so streaming for T does
@@ -271,6 +271,47 @@ func (d *discoverer) snapshotTableAt(ctx context.Context, table TableFQN, snapsh
 		return fmt.Errorf("getting primary key for %s: %w", table, err)
 	}
 	return d.stream.scanTableRange(ctx, snap, table, nil, nil, pkColumns)
+}
+
+// primaryKeyColumns queries the primary key columns for a table using the
+// discovery SQL connection rather than the main replication connection, which
+// is concurrently in use by the streaming goroutine and would error with
+// "conn busy". Returns quoted identifiers to match the shape expected by
+// scanTableRange.
+func (d *discoverer) primaryKeyColumns(ctx context.Context, table TableFQN) ([]string, error) {
+	q, err := sanitize.SQLQuery(`
+        SELECT a.attname
+        FROM   pg_index i
+        JOIN   pg_attribute a ON a.attrelid = i.indrelid
+            AND a.attnum = ANY(i.indkey)
+        WHERE  i.indrelid = $1::regclass
+        AND    i.indisprimary
+        ORDER BY array_position(i.indkey, a.attnum)
+    `, table.String())
+	if err != nil {
+		return nil, fmt.Errorf("sanitizing PK query: %w", err)
+	}
+	rows, err := d.pollConn.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("querying primary key: %w", err)
+	}
+	defer rows.Close()
+
+	var pkColumns []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scanning primary key column: %w", err)
+		}
+		pkColumns = append(pkColumns, sanitize.QuotePostgresIdentifier(name))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(pkColumns) == 0 {
+		return nil, fmt.Errorf("no primary key found for table %s", table)
+	}
+	return pkColumns, nil
 }
 
 func (d *discoverer) alterPublicationDropTable(ctx context.Context, table TableFQN) error {

--- a/internal/impl/postgresql/pglogicalstream/discovery.go
+++ b/internal/impl/postgresql/pglogicalstream/discovery.go
@@ -1,0 +1,310 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+)
+
+// discoverer periodically polls the configured schema for new tables and adds
+// them to the live replication set without restarting the main replication
+// slot.
+//
+// Per discovery tick, for each newly-found table T:
+//  1. ALTER PUBLICATION ... ADD TABLE T              (LSN advances past L_add)
+//  2. CREATE_REPLICATION_SLOT tmp_T ... EXPORT_SNAPSHOT
+//     -> returns (L_snap, snapshot_name)
+//  3. snapshot T at snapshot_name (single-worker sequential scan)
+//  4. record tableWatermark[T] = L_snap on the parent stream
+//  5. DROP_REPLICATION_SLOT tmp_T
+//  6. register T with the monitor
+//  7. add T to the parent stream's live tables set
+//
+// WAL events for T with LSN <= L_snap are suppressed by the parent stream's
+// processChange, since the snapshot at L_snap already contains them. Events
+// with LSN > L_snap flow through normally.
+type discoverer struct {
+	stream  *Stream
+	config  *Config
+	pubName string
+	logger  *service.Logger
+
+	// pollConn is a regular SQL connection used for: polling pg_tables,
+	// running ALTER PUBLICATION, and querying primary key info before
+	// snapshotting. ALTER PUBLICATION cannot run on a replication-mode
+	// connection on all PG versions, so we keep this separate from the
+	// replication conn used for slot creation.
+	pollConn *sql.DB
+
+	loop *asyncroutine.Periodic
+}
+
+func newDiscoverer(ctx context.Context, stream *Stream, config *Config, pubName string) (*discoverer, error) {
+	conn, err := openPgConnectionFromConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("opening discovery connection: %w", err)
+	}
+	if err := conn.PingContext(ctx); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("pinging discovery connection: %w", err)
+	}
+	d := &discoverer{
+		stream:   stream,
+		config:   config,
+		pubName:  pubName,
+		logger:   config.Logger,
+		pollConn: conn,
+	}
+	d.loop = asyncroutine.NewPeriodicWithContext(config.DiscoveryInterval, d.tick)
+	return d, nil
+}
+
+// Start begins the discovery polling loop.
+func (d *discoverer) Start() {
+	d.loop.Start()
+}
+
+// Stop halts the discovery loop and closes the connection.
+func (d *discoverer) Stop() error {
+	d.loop.Stop()
+	return d.pollConn.Close()
+}
+
+func (d *discoverer) tick(ctx context.Context) {
+	// One discovery cycle. Logs and continues on per-table errors so that a
+	// single bad table doesn't stall discovery for the rest of the schema.
+	candidates, err := d.listSchemaTables(ctx)
+	if err != nil {
+		d.logger.Warnf("table discovery: listing schema tables: %v", err)
+		return
+	}
+	known := d.stream.knownTableNames()
+	for _, t := range candidates {
+		if ctx.Err() != nil {
+			return
+		}
+		if _, seen := known[t.String()]; seen {
+			continue
+		}
+		if err := d.addTable(ctx, t); err != nil {
+			d.logger.Warnf("table discovery: adding %s: %v", t, err)
+			continue
+		}
+		d.logger.Infof("table discovery: added %s", t)
+	}
+}
+
+// listSchemaTables returns all base tables in the configured schema, with
+// schema and table name normalized to TableFQN form (quoted as needed).
+func (d *discoverer) listSchemaTables(ctx context.Context) ([]TableFQN, error) {
+	unquotedSchema, err := sanitize.UnquotePostgresIdentifier(d.stream.schema)
+	if err != nil {
+		return nil, fmt.Errorf("unquoting schema: %w", err)
+	}
+	rows, err := d.pollConn.QueryContext(ctx, `
+		SELECT tablename
+		FROM pg_tables
+		WHERE schemaname = $1
+		ORDER BY tablename
+	`, unquotedSchema)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []TableFQN
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		normalized, err := sanitize.NormalizePostgresIdentifier(name)
+		if err != nil {
+			d.logger.Warnf("table discovery: skipping table with invalid identifier %q: %v", name, err)
+			continue
+		}
+		out = append(out, TableFQN{Schema: d.stream.schema, Table: normalized})
+	}
+	return out, rows.Err()
+}
+
+// addTable runs the full discovery protocol for a single table.
+func (d *discoverer) addTable(ctx context.Context, table TableFQN) error {
+	// Step 1: ALTER PUBLICATION ADD TABLE.
+	if err := d.alterPublicationAddTable(ctx, table); err != nil {
+		// undefined_table = 42P01: table was dropped between listSchemaTables
+		// and now. Treat as benign; next tick will skip it.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			return nil
+		}
+		return fmt.Errorf("ALTER PUBLICATION ADD TABLE: %w", err)
+	}
+
+	// Step 2: open a replication connection and create a temporary slot
+	// with EXPORT_SNAPSHOT to anchor the snapshot at a known LSN.
+	repConn, err := pgconn.ConnectConfig(ctx, d.config.DBConfig.Copy())
+	if err != nil {
+		return fmt.Errorf("opening replication connection: %w", err)
+	}
+	defer func() {
+		if cerr := repConn.Close(ctx); cerr != nil {
+			d.logger.Warnf("table discovery: closing replication conn for %s: %v", table, cerr)
+		}
+	}()
+
+	tmpSlot, err := tempSlotName(d.stream.slotName)
+	if err != nil {
+		return fmt.Errorf("generating temp slot name: %w", err)
+	}
+	snapLSN, snapName, err := CreateReplicationSlot(
+		ctx,
+		repConn,
+		tmpSlot,
+		decodingPlugin,
+		CreateReplicationSlotOptions{Temporary: true, SnapshotAction: "EXPORT_SNAPSHOT"},
+	)
+	if err != nil {
+		return fmt.Errorf("creating temporary slot: %w", err)
+	}
+	// Slot is temporary and tied to repConn; closing repConn drops it. We
+	// also call DROP explicitly to release sooner where supported.
+	defer func() {
+		if dropErr := DropReplicationSlot(ctx, repConn, tmpSlot, DropReplicationSlotOptions{Wait: false}); dropErr != nil {
+			// Temp slots auto-drop on conn close; log at debug only.
+			d.logger.Debugf("table discovery: dropping temp slot %s: %v", tmpSlot, dropErr)
+		}
+	}()
+
+	// Step 3: snapshot T at the exported snapshot.
+	if err := d.snapshotTableAt(ctx, table, snapName); err != nil {
+		return fmt.Errorf("snapshotting %s: %w", table, err)
+	}
+
+	// Steps 4-7: register watermark, monitor entry, live table list. Order
+	// matters: the watermark must be set BEFORE the table appears in the
+	// known set, otherwise a WAL event for T arriving between knownTableNames
+	// being read by processChange and the watermark being installed would
+	// emit a duplicate.
+	d.stream.installDiscoveredTable(table, snapLSN)
+	if err := d.stream.monitor.RegisterTable(ctx, table); err != nil {
+		// Non-fatal: progress reporting will be incomplete for T but data
+		// flow is unaffected.
+		d.logger.Warnf("table discovery: registering %s with monitor: %v", table, err)
+	}
+	// Snapshot is complete by the time we get here.
+	d.stream.monitor.MarkSnapshotComplete(table)
+	return nil
+}
+
+func (d *discoverer) alterPublicationAddTable(ctx context.Context, table TableFQN) error {
+	// pubName and table.String() are both pre-validated identifiers, so
+	// fmt.Sprintf is safe here. We still go through sanitize.SQLQuery as a
+	// belt-and-braces check.
+	q, err := sanitize.SQLQuery(fmt.Sprintf("ALTER PUBLICATION %s ADD TABLE %s", d.pubName, table.String()))
+	if err != nil {
+		return fmt.Errorf("sanitizing ALTER PUBLICATION: %w", err)
+	}
+	if _, err := d.pollConn.ExecContext(ctx, q); err != nil {
+		// "relation already in publication" is benign — happens when a crash
+		// left the publication ahead of our local known-tables set.
+		if strings.Contains(err.Error(), "is already member of publication") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// snapshotTableAt snapshots a single table using the given exported snapshot
+// name. It opens its own snapshotter scoped to this snapshot, runs a
+// sequential scan, and emits messages on the parent stream's message channel.
+func (d *discoverer) snapshotTableAt(ctx context.Context, table TableFQN, snapshotName string) error {
+	// Use a single reader for incrementally-discovered tables. The
+	// keyspace-splitting parallelism in the initial snapshotter is mostly
+	// useful for very large tables on cold start; new tables are typically
+	// small and a single reader keeps the implementation simple and
+	// predictable.
+	snap, err := newSnapshotter(d.config, d.config.DBRawDSN, d.logger, snapshotName, 1)
+	if err != nil {
+		return fmt.Errorf("opening snapshotter: %w", err)
+	}
+	defer func() {
+		if err := snap.closeConn(); err != nil {
+			d.logger.Warnf("table discovery: closing snapshotter for %s: %v", table, err)
+		}
+	}()
+	if err := snap.Prepare(ctx); err != nil {
+		return fmt.Errorf("preparing snapshotter: %w", err)
+	}
+
+	pkColumns, err := d.stream.getPrimaryKeyColumn(ctx, table)
+	if err != nil {
+		// Tables without a primary key cannot be snapshotted by the existing
+		// scanner. Roll back the publication change so streaming for T does
+		// not silently emit WAL events for a table whose initial state we
+		// never captured.
+		d.logger.Warnf("table discovery: skipping %s (no primary key); rolling back publication change", table)
+		if rbErr := d.alterPublicationDropTable(ctx, table); rbErr != nil {
+			d.logger.Warnf("table discovery: rolling back %s from publication: %v", table, rbErr)
+		}
+		return fmt.Errorf("getting primary key for %s: %w", table, err)
+	}
+	return d.stream.scanTableRange(ctx, snap, table, nil, nil, pkColumns)
+}
+
+func (d *discoverer) alterPublicationDropTable(ctx context.Context, table TableFQN) error {
+	q, err := sanitize.SQLQuery(fmt.Sprintf("ALTER PUBLICATION %s DROP TABLE %s", d.pubName, table.String()))
+	if err != nil {
+		return err
+	}
+	_, err = d.pollConn.ExecContext(ctx, q)
+	return err
+}
+
+func tempSlotName(parent string) (string, error) {
+	// Append a random suffix so that overlapping tick cycles (or stale temp
+	// slots from a previous crash) don't collide. Slots are created with
+	// Temporary: true, so they are auto-dropped on connection close.
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	suffix := hex.EncodeToString(buf[:])
+	// Slot names must be <= 64 bytes and lowercase identifiers; truncate the
+	// parent if needed to leave room for "_dsc_" + 8 hex chars.
+	const reservedSuffix = len("_dsc_") + 8
+	maxParent := 63 - reservedSuffix
+	if len(parent) > maxParent {
+		parent = parent[:maxParent]
+	}
+	return fmt.Sprintf("%s_dsc_%s", parent, suffix), nil
+}
+
+// pingDiscoveryReady is exported for tests so they can wait until the
+// discovery goroutine has had a chance to run without sleeping.
+//
+//nolint:unused // used by tests in this package
+func (d *discoverer) pingDiscoveryReady() time.Duration {
+	return d.config.DiscoveryInterval
+}

--- a/internal/impl/postgresql/pglogicalstream/discovery_test.go
+++ b/internal/impl/postgresql/pglogicalstream/discovery_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTempSlotName(t *testing.T) {
+	t.Run("appends random suffix", func(t *testing.T) {
+		a, err := tempSlotName("my_slot")
+		require.NoError(t, err)
+		b, err := tempSlotName("my_slot")
+		require.NoError(t, err)
+		require.NotEqual(t, a, b, "two calls must produce distinct names to avoid collision")
+		require.True(t, strings.HasPrefix(a, "my_slot_dsc_"))
+		require.True(t, strings.HasPrefix(b, "my_slot_dsc_"))
+	})
+
+	t.Run("truncates long parent to fit pg slot name limit", func(t *testing.T) {
+		// PG slot names are limited to 64 bytes. Build a parent that would
+		// otherwise overflow.
+		parent := strings.Repeat("x", 80)
+		got, err := tempSlotName(parent)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(got), 64, "slot name must fit in postgres' 64-byte limit")
+		assert.True(t, strings.Contains(got, "_dsc_"))
+	})
+}
+
+func TestWatermarkKey(t *testing.T) {
+	cases := []struct {
+		name  string
+		fqn   TableFQN
+		want  string
+	}{
+		{
+			name: "unquoted simple identifiers",
+			fqn:  TableFQN{Schema: "public", Table: "orders"},
+			want: "public.orders",
+		},
+		{
+			name: "quoted case-sensitive identifiers are unquoted",
+			fqn:  TableFQN{Schema: `"MySchema"`, Table: `"MyTable"`},
+			want: "MySchema.MyTable",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, watermarkKey(tc.fqn))
+		})
+	}
+}
+
+func TestStreamWatermarkSuppressionLogic(t *testing.T) {
+	// Exercise the pure suppression logic on a Stream value, without spinning
+	// up postgres. We construct only the fields that shouldSuppressForWatermark
+	// touches.
+	s := &Stream{
+		tableWatermark: map[string]LSN{},
+	}
+
+	// No watermark → no suppression.
+	assert.False(t, s.shouldSuppressForWatermark("public", "orders", LSN(100)))
+
+	// Install a watermark via the same code path the discoverer uses.
+	s.installDiscoveredTable(TableFQN{Schema: "public", Table: "orders"}, LSN(500))
+
+	// Below or equal to watermark → suppress.
+	assert.True(t, s.shouldSuppressForWatermark("public", "orders", LSN(100)))
+	assert.True(t, s.shouldSuppressForWatermark("public", "orders", LSN(500)))
+
+	// Above watermark → emit.
+	assert.False(t, s.shouldSuppressForWatermark("public", "orders", LSN(501)))
+
+	// Different table → not affected.
+	assert.False(t, s.shouldSuppressForWatermark("public", "users", LSN(100)))
+
+	// Quoted-identifier installs are looked up by their unquoted form,
+	// matching the form pgoutput emits in RelationMessage.
+	s.installDiscoveredTable(TableFQN{Schema: `"MySchema"`, Table: `"MyTable"`}, LSN(700))
+	assert.True(t, s.shouldSuppressForWatermark("MySchema", "MyTable", LSN(700)))
+	assert.False(t, s.shouldSuppressForWatermark("MySchema", "MyTable", LSN(701)))
+}
+
+func TestStreamKnownTableNames(t *testing.T) {
+	s := &Stream{
+		tables: []TableFQN{
+			{Schema: "public", Table: "orders"},
+			{Schema: "public", Table: "users"},
+		},
+		tableWatermark: map[string]LSN{},
+	}
+	known := s.knownTableNames()
+	assert.Len(t, known, 2)
+	_, hasOrders := known["public.orders"]
+	_, hasUsers := known["public.users"]
+	assert.True(t, hasOrders)
+	assert.True(t, hasUsers)
+
+	// installDiscoveredTable must extend the known set so the next discovery
+	// tick treats the table as already-known.
+	s.installDiscoveredTable(TableFQN{Schema: "public", Table: "newly_discovered"}, LSN(1))
+	known = s.knownTableNames()
+	_, hasNew := known["public.newly_discovered"]
+	assert.True(t, hasNew)
+}

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -45,9 +45,20 @@ type Stream struct {
 	messages              chan []StreamMessage
 	errors                chan error
 
-	includeTxnMarkers       bool
-	slotName                string
-	tables                  []TableFQN
+	includeTxnMarkers bool
+	slotName          string
+	schema            string
+	// tablesMu guards tables and tableWatermark, both of which are mutated by
+	// the discovery goroutine while the streaming goroutine reads them on the
+	// hot path of every WAL event.
+	tablesMu sync.RWMutex
+	tables   []TableFQN
+	// tableWatermark maps a fully-qualified table name (schema.table, both
+	// unquoted as they appear in StreamMessage) to the LSN at which the
+	// table's snapshot was anchored during discovery. WAL events for the
+	// table at or below this LSN are duplicates of snapshot rows and must
+	// be suppressed.
+	tableWatermark          map[string]LSN
 	snapshotBatchSize       int
 	decodingPluginArguments []string
 	logger                  *service.Logger
@@ -55,6 +66,7 @@ type Stream struct {
 	heartbeat               *heartbeat
 	maxSnapshotWorkers      int
 	unchangedToastValue     any
+	discoverer              *discoverer
 }
 
 // NewPgStream creates a new instance of the Stream struct.
@@ -113,8 +125,10 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		messages:              make(chan []StreamMessage),
 		errors:                make(chan error, 1),
 		slotName:              config.ReplicationSlotName,
+		schema:                schema,
 		snapshotBatchSize:     batchSize,
 		tables:                tables,
+		tableWatermark:        map[string]LSN{},
 		maxSnapshotWorkers:    config.MaxSnapshotWorkers,
 		logger:                config.Logger,
 		shutSig:               shutdown.NewSignaller(),
@@ -217,6 +231,9 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 				stream.errors <- fmt.Errorf("logical replication stream error: %w", err)
 			}
 		}()
+		if err := stream.maybeStartDiscoverer(ctx, config, pubName); err != nil {
+			return nil, err
+		}
 		cleanups = nil
 		return stream, nil
 	}
@@ -303,6 +320,12 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 			stream.errors <- fmt.Errorf("starting logical replication: %w", err)
 			return
 		}
+		// Start discovery now that the main slot is established and streaming
+		// is about to begin. Errors here are non-fatal: log and continue with
+		// CDC for the originally-configured tables.
+		if err := stream.maybeStartDiscoverer(ctx, config, pubName); err != nil {
+			stream.logger.Errorf("table discovery failed to start: %v", err)
+		}
 		if err := stream.streamMessages(startLSN); err != nil {
 			stream.errors <- fmt.Errorf("logical replication stream error: %w", err)
 		}
@@ -313,10 +336,83 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	return stream, nil
 }
 
+// maybeStartDiscoverer starts the table discovery loop if AutoDiscoverTables
+// is enabled in the config. The discoverer is stored on the stream so that
+// Stop() can tear it down. No-op when discovery is disabled.
+func (s *Stream) maybeStartDiscoverer(ctx context.Context, config *Config, pubName string) error {
+	if !config.AutoDiscoverTables {
+		return nil
+	}
+	d, err := newDiscoverer(ctx, s, config, pubName)
+	if err != nil {
+		return fmt.Errorf("starting table discovery: %w", err)
+	}
+	s.discoverer = d
+	d.Start()
+	return nil
+}
+
 // GetProgress returns the progress of the stream.
 // including the % of snapshot messages processed and the WAL lag in bytes.
 func (s *Stream) GetProgress() *Report {
 	return s.monitor.Report()
+}
+
+// knownTableNames returns the set of table FQNs (as TableFQN.String()) that
+// the stream is currently tracking. Used by the discoverer to compute the
+// new-table delta on each tick.
+func (s *Stream) knownTableNames() map[string]struct{} {
+	s.tablesMu.RLock()
+	defer s.tablesMu.RUnlock()
+	out := make(map[string]struct{}, len(s.tables))
+	for _, t := range s.tables {
+		out[t.String()] = struct{}{}
+	}
+	return out
+}
+
+// installDiscoveredTable atomically records the snapshot watermark and adds
+// the table to the live set. Called by the discoverer after the per-table
+// snapshot has completed but before WAL events for the table can be emitted
+// downstream — until the watermark is set, processChange would let through
+// duplicate WAL events that overlap with the snapshot.
+func (s *Stream) installDiscoveredTable(table TableFQN, snapshotLSN LSN) {
+	key := watermarkKey(table)
+	s.tablesMu.Lock()
+	s.tableWatermark[key] = snapshotLSN
+	s.tables = append(s.tables, table)
+	s.tablesMu.Unlock()
+}
+
+// shouldSuppressForWatermark returns true if a WAL event at msgLSN for the
+// given (unquoted) schema/table is at or below the snapshot watermark and
+// should be suppressed because it is already represented in the snapshot.
+func (s *Stream) shouldSuppressForWatermark(schema, table string, msgLSN LSN) bool {
+	key := watermarkKeyFromUnquoted(schema, table)
+	s.tablesMu.RLock()
+	wm, ok := s.tableWatermark[key]
+	s.tablesMu.RUnlock()
+	return ok && msgLSN <= wm
+}
+
+// watermarkKey builds the lookup key used for tableWatermark from a TableFQN.
+// TableFQN holds quoted identifiers; we strip the quotes so it matches the
+// key shape used during streaming, where StreamMessage.Schema and .Table are
+// unquoted (they come from RelationMessage).
+func watermarkKey(table TableFQN) string {
+	schema, err := sanitize.UnquotePostgresIdentifier(table.Schema)
+	if err != nil {
+		schema = table.Schema
+	}
+	tbl, err := sanitize.UnquotePostgresIdentifier(table.Table)
+	if err != nil {
+		tbl = table.Table
+	}
+	return watermarkKeyFromUnquoted(schema, tbl)
+}
+
+func watermarkKeyFromUnquoted(schema, table string) string {
+	return schema + "." + table
 }
 
 func (s *Stream) startLr(ctx context.Context, lsnStart LSN) error {
@@ -527,6 +623,15 @@ func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, re
 		case BeginOpType:
 			return changeResultNoMessage, nil
 		}
+	}
+
+	// Per-table snapshot watermark dedup. For tables added by the discoverer
+	// mid-stream, WAL events at or below the snapshot LSN are duplicates of
+	// rows already emitted via the snapshot scan. Suppress them but treat
+	// like a suppressed-commit so the LSN is still considered processed for
+	// ack progression — otherwise postgres would replay them indefinitely.
+	if s.shouldSuppressForWatermark(message.Schema, message.Table, msgLSN) {
+		return changeResultSuppressedCommitMessage, nil
 	}
 
 	// Attach the column schema for DML messages, building it once per relation and
@@ -820,6 +925,12 @@ func (s *Stream) Stop(ctx context.Context) error {
 	wg.Go(func() error {
 		if s.heartbeat != nil {
 			return s.heartbeat.Stop()
+		}
+		return nil
+	})
+	wg.Go(func() error {
+		if s.discoverer != nil {
+			return s.discoverer.Stop()
 		}
 		return nil
 	})

--- a/internal/impl/postgresql/pglogicalstream/monitor.go
+++ b/internal/impl/postgresql/pglogicalstream/monitor.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -28,6 +29,10 @@ type Report struct {
 
 // Monitor is a structure that allows monitoring the progress of snapshot ingestion and replication lag
 type Monitor struct {
+	// mu guards tableStat and snapshotProgress when tables are added at runtime
+	// via RegisterTable. Without it, concurrent map access from the discovery
+	// goroutine and the snapshot/streaming goroutines races.
+	mu sync.RWMutex
 	// tableStat contains numbers of rows for each table determined at the moment of the snapshot creation
 	// this is used to calculate snapshot ingestion progress
 	tableStat map[TableFQN]float64
@@ -81,12 +86,40 @@ func NewMonitor(
 
 // UpdateSnapshotProgressForTable updates the snapshot ingestion progress for a given table.
 func (m *Monitor) UpdateSnapshotProgressForTable(table TableFQN, read int) {
-	m.snapshotProgress[table].Add(int64(read))
+	m.mu.RLock()
+	progress, ok := m.snapshotProgress[table]
+	m.mu.RUnlock()
+	if !ok {
+		return
+	}
+	progress.Add(int64(read))
 }
 
 // MarkSnapshotComplete means that we finished snapshotting.
 func (m *Monitor) MarkSnapshotComplete(table TableFQN) {
-	m.snapshotProgress[table].Store(int64(m.tableStat[table]))
+	m.mu.RLock()
+	progress, ok := m.snapshotProgress[table]
+	total := m.tableStat[table]
+	m.mu.RUnlock()
+	if !ok {
+		return
+	}
+	progress.Store(int64(total))
+}
+
+// RegisterTable adds a table discovered at runtime to the monitor so that
+// snapshot progress and reltuples are tracked alongside the original tables.
+// Safe to call concurrently with Report and the snapshot progress updaters.
+func (m *Monitor) RegisterTable(ctx context.Context, table TableFQN) error {
+	m.mu.Lock()
+	if _, exists := m.snapshotProgress[table]; exists {
+		m.mu.Unlock()
+		return nil
+	}
+	m.snapshotProgress[table] = &atomic.Int64{}
+	m.tableStat[table] = 0
+	m.mu.Unlock()
+	return m.readTablesStat(ctx, []TableFQN{table})
 }
 
 // we need to read the tables stat to calculate the snapshot ingestion progress.
@@ -107,7 +140,9 @@ func (m *Monitor) readTablesStat(ctx context.Context, tables []TableFQN) error {
 			return fmt.Errorf("error counting rows in table %s: %w", table, err)
 		}
 
+		m.mu.Lock()
 		m.tableStat[table] = count
+		m.mu.Unlock()
 	}
 	return nil
 }
@@ -139,7 +174,8 @@ func (m *Monitor) readReplicationLag(ctx context.Context) {
 func (m *Monitor) Report() *Report {
 	// report the snapshot ingestion progress
 	// report the replication lag
-	progress := map[TableFQN]float64{}
+	m.mu.RLock()
+	progress := make(map[TableFQN]float64, len(m.snapshotProgress))
 	for table, read := range m.snapshotProgress {
 		total := m.tableStat[table]
 		if total <= 0 {
@@ -147,6 +183,7 @@ func (m *Monitor) Report() *Report {
 		}
 		progress[table] = float64(read.Load()) / total
 	}
+	m.mu.RUnlock()
 	return &Report{
 		WalLagInBytes: m.replicationLagInBytes.Load(),
 		TableProgress: progress,


### PR DESCRIPTION
## Summary

Adds an opt-in `auto_discover_tables` flag to the `postgres_cdc` input. When enabled, a discovery loop polls the configured `schema` for new tables on `discovery_interval` (default `60s`) and incorporates them into the running CDC pipeline **without restarting the replication slot**.

This addresses the operational pain of having to restart pipelines (and redeploy config) every time a new table is added at the source — a common scenario at scale (we run 30+ source DBs) and a feature most competing CDC products (Debezium incremental snapshot, Fivetran, Airbyte, Estuary) already support.

> **Design tracking issue:** #4327 was filed alongside this PR per CONTRIBUTING.md §3.1.1. The issue captures the design and open questions for maintainer scoping. Happy to close this PR and work from the issue alone if that is preferred — the code is here for concreteness, not to bypass scoping.

## Design

For each newly-found table T, the discoverer:

1. `ALTER PUBLICATION pglog_stream_<slot> ADD TABLE T` — captures all future WAL events for T.
2. Opens a **temporary** logical replication slot with `EXPORT_SNAPSHOT` to anchor the snapshot at a known LSN (`L_snap`).
3. Snapshots T at the exported snapshot using a single reader (small/new tables don't need keyspace splitting).
4. Records `tableWatermark[T] = L_snap` on the parent stream.
5. Drops the temporary slot.
6. Registers T with the monitor and adds it to the live tables set.

A single branch in `processChange` suppresses WAL events for T where `event_LSN <= tableWatermark[T]` — these are duplicates already in the snapshot. The branch is a no-op when the watermark map is empty, so existing behavior is unchanged when the flag is off.

The main streaming slot is **never** restarted; LSN advances continuously. The implementation reuses existing primitives:

- `CreatePublication` already issues `ALTER PUBLICATION ... ADD TABLE` (pglogrepl.go:365)
- `EXPORT_SNAPSHOT` + `SET TRANSACTION SNAPSHOT` is the same mechanism the initial snapshotter uses (logical_stream.go:227)
- `scanTableRange` is reused for the per-table snapshot

## Why this shape

- **Additive.** Default `false`, no behavior change for existing pipelines.
- **No superuser required.** Avoids the `FOR ALL TABLES` trap on RDS.
- **Crash-safe.** If we crash between ALTER and snapshot completion, on restart the discovery loop re-detects T (still missing locally) and repeats steps 2–6 idempotently. ALTER PUBLICATION on an already-published table is a no-op.
- **Monotonic LSNs make dedup trivially correct.** No epoch, no replay queue, no buffering — one map read + one comparison on the hot path.
- **Tables without a primary key** are skipped with a warning and rolled out of the publication, so we never silently emit WAL for an unsnapshotted table.

## Open design questions for maintainers

1. **Config surface:** is `auto_discover_tables: bool` + `discovery_interval: duration` the right shape, or do you prefer a nested object like `auto_discovery: { enabled: true, interval: 60s }`?
2. **Tables without primary keys:** I currently skip + roll back the publication change. Alternatives: fall back to a sequential scan with no PK filtering, or fail loudly. Preference?
3. **Discovery scope:** I poll `pg_tables` for the configured schema only. Should we support cross-schema discovery via a list?
4. **Watermark persistence:** in-memory only. On restart the re-added table is also re-snapshotted (idempotent), but if persistence in the checkpoint cache is preferred I can add it.
5. **Metrics:** I did not add new metrics yet. Candidates: `postgres_discovered_tables_total` gauge, `postgres_discovery_lag_seconds`. Want them in this PR or a follow-up?
6. **Enterprise license gate:** `postgres_cdc` already gates on `license.CheckRunningEnterprise`. Auto-discovery inherits that gate at the input level. Is that the intended posture?

## Files changed (~760 LOC, mostly tests + comments)

- `input_pg_stream.go` — two new config fields, plumbing
- `pglogicalstream/config.go` — two new struct fields
- `pglogicalstream/logical_stream.go` — `tablesMu`, `tableWatermark` map, `installDiscoveredTable`, `shouldSuppressForWatermark`, dedup branch in `processChange`, `maybeStartDiscoverer`, lifecycle wiring in `Stop`
- `pglogicalstream/discovery.go` (new) — discoverer struct, polling loop, `addTable` orchestrator, `tempSlotName`
- `pglogicalstream/monitor.go` — `RegisterTable` + `sync.RWMutex` around mutating maps
- `pglogicalstream/discovery_test.go` (new) — unit tests for the watermark + slot-name helpers
- `integration_test.go` — `TestIntegrationPostgresAutoDiscoverTables` end-to-end test
- `CHANGELOG.md`

## Test plan

- [x] Unit tests pass: `go test ./internal/impl/postgresql/pglogicalstream/ -short`
- [x] Whole-repo build clean: `go build ./...`
- [x] `go vet ./internal/impl/postgresql/...` clean
- [x] **New integration test passes** against PG 16 via testcontainers: `TestIntegrationPostgresAutoDiscoverTables` — 4.18s. Covers: mid-stream `CREATE TABLE`, snapshot of pre-discovery rows emitted as `read`, post-discovery inserts arrive as `insert` exactly once, no duplicate reads (watermark dedup works).
- [x] **No regression in existing integration suite**: `TestIntegrationPostgresNoTxnMarkers`, `TestIntegrationPostgresIncludeTxnMarkers`, `TestIntegrationPostgresMetadata`, `TestIntegrationTOASTValues`, `TestIntegrationSnapshotConsistency`, `TestIntegrationSnapshotParallel` all pass (46.9s total, exit 0).
- [ ] Manual test against an RDS instance (no superuser required) — not yet done

### Bug caught during integration testing (fixed)

The first integration test run surfaced a real issue: primary-key lookup for discovered tables was routing through `s.pgConn` (the replication connection, concurrently owned by the streaming goroutine), causing `conn busy` errors. Fixed in commit `c4f0703` by moving the PK query to the discoverer's own SQL connection. All tests now green.

## Out of scope (separate issues if there is interest)

- Periodic full refresh of existing tables (uses the same watermark primitive but raises distinct upsert-vs-append semantics downstream)
- Auto-removal of dropped tables
- Generalizing the watermark abstraction to `mysql_cdc`, `mssqlserver_cdc`, `oracledb_cdc` (the same primitive applies; would be a follow-up after this lands and patterns are agreed)

