### PR TITLE
oracledb_cdc: add transaction_id metadata

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -120,6 +120,7 @@ This input adds the following metadata fields to each message:
 - table_name: Name of the table that the message originated from.
 - operation: Type of operation that generated the message: "read", "delete", "insert", or "update". "read" is from messages that are read in the initial snapshot phase.
 - scn: the System Change Number in Oracle.
+- transaction_id: The Oracle transaction ID in `USN.SLOT.SEQ` format, identifying the transaction that produced the change. Not present on snapshot (`read`) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - schema: The table schema, for use with schema-aware downstream processors such as `schema_registry_encode`. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -164,6 +164,9 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	msg.MetaSet("database_schema", m.Schema)
 	msg.MetaSet("table_name", m.Table)
 	msg.MetaSet("operation", m.Operation.String())
+	if m.TransactionID != "" {
+		msg.MetaSet("transaction_id", m.TransactionID)
+	}
 	if m.SCN.IsValid() {
 		msg.MetaSet("scn", m.SCN.String())
 	}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -76,6 +76,7 @@ This input adds the following metadata fields to each message:
 - table_name: Name of the table that the message originated from.
 - operation: Type of operation that generated the message: "read", "delete", "insert", or "update". "read" is from messages that are read in the initial snapshot phase.
 - scn: the System Change Number in Oracle.
+- transaction_id: The Oracle transaction ID in ` + "`USN.SLOT.SEQ`" + ` format, identifying the transaction that produced the change. Not present on snapshot (` + "`read`" + `) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - schema: The table schema, for use with schema-aware downstream processors such as ` + "`schema_registry_encode`" + `. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -530,19 +530,23 @@ oracledb_cdc:
 		t.Helper()
 		results := make(map[string][]*service.Message)
 		for i, msg := range msgs {
+			// assert database_schema metadata
 			schema, ok := msg.MetaGet("database_schema")
 			require.Truef(t, ok, "message %d missing 'database_schema' metadata", i)
 
+			// assert table_name metadata
 			table, ok := msg.MetaGet("table_name")
 			require.Truef(t, ok, "message %d missing 'table_name' metadata", i)
 
 			key := fmt.Sprintf("%s.%s", schema, table)
 			results[key] = append(results[key], msg)
 
+			// assert operation metadata
 			op, ok := msg.MetaGet("operation")
 			require.Truef(t, ok, "message %d missing 'operation' metadata", i)
 			assert.Equalf(t, operation, op, "message %d: expected operation '%s', got %q", i, operation, op)
 
+			// assert source_ts_ms metadata
 			tsStr, ok := msg.MetaGet("source_ts_ms")
 			require.Truef(t, ok, "message %d missing 'source_ts_ms' metadata", i)
 			tsMs, err := strconv.ParseInt(tsStr, 10, 64)
@@ -550,6 +554,11 @@ oracledb_cdc:
 			tsTime := time.UnixMilli(tsMs)
 			assert.Truef(t, tsTime.After(time.Now().Add(-5*time.Minute)), "message %d: source_ts_ms %d is too far in the past", i, tsMs)
 			assert.Truef(t, tsTime.Before(time.Now().Add(time.Minute)), "message %d: source_ts_ms %d is in the future", i, tsMs)
+
+			// assert transaction_id metadata
+			txID, ok := msg.MetaGet("transaction_id")
+			require.Truef(t, ok, "message %d missing 'transaction_id' metadata", i)
+			assert.Regexpf(t, `^\d+\.\d+\.\d+$`, txID, "message %d: transaction_id %q not in USN.SLOT.SEQ format", i, txID)
 		}
 
 		for _, expectedKey := range []string{"TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"} {

--- a/internal/impl/oracledb/logminer/cache.go
+++ b/internal/impl/oracledb/logminer/cache.go
@@ -19,19 +19,16 @@ import (
 // at which point we know it's safe to flush transactions to the Connect pipeline.
 // If a rollback events is received the cache will be be cleared instead of flushed.
 type TransactionCache interface {
-	StartTransaction(txnID string, scn uint64)
-	AddEvent(txnID string, scn uint64, event *sqlredo.DMLEvent)
-	GetTransaction(txnID string) *Transaction
-	CommitTransaction(txnID string)
-	RollbackTransaction(txnID string)
+	StartTransaction(txnID sqlredo.TransactionID, scn uint64)
+	AddEvent(txnID sqlredo.TransactionID, scn uint64, event *sqlredo.DMLEvent)
+	GetTransaction(txnID sqlredo.TransactionID) *Transaction
+	CommitTransaction(txnID sqlredo.TransactionID)
+	RollbackTransaction(txnID sqlredo.TransactionID)
 }
-
-// TransactionID uniquely identifies an Oracle database transaction.
-type TransactionID string
 
 // Transaction buffers events until commit
 type Transaction struct {
-	ID     string
+	ID     sqlredo.TransactionID
 	SCN    uint64
 	Events []*sqlredo.DMLEvent
 }
@@ -40,8 +37,8 @@ type Transaction struct {
 // transactions in a map. This cache is used to buffer DML events until a transaction
 // commits or rolls back. All operations are sequential and not protected by locks.
 type InMemoryCache struct {
-	transactions         map[string]*Transaction
-	discardedTxns        map[string]struct{}
+	transactions         map[sqlredo.TransactionID]*Transaction
+	discardedTxns        map[sqlredo.TransactionID]struct{}
 	maxTransactionEvents int
 	transactionsMetric   *service.MetricGauge
 	eventsMetric         *service.MetricGauge
@@ -53,8 +50,8 @@ type InMemoryCache struct {
 // sets the maximum number of events per transaction before it is discarded; 0 disables the limit.
 func NewInMemoryCache(maxTransactionEvents int, metrics *service.Metrics, logger *service.Logger) *InMemoryCache {
 	return &InMemoryCache{
-		transactions:         make(map[string]*Transaction),
-		discardedTxns:        make(map[string]struct{}),
+		transactions:         make(map[sqlredo.TransactionID]*Transaction),
+		discardedTxns:        make(map[sqlredo.TransactionID]struct{}),
 		maxTransactionEvents: maxTransactionEvents,
 		transactionsMetric:   metrics.NewGauge("oracledb_cdc_transactions_active"),
 		eventsMetric:         metrics.NewGauge("oracledb_cdc_transactions_events_inflight"),
@@ -65,7 +62,7 @@ func NewInMemoryCache(maxTransactionEvents int, metrics *service.Metrics, logger
 // StartTransaction initializes a new transaction in the cache with the given transaction ID and SCN.
 // If the transaction already exists in the cache it is left untouched so that previously
 // accumulated events are not lost when LogMiner re-emits the START record across polling cycles.
-func (tc *InMemoryCache) StartTransaction(txnID string, scn uint64) {
+func (tc *InMemoryCache) StartTransaction(txnID sqlredo.TransactionID, scn uint64) {
 	if _, discarded := tc.discardedTxns[txnID]; discarded {
 		return
 	}
@@ -83,7 +80,7 @@ func (tc *InMemoryCache) StartTransaction(txnID string, scn uint64) {
 // AddEvent adds a DML event to the specified transaction's buffer.
 // If the transaction doesn't exist, it creates a new transaction with the event.
 // If maxTransactionEvents is set and the buffer exceeds it, the transaction is discarded.
-func (tc *InMemoryCache) AddEvent(txnID string, scn uint64, event *sqlredo.DMLEvent) {
+func (tc *InMemoryCache) AddEvent(txnID sqlredo.TransactionID, scn uint64, event *sqlredo.DMLEvent) {
 	if _, discarded := tc.discardedTxns[txnID]; discarded {
 		return
 	}
@@ -114,12 +111,12 @@ func (tc *InMemoryCache) AddEvent(txnID string, scn uint64, event *sqlredo.DMLEv
 
 // GetTransaction retrieves the transaction with the given ID from the cache.
 // Returns nil if the transaction doesn't exist.
-func (tc *InMemoryCache) GetTransaction(txnID string) *Transaction {
+func (tc *InMemoryCache) GetTransaction(txnID sqlredo.TransactionID) *Transaction {
 	return tc.transactions[txnID]
 }
 
 // CommitTransaction removes the committed transaction from the cache.
-func (tc *InMemoryCache) CommitTransaction(txnID string) {
+func (tc *InMemoryCache) CommitTransaction(txnID sqlredo.TransactionID) {
 	delete(tc.discardedTxns, txnID)
 	tx, ok := tc.transactions[txnID]
 	if !ok {
@@ -134,7 +131,7 @@ func (tc *InMemoryCache) CommitTransaction(txnID string) {
 // LowWatermarkSCN returns the lowest start SCN among all currently open
 // (uncommitted) transactions. Returns math.MaxUint64 if no open transactions.
 // This behaviour is specific to in-memory caches and not part of the cache interface.
-func (tc *InMemoryCache) LowWatermarkSCN(excludeTxnID string) uint64 {
+func (tc *InMemoryCache) LowWatermarkSCN(excludeTxnID sqlredo.TransactionID) uint64 {
 	lowestOpenSCN := uint64(math.MaxUint64)
 	for id, txn := range tc.transactions {
 		if id != excludeTxnID && len(txn.Events) > 0 {
@@ -145,7 +142,7 @@ func (tc *InMemoryCache) LowWatermarkSCN(excludeTxnID string) uint64 {
 }
 
 // RollbackTransaction removes the rolled back transaction from the cache, discarding all buffered events.
-func (tc *InMemoryCache) RollbackTransaction(txnID string) {
+func (tc *InMemoryCache) RollbackTransaction(txnID sqlredo.TransactionID) {
 	delete(tc.discardedTxns, txnID)
 	tx, ok := tc.transactions[txnID]
 	if !ok {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -11,7 +11,6 @@ package logminer
 import (
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -52,7 +51,7 @@ type LogMiner struct {
 	lobColTypes map[string]string
 	// lob types are split between redo log lines, we use lobStates to track them
 	// until we have all data to merge into published INSERT or UPDATE event.
-	lobStates map[string]*sqlredo.TxnLOBState
+	lobStates map[sqlredo.TransactionID]*sqlredo.TxnLOBState
 }
 
 // NewMiner creates a new instance of LogMiner responsible for paging through change events based on the tables param.
@@ -109,7 +108,7 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 		sessionMgr:    NewSessionManager(cfg, logger),
 		txnCache:      NewInMemoryCache(cfg.MaxTransactionEvents, metrics, logger),
 		dmlParser:     sqlredo.NewParser(),
-		lobStates:     make(map[string]*sqlredo.TxnLOBState),
+		lobStates:     make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
 	}
 	return lm
 }
@@ -493,7 +492,7 @@ func (lm *LogMiner) loadLOBColumnTypes(ctx context.Context) (resErr error) {
 	return rows.Err()
 }
 
-func (lm *LogMiner) getOrCreateLOBState(txnID string) *sqlredo.TxnLOBState {
+func (lm *LogMiner) getOrCreateLOBState(txnID sqlredo.TransactionID) *sqlredo.TxnLOBState {
 	if state, ok := lm.lobStates[txnID]; ok {
 		return state
 	}
@@ -536,7 +535,6 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 	for rows.Next() {
 		event := &sqlredo.RedoEvent{}
 		var (
-			xid       []byte        // Oracle RAW type comes as []byte in Go
 			commitSCN sql.NullInt64 // COMMIT_SCN can be NULL for uncommitted transactions
 			csf       int64         // Continuation SQL Flag: 1 = more SQL in next row, 0 = complete
 		)
@@ -548,15 +546,12 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 			&event.TableName,
 			&event.SchemaName,
 			&event.Timestamp,
-			&xid,
+			&event.TransactionID,
 			&commitSCN,
 			&csf,
 		); err != nil {
 			return err
 		}
-
-		// XID is Oracle's native transaction identifier (RAW(8) = 8 bytes)
-		event.TransactionID = hex.EncodeToString(xid)
 
 		// CSF (Continuation SQL Flag): Oracle splits long SQL across multiple rows.
 		// Rows with CSF=1 are continuation fragments; CSF=0 is the final (or only) row.
@@ -776,6 +771,7 @@ func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64) *re
 		Table:         dml.Table,
 		Data:          data,
 		Timestamp:     dml.Timestamp,
+		TransactionID: dml.TransactionID.String(),
 	}
 
 	switch dml.Operation {

--- a/internal/impl/oracledb/logminer/logminer_test.go
+++ b/internal/impl/oracledb/logminer/logminer_test.go
@@ -101,7 +101,7 @@ func newLogMiner(pub replication.ChangePublisher, cache TransactionCache) *LogMi
 		dmlParser: sqlredo.NewParser(),
 		log:       service.NewLoggerFromSlog(slog.Default()),
 		cfg:       NewDefaultConfig(),
-		lobStates: make(map[string]*sqlredo.TxnLOBState),
+		lobStates: make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
 	}
 }
 

--- a/internal/impl/oracledb/logminer/sqlredo/events.go
+++ b/internal/impl/oracledb/logminer/sqlredo/events.go
@@ -10,11 +10,47 @@ package sqlredo
 
 import (
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
 	"time"
 )
+
+// TransactionID uniquely identifies an Oracle transaction. It is derived from
+// Oracle's native XID (RAW(8)) and formatted as "USN.SLOT.SEQ" — the three
+// little-endian components of the XID: undo segment number (uint16), slot
+// (uint16), and sequence number (uint32).
+type TransactionID string
+
+// Scan implements sql.Scanner, decoding Oracle's RAW(8) XID bytes directly
+// into the "USN.SLOT.SEQ" string representation.
+func (txID *TransactionID) Scan(src any) error {
+	if src == nil {
+		return errors.New("cannot scan nil into TransactionID")
+	}
+
+	switch v := src.(type) {
+	case []byte:
+		// V$LOGMNR_CONTENTS.XID is RAW(8) https://docs.oracle.com/en/database/oracle/oracle-database/21/refrn/V-LOGMNR_CONTENTS.html
+		if len(v) != 8 {
+			return fmt.Errorf("V$LOGMNR_CONTENTS.XID expected to be 8 bytes but was %d", len(v))
+		}
+
+		usn := binary.LittleEndian.Uint16(v[0:2])
+		slot := binary.LittleEndian.Uint16(v[2:4])
+		seq := binary.LittleEndian.Uint32(v[4:8])
+		*txID = TransactionID(fmt.Sprintf("%d.%d.%d", usn, slot, seq))
+	default:
+		return fmt.Errorf("cannot scan %T to transaction id", src)
+	}
+	return nil
+}
+
+// String returns the TransactionID in its "USN.SLOT.SEQ" string form.
+func (txID TransactionID) String() string {
+	return string(txID)
+}
 
 // Operation represents a LogMiner operation type
 type Operation int64
@@ -118,8 +154,9 @@ type DMLEvent struct {
 	Data      map[string]any
 	// OldValues holds the WHERE-clause column values for UPDATE and DELETE events.
 	// For LOB-init UPDATE events these are used to identify the source row for PK matching.
-	OldValues map[string]any
-	Timestamp time.Time
+	OldValues     map[string]any
+	Timestamp     time.Time
+	TransactionID TransactionID
 }
 
 // RedoEvent represents a redo log row from V$LOGMNR_CONTENTS
@@ -131,5 +168,5 @@ type RedoEvent struct {
 	TableName     sql.NullString
 	SchemaName    sql.NullString
 	Timestamp     time.Time
-	TransactionID string
+	TransactionID TransactionID
 }

--- a/internal/impl/oracledb/logminer/sqlredo/parser.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser.go
@@ -44,8 +44,9 @@ func (p Parser) RedoEventToDMLEvent(redoEvent *RedoEvent) (DMLEvent, error) {
 	}
 
 	event := DMLEvent{
-		Operation: redoEvent.Operation,
-		Timestamp: redoEvent.Timestamp,
+		Operation:     redoEvent.Operation,
+		Timestamp:     redoEvent.Timestamp,
+		TransactionID: redoEvent.TransactionID,
 	}
 
 	if redoEvent.SchemaName.Valid {

--- a/internal/impl/oracledb/replication/stream_message.go
+++ b/internal/impl/oracledb/replication/stream_message.go
@@ -125,4 +125,5 @@ type MessageEvent struct {
 	Data          any
 	Timestamp     time.Time
 	ColumnMeta    []ColumnMeta
+	TransactionID string
 }


### PR DESCRIPTION
This change adds the transaction ID to messages metadata to help support diagnosis. It also tidies up the parsing now we want to use it in a human readable form (beyond just a transaction cache key).

<img width="1421" height="578" alt="image" src="https://github.com/user-attachments/assets/26308fd9-9061-4b3c-a44d-721f59ff0f17" />
