### PR TITLE
oracledb_cdc: ensure LogMiner nullable numbers are consistent with snapshotting

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -851,7 +851,8 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		bit_col           NUMBER(1),                    -- Boolean-like (0,1,NULL)
 		-- xml_col           XMLTYPE,
 		json_col          CLOB,                         -- JSON stored as CLOB
-		noleadingzero_col NUMBER                        -- observe Oracle's non-leading zero decimal handling (0.15 -> .15)
+		noleadingzero_col NUMBER,                       -- observe Oracle's non-leading zero decimal handling (0.15 -> .15)
+		nullable_num      NUMBER(11,0)                  -- nullable number to verify NULL handling
 	) LOB(oolvarcharmax_col) STORE AS BASICFILE (DISABLE STORAGE IN ROW NOCACHE LOGGING)`
 	err := db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.all_data_types", q)
 	require.NoError(t, err)
@@ -867,7 +868,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		time_col, datetimeoffset_col, char_col, varchar_col,
 		nchar_col, nvarchar_col, binary_col, varbinary_col,
 		varcharmax_col, oolvarcharmax_col, nvarcharmax_col, varbinarymax_col,
-		bit_col, json_col, noleadingzero_col
+		bit_col, json_col, noleadingzero_col, nullable_num
 	) VALUES (
 		:1, :2, :3, :4,
 		:5, :6, :7, :8,
@@ -875,7 +876,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		:13, :14, :15, :16,
 		:17, :18, :19, :20,
 		:21, :22, :23, :24,
-		:25, :26, :27
+		:25, :26, :27, :28
 	)`
 
 	t.Log("Inserting min values for testing snapshot data...")
@@ -909,6 +910,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 			0,            // bit (number)
 			nil,          // json (clob)
 			"0.15",       // noleadingzero_col
+			nil,          // nullable_num (NULL to verify NULL handling)
 		)
 	}
 
@@ -1005,6 +1007,7 @@ oracledb_cdc:
 			1,                    // bit max (number)
 			`{"max": true}`,      // json (clob)
 			"0.15",               // noleadingzero_col
+			nil,                  // nullable_num (NULL to verify NULL handling when streaming)
 		)
 
 		minWant := 2
@@ -1034,7 +1037,8 @@ oracledb_cdc:
 
 	t.Log("Verifying values from snapshot...")
 	{
-		// assert min - uppercase column names from Oracle, NUMBER types as float64
+		// assert min values from snapshot.
+		// NULL columns are included as JSON null in snapshot rows.
 		require.JSONEq(t, `{
 		"BIGINT_COL": -9223372036854775808,
 		"BINARY_COL": "AAAAAAAAAAAAAAAAAAAAAA==",
@@ -1050,6 +1054,7 @@ oracledb_cdc:
 		"JSON_COL": null,
 		"NCHAR_COL": "АААААААААА",
 		"NUMERIC_COL": -999999999999999.99999,
+		"NULLABLE_NUM": null,
 		"NVARCHAR_COL": null,
 		"NVARCHARMAX_COL": null,
 		"REAL_COL": -3.4e+37,
@@ -1068,7 +1073,7 @@ oracledb_cdc:
 
 	t.Log("Verifying values from streaming...")
 	{
-		// assert max - uppercase column names from Oracle
+		// assert max values from streaming.
 		require.JSONEq(t, `{
 		"BIGINT_COL": 9223372036854775807,
 		"BINARY_COL": "AAAAAAAAAAAAAAAAAAAAAA==",
@@ -1084,6 +1089,7 @@ oracledb_cdc:
 		"JSON_COL": "{\"max\": true}",
 		"NCHAR_COL": "ZZZZZZZZZZ",
 		"NUMERIC_COL": 999999999999999.99999,
+		"NULLABLE_NUM": null,
 		"NVARCHAR_COL": "Max nvarchar value",
 		"NVARCHARMAX_COL": "Max nvarchar(max)",
 		"REAL_COL": 3.3999999e+37,

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -852,7 +852,8 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		-- xml_col           XMLTYPE,
 		json_col          CLOB,                         -- JSON stored as CLOB
 		noleadingzero_col NUMBER,                       -- observe Oracle's non-leading zero decimal handling (0.15 -> .15)
-		nullable_num      NUMBER(11,0)                  -- nullable number to verify NULL handling
+		nullable_num      NUMBER(11,0),                 -- nullable number to verify NULL handling
+		nonnullable_num   NUMBER(11,0) NOT NULL         -- NOT NULL
 	) LOB(oolvarcharmax_col) STORE AS BASICFILE (DISABLE STORAGE IN ROW NOCACHE LOGGING)`
 	err := db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.all_data_types", q)
 	require.NoError(t, err)
@@ -868,7 +869,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		time_col, datetimeoffset_col, char_col, varchar_col,
 		nchar_col, nvarchar_col, binary_col, varbinary_col,
 		varcharmax_col, oolvarcharmax_col, nvarcharmax_col, varbinarymax_col,
-		bit_col, json_col, noleadingzero_col, nullable_num
+		bit_col, json_col, noleadingzero_col, nullable_num, nonnullable_num
 	) VALUES (
 		:1, :2, :3, :4,
 		:5, :6, :7, :8,
@@ -876,7 +877,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 		:13, :14, :15, :16,
 		:17, :18, :19, :20,
 		:21, :22, :23, :24,
-		:25, :26, :27, :28
+		:25, :26, :27, :28, :29
 	)`
 
 	t.Log("Inserting min values for testing snapshot data...")
@@ -911,6 +912,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreamingAllTypes(t *testing.T) {
 			nil,          // json (clob)
 			"0.15",       // noleadingzero_col
 			nil,          // nullable_num (NULL to verify NULL handling)
+			0,            // nonnullable_num
 		)
 	}
 
@@ -1008,6 +1010,7 @@ oracledb_cdc:
 			`{"max": true}`,      // json (clob)
 			"0.15",               // noleadingzero_col
 			nil,                  // nullable_num (NULL to verify NULL handling when streaming)
+			0,                    // nonnullable_num
 		)
 
 		minWant := 2
@@ -1055,6 +1058,7 @@ oracledb_cdc:
 		"NCHAR_COL": "АААААААААА",
 		"NUMERIC_COL": -999999999999999.99999,
 		"NULLABLE_NUM": null,
+		"NONNULLABLE_NUM": 0,
 		"NVARCHAR_COL": null,
 		"NVARCHARMAX_COL": null,
 		"REAL_COL": -3.4e+37,
@@ -1090,6 +1094,7 @@ oracledb_cdc:
 		"NCHAR_COL": "ZZZZZZZZZZ",
 		"NUMERIC_COL": 999999999999999.99999,
 		"NULLABLE_NUM": null,
+		"NONNULLABLE_NUM": 0,
 		"NVARCHAR_COL": "Max nvarchar value",
 		"NVARCHARMAX_COL": "Max nvarchar(max)",
 		"REAL_COL": 3.3999999e+37,

--- a/internal/impl/oracledb/logminer/sqlredo/parser.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser.go
@@ -198,9 +198,7 @@ func extractWhereConditions(expr sqlparser.Expr, result map[string]any, converte
 func processValue(valStr string, converter *OracleValueConverter) any {
 	valStr = strings.TrimSpace(valStr)
 
-	// Handle NULL - return nil to exclude from map.
 	// vitess-sqlparser serialises NullVal as lowercase "null", so check both.
-	// if valStr == "NULL" || valStr == "Unsupported Type" {
 	if valStr == "NULL" || valStr == "null" || valStr == "Unsupported Type" {
 		return nil
 	}

--- a/internal/impl/oracledb/logminer/sqlredo/parser.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser.go
@@ -129,9 +129,7 @@ func extractInsertValues(stmt *sqlparser.Insert, converter *OracleValueConverter
 		for i, val := range row {
 			if i < len(columns) {
 				valStr := sqlparser.String(val)
-				if parsedVal := processValue(valStr, converter); parsedVal != nil {
-					result[columns[i]] = parsedVal
-				}
+				result[columns[i]] = processValue(valStr, converter)
 			}
 		}
 	}
@@ -147,9 +145,7 @@ func extractUpdateSetValues(stmt *sqlparser.Update, converter *OracleValueConver
 	for _, expr := range stmt.Exprs {
 		colName := sqlparser.String(expr.Name)
 		valStr := sqlparser.String(expr.Expr)
-		if parsedVal := processValue(valStr, converter); parsedVal != nil {
-			result[colName] = parsedVal
-		}
+		result[colName] = processValue(valStr, converter)
 	}
 
 	return result
@@ -202,8 +198,10 @@ func extractWhereConditions(expr sqlparser.Expr, result map[string]any, converte
 func processValue(valStr string, converter *OracleValueConverter) any {
 	valStr = strings.TrimSpace(valStr)
 
-	// Handle NULL - return nil to exclude from map
-	if valStr == "NULL" || valStr == "Unsupported Type" {
+	// Handle NULL - return nil to exclude from map.
+	// vitess-sqlparser serialises NullVal as lowercase "null", so check both.
+	// if valStr == "NULL" || valStr == "Unsupported Type" {
+	if valStr == "NULL" || valStr == "null" || valStr == "Unsupported Type" {
 		return nil
 	}
 

--- a/internal/impl/oracledb/logminer/sqlredo/parser_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser_test.go
@@ -96,7 +96,7 @@ func TestParseTest(t *testing.T) {
 			name: "INSERT with NULL value includes column as nil",
 			sql:  `insert into "MYAPP"."SAMPLES" ("ID","SPEC_CH_ID","SPEC_CKC_ID") values ('1',NULL,NULL)`,
 			wantNewValues: map[string]any{
-				"ID":         "1",
+				"ID":          "1",
 				"SPEC_CH_ID":  nil,
 				"SPEC_CKC_ID": nil,
 			},

--- a/internal/impl/oracledb/logminer/sqlredo/parser_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser_test.go
@@ -92,6 +92,15 @@ func TestParseTest(t *testing.T) {
 				"NAME": "Alice",
 			},
 		},
+		{
+			name: "INSERT with NULL value includes column as nil",
+			sql:  `insert into "MYAPP"."SAMPLES" ("ID","SPEC_CH_ID","SPEC_CKC_ID") values ('1',NULL,NULL)`,
+			wantNewValues: map[string]any{
+				"ID":         "1",
+				"SPEC_CH_ID":  nil,
+				"SPEC_CKC_ID": nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +177,15 @@ func TestExtractValuesWithConverter(t *testing.T) {
 			wantNewValues: map[string]any{
 				"ID": int64(1),
 				"TS": time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "INSERT with NULL numeric columns includes them as nil",
+			sql:  `insert into "SPACE"."T_EXT_SAMPLES" ("SAMPLE_ID","SPEC_CH_ID","SPEC_CKC_ID") values (2100318824,NULL,NULL)`,
+			wantNewValues: map[string]any{
+				"SAMPLE_ID":   int64(2100318824),
+				"SPEC_CH_ID":  nil,
+				"SPEC_CKC_ID": nil,
 			},
 		},
 	}


### PR DESCRIPTION
This change ensures nullable numbers are treated the same as with snapshotting and represented as null.

Change adds a unit test and also an integration test to verify handling is consistent with snapshotting.