### PR TITLE
iceberg: fix field ID collision when auto-creating tables with nested…

### DIFF
--- a/internal/impl/iceberg/integration/numeric_precision_test.go
+++ b/internal/impl/iceberg/integration/numeric_precision_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	icebergimpl "github.com/redpanda-data/connect/v4/internal/impl/iceberg"
+)
+
+// TestNumericPrecisionIntegration validates that typed Go values (as produced by
+// Avro deserialization) land with the correct Iceberg/Parquet column types and
+// that data round-trips without precision loss. This exercises the fix for the
+// customer escalation where financial fields defaulted to DOUBLE.
+func TestNumericPrecisionIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+
+	t.Run("TypedIntegersMapToCorrectColumnTypes", func(t *testing.T) {
+		const ns = "numeric_types_ns"
+		const tbl = "numeric_types_table"
+
+		router := infra.NewRouter(t, ns, tbl,
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		msg := service.NewMessage(nil)
+		msg.SetStructuredMut(map[string]any{
+			"amount_cents": int64(1234567890),
+			"count":        int32(42),
+			"label":        "payment",
+			"rate":         float64(0.035),
+			"enabled":      true,
+		})
+
+		produceMessages(t, ctx, router, service.MessageBatch{msg})
+
+		cols := querySQL[ColumnInfo](t, ctx, infra,
+			fmt.Sprintf(`DESCRIBE iceberg_cat."%s"."%s";`, ns, tbl))
+
+		colTypes := make(map[string]string)
+		for _, col := range cols {
+			colTypes[col.ColumnName] = col.ColumnType
+		}
+
+		assert.Equal(t, "BIGINT", colTypes["amount_cents"], "int64 should map to BIGINT (Iceberg long)")
+		assert.Equal(t, "INTEGER", colTypes["count"], "int32 should map to INTEGER (Iceberg int)")
+		assert.Equal(t, "VARCHAR", colTypes["label"], "string should map to VARCHAR")
+		assert.Equal(t, "DOUBLE", colTypes["rate"], "float64 should map to DOUBLE")
+		assert.Equal(t, "BOOLEAN", colTypes["enabled"], "bool should map to BOOLEAN")
+	})
+
+	t.Run("Int64ValuesPreservePrecision", func(t *testing.T) {
+		const ns = "precision_ns"
+		const tbl = "precision_table"
+
+		router := infra.NewRouter(t, ns, tbl,
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		// Use values that would lose precision if stored as float64.
+		// float64 has a 53-bit mantissa (~15.9 decimal digits).
+		// These 18-digit values are exact as int64 but not as float64.
+		msg := service.NewMessage(nil)
+		msg.SetStructuredMut(map[string]any{
+			"id":           int64(1),
+			"large_amount": int64(999999999999999999), // 18 digits
+			"negative":     int64(-123456789012345678),
+		})
+
+		produceMessages(t, ctx, router, service.MessageBatch{msg})
+
+		type row struct {
+			ID          int64 `json:"id"`
+			LargeAmount int64 `json:"large_amount"`
+			Negative    int64 `json:"negative"`
+		}
+
+		rows := querySQL[row](t, ctx, infra,
+			fmt.Sprintf(`SELECT id, large_amount, negative FROM iceberg_cat."%s"."%s";`, ns, tbl))
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(999999999999999999), rows[0].LargeAmount,
+			"large int64 should round-trip without precision loss")
+		assert.Equal(t, int64(-123456789012345678), rows[0].Negative,
+			"negative int64 should round-trip without precision loss")
+	})
+
+	t.Run("NestedStructs", func(t *testing.T) {
+		// Auto-create table with nested structs — mirrors Christan's Transfer schema.
+		const ns = "nested_ns"
+		const tbl = "nested_table"
+
+		router := infra.NewRouter(t, ns, tbl,
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		msg := service.NewMessage(nil)
+		msg.SetStructuredMut(map[string]any{
+			"transfer_id": "TXN-001",
+			"source": map[string]any{
+				"account_id":  "ACC-123",
+				"bank_code":   "SWIFT-XYZ",
+				"holder_name": "Alice",
+			},
+			"destination": map[string]any{
+				"account_id":  "ACC-456",
+				"bank_code":   "SWIFT-ABC",
+				"holder_name": "Bob",
+			},
+			"amount_cents": int64(5000000),
+			"currency":     "USD",
+		})
+
+		produceMessages(t, ctx, router, service.MessageBatch{msg})
+
+		// Verify column types
+		cols := querySQL[ColumnInfo](t, ctx, infra,
+			fmt.Sprintf(`DESCRIBE iceberg_cat."%s"."%s";`, ns, tbl))
+
+		colTypes := make(map[string]string)
+		for _, col := range cols {
+			colTypes[col.ColumnName] = col.ColumnType
+		}
+
+		assert.Equal(t, "VARCHAR", colTypes["transfer_id"])
+		assert.Equal(t, "BIGINT", colTypes["amount_cents"], "int64 amount_cents should be BIGINT")
+		assert.Equal(t, "VARCHAR", colTypes["currency"])
+		assert.Contains(t, colTypes["source"], "STRUCT", "nested record should be STRUCT")
+		assert.Contains(t, colTypes["destination"], "STRUCT", "nested record should be STRUCT")
+
+		// Verify data round-trips through nested structs
+		type result struct {
+			TransferID  string `json:"transfer_id"`
+			AmountCents int64  `json:"amount_cents"`
+			Currency    string `json:"currency"`
+		}
+
+		rows := querySQL[result](t, ctx, infra,
+			fmt.Sprintf(`SELECT transfer_id, amount_cents, currency FROM iceberg_cat."%s"."%s";`, ns, tbl))
+		require.Len(t, rows, 1)
+		assert.Equal(t, "TXN-001", rows[0].TransferID)
+		assert.Equal(t, int64(5000000), rows[0].AmountCents)
+		assert.Equal(t, "USD", rows[0].Currency)
+	})
+
+	t.Run("NestedStructsWithNullableFields", func(t *testing.T) {
+		// Auto-create table, then write messages where some nested fields are absent.
+		const ns = "nullable_nested_ns"
+		const tbl = "nullable_nested_table"
+
+		router := infra.NewRouter(t, ns, tbl,
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		// First message: fee present, reference present
+		msg1 := service.NewMessage(nil)
+		msg1.SetStructuredMut(map[string]any{
+			"transfer_id":  "TXN-001",
+			"amount_cents": int64(5000000),
+			"fee": map[string]any{
+				"amount_cents": int64(250),
+				"type":         "wire",
+			},
+			"reference": "INV-2026-001",
+		})
+
+		// Second message: fee absent, reference absent
+		msg2 := service.NewMessage(nil)
+		msg2.SetStructuredMut(map[string]any{
+			"transfer_id":  "TXN-002",
+			"amount_cents": int64(3000000),
+		})
+
+		produceMessages(t, ctx, router, service.MessageBatch{msg1, msg2})
+
+		// Verify row count
+		rows := querySQL[countResult](t, ctx, infra,
+			fmt.Sprintf(`SELECT COUNT(*) as count FROM iceberg_cat."%s"."%s";`, ns, tbl))
+		require.Len(t, rows, 1)
+		assert.Equal(t, 2, rows[0].Count)
+
+		// Verify column types
+		cols := querySQL[ColumnInfo](t, ctx, infra,
+			fmt.Sprintf(`DESCRIBE iceberg_cat."%s"."%s";`, ns, tbl))
+
+		colTypes := make(map[string]string)
+		for _, col := range cols {
+			colTypes[col.ColumnName] = col.ColumnType
+		}
+
+		assert.Equal(t, "BIGINT", colTypes["amount_cents"])
+		assert.Equal(t, "VARCHAR", colTypes["reference"])
+		assert.Contains(t, colTypes["fee"], "STRUCT", "fee should be STRUCT")
+	})
+
+	t.Run("SchemaEvolution_NewIntegerColumn", func(t *testing.T) {
+		const ns = "evo_int_ns"
+		const tbl = "evo_int_table"
+
+		router := infra.NewRouter(t, ns, tbl,
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		// First batch: creates table with {id, name}
+		msg1 := service.NewMessage(nil)
+		msg1.SetStructuredMut(map[string]any{
+			"id":   int64(1),
+			"name": "alice",
+		})
+		produceMessages(t, ctx, router, service.MessageBatch{msg1})
+
+		// Second batch: adds amount_cents column (int64) via schema evolution
+		msg2 := service.NewMessage(nil)
+		msg2.SetStructuredMut(map[string]any{
+			"id":           int64(2),
+			"name":         "bob",
+			"amount_cents": int64(9999999),
+		})
+		produceMessages(t, ctx, router, service.MessageBatch{msg2})
+
+		cols := querySQL[ColumnInfo](t, ctx, infra,
+			fmt.Sprintf(`DESCRIBE iceberg_cat."%s"."%s";`, ns, tbl))
+
+		colTypes := make(map[string]string)
+		for _, col := range cols {
+			colTypes[col.ColumnName] = col.ColumnType
+		}
+
+		assert.Equal(t, "BIGINT", colTypes["id"], "int64 id should be BIGINT")
+		assert.Equal(t, "BIGINT", colTypes["amount_cents"],
+			"schema-evolved int64 column should be BIGINT, not DOUBLE")
+
+		// Verify data
+		type result struct {
+			ID          int64  `json:"id"`
+			Name        string `json:"name"`
+			AmountCents *int64 `json:"amount_cents"`
+		}
+		dataRows := querySQL[result](t, ctx, infra,
+			fmt.Sprintf(`SELECT id, name, amount_cents FROM iceberg_cat."%s"."%s" ORDER BY id;`, ns, tbl))
+		require.Len(t, dataRows, 2)
+
+		// First row: amount_cents is null (column didn't exist yet)
+		assert.Equal(t, int64(1), dataRows[0].ID)
+		assert.Nil(t, dataRows[0].AmountCents)
+
+		// Second row: amount_cents is present
+		assert.Equal(t, int64(2), dataRows[1].ID)
+		require.NotNil(t, dataRows[1].AmountCents)
+		assert.Equal(t, int64(9999999), *dataRows[1].AmountCents)
+	})
+}

--- a/internal/impl/iceberg/integration/numeric_precision_test.go
+++ b/internal/impl/iceberg/integration/numeric_precision_test.go
@@ -100,7 +100,6 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 	})
 
 	t.Run("NestedStructs", func(t *testing.T) {
-		// Auto-create table with nested structs — mirrors Christan's Transfer schema.
 		const ns = "nested_ns"
 		const tbl = "nested_table"
 

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -381,7 +381,7 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 			continue // nil value, skip
 		}
 		fields = append(fields, iceberg.NestedField{
-			ID:       ti.allocateFieldID(), // Uses shared allocator — nested struct IDs are already assigned by ti
+			ID:       ti.allocateFieldID(), // For primitives this is the only allocation; for nested structs, inner IDs were already assigned by ti
 			Name:     name,
 			Type:     fieldType,
 			Required: false,

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -373,7 +373,7 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	fields := make([]iceberg.NestedField, 0, len(record))
 
 	for name, value := range record {
-		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, key.namespace, key.table)
+		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, key.namespace, key.table, ti)
 		if err != nil {
 			return nil, fmt.Errorf("resolving type for field %q: %w", name, err)
 		}
@@ -381,7 +381,7 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 			continue // nil value, skip
 		}
 		fields = append(fields, iceberg.NestedField{
-			ID:       ti.allocateFieldID(),
+			ID:       ti.allocateFieldID(), // Uses shared allocator — nested struct IDs are already assigned by ti
 			Name:     name,
 			Type:     fieldType,
 			Required: false,

--- a/internal/impl/iceberg/type_inference.go
+++ b/internal/impl/iceberg/type_inference.go
@@ -56,13 +56,6 @@ func InferIcebergType(value any) (iceberg.Type, error) {
 	return ti.inferType(value)
 }
 
-// inferIcebergTypeWith infers an Iceberg type using a shared typeInferrer so that
-// field IDs are unique across the entire schema. This must be used when building
-// a schema with multiple fields to avoid field ID collisions in nested structs.
-func inferIcebergTypeWith(ti *typeInferrer, value any) (iceberg.Type, error) {
-	return ti.inferType(value)
-}
-
 // inferType is the internal recursive implementation.
 func (ti *typeInferrer) inferType(value any) (iceberg.Type, error) {
 	if value == nil {

--- a/internal/impl/iceberg/type_inference.go
+++ b/internal/impl/iceberg/type_inference.go
@@ -56,6 +56,13 @@ func InferIcebergType(value any) (iceberg.Type, error) {
 	return ti.inferType(value)
 }
 
+// inferIcebergTypeWith infers an Iceberg type using a shared typeInferrer so that
+// field IDs are unique across the entire schema. This must be used when building
+// a schema with multiple fields to avoid field ID collisions in nested structs.
+func inferIcebergTypeWith(ti *typeInferrer, value any) (iceberg.Type, error) {
+	return ti.inferType(value)
+}
+
 // inferType is the internal recursive implementation.
 func (ti *typeInferrer) inferType(value any) (iceberg.Type, error) {
 	if value == nil {

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -77,8 +77,9 @@ func (r *typeResolver) resolveTypeForAddColumn(
 }
 
 // resolveTypeForCreateTable resolves the Iceberg type for a field during initial table creation.
-// If ti is non-nil, it is used as a shared field ID allocator so that nested struct field IDs
-// are unique across the entire schema. If nil, a fresh allocator is created per field.
+// ti is a shared field ID allocator so that nested struct field IDs are unique across the entire
+// schema. Note: if stage 2 or 3 overrides replace a nested struct type, the IDs allocated during
+// inference are consumed but unused, leaving harmless gaps in the field ID sequence.
 func (r *typeResolver) resolveTypeForCreateTable(
 	fieldName string,
 	value any,
@@ -86,16 +87,8 @@ func (r *typeResolver) resolveTypeForCreateTable(
 	namespace, table string,
 	ti *typeInferrer,
 ) (iceberg.Type, error) {
-	// Stage 1: Default inference
-	var (
-		inferredType iceberg.Type
-		err          error
-	)
-	if ti != nil {
-		inferredType, err = inferIcebergTypeWith(ti, value)
-	} else {
-		inferredType, err = InferIcebergType(value)
-	}
+	// Stage 1: Default inference using shared allocator
+	inferredType, err := ti.inferType(value)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -56,7 +56,7 @@ func (r *typeResolver) resolveTypeForAddColumn(
 
 	// Stage 2: schema_metadata override
 	if r.schemaMetadataKey != "" {
-		if metaType, err := r.resolveFromSchemaMetadata(msg, field.FullPath()); err != nil {
+		if metaType, err := r.resolveFromSchemaMetadata(msg, field.FullPath(), newTypeInferrer()); err != nil {
 			return nil, fmt.Errorf("resolving type from schema metadata for field %v: %w", field.FullPath(), err)
 		} else if metaType != nil {
 			// If the metatype was not found then just stick with the default inferred type
@@ -78,8 +78,8 @@ func (r *typeResolver) resolveTypeForAddColumn(
 
 // resolveTypeForCreateTable resolves the Iceberg type for a field during initial table creation.
 // ti is a shared field ID allocator so that nested struct field IDs are unique across the entire
-// schema. Note: if stage 2 or 3 overrides replace a nested struct type, the IDs allocated during
-// inference are consumed but unused, leaving harmless gaps in the field ID sequence.
+// schema, including IDs assigned by the schema_metadata override path. If stage 2 or 3 overrides
+// replace a nested struct, IDs allocated during stage 1 inference become harmless gaps.
 func (r *typeResolver) resolveTypeForCreateTable(
 	fieldName string,
 	value any,
@@ -96,10 +96,10 @@ func (r *typeResolver) resolveTypeForCreateTable(
 		return nil, nil // nil value, skip
 	}
 
-	// Stage 2: schema_metadata override
+	// Stage 2: schema_metadata override (uses shared ti so override structs share the ID space)
 	if r.schemaMetadataKey != "" {
 		path := icebergx.Path{{Kind: icebergx.PathField, Name: fieldName}}
-		if metaType, err := r.resolveFromSchemaMetadata(msg, path); err != nil {
+		if metaType, err := r.resolveFromSchemaMetadata(msg, path, ti); err != nil {
 			return nil, fmt.Errorf("resolving type from schema metadata for field %q: %w", fieldName, err)
 		} else if metaType != nil {
 			// If the metatype was not found then just stick with the default inferred type
@@ -121,8 +121,10 @@ func (r *typeResolver) resolveTypeForCreateTable(
 }
 
 // resolveFromSchemaMetadata looks up the type for a field path in the schema.Common
-// structure found in message metadata.
-func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath icebergx.Path) (iceberg.Type, error) {
+// structure found in message metadata. ti is the field ID allocator used when the
+// resolved type is a struct or list; pass the schema's shared allocator to keep IDs
+// unique across the whole schema, or a fresh one when the result is single-column.
+func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath icebergx.Path, ti *typeInferrer) (iceberg.Type, error) {
 	metaAny, exists := msg.MetaGetMut(r.schemaMetadataKey)
 	if !exists {
 		if r.logger != nil {
@@ -141,7 +143,7 @@ func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath
 		return nil, nil
 	}
 
-	return commonTypeToIcebergType(field)
+	return commonTypeToIcebergType(field, ti)
 }
 
 // findCommonField walks a schema.Common tree to find the field at the given path.
@@ -181,9 +183,9 @@ func findCommonField(root schema.Common, path icebergx.Path) (*schema.Common, bo
 	return current, true
 }
 
-// commonTypeToIcebergType converts a schema.Common to an iceberg.Type.
-func commonTypeToIcebergType(c *schema.Common) (iceberg.Type, error) {
-	ti := newTypeInferrer()
+// commonTypeToIcebergType converts a schema.Common to an iceberg.Type using ti to
+// allocate field IDs for any nested struct/list elements it produces.
+func commonTypeToIcebergType(c *schema.Common, ti *typeInferrer) (iceberg.Type, error) {
 	return commonTypeToIcebergTypeRec(c, ti)
 }
 

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -77,14 +77,25 @@ func (r *typeResolver) resolveTypeForAddColumn(
 }
 
 // resolveTypeForCreateTable resolves the Iceberg type for a field during initial table creation.
+// If ti is non-nil, it is used as a shared field ID allocator so that nested struct field IDs
+// are unique across the entire schema. If nil, a fresh allocator is created per field.
 func (r *typeResolver) resolveTypeForCreateTable(
 	fieldName string,
 	value any,
 	msg *service.Message,
 	namespace, table string,
+	ti *typeInferrer,
 ) (iceberg.Type, error) {
 	// Stage 1: Default inference
-	inferredType, err := InferIcebergType(value)
+	var (
+		inferredType iceberg.Type
+		err          error
+	)
+	if ti != nil {
+		inferredType, err = inferIcebergTypeWith(ti, value)
+	} else {
+		inferredType, err = InferIcebergType(value)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -340,7 +340,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"name": "hello"})
 
-		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl")
+		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "string", got.Type())
 	})
@@ -351,7 +351,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{})
 
-		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl")
+		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", nil)
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
@@ -369,7 +369,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg.SetStructuredMut(map[string]any{"count": 42})
 		msg.MetaSetMut("test_schema", commonSchema.ToAny())
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl")
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -381,7 +381,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl")
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -392,7 +392,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl")
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
 		require.NoError(t, err, "should not error when schema_metadata is missing from message")
 		assert.Equal(t, "long", got.Type(), "should fall back to inference")
 	})

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -340,7 +340,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"name": "hello"})
 
-		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", nil)
+		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", newTypeInferrer())
 		require.NoError(t, err)
 		assert.Equal(t, "string", got.Type())
 	})
@@ -351,7 +351,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{})
 
-		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", nil)
+		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", newTypeInferrer())
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
@@ -369,7 +369,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg.SetStructuredMut(map[string]any{"count": 42})
 		msg.MetaSetMut("test_schema", commonSchema.ToAny())
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -381,7 +381,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -392,8 +392,55 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", nil)
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
 		require.NoError(t, err, "should not error when schema_metadata is missing from message")
 		assert.Equal(t, "long", got.Type(), "should fall back to inference")
+	})
+
+	t.Run("shared allocator produces unique field IDs across nested structs", func(t *testing.T) {
+		r := newTypeResolver("", nil, nil)
+		ti := newTypeInferrer()
+
+		record := map[string]any{
+			"id": int64(1),
+			"source": map[string]any{
+				"account_id": "ACC-123",
+				"bank_code":  "SWIFT-XYZ",
+			},
+			"destination": map[string]any{
+				"account_id": "ACC-456",
+				"bank_code":  "SWIFT-ABC",
+			},
+		}
+
+		msg := service.NewMessage(nil)
+		msg.SetStructuredMut(record)
+
+		// Build fields the same way buildSchemaWithResolver does.
+		var allIDs []int
+		for name, value := range record {
+			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, "ns", "tbl", ti)
+			require.NoError(t, err)
+			if fieldType == nil {
+				continue
+			}
+			topID := ti.allocateFieldID()
+			allIDs = append(allIDs, topID)
+
+			// Collect nested field IDs from struct types.
+			if st, ok := fieldType.(*iceberg.StructType); ok {
+				for _, f := range st.FieldList {
+					allIDs = append(allIDs, f.ID)
+				}
+			}
+		}
+
+		// Every ID must be unique — this is the regression test for the collision bug.
+		seen := make(map[int]bool, len(allIDs))
+		for _, id := range allIDs {
+			assert.False(t, seen[id], "duplicate field ID %d — nested struct IDs collide with top-level", id)
+			seen[id] = true
+		}
+		assert.GreaterOrEqual(t, len(allIDs), 7, "expected at least 7 fields (1 primitive + 2 structs with 2 fields each)")
 	})
 }

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -500,6 +500,6 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 			assert.False(t, seen[id], "duplicate field ID %d — metadata-override path is not sharing ti", id)
 			seen[id] = true
 		}
-		assert.Equal(t, 6, len(allIDs), "expected 2 top-level + 4 nested IDs")
+		assert.Len(t, allIDs, 6, "expected 2 top-level + 4 nested IDs")
 	})
 }

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -107,7 +107,7 @@ func TestCommonTypeToIcebergType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := commonTypeToIcebergType(&tt.common)
+			got, err := commonTypeToIcebergType(&tt.common, newTypeInferrer())
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -442,5 +442,64 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 			seen[id] = true
 		}
 		assert.GreaterOrEqual(t, len(allIDs), 7, "expected at least 7 fields (1 primitive + 2 structs with 2 fields each)")
+	})
+
+	t.Run("schema_metadata override shares allocator with stage 1", func(t *testing.T) {
+		// Two top-level fields are both objects described in schema_metadata. Without
+		// threading the shared `ti` through the override path, each metadata-resolved
+		// struct would re-start IDs at 1, colliding with each other and with stage-1
+		// inferred fields.
+		commonRoot := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "source", Type: schema.Object, Children: []schema.Common{
+					{Name: "account_id", Type: schema.String},
+					{Name: "bank_code", Type: schema.String},
+				}},
+				{Name: "destination", Type: schema.Object, Children: []schema.Common{
+					{Name: "account_id", Type: schema.String},
+					{Name: "bank_code", Type: schema.String},
+				}},
+			},
+		}
+
+		r := newTypeResolver("test_schema", nil, nil)
+		ti := newTypeInferrer()
+
+		record := map[string]any{
+			"source": map[string]any{
+				"account_id": "ACC-123",
+				"bank_code":  "SWIFT-XYZ",
+			},
+			"destination": map[string]any{
+				"account_id": "ACC-456",
+				"bank_code":  "SWIFT-ABC",
+			},
+		}
+		msg := service.NewMessage(nil)
+		msg.SetStructuredMut(record)
+		msg.MetaSetMut("test_schema", commonRoot.ToAny())
+
+		var allIDs []int
+		for name, value := range record {
+			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, "ns", "tbl", ti)
+			require.NoError(t, err)
+			require.NotNil(t, fieldType)
+			topID := ti.allocateFieldID()
+			allIDs = append(allIDs, topID)
+
+			st, ok := fieldType.(*iceberg.StructType)
+			require.True(t, ok, "expected metadata override to return StructType")
+			for _, f := range st.FieldList {
+				allIDs = append(allIDs, f.ID)
+			}
+		}
+
+		seen := make(map[int]bool, len(allIDs))
+		for _, id := range allIDs {
+			assert.False(t, seen[id], "duplicate field ID %d — metadata-override path is not sharing ti", id)
+			seen[id] = true
+		}
+		assert.Equal(t, 6, len(allIDs), "expected 2 top-level + 4 nested IDs")
 	})
 }


### PR DESCRIPTION
… structs

buildSchemaWithResolver created a fresh typeInferrer per InferIcebergType call, so nested struct fields got IDs starting at 1 that collided with top-level field IDs. Thread a shared typeInferrer from the router through type resolution so all field IDs in the schema are unique.

Adds integration tests for numeric type precision, nested structs, nullable fields, and schema evolution with typed integers.