### PR TITLE
mysql_cdc: support parallel table snapshots

### DIFF
--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -46,6 +46,7 @@ input:
     checkpoint_key: mysql_binlog_position
     snapshot_max_batch_size: 1000
     stream_snapshot: false # No default (required)
+    max_parallel_snapshot_tables: 1
     auto_replay_nacks: true
     checkpoint_limit: 1024
     batching:
@@ -73,6 +74,7 @@ input:
     snapshot_max_batch_size: 1000
     max_reconnect_attempts: 10
     stream_snapshot: false # No default (required)
+    max_parallel_snapshot_tables: 1
     auto_replay_nacks: true
     checkpoint_limit: 1024
     tls:
@@ -205,6 +207,15 @@ If set to true, the connector will query all the existing data as a part of snap
 
 *Type*: `bool`
 
+
+=== `max_parallel_snapshot_tables`
+
+Specifies the number of tables that will be snapshotted in parallel.
+
+
+*Type*: `int`
+
+*Default*: `1`
 
 === `auto_replay_nacks`
 

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -603,7 +603,7 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 				}
 				row[columns[idx]] = v
 				if _, ok := lastSeenPksValues[columns[idx]]; ok {
-					lastSeenPksValues[columns[idx]] = value
+					lastSeenPksValues[columns[idx]] = v
 				}
 			}
 

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -113,7 +113,8 @@ This input adds the following metadata fields to each message:
 			Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current binlog position."),
 		service.NewIntField(fieldMaxParallelSnapshotTables).
 			Description("Specifies the number of tables that will be snapshotted in parallel.").
-			Default(1),
+			Default(1).
+			LintRule(`root = if this < 1 { [ "`+fieldMaxParallelSnapshotTables+` must be at least 1" ] }`),
 		service.NewAutoRetryNacksToggleField(),
 		service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given BinLog Position will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -467,12 +467,12 @@ func (i *mysqlStreamInput) refreshIAMAuthToken(ctx context.Context) error {
 func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, snapshot *Snapshot) error {
 	// If we are given a snapshot, then we need to read it.
 	if snapshot != nil {
-		startPos, err := snapshot.prepareSnapshot(ctx, i.tables)
+		startPos, err := snapshot.prepareSnapshot(ctx, i.tables, i.snapshotMaxWorkers)
 		if err != nil {
 			_ = snapshot.close()
 			return fmt.Errorf("unable to prepare snapshot: %w", err)
 		}
-		if err = i.readSnapshot(ctx, snapshot, i.snapshotMaxWorkers); err != nil {
+		if err = i.readSnapshot(ctx, snapshot); err != nil {
 			_ = snapshot.close()
 			return fmt.Errorf("failed reading snapshot: %w", err)
 		}
@@ -513,105 +513,112 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 	return nil
 }
 
-func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot, maxWorkers int) error {
-	wg, wgCtx := errgroup.WithContext(ctx)
-	wg.SetLimit(maxWorkers)
-
+func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot) error {
+	tableQueue := make(chan string, len(i.tables))
 	for _, table := range i.tables {
-		tx, ok := snapshot.tableTxs[table]
-		if !ok {
-			return fmt.Errorf("no snapshot transaction found for table %s", table)
-		}
+		tableQueue <- table
+	}
+	close(tableQueue)
 
+	wg, wgCtx := errgroup.WithContext(ctx)
+	for _, tx := range snapshot.workerTxs {
 		wg.Go(func() error {
-			// Pre-populate schema cache so snapshot messages carry schema metadata.
-			if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
-				if _, err := i.getTableSchema(tbl); err != nil {
-					i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
-				}
-			} else {
-				i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
-			}
-
-			tablePks, err := snapshot.getTablePrimaryKeys(wgCtx, tx, table)
-			if err != nil {
-				return err
-			}
-			i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
-			lastSeenPksValues := map[string]any{}
-			for _, pk := range tablePks {
-				lastSeenPksValues[pk] = nil
-			}
-
-			var numRowsProcessed int
-			for {
-				var batchRows *sql.Rows
-				if numRowsProcessed == 0 {
-					batchRows, err = snapshot.querySnapshotTable(wgCtx, tx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
-				} else {
-					batchRows, err = snapshot.querySnapshotTable(wgCtx, tx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
-				}
-				if err != nil {
-					return fmt.Errorf("executing snapshot table query: %s", err)
-				}
-
-				colTypes, err := batchRows.ColumnTypes()
-				if err != nil {
-					return fmt.Errorf("fetching column types: %s", err)
-				}
-
-				values, mappers := prepSnapshotScannerAndMappers(colTypes)
-				columns, err := batchRows.Columns()
-				if err != nil {
-					return fmt.Errorf("fetching columns: %s", err)
-				}
-
-				var batchRowsCount int
-				for batchRows.Next() {
-					numRowsProcessed++
-					batchRowsCount++
-
-					if err := batchRows.Scan(values...); err != nil {
-						return err
-					}
-
-					row := map[string]any{}
-					for idx, value := range values {
-						v, err := mappers[idx](value)
-						if err != nil {
-							return err
-						}
-						row[columns[idx]] = v
-						if _, ok := lastSeenPksValues[columns[idx]]; ok {
-							lastSeenPksValues[columns[idx]] = value
-						}
-					}
-
-					select {
-					case i.rawMessageEvents <- MessageEvent{
-						Row:       row,
-						Operation: MessageOperationRead,
-						Table:     table,
-						Position:  nil,
-					}:
-					case <-wgCtx.Done():
-						return wgCtx.Err()
-					}
-				}
-
-				if err := batchRows.Err(); err != nil {
-					return fmt.Errorf("iterating snapshot table: %s", err)
-				}
-
-				if batchRowsCount < i.fieldSnapshotMaxBatchSize {
-					break
+			for table := range tableQueue {
+				if err := i.snapshotTable(wgCtx, snapshot, tx, table); err != nil {
+					return err
 				}
 			}
 			return nil
 		})
 	}
-
 	return wg.Wait()
+}
+
+func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot, tx *sql.Tx, table string) error {
+	// Pre-populate schema cache so snapshot messages carry schema metadata.
+	if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
+		if _, err := i.getTableSchema(tbl); err != nil {
+			i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
+		}
+	} else {
+		i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
+	}
+
+	tablePks, err := snapshot.getTablePrimaryKeys(ctx, tx, table)
+	if err != nil {
+		return err
+	}
+	i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
+	lastSeenPksValues := map[string]any{}
+	for _, pk := range tablePks {
+		lastSeenPksValues[pk] = nil
+	}
+
+	var numRowsProcessed int
+	for {
+		var batchRows *sql.Rows
+		if numRowsProcessed == 0 {
+			batchRows, err = snapshot.querySnapshotTable(ctx, tx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
+		} else {
+			batchRows, err = snapshot.querySnapshotTable(ctx, tx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
+		}
+		if err != nil {
+			return fmt.Errorf("executing snapshot table query: %s", err)
+		}
+
+		colTypes, err := batchRows.ColumnTypes()
+		if err != nil {
+			return fmt.Errorf("fetching column types: %s", err)
+		}
+
+		values, mappers := prepSnapshotScannerAndMappers(colTypes)
+		columns, err := batchRows.Columns()
+		if err != nil {
+			return fmt.Errorf("fetching columns: %s", err)
+		}
+
+		var batchRowsCount int
+		for batchRows.Next() {
+			numRowsProcessed++
+			batchRowsCount++
+
+			if err := batchRows.Scan(values...); err != nil {
+				return err
+			}
+
+			row := map[string]any{}
+			for idx, value := range values {
+				v, err := mappers[idx](value)
+				if err != nil {
+					return err
+				}
+				row[columns[idx]] = v
+				if _, ok := lastSeenPksValues[columns[idx]]; ok {
+					lastSeenPksValues[columns[idx]] = value
+				}
+			}
+
+			select {
+			case i.rawMessageEvents <- MessageEvent{
+				Row:       row,
+				Operation: MessageOperationRead,
+				Table:     table,
+				Position:  nil,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		if err := batchRows.Err(); err != nil {
+			return fmt.Errorf("iterating snapshot table: %s", err)
+		}
+
+		if batchRowsCount < i.fieldSnapshotMaxBatchSize {
+			break
+		}
+	}
+	return nil
 }
 
 func snapshotValueMapper[T any](v any) (any, error) {

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -37,17 +37,18 @@ import (
 )
 
 const (
-	fieldMySQLFlavor          = "flavor"
-	fieldMySQLDSN             = "dsn"
-	fieldMySQLTables          = "tables"
-	fieldStreamSnapshot       = "stream_snapshot"
-	fieldSnapshotMaxBatchSize = "snapshot_max_batch_size"
-	fieldMaxReconnectAttempts = "max_reconnect_attempts"
-	fieldBatching             = "batching"
-	fieldCheckpointKey        = "checkpoint_key"
-	fieldCheckpointCache      = "checkpoint_cache"
-	fieldCheckpointLimit      = "checkpoint_limit"
-	fieldAWSIAMAuth           = "aws"
+	fieldMySQLFlavor               = "flavor"
+	fieldMySQLDSN                  = "dsn"
+	fieldMySQLTables               = "tables"
+	fieldStreamSnapshot            = "stream_snapshot"
+	fieldMaxParallelSnapshotTables = "max_parallel_snapshot_tables"
+	fieldSnapshotMaxBatchSize      = "snapshot_max_batch_size"
+	fieldMaxReconnectAttempts      = "max_reconnect_attempts"
+	fieldBatching                  = "batching"
+	fieldCheckpointKey             = "checkpoint_key"
+	fieldCheckpointCache           = "checkpoint_cache"
+	fieldCheckpointLimit           = "checkpoint_limit"
+	fieldAWSIAMAuth                = "aws"
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
 
@@ -110,6 +111,9 @@ This input adds the following metadata fields to each message:
 			Default(10),
 		service.NewBoolField(fieldStreamSnapshot).
 			Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current binlog position."),
+		service.NewIntField(fieldMaxParallelSnapshotTables).
+			Description("Specifies the number of tables that will be snapshotted in parallel.").
+			Default(1),
 		service.NewAutoRetryNacksToggleField(),
 		service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given BinLog Position will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
@@ -178,9 +182,10 @@ type mysqlStreamInput struct {
 	binLogCacheKey       string
 	currentBinlogName    string
 
-	dsn            string
-	tables         []string
-	streamSnapshot bool
+	dsn                string
+	tables             []string
+	streamSnapshot     bool
+	snapshotMaxWorkers int
 
 	batching                  service.BatchPolicy
 	batchPolicy               *service.Batcher
@@ -274,6 +279,10 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	}
 
 	if i.streamSnapshot, err = conf.FieldBool(fieldStreamSnapshot); err != nil {
+		return nil, err
+	}
+
+	if i.snapshotMaxWorkers, err = conf.FieldInt(fieldMaxParallelSnapshotTables); err != nil {
 		return nil, err
 	}
 
@@ -463,7 +472,7 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 			_ = snapshot.close()
 			return fmt.Errorf("unable to prepare snapshot: %w", err)
 		}
-		if err = i.readSnapshot(ctx, snapshot); err != nil {
+		if err = i.readSnapshot(ctx, snapshot, i.snapshotMaxWorkers); err != nil {
 			_ = snapshot.close()
 			return fmt.Errorf("failed reading snapshot: %w", err)
 		}
@@ -504,94 +513,105 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 	return nil
 }
 
-func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot) error {
-	// TODO(cdc): Process tables in parallel
+func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot, maxWorkers int) error {
+	wg, wgCtx := errgroup.WithContext(ctx)
+	wg.SetLimit(maxWorkers)
+
 	for _, table := range i.tables {
-		// Pre-populate schema cache so snapshot messages carry schema metadata.
-		if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
-			if _, err := i.getTableSchema(tbl); err != nil {
-				i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
-			}
-		} else {
-			i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
-		}
-		tablePks, err := snapshot.getTablePrimaryKeys(ctx, table)
-		if err != nil {
-			return err
-		}
-		i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
-		lastSeenPksValues := map[string]any{}
-		for _, pk := range tablePks {
-			lastSeenPksValues[pk] = nil
+		tx, ok := snapshot.tableTxs[table]
+		if !ok {
+			return fmt.Errorf("no snapshot transaction found for table %s", table)
 		}
 
-		var numRowsProcessed int
-		for {
-			var batchRows *sql.Rows
-			if numRowsProcessed == 0 {
-				batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
+		wg.Go(func() error {
+			// Pre-populate schema cache so snapshot messages carry schema metadata.
+			if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
+				if _, err := i.getTableSchema(tbl); err != nil {
+					i.logger.Warnf("Failed to pre-populate schema for table %s during snapshot: %v", table, err)
+				}
 			} else {
-				batchRows, err = snapshot.querySnapshotTable(ctx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
+				i.logger.Warnf("Failed to fetch schema for table %s during snapshot: %v", table, err)
 			}
+
+			tablePks, err := snapshot.getTablePrimaryKeys(wgCtx, tx, table)
 			if err != nil {
-				return fmt.Errorf("executing snapshot table query: %s", err)
+				return err
+			}
+			i.logger.Tracef("primary keys for table %s: %v", table, tablePks)
+			lastSeenPksValues := map[string]any{}
+			for _, pk := range tablePks {
+				lastSeenPksValues[pk] = nil
 			}
 
-			types, err := batchRows.ColumnTypes()
-			if err != nil {
-				return fmt.Errorf("fetching column types: %s", err)
-			}
-
-			values, mappers := prepSnapshotScannerAndMappers(types)
-
-			columns, err := batchRows.Columns()
-			if err != nil {
-				return fmt.Errorf("fetching columns: %s", err)
-			}
-
-			var batchRowsCount int
-			for batchRows.Next() {
-				numRowsProcessed++
-				batchRowsCount++
-
-				if err := batchRows.Scan(values...); err != nil {
-					return err
+			var numRowsProcessed int
+			for {
+				var batchRows *sql.Rows
+				if numRowsProcessed == 0 {
+					batchRows, err = snapshot.querySnapshotTable(wgCtx, tx, table, tablePks, nil, i.fieldSnapshotMaxBatchSize)
+				} else {
+					batchRows, err = snapshot.querySnapshotTable(wgCtx, tx, table, tablePks, &lastSeenPksValues, i.fieldSnapshotMaxBatchSize)
+				}
+				if err != nil {
+					return fmt.Errorf("executing snapshot table query: %s", err)
 				}
 
-				row := map[string]any{}
-				for idx, value := range values {
-					v, err := mappers[idx](value)
-					if err != nil {
+				colTypes, err := batchRows.ColumnTypes()
+				if err != nil {
+					return fmt.Errorf("fetching column types: %s", err)
+				}
+
+				values, mappers := prepSnapshotScannerAndMappers(colTypes)
+				columns, err := batchRows.Columns()
+				if err != nil {
+					return fmt.Errorf("fetching columns: %s", err)
+				}
+
+				var batchRowsCount int
+				for batchRows.Next() {
+					numRowsProcessed++
+					batchRowsCount++
+
+					if err := batchRows.Scan(values...); err != nil {
 						return err
 					}
-					row[columns[idx]] = v
-					if _, ok := lastSeenPksValues[columns[idx]]; ok {
-						lastSeenPksValues[columns[idx]] = value
+
+					row := map[string]any{}
+					for idx, value := range values {
+						v, err := mappers[idx](value)
+						if err != nil {
+							return err
+						}
+						row[columns[idx]] = v
+						if _, ok := lastSeenPksValues[columns[idx]]; ok {
+							lastSeenPksValues[columns[idx]] = value
+						}
+					}
+
+					select {
+					case i.rawMessageEvents <- MessageEvent{
+						Row:       row,
+						Operation: MessageOperationRead,
+						Table:     table,
+						Position:  nil,
+					}:
+					case <-wgCtx.Done():
+						return wgCtx.Err()
 					}
 				}
 
-				select {
-				case i.rawMessageEvents <- MessageEvent{
-					Row:       row,
-					Operation: MessageOperationRead,
-					Table:     table,
-					Position:  nil,
-				}:
-				case <-ctx.Done():
-					return ctx.Err()
+				if err := batchRows.Err(); err != nil {
+					return fmt.Errorf("iterating snapshot table: %s", err)
+				}
+
+				if batchRowsCount < i.fieldSnapshotMaxBatchSize {
+					break
 				}
 			}
-
-			if err := batchRows.Err(); err != nil {
-				return fmt.Errorf("iterating snapshot table: %s", err)
-			}
-
-			if batchRowsCount < i.fieldSnapshotMaxBatchSize {
-				break
-			}
-		}
+			return nil
+		})
 	}
-	return nil
+
+	return wg.Wait()
 }
 
 func snapshotValueMapper[T any](v any) (any, error) {

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -193,8 +193,9 @@ type mysqlStreamInput struct {
 	checkPointLimit           int
 	fieldSnapshotMaxBatchSize int
 
-	logger *service.Logger
-	res    *service.Resources
+	logger                     *service.Logger
+	res                        *service.Resources
+	snapshotRowsProcessedTotal *service.MetricCounter
 
 	rawMessageEvents chan MessageEvent
 	msgChan          chan asyncMessage
@@ -329,6 +330,8 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	} else if batching.IsNoop() {
 		batching.Count = 1
 	}
+
+	i.snapshotRowsProcessedTotal = res.Metrics().NewCounter("mysql_snapshot_rows_processed_total", "table")
 
 	r, err := service.AutoRetryNacksBatchedToggled(conf, &i)
 	if err != nil {
@@ -536,6 +539,7 @@ func (i *mysqlStreamInput) readSnapshot(ctx context.Context, snapshot *Snapshot)
 }
 
 func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot, tx *sql.Tx, table string) error {
+	i.logger.Infof("Starting snapshot of table '%s'", table)
 	// Pre-populate schema cache so snapshot messages carry schema metadata.
 	if tbl, err := i.canal.GetTable(i.mysqlConfig.DBName, table); err == nil {
 		if _, err := i.getTableSchema(tbl); err != nil {
@@ -615,10 +619,13 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 			return fmt.Errorf("iterating snapshot table: %s", err)
 		}
 
+		i.snapshotRowsProcessedTotal.Incr(int64(batchRowsCount), table)
+
 		if batchRowsCount < i.fieldSnapshotMaxBatchSize {
 			break
 		}
 	}
+	i.logger.Infof("Finished snapshot of table '%s' (%d rows)", table, numRowsProcessed)
 	return nil
 }
 

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -573,12 +573,14 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 
 		colTypes, err := batchRows.ColumnTypes()
 		if err != nil {
+			_ = batchRows.Close()
 			return fmt.Errorf("fetching column types: %s", err)
 		}
 
 		values, mappers := prepSnapshotScannerAndMappers(colTypes)
 		columns, err := batchRows.Columns()
 		if err != nil {
+			_ = batchRows.Close()
 			return fmt.Errorf("fetching columns: %s", err)
 		}
 
@@ -588,6 +590,7 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 			batchRowsCount++
 
 			if err := batchRows.Scan(values...); err != nil {
+				_ = batchRows.Close()
 				return err
 			}
 
@@ -595,6 +598,7 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 			for idx, value := range values {
 				v, err := mappers[idx](value)
 				if err != nil {
+					_ = batchRows.Close()
 					return err
 				}
 				row[columns[idx]] = v
@@ -611,13 +615,16 @@ func (i *mysqlStreamInput) snapshotTable(ctx context.Context, snapshot *Snapshot
 				Position:  nil,
 			}:
 			case <-ctx.Done():
+				_ = batchRows.Close()
 				return ctx.Err()
 			}
 		}
 
 		if err := batchRows.Err(); err != nil {
+			_ = batchRows.Close()
 			return fmt.Errorf("iterating snapshot table: %s", err)
 		}
+		_ = batchRows.Close()
 
 		i.snapshotRowsProcessedTotal.Incr(int64(batchRowsCount), table)
 

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -1407,3 +1407,78 @@ func TestIntegrationMySQLCDCRepeatedConnectionDrops(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegrationMySQLCDCConcurrentSnapshot(t *testing.T) {
+	dsn, db := setupTestWithMySQLVersion(t, "8.0")
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS snap_foo (id INT AUTO_INCREMENT PRIMARY KEY)`)
+	db.Exec(`CREATE TABLE IF NOT EXISTS snap_bar (id INT AUTO_INCREMENT PRIMARY KEY)`)
+	db.Exec(`CREATE TABLE IF NOT EXISTS snap_baz (id INT AUTO_INCREMENT PRIMARY KEY)`)
+
+	want := 3000
+	for range 1000 {
+		db.Exec("INSERT INTO snap_foo (id) VALUES (DEFAULT)")
+		db.Exec("INSERT INTO snap_bar (id) VALUES (DEFAULT)")
+		db.Exec("INSERT INTO snap_baz (id) VALUES (DEFAULT)")
+	}
+
+	template := fmt.Sprintf(`
+mysql_cdc:
+  dsn: %s
+  stream_snapshot: true
+  snapshot_max_batch_size: 10
+  max_parallel_snapshot_tables: 3
+  checkpoint_cache: foocache
+  tables:
+    - snap_foo
+    - snap_bar
+    - snap_baz
+`, dsn)
+
+	cacheConf := fmt.Sprintf(`
+label: foocache
+file:
+  directory: %s`, t.TempDir())
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+
+	var (
+		outBatches   []string
+		outBatchesMu sync.Mutex
+	)
+
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		msgBytes, err := mb[0].AsBytes()
+		require.NoError(t, err)
+		outBatchesMu.Lock()
+		outBatches = append(outBatches, string(msgBytes))
+		outBatchesMu.Unlock()
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	assert.Eventually(t, func() bool {
+		outBatchesMu.Lock()
+		defer outBatchesMu.Unlock()
+
+		got := len(outBatches)
+		if got > want {
+			t.Fatalf("Wanted %d snapshot messages but got %d", want, got)
+		}
+		return got == want
+	}, time.Minute*5, time.Second*1)
+
+	require.NoError(t, streamOut.StopWithin(10*time.Second))
+}

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -1408,21 +1408,23 @@ func TestIntegrationMySQLCDCRepeatedConnectionDrops(t *testing.T) {
 	}
 }
 
-func TestIntegrationMySQLCDCConcurrentSnapshot(t *testing.T) {
+func TestIntegrationMySQLCDCParallelSnapshot(t *testing.T) {
 	dsn, db := setupTestWithMySQLVersion(t, "8.0")
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS snap_foo (id INT AUTO_INCREMENT PRIMARY KEY)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS snap_bar (id INT AUTO_INCREMENT PRIMARY KEY)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS snap_baz (id INT AUTO_INCREMENT PRIMARY KEY)`)
 
-	want := 3000
-	for range 1000 {
+	t.Log("Inserting snapshot records")
+	want := 30000
+	for range 10000 {
 		db.Exec("INSERT INTO snap_foo (id) VALUES (DEFAULT)")
 		db.Exec("INSERT INTO snap_bar (id) VALUES (DEFAULT)")
 		db.Exec("INSERT INTO snap_baz (id) VALUES (DEFAULT)")
 	}
 
-	template := fmt.Sprintf(`
+	t.Run("parralel snapshot", func(t *testing.T) {
+		template := fmt.Sprintf(`
 mysql_cdc:
   dsn: %s
   stream_snapshot: true
@@ -1435,48 +1437,109 @@ mysql_cdc:
     - snap_baz
 `, dsn)
 
-	cacheConf := fmt.Sprintf(`
+		cacheConf := fmt.Sprintf(`
 label: foocache
 file:
   directory: %s`, t.TempDir())
 
-	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
-	require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+		streamOutBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
+		require.NoError(t, streamOutBuilder.AddInputYAML(template))
 
-	var (
-		outBatches   []string
-		outBatchesMu sync.Mutex
-	)
+		var (
+			outBatches   []string
+			outBatchesMu sync.Mutex
+		)
 
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
-		msgBytes, err := mb[0].AsBytes()
+		require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			msgBytes, err := mb[0].AsBytes()
+			require.NoError(t, err)
+			outBatchesMu.Lock()
+			outBatches = append(outBatches, string(msgBytes))
+			outBatchesMu.Unlock()
+			return nil
+		}))
+
+		streamOut, err := streamOutBuilder.Build()
 		require.NoError(t, err)
-		outBatchesMu.Lock()
-		outBatches = append(outBatches, string(msgBytes))
-		outBatchesMu.Unlock()
-		return nil
-	}))
+		license.InjectTestService(streamOut.Resources())
 
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
+		go func() {
+			if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
 
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+		var got int
+		assert.Eventually(t, func() bool {
+			outBatchesMu.Lock()
+			defer outBatchesMu.Unlock()
+			got = len(outBatches)
+			return got >= want
+		}, time.Minute*5, time.Second*1)
+		assert.Equalf(t, want, got, "Wanted %d snapshot messages but got %d", want, got)
 
-	var got int
-	assert.Eventually(t, func() bool {
-		outBatchesMu.Lock()
-		defer outBatchesMu.Unlock()
-		got = len(outBatches)
-		return got >= want
-	}, time.Minute*5, time.Second*1)
-	assert.Equalf(t, want, got, "Wanted %d snapshot messages but got %d", want, got)
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
 
-	require.NoError(t, streamOut.StopWithin(10*time.Second))
+	t.Run("sequential snapshot", func(t *testing.T) {
+		template := fmt.Sprintf(`
+mysql_cdc:
+  dsn: %s
+  stream_snapshot: true
+  snapshot_max_batch_size: 10
+  max_parallel_snapshot_tables: 1
+  checkpoint_cache: foocache
+  tables:
+    - snap_foo
+    - snap_bar
+    - snap_baz
+`, dsn)
+
+		cacheConf := fmt.Sprintf(`
+label: foocache
+file:
+  directory: %s`, t.TempDir())
+
+		streamOutBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamOutBuilder.AddCacheYAML(cacheConf))
+		require.NoError(t, streamOutBuilder.AddInputYAML(template))
+
+		var (
+			outBatches   []string
+			outBatchesMu sync.Mutex
+		)
+
+		require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			msgBytes, err := mb[0].AsBytes()
+			require.NoError(t, err)
+			outBatchesMu.Lock()
+			outBatches = append(outBatches, string(msgBytes))
+			outBatchesMu.Unlock()
+			return nil
+		}))
+
+		streamOut, err := streamOutBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(streamOut.Resources())
+
+		go func() {
+			if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		var got int
+		assert.Eventually(t, func() bool {
+			outBatchesMu.Lock()
+			defer outBatchesMu.Unlock()
+			got = len(outBatches)
+			return got >= want
+		}, time.Minute*5, time.Second*1)
+		assert.Equalf(t, want, got, "Wanted %d snapshot messages but got %d", want, got)
+
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
 }

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -1455,6 +1455,9 @@ file:
 		require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 			msgBytes, err := mb[0].AsBytes()
 			require.NoError(t, err)
+			op, _ := mb[0].MetaGet("operation")
+			assert.Equal(t, "read", op, "expected snapshot message operation to be 'read'")
+
 			outBatchesMu.Lock()
 			outBatches = append(outBatches, string(msgBytes))
 			outBatchesMu.Unlock()
@@ -1515,6 +1518,9 @@ file:
 		require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 			msgBytes, err := mb[0].AsBytes()
 			require.NoError(t, err)
+			op, _ := mb[0].MetaGet("operation")
+			assert.Equal(t, "read", op, "expected snapshot message operation to be 'read'")
+
 			outBatchesMu.Lock()
 			outBatches = append(outBatches, string(msgBytes))
 			outBatchesMu.Unlock()

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -1423,7 +1423,7 @@ func TestIntegrationMySQLCDCParallelSnapshot(t *testing.T) {
 		db.Exec("INSERT INTO snap_baz (id) VALUES (DEFAULT)")
 	}
 
-	t.Run("parralel snapshot", func(t *testing.T) {
+	t.Run("parallel snapshot", func(t *testing.T) {
 		template := fmt.Sprintf(`
 mysql_cdc:
   dsn: %s

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -1469,16 +1469,14 @@ file:
 		}
 	}()
 
+	var got int
 	assert.Eventually(t, func() bool {
 		outBatchesMu.Lock()
 		defer outBatchesMu.Unlock()
-
-		got := len(outBatches)
-		if got > want {
-			t.Fatalf("Wanted %d snapshot messages but got %d", want, got)
-		}
-		return got == want
+		got = len(outBatches)
+		return got >= want
 	}, time.Minute*5, time.Second*1)
+	assert.Equalf(t, want, got, "Wanted %d snapshot messages but got %d", want, got)
 
 	require.NoError(t, streamOut.StopWithin(10*time.Second))
 }

--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -21,8 +21,9 @@ import (
 // Snapshot represents a structure that prepares a transaction
 // and creates mysql consistent snapshot inside the transaction
 type Snapshot struct {
-	db       *sql.DB
-	lockConn *sql.Conn
+	db          *sql.DB
+	lockConn    *sql.Conn
+	workerConns []*sql.Conn
 	// workerTxs holds one consistent-snapshot transaction per worker, established
 	// inside the FLUSH TABLES WITH READ LOCK window so all readers see identical data.
 	// Workers pull tables from a queue and reuse their transaction across multiple tables.
@@ -84,9 +85,17 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string, maxWork
 	// implicitly replaces the transaction with a consistent-snapshot one.
 	// The go-sql-driver/mysql driver does not expose this directly via TxOptions.
 	numWorkers := min(maxWorkers, len(tables))
+	s.workerConns = make([]*sql.Conn, 0, numWorkers)
 	s.workerTxs = make([]*sql.Tx, 0, numWorkers)
 	for range numWorkers {
-		tx, txErr := s.db.BeginTx(ctx, &sql.TxOptions{
+		conn, connErr := s.db.Conn(ctx)
+		if connErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("open worker connection: %w", connErr),
+				unlockTables())
+		}
+		s.workerConns = append(s.workerConns, conn)
+		tx, txErr := conn.BeginTx(ctx, &sql.TxOptions{
 			ReadOnly:  true,
 			Isolation: sql.LevelRepeatableRead,
 		})
@@ -243,6 +252,14 @@ func (s *Snapshot) releaseSnapshot(_ context.Context) error {
 		}
 	}
 	s.workerTxs = nil
+	for idx, conn := range s.workerConns {
+		if conn != nil {
+			if err := conn.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close worker connection %d: %w", idx, err))
+			}
+		}
+	}
+	s.workerConns = nil
 	return errors.Join(errs...)
 }
 
@@ -255,6 +272,14 @@ func (s *Snapshot) close() error {
 		}
 	}
 	s.workerTxs = nil
+	for idx, conn := range s.workerConns {
+		if conn != nil {
+			if err := conn.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close worker connection %d: %w", idx, err))
+			}
+		}
+	}
+	s.workerConns = nil
 
 	if s.lockConn != nil {
 		if err := s.lockConn.Close(); err != nil {

--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -200,7 +200,7 @@ func (s *Snapshot) querySnapshotTable(ctx context.Context, tx *sql.Tx, table str
 		placeholders = append(placeholders, "?")
 	}
 
-	snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("WHERE (%s) > (%s)", strings.Join(pk, ", "), strings.Join(placeholders, ", ")))
+	snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("WHERE (%s) > (%s)", strings.Join(quoteIdentifiers(pk), ", "), strings.Join(placeholders, ", ")))
 	snapshotQueryParts = append(snapshotQueryParts, buildOrderByClause(pk))
 	snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("LIMIT %d", limit))
 	q := strings.Join(snapshotQueryParts, " ")
@@ -209,11 +209,15 @@ func (s *Snapshot) querySnapshotTable(ctx context.Context, tx *sql.Tx, table str
 }
 
 func buildOrderByClause(pk []string) string {
-	if len(pk) == 1 {
-		return "ORDER BY " + pk[0]
-	}
+	return "ORDER BY " + strings.Join(quoteIdentifiers(pk), ", ")
+}
 
-	return "ORDER BY " + strings.Join(pk, ", ")
+func quoteIdentifiers(names []string) []string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = "`" + strings.ReplaceAll(n, "`", "``") + "`"
+	}
+	return quoted
 }
 
 func (s *Snapshot) getCurrentBinlogPosition(ctx context.Context) (position, error) {

--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -21,11 +21,11 @@ import (
 // Snapshot represents a structure that prepares a transaction
 // and creates mysql consistent snapshot inside the transaction
 type Snapshot struct {
-	db *sql.DB
-	tx *sql.Tx
-
-	lockConn     *sql.Conn
-	snapshotConn *sql.Conn
+	db       *sql.DB
+	lockConn *sql.Conn
+	// tableTxs holds one consistent-snapshot transaction per table, established
+	// inside the FLUSH TABLES WITH READ LOCK window so all readers see identical data.
+	tableTxs map[string]*sql.Tx
 
 	logger *service.Logger
 }
@@ -44,44 +44,26 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 	}
 
 	var err error
-	// Create a separate connection for table locks
 	s.lockConn, err = s.db.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create lock connection: %v", err)
 	}
 
-	// Create another connection for the snapshot
-	s.snapshotConn, err = s.db.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("create snapshot connection: %v", err)
-	}
-
-	// Start a consistent snapshot transaction
-	s.tx, err = s.snapshotConn.BeginTx(ctx, &sql.TxOptions{
-		ReadOnly:  true,
-		Isolation: sql.LevelRepeatableRead,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("start transaction: %v", err)
-	}
-
 	/*
-		FLUSH TABLES WITH READ LOCK is executed after CONSISTENT SNAPSHOT to:
-		1. Force MySQL to flush all data from memory to disk
-		2. Prevent any writes to tables while we read the binlog position
+		FLUSH TABLES WITH READ LOCK prevents any writes to tables while we:
+		  1. Establish consistent-snapshot transactions on all worker connections
+		  2. Read the binlog position
 
-		This lock MUST be released quickly to avoid blocking other connections. Only use it
-		to capture the binlog coordinates, then release immediately with UNLOCK TABLES.
+		The lock MUST be released quickly to avoid blocking other connections.
 
 		See https://dev.mysql.com/doc/refman/8.4/en/flush.html#flush-tables
 	*/
 	lockQuery := buildFlushAndLockTablesQuery(tables)
 	s.logger.Infof("Acquiring table-level read locks with: %s", lockQuery)
 	if _, err := s.lockConn.ExecContext(ctx, lockQuery); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("acquire table-level read locks: %w", err),
-			s.tx.Rollback())
+		return nil, fmt.Errorf("acquire table-level read locks: %w", err)
 	}
+
 	unlockTables := func() error {
 		if _, err := s.lockConn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
 			return fmt.Errorf("release table-level read locks: %w", err)
@@ -89,43 +71,57 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 		return nil
 	}
 
-	/*
-		START TRANSACTION WITH CONSISTENT SNAPSHOT ensures a consistent view of database state
-		when reading historical data during CDC initialization. Without it, concurrent writes
-		could create inconsistencies between binlog position and table snapshots, potentially
-		missing or duplicating events. The snapshot prevents other transactions from modifying
-		the data being read, maintaining referential integrity across tables while capturing
-		the initial state.
+	// Open one dedicated connection per table and establish a consistent snapshot
+	// on each while the read lock is still held. This guarantees all parallel
+	// readers see the exact same database state.
+	s.tableTxs = make(map[string]*sql.Tx, len(tables))
+	for _, table := range tables {
+		conn, connErr := s.db.Conn(ctx)
+		if connErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("create snapshot connection for table %s: %w", table, connErr),
+				unlockTables())
+		}
 
-		It's important that we do this AFTER we acquire the READ LOCK and flushing the tables,
-		otherwise other writes could sneak in between our transaction snapshot and acquiring the
-		lock.
-	*/
+		/*
+			START TRANSACTION WITH CONSISTENT SNAPSHOT ensures a consistent view of
+			database state for all parallel readers. We do this AFTER acquiring the
+			read lock so no writes can sneak in between the snapshot and the lock.
 
-	// NOTE: this is a little sneaky because we're actually implicitly closing the transaction
-	// started with `BeginTx` above and replacing it with this one. We have to do this because
-	// the `database/sql` driver we're using does not support this WITH CONSISTENT SNAPSHOT.
-	if _, err := s.tx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("start consistent snapshot: %w", err),
-			unlockTables(),
-			s.tx.Rollback())
+			NOTE: BeginTx is called first to obtain a *sql.Tx handle, then
+			START TRANSACTION WITH CONSISTENT SNAPSHOT is executed on it, which
+			implicitly replaces the transaction with a consistent-snapshot one.
+			The go-sql-driver/mysql driver does not expose this directly via TxOptions.
+		*/
+		tx, txErr := conn.BeginTx(ctx, &sql.TxOptions{
+			ReadOnly:  true,
+			Isolation: sql.LevelRepeatableRead,
+		})
+		if txErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("start transaction for table %s: %w", table, txErr),
+				unlockTables())
+		}
+		if _, txErr = tx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); txErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("start consistent snapshot for table %s: %w", table, txErr),
+				tx.Rollback(),
+				unlockTables())
+		}
+		s.tableTxs[table] = tx
 	}
 
-	// Get binary log position (while tables are locked)
+	// Capture the binlog position while the read lock is still held.
 	pos, err := s.getCurrentBinlogPosition(ctx)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("get binlog position: %w", err),
-			unlockTables(),
-			s.tx.Rollback())
+			unlockTables())
 	}
 
-	// Release the table locks immediately after getting the binlog position
-	if _, err := s.lockConn.ExecContext(ctx, "UNLOCK TABLES"); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("release table-level read locks: %w", err),
-			s.tx.Rollback())
+	// Release the table locks immediately after capturing the binlog position.
+	if err := unlockTables(); err != nil {
+		return nil, err
 	}
 
 	return &pos, nil
@@ -144,7 +140,7 @@ func buildFlushAndLockTablesQuery(tables []string) string {
 	return sb.String()
 }
 
-func (s *Snapshot) getTablePrimaryKeys(ctx context.Context, table string) ([]string, error) {
+func (*Snapshot) getTablePrimaryKeys(ctx context.Context, tx *sql.Tx, table string) ([]string, error) {
 	pkSql := `
 SELECT COLUMN_NAME
 FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
@@ -152,8 +148,7 @@ WHERE TABLE_NAME = '%s' AND CONSTRAINT_NAME = 'PRIMARY' AND TABLE_SCHEMA = DATAB
 ORDER BY ORDINAL_POSITION
 `
 
-	// Get primary key columns for the table
-	rows, err := s.tx.QueryContext(ctx, fmt.Sprintf(pkSql, table))
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(pkSql, table))
 	if err != nil {
 		return nil, fmt.Errorf("get primary key: %v", err)
 	}
@@ -180,18 +175,17 @@ ORDER BY ORDINAL_POSITION
 	return pks, nil
 }
 
-func (s *Snapshot) querySnapshotTable(ctx context.Context, table string, pk []string, lastSeenPkVal *map[string]any, limit int) (*sql.Rows, error) {
+func (s *Snapshot) querySnapshotTable(ctx context.Context, tx *sql.Tx, table string, pk []string, lastSeenPkVal *map[string]any, limit int) (*sql.Rows, error) {
 	snapshotQueryParts := []string{
 		"SELECT * FROM " + table,
 	}
 
 	if lastSeenPkVal == nil {
 		snapshotQueryParts = append(snapshotQueryParts, buildOrderByClause(pk))
-
 		snapshotQueryParts = append(snapshotQueryParts, "LIMIT ?")
 		q := strings.Join(snapshotQueryParts, " ")
-		s.logger.Infof("Querying snapshot: %s", q)
-		return s.tx.QueryContext(ctx, strings.Join(snapshotQueryParts, " "), limit)
+		s.logger.Debugf("Querying snapshot: %s", q)
+		return tx.QueryContext(ctx, q, limit)
 	}
 
 	var lastSeenPkVals []any
@@ -209,8 +203,8 @@ func (s *Snapshot) querySnapshotTable(ctx context.Context, table string, pk []st
 	snapshotQueryParts = append(snapshotQueryParts, buildOrderByClause(pk))
 	snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("LIMIT %d", limit))
 	q := strings.Join(snapshotQueryParts, " ")
-	s.logger.Infof("Querying snapshot: %s", q)
-	return s.tx.QueryContext(ctx, q, lastSeenPkVals...)
+	s.logger.Debugf("Querying snapshot: %s", q)
+	return tx.QueryContext(ctx, q, lastSeenPkVals...)
 }
 
 func buildOrderByClause(pk []string) string {
@@ -237,8 +231,8 @@ func (s *Snapshot) getCurrentBinlogPosition(ctx context.Context) (position, erro
 	}
 
 	// "SHOW BINARY LOG STATUS" replaces "SHOW MASTER STATUS" IN MySQL 8.4+
-	if err := scanRow(s.snapshotConn.QueryRowContext(ctx, "SHOW BINARY LOG STATUS")); err != nil {
-		if err = scanRow(s.snapshotConn.QueryRowContext(ctx, "SHOW MASTER STATUS")); err != nil {
+	if err := scanRow(s.lockConn.QueryRowContext(ctx, "SHOW BINARY LOG STATUS")); err != nil {
+		if err = scanRow(s.lockConn.QueryRowContext(ctx, "SHOW MASTER STATUS")); err != nil {
 			return position{}, err
 		}
 	}
@@ -250,33 +244,29 @@ func (s *Snapshot) getCurrentBinlogPosition(ctx context.Context) (position, erro
 }
 
 func (s *Snapshot) releaseSnapshot(_ context.Context) error {
-	if s.tx != nil {
-		if err := s.tx.Commit(); err != nil {
-			return fmt.Errorf("commit transaction: %v", err)
+	var errs []error
+	for table, tx := range s.tableTxs {
+		if err := tx.Commit(); err != nil {
+			errs = append(errs, fmt.Errorf("commit transaction for table %s: %w", table, err))
 		}
 	}
-
-	// reset transaction
-	s.tx = nil
-	return nil
+	s.tableTxs = nil
+	return errors.Join(errs...)
 }
 
 func (s *Snapshot) close() error {
 	var errs []error
 
-	if s.tx != nil {
-		if err := s.tx.Rollback(); err != nil {
+	for _, tx := range s.tableTxs {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 			errs = append(errs, fmt.Errorf("rollback transaction: %w", err))
 		}
-		s.tx = nil
 	}
+	s.tableTxs = nil
 
-	for _, conn := range []*sql.Conn{s.lockConn, s.snapshotConn} {
-		if conn == nil {
-			continue
-		}
-		if err := conn.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("close connection: %w", err))
+	if s.lockConn != nil {
+		if err := s.lockConn.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close lock connection: %w", err))
 		}
 	}
 

--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -23,9 +23,10 @@ import (
 type Snapshot struct {
 	db       *sql.DB
 	lockConn *sql.Conn
-	// tableTxs holds one consistent-snapshot transaction per table, established
+	// workerTxs holds one consistent-snapshot transaction per worker, established
 	// inside the FLUSH TABLES WITH READ LOCK window so all readers see identical data.
-	tableTxs map[string]*sql.Tx
+	// Workers pull tables from a queue and reuse their transaction across multiple tables.
+	workerTxs []*sql.Tx
 
 	logger *service.Logger
 }
@@ -38,7 +39,7 @@ func NewSnapshot(logger *service.Logger, db *sql.DB) *Snapshot {
 	}
 }
 
-func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*position, error) {
+func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string, maxWorkers int) (*position, error) {
 	if len(tables) == 0 {
 		return nil, errors.New("no tables provided")
 	}
@@ -71,35 +72,33 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 		return nil
 	}
 
-	// Open one transaction per table and establish a consistent snapshot on each
-	// while the read lock is still held. This guarantees all parallel readers see
-	// the exact same database state.
-	s.tableTxs = make(map[string]*sql.Tx, len(tables))
-	for _, table := range tables {
-		/*
-			START TRANSACTION WITH CONSISTENT SNAPSHOT ensures a consistent view of
-			database state for all parallel readers. We do this AFTER acquiring the
-			read lock so no writes can sneak in between the snapshot and the lock.
-
-			NOTE: BeginTx is called first to obtain a *sql.Tx handle, then
-			START TRANSACTION WITH CONSISTENT SNAPSHOT is executed on it, which
-			implicitly replaces the transaction with a consistent-snapshot one.
-			The go-sql-driver/mysql driver does not expose this directly via TxOptions.
-		*/
+	// Open one transaction per worker (up to min(maxWorkers, len(tables))) while
+	// the read lock is still held. This guarantees all workers see the exact same
+	// database state. Workers pull tables from a queue and reuse their transaction
+	// across multiple tables — START TRANSACTION WITH CONSISTENT SNAPSHOT
+	// establishes a read view of the entire database, not a single table, so a
+	// single transaction can safely read multiple tables at the same snapshot point.
+	//
+	// NOTE: BeginTx is called first to obtain a *sql.Tx handle, then
+	// START TRANSACTION WITH CONSISTENT SNAPSHOT is executed on it, which
+	// implicitly replaces the transaction with a consistent-snapshot one.
+	// The go-sql-driver/mysql driver does not expose this directly via TxOptions.
+	numWorkers := min(maxWorkers, len(tables))
+	s.workerTxs = make([]*sql.Tx, 0, numWorkers)
+	for range numWorkers {
 		tx, txErr := s.db.BeginTx(ctx, &sql.TxOptions{
 			ReadOnly:  true,
 			Isolation: sql.LevelRepeatableRead,
 		})
 		if txErr != nil {
 			return nil, errors.Join(
-				fmt.Errorf("start transaction for table %s: %w", table, txErr),
+				fmt.Errorf("start worker transaction: %w", txErr),
 				unlockTables())
 		}
-		// Store before ExecContext so close() rolls back on failure.
-		s.tableTxs[table] = tx
+		s.workerTxs = append(s.workerTxs, tx)
 		if _, txErr = tx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); txErr != nil {
 			return nil, errors.Join(
-				fmt.Errorf("start consistent snapshot for table %s: %w", table, txErr),
+				fmt.Errorf("start consistent snapshot for worker: %w", txErr),
 				unlockTables())
 		}
 	}
@@ -238,24 +237,24 @@ func (s *Snapshot) getCurrentBinlogPosition(ctx context.Context) (position, erro
 
 func (s *Snapshot) releaseSnapshot(_ context.Context) error {
 	var errs []error
-	for table, tx := range s.tableTxs {
+	for idx, tx := range s.workerTxs {
 		if err := tx.Commit(); err != nil {
-			errs = append(errs, fmt.Errorf("commit transaction for table %s: %w", table, err))
+			errs = append(errs, fmt.Errorf("commit transaction for worker %d: %w", idx, err))
 		}
 	}
-	s.tableTxs = nil
+	s.workerTxs = nil
 	return errors.Join(errs...)
 }
 
 func (s *Snapshot) close() error {
 	var errs []error
 
-	for _, tx := range s.tableTxs {
+	for _, tx := range s.workerTxs {
 		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 			errs = append(errs, fmt.Errorf("rollback transaction: %w", err))
 		}
 	}
-	s.tableTxs = nil
+	s.workerTxs = nil
 
 	if s.lockConn != nil {
 		if err := s.lockConn.Close(); err != nil {

--- a/internal/impl/mysql/snapshot.go
+++ b/internal/impl/mysql/snapshot.go
@@ -71,18 +71,11 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 		return nil
 	}
 
-	// Open one dedicated connection per table and establish a consistent snapshot
-	// on each while the read lock is still held. This guarantees all parallel
-	// readers see the exact same database state.
+	// Open one transaction per table and establish a consistent snapshot on each
+	// while the read lock is still held. This guarantees all parallel readers see
+	// the exact same database state.
 	s.tableTxs = make(map[string]*sql.Tx, len(tables))
 	for _, table := range tables {
-		conn, connErr := s.db.Conn(ctx)
-		if connErr != nil {
-			return nil, errors.Join(
-				fmt.Errorf("create snapshot connection for table %s: %w", table, connErr),
-				unlockTables())
-		}
-
 		/*
 			START TRANSACTION WITH CONSISTENT SNAPSHOT ensures a consistent view of
 			database state for all parallel readers. We do this AFTER acquiring the
@@ -93,7 +86,7 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 			implicitly replaces the transaction with a consistent-snapshot one.
 			The go-sql-driver/mysql driver does not expose this directly via TxOptions.
 		*/
-		tx, txErr := conn.BeginTx(ctx, &sql.TxOptions{
+		tx, txErr := s.db.BeginTx(ctx, &sql.TxOptions{
 			ReadOnly:  true,
 			Isolation: sql.LevelRepeatableRead,
 		})
@@ -102,13 +95,13 @@ func (s *Snapshot) prepareSnapshot(ctx context.Context, tables []string) (*posit
 				fmt.Errorf("start transaction for table %s: %w", table, txErr),
 				unlockTables())
 		}
+		// Store before ExecContext so close() rolls back on failure.
+		s.tableTxs[table] = tx
 		if _, txErr = tx.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT"); txErr != nil {
 			return nil, errors.Join(
 				fmt.Errorf("start consistent snapshot for table %s: %w", table, txErr),
-				tx.Rollback(),
 				unlockTables())
 		}
-		s.tableTxs[table] = tx
 	}
 
 	// Capture the binlog position while the read lock is still held.


### PR DESCRIPTION
This change adds support for parallel snapshots, aligning the behaviour and structure to the MS SQL Server CDC connector. 

Left: 3 tables snapshotted serially, Right: 3 tables snapshot in parallel:

<img width="1369" height="301" alt="image" src="https://github.com/user-attachments/assets/4836d8d4-4247-4eba-bc6e-07ab045fb20c" />


<img width="1379" height="704" alt="image" src="https://github.com/user-attachments/assets/af79381a-1461-4063-9113-e9dac6281a1f" />

