### PR TITLE
oracledb_cdc: add commit_ts_ms to metadata

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -122,6 +122,7 @@ This input adds the following metadata fields to each message:
 - scn: the System Change Number in Oracle.
 - transaction_id: The Oracle transaction ID in `USN.SLOT.SEQ` format, identifying the transaction that produced the change. Not present on snapshot (`read`) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
+- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Not present on snapshot (`read`) messages.
 - schema: The table schema, for use with schema-aware downstream processors such as `schema_registry_encode`. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -179,6 +179,9 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	if m.CheckpointSCN.IsValid() {
 		msg.MetaSet("checkpoint_scn", m.CheckpointSCN.String())
 	}
+	if !m.CommitTimestamp.IsZero() {
+		msg.MetaSet("commit_ts_ms", strconv.FormatInt(m.CommitTimestamp.UnixMilli(), 10))
+	}
 
 	if schemaAny != nil {
 		msg.MetaSetImmut("schema", service.ImmutableAny{V: schemaAny})

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -78,6 +78,7 @@ This input adds the following metadata fields to each message:
 - scn: the System Change Number in Oracle.
 - transaction_id: The Oracle transaction ID in ` + "`USN.SLOT.SEQ`" + ` format, identifying the transaction that produced the change. Not present on snapshot (` + "`read`" + `) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
+- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Not present on snapshot (` + "`read`" + `) messages.
 - schema: The table schema, for use with schema-aware downstream processors such as ` + "`schema_registry_encode`" + `. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -555,6 +555,15 @@ oracledb_cdc:
 			assert.Truef(t, tsTime.After(time.Now().Add(-5*time.Minute)), "message %d: source_ts_ms %d is too far in the past", i, tsMs)
 			assert.Truef(t, tsTime.Before(time.Now().Add(time.Minute)), "message %d: source_ts_ms %d is in the future", i, tsMs)
 
+			// assert commit_ts_ms metadata
+			tsStr, ok = msg.MetaGet("commit_ts_ms")
+			require.Truef(t, ok, "message %d missing 'commit_ts_ms' metadata", i)
+			tsMs, err = strconv.ParseInt(tsStr, 10, 64)
+			require.NoErrorf(t, err, "message %d: commit_ts_ms %q is not a valid int64", i, tsStr)
+			tsTime = time.UnixMilli(tsMs)
+			assert.Truef(t, tsTime.After(time.Now().Add(-5*time.Minute)), "message %d: commit_ts_ms %d is too far in the past", i, tsMs)
+			assert.Truef(t, tsTime.Before(time.Now().Add(time.Minute)), "message %d: commit_ts_ms %d is in the future", i, tsMs)
+
 			// assert transaction_id metadata
 			txID, ok := msg.MetaGet("transaction_id")
 			require.Truef(t, ok, "message %d missing 'transaction_id' metadata", i)

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -395,7 +395,7 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 						continue
 					}
 				}
-				msg := toMessageEvent(dmlEvent, redoEvent.SCN, safeCheckpointSCN)
+				msg := toMessageEvent(dmlEvent, redoEvent.SCN, safeCheckpointSCN, redoEvent.Timestamp)
 				if err := lm.publisher.Publish(ctx, msg); err != nil {
 					return fmt.Errorf("publishing event with SCN '%d': %w", redoEvent.SCN, err)
 				}
@@ -749,7 +749,7 @@ func (lm *LogMiner) prepareLogsAndStartSession(ctx context.Context, conn *sql.Co
 	return nil
 }
 
-func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64) *replication.MessageEvent {
+func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64, commitTimestamp time.Time) *replication.MessageEvent {
 	var data map[string]any
 	switch dml.Operation {
 	case sqlredo.OpDelete:
@@ -765,13 +765,14 @@ func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64) *re
 	}
 
 	m := &replication.MessageEvent{
-		SCN:           replication.SCN(scn),
-		CheckpointSCN: replication.SCN(checkpointSCN),
-		Schema:        dml.Schema,
-		Table:         dml.Table,
-		Data:          data,
-		Timestamp:     dml.Timestamp,
-		TransactionID: dml.TransactionID.String(),
+		SCN:             replication.SCN(scn),
+		CheckpointSCN:   replication.SCN(checkpointSCN),
+		Schema:          dml.Schema,
+		Table:           dml.Table,
+		Data:            data,
+		Timestamp:       dml.Timestamp,
+		TransactionID:   dml.TransactionID.String(),
+		CommitTimestamp: commitTimestamp,
 	}
 
 	switch dml.Operation {

--- a/internal/impl/oracledb/replication/stream_message.go
+++ b/internal/impl/oracledb/replication/stream_message.go
@@ -117,13 +117,14 @@ type ColumnMeta struct {
 
 // MessageEvent represents a single change from Table's change table in the database.
 type MessageEvent struct {
-	SCN           SCN
-	CheckpointSCN SCN
-	Operation     OpType
-	Schema        string
-	Table         string
-	Data          any
-	Timestamp     time.Time
-	ColumnMeta    []ColumnMeta
-	TransactionID string
+	SCN             SCN
+	CheckpointSCN   SCN
+	Operation       OpType
+	Schema          string
+	Table           string
+	Data            any
+	Timestamp       time.Time
+	CommitTimestamp time.Time
+	ColumnMeta      []ColumnMeta
+	TransactionID   string
 }


### PR DESCRIPTION
Adds `commit_ts_ms` to message metadata, capturing the time of the transaction's commit that resulted in the buffer being flushed.