### PR TITLE
chore: enable all non-deprecated connectors for cloud in info.csv

### DIFF
--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -2,16 +2,16 @@ name                      ,type      ,commercial_name           ,version ,suppor
 a2a_message               ,processor ,a2a_message               ,4.66.0  ,enterprise ,n          ,y     ,y
 amqp_0_9                  ,input     ,amqp_0_9                  ,0.0.0   ,certified  ,n          ,y     ,y
 amqp_0_9                  ,output    ,amqp_0_9                  ,0.0.0   ,certified  ,n          ,y     ,y
-amqp_1                    ,input     ,amqp_1                    ,0.0.0   ,community  ,n          ,n     ,n
-amqp_1                    ,output    ,amqp_1                    ,0.0.0   ,community  ,n          ,n     ,n
+amqp_1                    ,input     ,amqp_1                    ,0.0.0   ,community  ,n          ,y     ,y
+amqp_1                    ,output    ,amqp_1                    ,0.0.0   ,community  ,n          ,y     ,y
 arc                       ,output    ,arc                       ,4.88.0  ,community  ,n          ,y     ,y
 archive                   ,processor ,archive                   ,0.0.0   ,certified  ,n          ,y     ,y
 avro                      ,processor ,avro                      ,0.0.0   ,community  ,n          ,y     ,y
 avro                      ,scanner   ,avro                      ,0.0.0   ,community  ,n          ,y     ,y
-awk                       ,processor ,awk                       ,0.0.0   ,community  ,n          ,n     ,n
+awk                       ,processor ,awk                       ,0.0.0   ,community  ,n          ,y     ,y
 aws_bedrock_chat          ,processor ,aws_bedrock_chat          ,4.34.0  ,certified  ,n          ,y     ,y
 aws_bedrock_embeddings    ,processor ,aws_bedrock_embeddings    ,4.37.0  ,certified  ,n          ,y     ,y
-aws_cloudwatch            ,metric    ,aws_cloudwatch            ,3.36.0  ,community  ,n          ,n     ,n
+aws_cloudwatch            ,metric    ,aws_cloudwatch            ,3.36.0  ,community  ,n          ,y     ,y
 aws_cloudwatch_logs       ,input     ,AWS CloudWatch Logs       ,4.81.0  ,community  ,n          ,y     ,y
 aws_dynamodb              ,cache     ,AWS DynamoDB              ,3.36.0  ,community  ,n          ,y     ,y
 aws_dynamodb              ,output    ,AWS DynamoDB              ,3.36.0  ,community  ,n          ,y     ,y
@@ -38,8 +38,8 @@ azure_queue_storage       ,output    ,azure_queue_storage       ,3.36.0  ,certif
 azure_table_storage       ,input     ,azure_table_storage       ,4.10.0  ,certified  ,n          ,y     ,y
 azure_table_storage       ,output    ,azure_table_storage       ,3.36.0  ,certified  ,n          ,y     ,y
 batched                   ,input     ,batched                   ,4.11.0  ,certified  ,n          ,y     ,y
-beanstalkd                ,input     ,beanstalkd                ,4.7.0   ,community  ,n          ,n     ,n
-beanstalkd                ,output    ,beanstalkd                ,4.7.0   ,community  ,n          ,n     ,n
+beanstalkd                ,input     ,beanstalkd                ,4.7.0   ,community  ,n          ,y     ,y
+beanstalkd                ,output    ,beanstalkd                ,4.7.0   ,community  ,n          ,y     ,y
 benchmark                 ,processor ,benchmark                 ,4.40.0  ,certified  ,n          ,y     ,y
 bloblang                  ,processor ,bloblang                  ,0.0.0   ,certified  ,n          ,y     ,y
 bounds_check              ,processor ,bounds_check              ,0.0.0   ,certified  ,n          ,y     ,y
@@ -49,35 +49,35 @@ broker                    ,output    ,broker                    ,0.0.0   ,certif
 cache                     ,output    ,cache                     ,0.0.0   ,certified  ,n          ,y     ,y
 cache                     ,processor ,cache                     ,0.0.0   ,certified  ,n          ,y     ,y
 cached                    ,processor ,cached                    ,4.3.0   ,certified  ,n          ,y     ,y
-cassandra                 ,input     ,cassandra                 ,0.0.0   ,community  ,n          ,n     ,n
-cassandra                 ,output    ,cassandra                 ,0.0.0   ,community  ,n          ,n     ,n
+cassandra                 ,input     ,cassandra                 ,0.0.0   ,community  ,n          ,y     ,y
+cassandra                 ,output    ,cassandra                 ,0.0.0   ,community  ,n          ,y     ,y
 catch                     ,processor ,catch                     ,0.0.0   ,certified  ,n          ,y     ,y
 chunker                   ,scanner   ,chunker                   ,0.0.0   ,certified  ,n          ,y     ,y
-cockroachdb_changefeed    ,input     ,cockroachdb_changefeed    ,0.0.0   ,community  ,n          ,n     ,n
+cockroachdb_changefeed    ,input     ,cockroachdb_changefeed    ,0.0.0   ,community  ,n          ,y     ,y
 cohere_chat               ,processor ,cohere_chat               ,4.37.0  ,certified  ,n          ,y     ,y
 cohere_embeddings         ,processor ,cohere_embeddings         ,4.37.0  ,certified  ,n          ,y     ,y
 cohere_rerank             ,processor ,cohere_rerank             ,4.53.0  ,certified  ,n          ,y     ,y
 command                   ,processor ,command                   ,4.21.0  ,certified  ,n          ,n     ,n
 compress                  ,processor ,compress                  ,0.0.0   ,certified  ,n          ,y     ,y
-couchbase                 ,cache     ,Couchbase                 ,4.12.0  ,community  ,n          ,n     ,n
-couchbase                 ,output    ,Couchbase                 ,4.37.0  ,community  ,n          ,n     ,n
-couchbase                 ,processor ,Couchbase                 ,4.11.0  ,community  ,n          ,n     ,n
+couchbase                 ,cache     ,Couchbase                 ,4.12.0  ,community  ,n          ,y     ,y
+couchbase                 ,output    ,Couchbase                 ,4.37.0  ,community  ,n          ,y     ,y
+couchbase                 ,processor ,Couchbase                 ,4.11.0  ,community  ,n          ,y     ,y
 crash                     ,processor ,crash                     ,4.47.0  ,certified  ,n          ,n     ,n
-csv                       ,input     ,csv                       ,0.0.0   ,certified  ,n          ,n     ,n
+csv                       ,input     ,csv                       ,0.0.0   ,certified  ,n          ,y     ,y
 csv                       ,scanner   ,csv                       ,0.0.0   ,certified  ,n          ,y     ,y
 cyborgdb                  ,output    ,cyborgdb                  ,4.66.0  ,community  ,n          ,y     ,y
-cypher                    ,output    ,cypher                    ,4.37.0  ,community  ,n          ,n     ,n
+cypher                    ,output    ,cypher                    ,4.37.0  ,community  ,n          ,y     ,y
 decompress                ,processor ,decompress                ,0.0.0   ,certified  ,n          ,y     ,y
 decompress                ,scanner   ,decompress                ,0.0.0   ,certified  ,n          ,y     ,y
 dedupe                    ,processor ,dedupe                    ,0.0.0   ,certified  ,n          ,y     ,y
-discord                   ,input     ,discord                   ,0.0.0   ,community  ,n          ,n     ,n
-discord                   ,output    ,discord                   ,0.0.0   ,community  ,n          ,n     ,n
+discord                   ,input     ,discord                   ,0.0.0   ,community  ,n          ,y     ,y
+discord                   ,output    ,discord                   ,0.0.0   ,community  ,n          ,y     ,y
 drop                      ,output    ,drop                      ,0.0.0   ,certified  ,n          ,y     ,y
 drop_on                   ,output    ,drop_on                   ,0.0.0   ,certified  ,n          ,y     ,y
-dynamic                   ,input     ,dynamic                   ,0.0.0   ,community  ,n          ,n     ,n
-dynamic                   ,output    ,dynamic                   ,0.0.0   ,community  ,n          ,n     ,n
+dynamic                   ,input     ,dynamic                   ,0.0.0   ,community  ,n          ,y     ,y
+dynamic                   ,output    ,dynamic                   ,0.0.0   ,community  ,n          ,y     ,y
 elasticsearch_v8          ,output    ,elasticsearch_v8          ,4.47.0  ,certified  ,n          ,y     ,y
-elasticsearch_v9          ,output    ,elasticsearch_v9          ,0.0.0   ,community  ,n          ,n     ,n
+elasticsearch_v9          ,output    ,elasticsearch_v9          ,0.0.0   ,community  ,n          ,y     ,y
 fallback                  ,output    ,fallback                  ,3.58.0  ,certified  ,n          ,y     ,y
 ffi                       ,processor ,Foreign Function Interface,4.69.0  ,certified  ,n          ,n     ,n
 file                      ,cache     ,File                      ,0.0.0   ,certified  ,n          ,n     ,n
@@ -102,27 +102,27 @@ git                       ,input     ,git                       ,4.51.0  ,certif
 google_drive_download     ,processor ,google_drive_download     ,4.53.0  ,enterprise ,n          ,y     ,y
 google_drive_list_labels  ,processor ,google_drive_list_labels  ,4.53.0  ,enterprise ,n          ,y     ,y
 google_drive_search       ,processor ,google_drive_search       ,4.53.0  ,enterprise ,n          ,y     ,y
-grok                      ,processor ,grok                      ,0.0.0   ,community  ,n          ,n     ,n
+grok                      ,processor ,grok                      ,0.0.0   ,community  ,n          ,y     ,y
 group_by                  ,processor ,group_by                  ,0.0.0   ,certified  ,n          ,y     ,y
 group_by_value            ,processor ,group_by_value            ,0.0.0   ,certified  ,n          ,y     ,y
-hdfs                      ,input     ,hdfs                      ,0.0.0   ,community  ,n          ,n     ,n
-hdfs                      ,output    ,hdfs                      ,0.0.0   ,community  ,n          ,n     ,n
+hdfs                      ,input     ,hdfs                      ,0.0.0   ,community  ,n          ,y     ,y
+hdfs                      ,output    ,hdfs                      ,0.0.0   ,community  ,n          ,y     ,y
 http                      ,processor ,HTTP                      ,0.0.0   ,certified  ,n          ,y     ,y
 http_client               ,input     ,http_client               ,0.0.0   ,certified  ,n          ,y     ,y
 http_client               ,output    ,http_client               ,0.0.0   ,certified  ,n          ,y     ,y
 http_server               ,input     ,http_server               ,0.0.0   ,certified  ,n          ,y     ,y
-http_server               ,output    ,http_server               ,0.0.0   ,certified  ,n          ,n     ,n
+http_server               ,output    ,http_server               ,0.0.0   ,certified  ,n          ,y     ,y
 iceberg                   ,output    ,Apache Iceberg            ,4.80.0  ,enterprise ,n          ,y     ,y
-influxdb                  ,metric    ,influxdb                  ,3.36.0  ,community  ,n          ,n     ,n
+influxdb                  ,metric    ,influxdb                  ,3.36.0  ,community  ,n          ,y     ,y
 inproc                    ,input     ,inproc                    ,0.0.0   ,certified  ,n          ,y     ,y
 inproc                    ,output    ,inproc                    ,0.0.0   ,certified  ,n          ,y     ,y
 insert_part               ,processor ,insert_part               ,0.0.0   ,certified  ,n          ,y     ,y
-jaeger                    ,tracer    ,jaeger                    ,0.0.0   ,community  ,n          ,n     ,n
-javascript                ,processor ,javascript                ,4.14.0  ,certified  ,n          ,n     ,n
-jira                      ,processor ,jira                      ,4.68.0  ,certified  ,n          ,y     ,n
+jaeger                    ,tracer    ,jaeger                    ,0.0.0   ,community  ,n          ,y     ,y
+javascript                ,processor ,javascript                ,4.14.0  ,certified  ,n          ,y     ,y
+jira                      ,processor ,jira                      ,4.68.0  ,certified  ,n          ,y     ,y
 jmespath                  ,processor ,JMESPath                  ,0.0.0   ,certified  ,n          ,y     ,y
 jq                        ,processor ,jq                        ,0.0.0   ,certified  ,n          ,y     ,y
-json_api                  ,metric    ,json_api                  ,0.0.0   ,certified  ,n          ,n     ,n
+json_api                  ,metric    ,json_api                  ,0.0.0   ,certified  ,n          ,y     ,y
 json_array                ,scanner   ,json_array                ,4.65.0  ,community  ,n          ,y     ,y
 json_documents            ,scanner   ,json_documents            ,4.27.0  ,certified  ,n          ,y     ,y
 json_schema               ,processor ,JSON Schema               ,0.0.0   ,certified  ,n          ,y     ,y
@@ -133,7 +133,7 @@ kafka_franz               ,output    ,kafka_franz               ,3.61.0  ,certif
 lines                     ,scanner   ,lines                     ,0.0.0   ,certified  ,n          ,y     ,y
 local                     ,rate_limit,local                     ,0.0.0   ,certified  ,n          ,y     ,y
 log                       ,processor ,log                       ,0.0.0   ,certified  ,n          ,y     ,y
-logger                    ,metric    ,logger                    ,0.0.0   ,certified  ,n          ,n     ,n
+logger                    ,metric    ,logger                    ,0.0.0   ,certified  ,n          ,y     ,y
 lru                       ,cache     ,lru                       ,0.0.0   ,community  ,n          ,y     ,y
 mapping                   ,processor ,mapping                   ,4.5.0   ,certified  ,n          ,y     ,y
 memcached                 ,cache     ,Memcached                 ,0.0.0   ,community  ,n          ,y     ,y
@@ -148,12 +148,12 @@ mongodb                   ,processor ,MongoDB                   ,3.43.0  ,certif
 mongodb_cdc               ,input     ,MongoDB CDC               ,4.48.0  ,enterprise ,n          ,y     ,y
 mqtt                      ,input     ,mqtt                      ,4.37.0  ,certified  ,n          ,y     ,y
 mqtt                      ,output    ,mqtt                      ,4.37.0  ,certified  ,n          ,y     ,y
-msgpack                   ,processor ,msgpack                   ,3.59.0  ,community  ,n          ,n     ,n
+msgpack                   ,processor ,msgpack                   ,3.59.0  ,community  ,n          ,y     ,y
 multilevel                ,cache     ,Multilevel                ,0.0.0   ,certified  ,n          ,y     ,y
 mutation                  ,processor ,mutation                  ,4.5.0   ,certified  ,n          ,y     ,y
 mysql_cdc                 ,input     ,mysql_cdc                 ,4.45.0  ,enterprise ,n          ,y     ,y
-nanomsg                   ,input     ,nanomsg                   ,0.0.0   ,community  ,n          ,n     ,n
-nanomsg                   ,output    ,nanomsg                   ,0.0.0   ,community  ,n          ,n     ,n
+nanomsg                   ,input     ,nanomsg                   ,0.0.0   ,community  ,n          ,y     ,y
+nanomsg                   ,output    ,nanomsg                   ,0.0.0   ,community  ,n          ,y     ,y
 nats                      ,input     ,NATS                      ,0.0.0   ,certified  ,n          ,y     ,y
 nats                      ,output    ,NATS                      ,0.0.0   ,certified  ,n          ,y     ,y
 nats_jetstream            ,input     ,NATS JetStream            ,3.46.0  ,certified  ,n          ,y     ,y
@@ -163,22 +163,22 @@ nats_kv                   ,input     ,NATS KV                   ,4.12.0  ,certif
 nats_kv                   ,output    ,NATS KV                   ,4.12.0  ,certified  ,n          ,y     ,y
 nats_kv                   ,processor ,NATS KV                   ,4.12.0  ,certified  ,n          ,y     ,y
 nats_request_reply        ,processor ,NATS Request Reply        ,4.27.0  ,certified  ,n          ,y     ,y
-nats_stream               ,input     ,NATS Stream               ,0.0.0   ,community  ,n          ,n     ,n
-nats_stream               ,output    ,NATS Stream               ,0.0.0   ,community  ,n          ,n     ,n
+nats_stream               ,input     ,NATS Stream               ,0.0.0   ,community  ,n          ,y     ,y
+nats_stream               ,output    ,NATS Stream               ,0.0.0   ,community  ,n          ,y     ,y
 none                      ,buffer    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
 none                      ,metric    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
 none                      ,tracer    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
 noop                      ,cache     ,noop                      ,4.27.0  ,certified  ,n          ,y     ,y
 noop                      ,processor ,noop                      ,0.0.0   ,certified  ,n          ,y     ,y
-nsq                       ,input     ,nsq                       ,0.0.0   ,community  ,n          ,n     ,n
-nsq                       ,output    ,nsq                       ,0.0.0   ,community  ,n          ,n     ,n
-ockam_kafka               ,input     ,ockam_kafka               ,0.0.0   ,community  ,n          ,n     ,n
-ockam_kafka               ,output    ,ockam_kafka               ,0.0.0   ,community  ,n          ,n     ,n
+nsq                       ,input     ,nsq                       ,0.0.0   ,community  ,n          ,y     ,y
+nsq                       ,output    ,nsq                       ,0.0.0   ,community  ,n          ,y     ,y
+ockam_kafka               ,input     ,ockam_kafka               ,0.0.0   ,community  ,n          ,y     ,y
+ockam_kafka               ,output    ,ockam_kafka               ,0.0.0   ,community  ,n          ,y     ,y
 ollama_chat               ,processor ,ollama_chat               ,4.32.0  ,certified  ,n          ,n     ,y
 ollama_embeddings         ,processor ,ollama_embeddings         ,4.32.0  ,certified  ,n          ,n     ,y
 ollama_moderation         ,processor ,ollama_moderation         ,4.42.0  ,certified  ,n          ,n     ,y
-open_telemetry_collector  ,metric    ,open_telemetry_collector  ,0.0.0   ,community  ,n          ,n     ,n
-open_telemetry_collector  ,tracer    ,open_telemetry_collector  ,0.0.0   ,community  ,n          ,n     ,n
+open_telemetry_collector  ,metric    ,open_telemetry_collector  ,0.0.0   ,community  ,n          ,y     ,y
+open_telemetry_collector  ,tracer    ,open_telemetry_collector  ,0.0.0   ,community  ,n          ,y     ,y
 openai_chat_completion    ,processor ,openai_chat_completion    ,4.32.0  ,certified  ,n          ,y     ,y
 openai_embeddings         ,processor ,openai_embeddings         ,4.32.0  ,certified  ,n          ,y     ,y
 openai_image_generation   ,processor ,openai_image_generation   ,4.32.0  ,certified  ,n          ,y     ,y
@@ -192,7 +192,7 @@ otlp_grpc                 ,output    ,otlp_grpc                 ,4.78.0  ,enterp
 otlp_http                 ,input     ,otlp_http                 ,4.78.0  ,enterprise ,n          ,y     ,y
 otlp_http                 ,output    ,otlp_http                 ,4.78.0  ,enterprise ,n          ,y     ,y
 parallel                  ,processor ,parallel                  ,0.0.0   ,certified  ,n          ,y     ,y
-parquet                   ,input     ,parquet                   ,4.8.0   ,certified  ,n          ,n     ,n
+parquet                   ,input     ,parquet                   ,4.8.0   ,certified  ,n          ,y     ,y
 parquet                   ,processor ,parquet                   ,3.62.0  ,community  ,y          ,n     ,n
 parquet_decode            ,processor ,parquet_decode            ,4.4.0   ,certified  ,n          ,y     ,y
 parquet_encode            ,processor ,parquet_encode            ,4.4.0   ,certified  ,n          ,y     ,y
@@ -202,10 +202,10 @@ pinecone                  ,output    ,pinecone                  ,4.31.0  ,certif
 postgres_cdc              ,input     ,postgres_cdc              ,4.43.0  ,enterprise ,n          ,y     ,y
 processors                ,processor ,processors                ,0.0.0   ,certified  ,n          ,y     ,y
 prometheus                ,metric    ,prometheus                ,0.0.0   ,certified  ,n          ,y     ,y
-protobuf                  ,processor ,Protobuf                  ,0.0.0   ,certified  ,n          ,n     ,n
-pulsar                    ,input     ,pulsar                    ,3.43.0  ,community  ,n          ,n     ,n
-pulsar                    ,output    ,pulsar                    ,3.43.0  ,community  ,n          ,n     ,n
-pusher                    ,output    ,pusher                    ,4.3.0   ,community  ,n          ,n     ,n
+protobuf                  ,processor ,Protobuf                  ,0.0.0   ,certified  ,n          ,y     ,y
+pulsar                    ,input     ,pulsar                    ,3.43.0  ,community  ,n          ,y     ,y
+pulsar                    ,output    ,pulsar                    ,3.43.0  ,community  ,n          ,y     ,y
+pusher                    ,output    ,pusher                    ,4.3.0   ,community  ,n          ,y     ,y
 qdrant                    ,output    ,qdrant                    ,4.33.0  ,certified  ,n          ,y     ,y
 qdrant                    ,processor ,qdrant                    ,4.54.0  ,certified  ,n          ,y     ,y
 questdb                   ,output    ,questdb                   ,4.37.0  ,certified  ,n          ,y     ,y
@@ -230,7 +230,7 @@ redpanda                  ,output    ,redpanda                  ,4.39.0  ,certif
 redpanda                  ,tracer    ,redpanda                  ,4.71.0  ,certified  ,n          ,y     ,y
 redpanda_common           ,input     ,redpanda_common           ,4.39.0  ,enterprise ,y          ,y     ,y
 redpanda_common           ,output    ,redpanda_common           ,4.39.0  ,enterprise ,y          ,y     ,y
-redpanda_data_transform   ,processor ,redpanda_data_transform   ,4.31.0  ,certified  ,n          ,n     ,n
+redpanda_data_transform   ,processor ,redpanda_data_transform   ,4.31.0  ,certified  ,n          ,y     ,y
 redpanda_migrator         ,input     ,redpanda_migrator         ,4.66.0  ,certified  ,n          ,y     ,y
 redpanda_migrator         ,output    ,redpanda_migrator         ,4.66.0  ,certified  ,n          ,y     ,y
 reject                    ,output    ,reject                    ,0.0.0   ,certified  ,n          ,y     ,y
@@ -248,7 +248,7 @@ schema_registry           ,output    ,schema_registry           ,4.33.0  ,certif
 schema_registry_decode    ,processor ,schema_registry_decode    ,0.0.0   ,certified  ,n          ,y     ,y
 schema_registry_encode    ,processor ,schema_registry_encode    ,3.58.0  ,certified  ,n          ,y     ,y
 select_parts              ,processor ,select_parts              ,0.0.0   ,certified  ,n          ,y     ,y
-sentry_capture            ,processor ,sentry_capture            ,4.16.0  ,community  ,n          ,n     ,n
+sentry_capture            ,processor ,sentry_capture            ,4.16.0  ,community  ,n          ,y     ,y
 sequence                  ,input     ,sequence                  ,0.0.0   ,certified  ,n          ,y     ,y
 sftp                      ,input     ,sftp                      ,3.39.0  ,certified  ,n          ,y     ,y
 sftp                      ,output    ,sftp                      ,3.39.0  ,certified  ,n          ,y     ,y
@@ -272,14 +272,14 @@ sql                       ,cache     ,SQL                       ,4.26.0  ,certif
 sql                       ,output    ,SQL                       ,3.65.0  ,community  ,y          ,n     ,n
 sql                       ,processor ,SQL                       ,3.65.0  ,community  ,y          ,n     ,n
 sql_driver_clickhouse     ,sql_driver,ClickHouse                ,0.0.0   ,community  ,n          ,y     ,y
-sql_driver_gocosmos       ,sql_driver,Azure Cosmos DB           ,0.0.0   ,community  ,n          ,n     ,n
-sql_driver_mssql          ,sql_driver,Microsoft SQL Server      ,0.0.0   ,community  ,n          ,n     ,n
+sql_driver_gocosmos       ,sql_driver,Azure Cosmos DB           ,0.0.0   ,community  ,n          ,y     ,y
+sql_driver_mssql          ,sql_driver,Microsoft SQL Server      ,0.0.0   ,community  ,n          ,y     ,y
 sql_driver_mysql          ,sql_driver,MYSQL                     ,0.0.0   ,certified  ,n          ,y     ,y
 sql_driver_oracle         ,sql_driver,Oracle                    ,0.0.0   ,certified  ,n          ,y     ,y
 sql_driver_postgres       ,sql_driver,PostgreSQL                ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_snowflake      ,sql_driver,Snowflake                 ,0.0.0   ,community  ,n          ,n     ,n
+sql_driver_snowflake      ,sql_driver,Snowflake                 ,0.0.0   ,community  ,n          ,y     ,y
 sql_driver_sqlite         ,sql_driver,SQLite                    ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_trino          ,sql_driver,Trino                     ,0.0.0   ,community  ,n          ,n     ,n
+sql_driver_trino          ,sql_driver,Trino                     ,0.0.0   ,community  ,n          ,y     ,y
 sql_insert                ,output    ,sql_insert                ,3.59.0  ,certified  ,n          ,y     ,y
 sql_insert                ,processor ,sql_insert                ,3.59.0  ,certified  ,n          ,y     ,y
 sql_raw                   ,input     ,sql_raw                   ,4.10.0  ,certified  ,n          ,y     ,y
@@ -288,7 +288,7 @@ sql_raw                   ,processor ,sql_raw                   ,3.65.0  ,certif
 sql_select                ,input     ,sql_select                ,3.59.0  ,certified  ,n          ,y     ,y
 sql_select                ,processor ,sql_select                ,3.59.0  ,certified  ,n          ,y     ,y
 sqlite                    ,buffer    ,sqlite                    ,0.0.0   ,community  ,n          ,n     ,n
-statsd                    ,metric    ,statsd                    ,0.0.0   ,certified  ,n          ,n     ,n
+statsd                    ,metric    ,statsd                    ,0.0.0   ,certified  ,n          ,y     ,y
 stdin                     ,input     ,stdin                     ,0.0.0   ,certified  ,n          ,n     ,n
 stdout                    ,output    ,stdout                    ,0.0.0   ,certified  ,n          ,n     ,n
 string_split              ,processor ,string_split              ,4.86.0  ,certified  ,n          ,y     ,y
@@ -303,19 +303,19 @@ sync_response             ,processor ,sync_response             ,0.0.0   ,certif
 system_window             ,buffer    ,system_window             ,3.53.0  ,certified  ,n          ,y     ,y
 tar                       ,scanner   ,tar                       ,0.0.0   ,certified  ,n          ,y     ,y
 text_chunker              ,processor ,text_chunker              ,4.51.0  ,certified  ,n          ,y     ,y
-tigerbeetle_cdc           ,input     ,tigerbeetle_cdc           ,4.65.0  ,certified  ,n          ,n     ,n
+tigerbeetle_cdc           ,input     ,tigerbeetle_cdc           ,4.65.0  ,certified  ,n          ,y     ,y
 timeplus                  ,input     ,timeplus                  ,4.39.0  ,community  ,n          ,y     ,y
 timeplus                  ,output    ,timeplus                  ,4.38.0  ,community  ,n          ,y     ,y
 to_the_end                ,scanner   ,to_the_end                ,0.0.0   ,certified  ,n          ,y     ,y
 try                       ,processor ,try                       ,0.0.0   ,certified  ,n          ,y     ,y
 ttlru                     ,cache     ,ttlru                     ,0.0.0   ,community  ,n          ,y     ,y
-twitter_search            ,input     ,twitter_search            ,0.0.0   ,community  ,n          ,n     ,n
+twitter_search            ,input     ,twitter_search            ,0.0.0   ,community  ,n          ,y     ,y
 unarchive                 ,processor ,unarchive                 ,0.0.0   ,certified  ,n          ,y     ,y
-wasm                      ,processor ,wasm                      ,4.11.0  ,community  ,n          ,n     ,n
-websocket                 ,input     ,websocket                 ,0.0.0   ,certified  ,n          ,n     ,n
-websocket                 ,output    ,websocket                 ,0.0.0   ,certified  ,n          ,n     ,n
+wasm                      ,processor ,wasm                      ,4.11.0  ,community  ,n          ,y     ,y
+websocket                 ,input     ,websocket                 ,0.0.0   ,certified  ,n          ,y     ,y
+websocket                 ,output    ,websocket                 ,0.0.0   ,certified  ,n          ,y     ,y
 while                     ,processor ,while                     ,0.0.0   ,certified  ,n          ,y     ,y
 workflow                  ,processor ,workflow                  ,0.0.0   ,certified  ,n          ,y     ,y
 xml                       ,processor ,xml                       ,0.0.0   ,community  ,n          ,y     ,y
-zmq4                      ,input     ,zmq4                      ,0.0.0   ,community  ,n          ,n     ,n
-zmq4                      ,output    ,zmq4                      ,0.0.0   ,community  ,n          ,n     ,n
+zmq4                      ,input     ,zmq4                      ,0.0.0   ,community  ,n          ,y     ,y
+zmq4                      ,output    ,zmq4                      ,0.0.0   ,community  ,n          ,y     ,y


### PR DESCRIPTION
Enable 58 connectors (plus jira's cloud_with_gpu) that were previously disabled for cloud. Keeps disabled: deprecated connectors, ollama GPU-only connectors, and 15 unsafe connectors (stdin, stdout, file, subprocess, command, crash, ffi, socket, socket_server, sqlite).