### PR TITLE
fix: fetch full git history for GoReleaser to correctly push latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Check Out Repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Configure AWS credentials for access to AWS Secrets Manager
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Problem

Fixes #4087

The `latest` Docker tag for `redpandadata/connect` has been stuck on `4.67.5` since October 2025. Subsequent releases (`4.68.0` through `4.87.0+`) built successfully but never updated the `latest` tag on Docker Hub or ECR.

## Root Cause

The release workflow was checking out the repository with the default shallow clone (`fetch-depth: 1`). GoReleaser requires full git history to correctly parse tag metadata and evaluate its template variables.

This was visible in the GoReleaser release logs as an explicit warning:

> `• couldn't find any tags before "v4.87.0"`  
> `• running against a shallow clone - check your CI documentation at https://goreleaser.com/ci`

With an incomplete git history, GoReleaser cannot correctly resolve `.Prerelease` from the tag context, causing the `latest` tag template in `.goreleaser/connect.yaml` to silently evaluate to an empty string and be skipped entirely:

```yaml
- "{{ if and (not .IsSnapshot) (eq .Prerelease ``) }}latest{{ end }}"
```

As a result, only versioned tags (`4.87.0`, `4.87`, `4`) were pushed — never `latest`.

## Fix

Add `fetch-depth: 0` and `fetch-tags: true` to the checkout step in the release workflow so GoReleaser has the full git history it needs to correctly evaluate tag templates.

```yaml
- name: Check Out Repo
  uses: actions/checkout@v6
  with:
    fetch-depth: 0
    fetch-tags: true
```

## Testing

The next stable release after this fix should show `latest` appearing in the GoReleaser publishing logs alongside the versioned tags, and `docker pull redpandadata/connect:latest` should return the most recent version.