### PR TITLE
iceberg: add case_sensitive_columns option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- iceberg: Added a `case_sensitive_columns` field to the `iceberg` output. When `false`, column-name matching follows iceberg's recommended case-insensitive convention end-to-end (shredding, schema evolution, partition specs, `schema_metadata`). Defaults to `true` for backwards compatibility. (@Jeffail)
+
 ## 4.89.2 - 2026-04-28
 
 ### Fixed

--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -119,6 +119,7 @@ output:
       tls_skip_verify: false
     namespace: analytics.events # No default (required)
     table: user_events # No default (required)
+    case_sensitive_columns: true
     storage:
       aws_s3:
         bucket: my-iceberg-data # No default (required)
@@ -551,6 +552,15 @@ table: user_events
 
 table: events_${!meta("topic")}
 ```
+
+=== `case_sensitive_columns`
+
+Controls how message field names are matched against table column names, and how column references in the partition spec are resolved. When `true` (the default), names must match exactly. When `false`, matching is case-insensitive — set this when your downstream catalog or query engine treats column names as case-insensitive (the iceberg specification's recommended convention) so that, for example, a message keyed `"COLUMN"` lands in an existing `column` rather than triggering schema evolution. Ambiguous case-only duplicates in the input are rejected.
+
+
+*Type*: `bool`
+
+*Default*: `true`
 
 === `storage`
 

--- a/internal/impl/iceberg/catalogx/catalog.go
+++ b/internal/impl/iceberg/catalogx/catalog.go
@@ -171,20 +171,24 @@ func (c *Client) CreateTable(ctx context.Context, tableName string, schema *iceb
 	return tbl, nil
 }
 
-// UpdateSchema applies schema changes to the table using a transaction.
-// The callback function receives an UpdateSchema instance that can be used to add, delete,
-// rename, or update columns. The transaction is automatically committed after the callback.
+// UpdateSchema applies schema changes to the table using a transaction. The
+// callback receives an UpdateSchema instance for adding, deleting, renaming, or
+// updating columns. The transaction is automatically committed after the
+// callback. The caseSensitive flag controls how column references inside the
+// callback (e.g. to UpdateColumn) are matched against the existing schema, and
+// whether the underlying iceberg-go transaction treats added column names as
+// case-sensitive duplicates of existing columns.
 //
 // Example usage:
 //
-//	err := client.UpdateSchema(ctx, tbl, func(us *table.UpdateSchema) {
+//	err := client.UpdateSchema(ctx, tbl, true, func(us *table.UpdateSchema) {
 //	    us.AddColumn([]string{"email"}, iceberg.StringType{}, "Email address", false, nil)
 //	    us.AddColumn([]string{"age"}, iceberg.Int32Type{}, "", false, nil)
 //	})
-func (c *Client) UpdateSchema(ctx context.Context, tbl *table.Table, fn func(*table.UpdateSchema), opts ...table.UpdateSchemaOption) (*table.Table, error) {
+func (c *Client) UpdateSchema(ctx context.Context, tbl *table.Table, caseSensitive bool, fn func(*table.UpdateSchema), opts ...table.UpdateSchemaOption) (*table.Table, error) {
 	txn := tbl.NewTransaction()
 	updateSchema := txn.UpdateSchema(
-		true,  // caseSensitive
+		caseSensitive,
 		false, // allowIncompatibleChanges
 		opts...,
 	)

--- a/internal/impl/iceberg/config.go
+++ b/internal/impl/iceberg/config.go
@@ -33,8 +33,9 @@ const (
 	ioFieldCatalogTLSSkipVer  = "tls_skip_verify"
 
 	// Table fields
-	ioFieldNamespace = "namespace"
-	ioFieldTable     = "table"
+	ioFieldNamespace            = "namespace"
+	ioFieldTable                = "table"
+	ioFieldCaseSensitiveColumns = "case_sensitive_columns"
 
 	// Storage fields - common
 	ioFieldStorage = "storage"
@@ -207,6 +208,11 @@ array:list
 				Description("The Iceberg table name. Supports interpolation functions for dynamic table names.").
 				Example("user_events").
 				Example(`events_${!meta("topic")}`),
+
+			service.NewBoolField(ioFieldCaseSensitiveColumns).
+				Description("Controls how message field names are matched against table column names, and how column references in the partition spec are resolved. When `true` (the default), names must match exactly. When `false`, matching is case-insensitive — set this when your downstream catalog or query engine treats column names as case-insensitive (the iceberg specification's recommended convention) so that, for example, a message keyed `\"COLUMN\"` lands in an existing `column` rather than triggering schema evolution. Ambiguous case-only duplicates in the input are rejected.").
+				Default(true).
+				Advanced(),
 
 			// Storage configuration - one of s3, gcs, or azure must be specified
 			service.NewObjectField(ioFieldStorage,

--- a/internal/impl/iceberg/e2e/glue/e2e_test.go
+++ b/internal/impl/iceberg/e2e/glue/e2e_test.go
@@ -77,7 +77,7 @@ func newRouter(t *testing.T, namespace, table string, schemaEvo bool) *icebergim
 		Enabled:       schemaEvo,
 		TableLocation: fmt.Sprintf("s3://%s/", *glueBucket),
 	}
-	router := icebergimpl.NewRouter(catalogConfig(), namespaceStr, tableStr, schemaEvoCfg, commitCfg, logger)
+	router := icebergimpl.NewRouter(catalogConfig(), namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/e2e/polaris-aws/e2e_test.go
+++ b/internal/impl/iceberg/e2e/polaris-aws/e2e_test.go
@@ -202,7 +202,7 @@ func newRouter(t *testing.T, catalogCfg catalogx.Config, namespace, tableName st
 	schemaEvoCfg := icebergimpl.SchemaEvolutionConfig{
 		Enabled: schemaEvo,
 	}
-	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, schemaEvoCfg, commitCfg, logger)
+	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/e2e/polaris-azure/e2e_test.go
+++ b/internal/impl/iceberg/e2e/polaris-azure/e2e_test.go
@@ -192,7 +192,7 @@ func newRouter(t *testing.T, catalogCfg catalogx.Config, namespace, table string
 	schemaEvoCfg := icebergimpl.SchemaEvolutionConfig{
 		Enabled: schemaEvo,
 	}
-	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, schemaEvoCfg, commitCfg, logger)
+	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/icebergx/partition_key.go
+++ b/internal/impl/iceberg/icebergx/partition_key.go
@@ -230,6 +230,8 @@ func formatLiteralValue(transform iceberg.Transform, lit iceberg.Literal) string
 }
 
 // ParsePartitionSpec parses a Spark-like DDL expression string into an iceberg PartitionSpec.
+// caseSensitive controls whether column references in the spec are matched
+// against schema field names case-sensitively or case-insensitively.
 //
 // Supported syntax:
 //   - Optional parentheses: "(field1, field2)" or "field1, field2"
@@ -241,20 +243,22 @@ func formatLiteralValue(transform iceberg.Transform, lit iceberg.Literal) string
 //   - Nested column names: "foo.bar.baz"
 //
 // See: https://github.com/redpanda-data/redpanda/blob/dev/src/v/datalake/partition_spec_parser.cc
-func ParsePartitionSpec(input string, schema *iceberg.Schema) (iceberg.PartitionSpec, error) {
+func ParsePartitionSpec(input string, schema *iceberg.Schema, caseSensitive bool) (iceberg.PartitionSpec, error) {
 	p := &partitionSpecParser{
-		input:  input,
-		pos:    0,
-		schema: schema,
+		input:         input,
+		pos:           0,
+		schema:        schema,
+		caseSensitive: caseSensitive,
 	}
 	return p.parse()
 }
 
 // partitionSpecParser implements a recursive descent parser for partition specs.
 type partitionSpecParser struct {
-	input  string
-	pos    int
-	schema *iceberg.Schema
+	input         string
+	pos           int
+	schema        *iceberg.Schema
+	caseSensitive bool
 }
 
 // parse is the main entry point.
@@ -656,7 +660,15 @@ func (p *partitionSpecParser) resolveColumnRef(colRef string) (int, error) {
 
 	// Handle dotted path
 	parts := splitColumnRef(colRef)
-	field, ok := p.schema.FindFieldByName(parts[0])
+	var (
+		field iceberg.NestedField
+		ok    bool
+	)
+	if p.caseSensitive {
+		field, ok = p.schema.FindFieldByName(parts[0])
+	} else {
+		field, ok = p.schema.FindFieldByNameCaseInsensitive(parts[0])
+	}
 	if !ok {
 		return 0, fmt.Errorf("field not found: %s", parts[0])
 	}
@@ -672,7 +684,7 @@ func (p *partitionSpecParser) resolveColumnRef(colRef string) (int, error) {
 
 		found := false
 		for _, f := range st.FieldList {
-			if f.Name == parts[i] {
+			if p.namesEqual(f.Name, parts[i]) {
 				field = f
 				fieldID = f.ID
 				found = true
@@ -738,6 +750,15 @@ func (p *partitionSpecParser) matchKeyword(keyword string) bool {
 
 func (p *partitionSpecParser) errorf(format string, args ...any) error {
 	return fmt.Errorf("col %d: "+format, append([]any{p.pos + 1}, args...)...)
+}
+
+// namesEqual compares two field names according to the parser's case
+// sensitivity setting.
+func (p *partitionSpecParser) namesEqual(a, b string) bool {
+	if p.caseSensitive {
+		return a == b
+	}
+	return strings.EqualFold(a, b)
 }
 
 func isWhitespace(ch byte) bool {

--- a/internal/impl/iceberg/icebergx/partition_key_test.go
+++ b/internal/impl/iceberg/icebergx/partition_key_test.go
@@ -460,7 +460,7 @@ func TestParsePartitionSpecEmpty(t *testing.T) {
 
 	for _, input := range testCases {
 		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(input, schema)
+			spec, err := ParsePartitionSpec(input, schema, true)
 			require.NoError(t, err, "input: %q", input)
 			assert.Equal(t, 0, spec.NumFields(), "expected empty spec for input: %q", input)
 		})
@@ -486,7 +486,7 @@ func TestParsePartitionSpecIdentity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err, "input: %q", tc.input)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -501,7 +501,7 @@ func TestParsePartitionSpecIdentity(t *testing.T) {
 func TestParsePartitionSpecMultipleFields(t *testing.T) {
 	schema := makeTestSchema()
 
-	spec, err := ParsePartitionSpec("(test_int, test_string)", schema)
+	spec, err := ParsePartitionSpec("(test_int, test_string)", schema, true)
 	require.NoError(t, err)
 	require.Equal(t, 2, spec.NumFields())
 
@@ -535,7 +535,7 @@ func TestParsePartitionSpecTimeTransforms(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -563,7 +563,7 @@ func TestParsePartitionSpecBucketTransform(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -593,7 +593,7 @@ func TestParsePartitionSpecTruncateTransform(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -623,7 +623,7 @@ func TestParsePartitionSpecWithAlias(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, spec.NumFields(), 1)
 
@@ -656,7 +656,7 @@ func TestParsePartitionSpecQuotedIdentifiers(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -705,7 +705,7 @@ func TestParsePartitionSpecNestedFields(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 
@@ -721,7 +721,7 @@ func TestParsePartitionSpecComplexSpec(t *testing.T) {
 	schema := makeTestSchema()
 
 	input := "(hour(test_timestamp) as ts_hour, bucket(16, test_int) as int_bucket, test_string)"
-	spec, err := ParsePartitionSpec(input, schema)
+	spec, err := ParsePartitionSpec(input, schema, true)
 	require.NoError(t, err)
 	require.Equal(t, 3, spec.NumFields())
 
@@ -770,7 +770,7 @@ func TestParsePartitionSpecErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			_, err := ParsePartitionSpec(tc.input, schema)
+			_, err := ParsePartitionSpec(tc.input, schema, true)
 			require.Error(t, err)
 			assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.errContains),
 				"error should contain %q, got: %v", tc.errContains, err)
@@ -800,12 +800,53 @@ func TestParsePartitionSpecCaseInsensitiveTransforms(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(tc.input, schema)
+			spec, err := ParsePartitionSpec(tc.input, schema, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, spec.NumFields())
 			assert.Equal(t, tc.transformType, spec.Field(0).Transform)
 		})
 	}
+}
+
+// TestParsePartitionSpecCaseInsensitiveColumns covers the column-resolution
+// half of case sensitivity (transform names were already case-insensitive).
+// When caseSensitive=false, partition specs may reference columns using any
+// casing the user prefers; when caseSensitive=true, the historical strict
+// matching is preserved.
+func TestParsePartitionSpecCaseInsensitiveColumns(t *testing.T) {
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 2, Name: "user", Type: &iceberg.StructType{
+			FieldList: []iceberg.NestedField{
+				{ID: 3, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+			},
+		}, Required: true},
+	)
+
+	t.Run("uppercase column name resolves case-insensitive", func(t *testing.T) {
+		spec, err := ParsePartitionSpec("(year(TS))", schema, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, spec.NumFields())
+		assert.Equal(t, 1, spec.Field(0).SourceID())
+	})
+
+	t.Run("nested mixed-case column resolves case-insensitive", func(t *testing.T) {
+		spec, err := ParsePartitionSpec("(USER.Id)", schema, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, spec.NumFields())
+		assert.Equal(t, 3, spec.Field(0).SourceID())
+	})
+
+	t.Run("uppercase column name fails case-sensitive", func(t *testing.T) {
+		_, err := ParsePartitionSpec("(year(TS))", schema, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field not found")
+	})
+
+	t.Run("nested case mismatch fails case-sensitive", func(t *testing.T) {
+		_, err := ParsePartitionSpec("(USER.Id)", schema, true)
+		require.Error(t, err)
+	})
 }
 
 // TestParsePartitionSpecWhitespaceHandling tests various whitespace scenarios.
@@ -824,7 +865,7 @@ func TestParsePartitionSpecWhitespaceHandling(t *testing.T) {
 
 	for _, input := range testCases {
 		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
-			spec, err := ParsePartitionSpec(input, schema)
+			spec, err := ParsePartitionSpec(input, schema, true)
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, spec.NumFields(), 1)
 		})

--- a/internal/impl/iceberg/integration/catalogx_integration_test.go
+++ b/internal/impl/iceberg/integration/catalogx_integration_test.go
@@ -149,7 +149,7 @@ func TestCatalogxIntegration(t *testing.T) {
 		tbl, err := client.CreateTable(ctx, tableName, initialSchema)
 		require.NoError(t, err)
 
-		_, err = client.UpdateSchema(ctx, tbl, func(us *table.UpdateSchema) {
+		_, err = client.UpdateSchema(ctx, tbl, true, func(us *table.UpdateSchema) {
 			us.AddColumn([]string{"col2"}, iceberg.StringType{}, "", false, nil)
 		})
 		require.NoError(t, err)

--- a/internal/impl/iceberg/integration/schema_evolution_test.go
+++ b/internal/impl/iceberg/integration/schema_evolution_test.go
@@ -171,6 +171,151 @@ func TestSchemaEvolutionIntegration(t *testing.T) {
 		assert.Equal(t, 1, rows[0].Count)
 	})
 
+	// CaseInsensitiveColumnMatching covers a customer scenario where the iceberg
+	// table schema uses lowercase column names (the iceberg convention) but the
+	// inbound messages have uppercase keys. The router must route the upper-case
+	// values into the existing lowercase columns rather than treating them as
+	// new columns and triggering schema evolution — adding a case-only duplicate
+	// would either corrupt the schema or be rejected by case-insensitive
+	// catalogs.
+	t.Run("CaseInsensitiveColumnMatching", func(t *testing.T) {
+		const ns = "case_match_ns"
+		const tblName = "case_match_table"
+		infra.CreateNamespace(t, ns)
+
+		// Pre-create the table with lowercase column names.
+		client := infra.NewCatalogClient(t, ns)
+		schema := iceberg.NewSchema(
+			0,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: false},
+			iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.StringType{}, Required: false},
+		)
+		_, err := client.CreateTable(ctx, tblName, schema)
+		require.NoError(t, err)
+
+		// Send messages with upper-case keys (the customer's payload shape).
+		// case_sensitive_columns=false matches iceberg's recommended convention.
+		router := infra.NewRouter(t, ns, tblName,
+			WithCaseSensitive(false),
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+		produce(t, ctx, router,
+			`{"ID": 1, "NAME": "alice"}`,
+			`{"ID": 2, "NAME": "bob"}`,
+		)
+
+		// Schema must not have evolved: still two columns, both lowercase.
+		tbl, err := client.LoadTable(ctx, tblName)
+		require.NoError(t, err)
+		fields := tbl.Schema().Fields()
+		require.Len(t, fields, 2, "schema must not have evolved for case-only mismatches")
+		assert.Equal(t, "id", fields[0].Name)
+		assert.Equal(t, "name", fields[1].Name)
+
+		// Data must land in the lowercase columns.
+		cols := querySQL[ColumnInfo](t, ctx, infra,
+			`DESCRIBE iceberg_cat."`+ns+`"."`+tblName+`";`)
+		require.Len(t, cols, 2)
+
+		rows := querySQL[countResult](t, ctx, infra,
+			`SELECT COUNT(*) as count FROM iceberg_cat."`+ns+`"."`+tblName+`" WHERE name IN ('alice', 'bob');`)
+		assert.Equal(t, 2, rows[0].Count)
+	})
+
+	// CaseInsensitiveCreateTimeDuplicate verifies the create-time guard: when
+	// case_sensitive_columns=false and the first message contains two keys
+	// differing only in case, table creation is rejected before we hand the
+	// schema to iceberg-go.
+	t.Run("CaseInsensitiveCreateTimeDuplicate", func(t *testing.T) {
+		const ns = "case_dup_create_ns"
+		const tblName = "case_dup_create_table"
+		infra.CreateNamespace(t, ns)
+
+		router := infra.NewRouter(t, ns, tblName,
+			WithCaseSensitive(false),
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		batch := service.MessageBatch{service.NewMessage([]byte(`{"id": 1, "ID": 2}`))}
+		err := router.Route(ctx, batch)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous columns")
+
+		// Table must not have been created.
+		client := infra.NewCatalogClient(t, ns)
+		exists, err := client.CheckTableExists(ctx, tblName)
+		require.NoError(t, err)
+		assert.False(t, exists, "table should not exist after rejected create")
+	})
+
+	// CaseInsensitiveNewFieldDedupAcrossBatch covers the sink-level dedup
+	// fix end-to-end: when two messages in a single batch each introduce a
+	// new field that differs from the other only in case, schema evolution
+	// must add the column exactly once. Without dedup folding, the second
+	// add would race the first and be rejected by case-insensitive
+	// UpdateSchema, breaking the entire batch.
+	t.Run("CaseInsensitiveNewFieldDedupAcrossBatch", func(t *testing.T) {
+		const ns = "case_dedup_ns"
+		const tblName = "case_dedup_table"
+		infra.CreateNamespace(t, ns)
+
+		client := infra.NewCatalogClient(t, ns)
+		base := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.Int64Type{}, Required: false},
+		)
+		_, err := client.CreateTable(ctx, tblName, base)
+		require.NoError(t, err)
+
+		router := infra.NewRouter(t, ns, tblName,
+			WithCaseSensitive(false),
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
+
+		produce(t, ctx, router,
+			`{"id": 1, "EMAIL": "a@x.z"}`,
+			`{"id": 2, "email": "b@x.z"}`,
+		)
+
+		tbl, err := client.LoadTable(ctx, tblName)
+		require.NoError(t, err)
+		// Expect base id + exactly one email column added; whichever case
+		// arrived first wins, but there must not be both.
+		assert.Len(t, tbl.Schema().Fields(), 2)
+
+		rows := querySQL[countResult](t, ctx, infra,
+			`SELECT COUNT(*) as count FROM iceberg_cat."`+ns+`"."`+tblName+`";`)
+		assert.Equal(t, 2, rows[0].Count)
+	})
+
+	// CaseInsensitivePartitionSpecCreate verifies the partition-spec parser
+	// resolves column references case-insensitively when the flag is off.
+	// The first message creates the table with lowercase columns, while the
+	// configured partition spec references the column in uppercase — the
+	// parse must succeed against the schema produced from the message.
+	t.Run("CaseInsensitivePartitionSpecCreate", func(t *testing.T) {
+		const ns = "case_partition_ns"
+		const tblName = "case_partition_table"
+		infra.CreateNamespace(t, ns)
+
+		// Partition spec references VALUE in upper case; the table schema
+		// will be inferred from the message whose key is lowercase value.
+		partitionSpecStr, err := service.NewInterpolatedString("(bucket(16, VALUE))")
+		require.NoError(t, err)
+
+		router := infra.NewRouter(t, ns, tblName,
+			WithCaseSensitive(false),
+			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{
+				Enabled:       true,
+				PartitionSpec: partitionSpecStr,
+			}))
+
+		produce(t, ctx, router, `{"id": 1, "value": "test"}`)
+
+		client := infra.NewCatalogClient(t, ns)
+		tbl, err := client.LoadTable(ctx, tblName)
+		require.NoError(t, err)
+		spec := tbl.Spec()
+		assert.False(t, spec.IsUnpartitioned())
+		assert.Equal(t, 1, spec.NumFields())
+	})
+
 	t.Run("RowCount", func(t *testing.T) {
 		router := infra.NewRouter(t, "auto_create_ns", "auto_create_table",
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))

--- a/internal/impl/iceberg/integration/test_helpers.go
+++ b/internal/impl/iceberg/integration/test_helpers.go
@@ -89,13 +89,23 @@ func (infra *testInfrastructure) NewCatalogClient(t *testing.T, namespace string
 type RouterOption func(*routerOpts)
 
 type routerOpts struct {
-	schemaEvoCfg icebergimpl.SchemaEvolutionConfig
+	caseSensitive bool
+	schemaEvoCfg  icebergimpl.SchemaEvolutionConfig
 }
 
 // WithSchemaEvolution enables schema evolution on the test router.
 func WithSchemaEvolution(cfg icebergimpl.SchemaEvolutionConfig) RouterOption {
 	return func(o *routerOpts) {
 		o.schemaEvoCfg = cfg
+	}
+}
+
+// WithCaseSensitive sets the case sensitivity behavior on the test router.
+// The default (when this option is not used) is case-sensitive matching, to
+// preserve the released production default.
+func WithCaseSensitive(caseSensitive bool) RouterOption {
+	return func(o *routerOpts) {
+		o.caseSensitive = caseSensitive
 	}
 }
 
@@ -110,7 +120,8 @@ func (infra *testInfrastructure) NewRouter(
 	t.Helper()
 
 	o := routerOpts{
-		schemaEvoCfg: icebergimpl.SchemaEvolutionConfig{Enabled: false},
+		caseSensitive: true,
+		schemaEvoCfg:  icebergimpl.SchemaEvolutionConfig{Enabled: false},
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -127,7 +138,7 @@ func (infra *testInfrastructure) NewRouter(
 		MaxSnapshotAge:       24 * time.Hour,
 		MaxRetries:           3,
 	}
-	router := icebergimpl.NewRouter(infra.CatalogConfig(), namespaceStr, tableStr, o.schemaEvoCfg, commitCfg, logger)
+	router := icebergimpl.NewRouter(infra.CatalogConfig(), namespaceStr, tableStr, o.caseSensitive, o.schemaEvoCfg, commitCfg, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -85,6 +85,11 @@ func newIcebergOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 		return nil, fmt.Errorf("parsing table name: %w", err)
 	}
 
+	caseSensitive, err := conf.FieldBool(ioFieldCaseSensitiveColumns)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", ioFieldCaseSensitiveColumns, err)
+	}
+
 	// Parse schema evolution config
 	schemaEvoCfg, err := parseSchemaEvolutionConfig(conf)
 	if err != nil {
@@ -98,7 +103,7 @@ func newIcebergOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 	}
 
 	// Create router
-	rtr := NewRouter(catalogCfg, namespaceStr, tableStr, schemaEvoCfg, commitCfg, mgr.Logger())
+	rtr := NewRouter(catalogCfg, namespaceStr, tableStr, caseSensitive, schemaEvoCfg, commitCfg, mgr.Logger())
 
 	return &icebergOutput{
 		router: rtr,

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -63,35 +63,41 @@ type tableEntry struct {
 
 // Router routes message batches to per-table writers.
 type Router struct {
-	catalogCfg   catalogx.Config
-	namespaceStr *service.InterpolatedString
-	tableStr     *service.InterpolatedString
-	schemaEvoCfg SchemaEvolutionConfig
-	commitCfg    CommitConfig
-	resolver     *typeResolver
+	catalogCfg    catalogx.Config
+	namespaceStr  *service.InterpolatedString
+	tableStr      *service.InterpolatedString
+	caseSensitive bool
+	schemaEvoCfg  SchemaEvolutionConfig
+	commitCfg     CommitConfig
+	resolver      *typeResolver
 
 	entries sync.Map // tableKey -> *tableEntry
 
 	logger *service.Logger
 }
 
-// NewRouter creates a new router.
+// NewRouter creates a new router. caseSensitive controls how message keys are
+// matched against schema field names and how column references are resolved
+// during schema evolution and partition spec parsing. When false, names are
+// compared case-insensitively, matching iceberg's recommended convention.
 func NewRouter(
 	catalogCfg catalogx.Config,
 	namespaceStr *service.InterpolatedString,
 	tableStr *service.InterpolatedString,
+	caseSensitive bool,
 	schemaEvoCfg SchemaEvolutionConfig,
 	commitCfg CommitConfig,
 	logger *service.Logger,
 ) *Router {
 	return &Router{
-		catalogCfg:   catalogCfg,
-		namespaceStr: namespaceStr,
-		tableStr:     tableStr,
-		schemaEvoCfg: schemaEvoCfg,
-		commitCfg:    commitCfg,
-		resolver:     newTypeResolver(schemaEvoCfg.SchemaMetadata, schemaEvoCfg.NewColumnTypeMapping, logger),
-		logger:       logger,
+		catalogCfg:    catalogCfg,
+		namespaceStr:  namespaceStr,
+		tableStr:      tableStr,
+		caseSensitive: caseSensitive,
+		schemaEvoCfg:  schemaEvoCfg,
+		commitCfg:     commitCfg,
+		resolver:      newTypeResolver(schemaEvoCfg.SchemaMetadata, schemaEvoCfg.NewColumnTypeMapping, caseSensitive, logger),
+		logger:        logger,
 	}
 }
 
@@ -331,7 +337,7 @@ func (r *Router) createTable(ctx context.Context, key tableKey, batch service.Me
 			return fmt.Errorf("interpolating partition spec: %w", err)
 		}
 		if specStr != "" {
-			spec, err := icebergx.ParsePartitionSpec(specStr, schema)
+			spec, err := icebergx.ParsePartitionSpec(specStr, schema, r.caseSensitive)
 			if err != nil {
 				return fmt.Errorf("parsing partition spec %q: %w", specStr, err)
 			}
@@ -369,7 +375,17 @@ func (r *Router) createTable(ctx context.Context, key tableKey, batch service.Me
 
 // buildSchemaWithResolver builds a schema using the type resolver for type resolution.
 func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Message, key tableKey) (*iceberg.Schema, error) {
-	ti := newTypeInferrer()
+	// In case-insensitive mode, two record keys differing only in case would
+	// collapse to a single iceberg column under spec rules — admitting both
+	// would either be silently rejected by the catalog or, worse, accepted
+	// and then conflict on every subsequent write. Refuse at create time.
+	if !r.caseSensitive {
+		if dupA, dupB, ok := findCaseOnlyDuplicate(record); ok {
+			return nil, fmt.Errorf("ambiguous columns at table creation: %q and %q differ only in case", dupA, dupB)
+		}
+	}
+
+	ti := newTypeInferrer(r.caseSensitive)
 	fields := make([]iceberg.NestedField, 0, len(record))
 
 	for name, value := range record {
@@ -389,6 +405,21 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	}
 
 	return iceberg.NewSchema(0, fields...), nil
+}
+
+// findCaseOnlyDuplicate returns the first pair of map keys that fold to the
+// same lowercase string, if any. Used by case-insensitive table creation to
+// reject input that would collapse to a single iceberg column.
+func findCaseOnlyDuplicate(record map[string]any) (string, string, bool) {
+	seen := make(map[string]string, len(record))
+	for name := range record {
+		lower := strings.ToLower(name)
+		if existing, ok := seen[lower]; ok {
+			return existing, name, true
+		}
+		seen[lower] = name
+	}
+	return "", "", false
 }
 
 // evolveSchema adds new columns to the table.
@@ -414,7 +445,7 @@ func (r *Router) evolveSchema(ctx context.Context, key tableKey, schemaErr *Batc
 
 	// Update schema with new columns
 	added := 0
-	_, err = client.UpdateSchema(ctx, tbl, func(us *table.UpdateSchema) {
+	_, err = client.UpdateSchema(ctx, tbl, r.caseSensitive, func(us *table.UpdateSchema) {
 		for _, fields := range groups {
 			for _, field := range fields {
 				// Resolve type using the three-stage pipeline
@@ -478,7 +509,7 @@ func (r *Router) makeColumnOptional(ctx context.Context, key tableKey, reqNullEr
 	colPath = append(colPath, reqNullErr.Field.Name)
 
 	// Update schema to make the column optional
-	_, err = client.UpdateSchema(ctx, tbl, func(us *table.UpdateSchema) {
+	_, err = client.UpdateSchema(ctx, tbl, r.caseSensitive, func(us *table.UpdateSchema) {
 		us.UpdateColumn(colPath, table.ColumnUpdate{
 			Required: iceberg.Optional[bool]{Val: false, Valid: true},
 		})
@@ -547,7 +578,7 @@ func (r *Router) createWriter(ctx context.Context, key tableKey) (*writer, error
 	}
 
 	// Create writer with its own table reference and the committer
-	w := NewWriter(writerTbl, comm, r.logger)
+	w := NewWriter(writerTbl, comm, r.caseSensitive, r.logger)
 	r.logger.Debugf("Created writer for table %s.%s", key.namespace, key.table)
 
 	return w, nil

--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFindCaseOnlyDuplicate covers the create-time guard that prevents an
+// inbound record with two keys differing only in case from being committed
+// as two separate iceberg columns under case-insensitive matching, which
+// would either be rejected by the catalog or corrupt the schema.
+func TestFindCaseOnlyDuplicate(t *testing.T) {
+	t.Run("no duplicates returns false", func(t *testing.T) {
+		record := map[string]any{"id": 1, "name": "alice", "email": "x@y.z"}
+		_, _, ok := findCaseOnlyDuplicate(record)
+		assert.False(t, ok)
+	})
+
+	t.Run("uppercase and lowercase duplicate", func(t *testing.T) {
+		record := map[string]any{"id": 1, "ID": 2}
+		a, b, ok := findCaseOnlyDuplicate(record)
+		assert.True(t, ok)
+		// Order is non-deterministic over map iteration; assert the pair.
+		assert.ElementsMatch(t, []string{"id", "ID"}, []string{a, b})
+	})
+
+	t.Run("mixed-case duplicate", func(t *testing.T) {
+		record := map[string]any{"User_Id": 1, "user_id": 2}
+		a, b, ok := findCaseOnlyDuplicate(record)
+		assert.True(t, ok)
+		pair := []string{strings.ToLower(a), strings.ToLower(b)}
+		assert.Equal(t, []string{"user_id", "user_id"}, pair)
+	})
+
+	t.Run("empty record returns false", func(t *testing.T) {
+		_, _, ok := findCaseOnlyDuplicate(map[string]any{})
+		assert.False(t, ok)
+	})
+}

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/big"
 	"slices"
+	"strings"
 
 	"github.com/apache/iceberg-go"
 	"github.com/gofrs/uuid/v5"
@@ -73,12 +74,22 @@ type Sink interface {
 // and definition levels that allow perfect reconstruction.
 type RecordShredder struct {
 	schema *iceberg.Schema
+	// caseSensitive controls how input record keys are matched against schema
+	// field names. When true (the historical default) names are matched
+	// exactly; when false, matching is case-insensitive — which aligns with
+	// iceberg's recommended convention and with engines like Spark and Trino
+	// in their default configurations.
+	caseSensitive bool
 }
 
 // NewRecordShredder creates a new shredder for the given schema.
-func NewRecordShredder(schema *iceberg.Schema) *RecordShredder {
+// If caseSensitive is true, input keys must match schema field names exactly;
+// if false, matching is case-insensitive (and ambiguous case-only duplicates
+// in the input cause an error).
+func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredder {
 	return &RecordShredder{
-		schema: schema,
+		schema:        schema,
+		caseSensitive: caseSensitive,
 	}
 }
 
@@ -98,13 +109,40 @@ func (rs *RecordShredder) shredStruct(
 	repLevel, defLevel, maxRepLevel int,
 	sink Sink,
 ) error {
-	// Build set of known field names for new field detection.
-	knownFields := make(map[string]struct{}, len(fields))
+	// Build an index of input keys by their match-key (the original key in
+	// case-sensitive mode, or its lowercase form in case-insensitive mode).
+	// In case-insensitive mode, multiple input keys may collide on the same
+	// match-key — we detect that as ambiguity rather than silently picking
+	// one. In case-sensitive mode, collisions are impossible because Go map
+	// keys are themselves case-sensitive.
+	keysByLookup := make(map[string][]string, len(value))
+	for k := range value {
+		mk := rs.matchKey(k)
+		keysByLookup[mk] = append(keysByLookup[mk], k)
+	}
 
-	// Process schema fields.
+	// Track which input keys matched a schema field; remaining keys are
+	// candidates for new-field detection.
+	matched := make(map[string]struct{}, len(fields))
+
 	for _, field := range fields {
-		knownFields[field.Name] = struct{}{}
-		fieldValue, exists := value[field.Name]
+		candidates := keysByLookup[rs.matchKey(field.Name)]
+		// If the input contains multiple keys that all map to the same schema
+		// field (only possible in case-insensitive mode), we cannot pick one
+		// without silently dropping data — refuse rather than guess.
+		if len(candidates) > 1 {
+			return fmt.Errorf("ambiguous case for field %q: input has %d keys differing only in case: %v", field.Name, len(candidates), candidates)
+		}
+
+		var (
+			fieldValue any
+			exists     bool
+		)
+		if len(candidates) == 1 {
+			fieldValue = value[candidates[0]]
+			exists = true
+			matched[candidates[0]] = struct{}{}
+		}
 
 		// Validate required fields.
 		if field.Required && (!exists || fieldValue == nil) {
@@ -117,7 +155,8 @@ func (rs *RecordShredder) shredStruct(
 			fieldDefLevel++ // Optional field adds to max def level.
 		}
 
-		// Build path for this field.
+		// Build path for this field using the schema's casing so downstream
+		// consumers see canonical names regardless of the input's casing.
 		fieldPath := append(path, icebergx.PathSegment{Kind: icebergx.PathField, Name: field.Name})
 
 		if !exists || fieldValue == nil {
@@ -136,12 +175,22 @@ func (rs *RecordShredder) shredStruct(
 
 	// Detect unknown fields in input.
 	for key, val := range value {
-		if _, known := knownFields[key]; !known {
+		if _, ok := matched[key]; !ok {
 			sink.OnNewField(slices.Clone(path), key, val)
 		}
 	}
 
 	return nil
+}
+
+// matchKey returns the lookup key used to compare an input record key against
+// a schema field name. In case-sensitive mode it is the identity; in
+// case-insensitive mode it folds to lowercase.
+func (rs *RecordShredder) matchKey(s string) string {
+	if rs.caseSensitive {
+		return s
+	}
+	return strings.ToLower(s)
 }
 
 // shredValue processes a value according to its schema type.

--- a/internal/impl/iceberg/shredder/shredder_test.go
+++ b/internal/impl/iceberg/shredder/shredder_test.go
@@ -59,7 +59,7 @@ func TestShredSimpleRecord(t *testing.T) {
 		"name": "alice",
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestShredNullOptionalField(t *testing.T) {
 		"name": nil, // null value
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestShredList(t *testing.T) {
 		"tags": []any{"a", "b", "c"},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestShredEmptyList(t *testing.T) {
 		"tags": []any{},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestShredNestedStruct(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestShredNullNestedStruct(t *testing.T) {
 		"user": nil,
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -282,7 +282,7 @@ func TestShredMap(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -328,7 +328,7 @@ func TestShredListOfStructs(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestShredMissingRequiredField(t *testing.T) {
 		"name": "alice",
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.Error(t, err)
@@ -384,7 +384,7 @@ func TestShredNullRequiredField(t *testing.T) {
 		"id": nil,
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.Error(t, err)
@@ -402,7 +402,7 @@ func TestShredNewFieldDetection(t *testing.T) {
 		"newField": "surprise",
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -436,7 +436,7 @@ func TestShredNestedNewField(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -478,7 +478,7 @@ func TestShredNewFieldInList(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -516,7 +516,7 @@ func TestListOfStrings(t *testing.T) {
 		"values": []any{"a", "b", "c"},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -608,7 +608,7 @@ func TestDefinitionLevels(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			shredder := NewRecordShredder(schema)
+			shredder := NewRecordShredder(schema, true)
 			sink := &testSink{}
 			err := shredder.Shred(tc.record, sink)
 			require.NoError(t, err)
@@ -655,7 +655,7 @@ func TestRepetitionLevels(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record1, sink)
 	require.NoError(t, err)
@@ -726,7 +726,7 @@ func TestAddressBookExample(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record1, sink)
 	require.NoError(t, err)
@@ -811,7 +811,7 @@ func TestAddressBookNoContacts(t *testing.T) {
 		"contacts":          []any{},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -896,7 +896,7 @@ func TestRequiredGroupWrappedInOptionalGroup(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			shredder := NewRecordShredder(schema)
+			shredder := NewRecordShredder(schema, true)
 			sink := &testSink{}
 			err := shredder.Shred(tc.record, sink)
 			require.NoError(t, err)
@@ -969,7 +969,7 @@ func TestRequiredValuesNotNullValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			shredder := NewRecordShredder(schema)
+			shredder := NewRecordShredder(schema, true)
 			sink := &testSink{}
 			err := shredder.Shred(tc.record, sink)
 			require.Error(t, err)
@@ -1005,7 +1005,7 @@ func TestLogicalMap(t *testing.T) {
 		},
 	}
 
-	shredder := NewRecordShredder(schema)
+	shredder := NewRecordShredder(schema, true)
 	sink := &testSink{}
 	err := shredder.Shred(record, sink)
 	require.NoError(t, err)
@@ -1195,4 +1195,149 @@ func TestConvertLeafValueUint64Overflow(t *testing.T) {
 	// Value within range should succeed
 	_, err = convertLeafValue(uint64(math.MaxInt64), iceberg.Int64Type{})
 	require.NoError(t, err)
+}
+
+// TestShredCaseInsensitiveTopLevel covers the case where the iceberg schema is
+// lowercase (the iceberg convention) but a message arrives with upper-case keys
+// — for example because some upstream system emitted them or the customer's
+// application uses upper-case identifiers. Iceberg field matching is
+// case-insensitive by convention, so the shredder must route the upper-case
+// message values into the lowercase schema columns rather than declaring them
+// unknown and triggering schema evolution.
+func TestShredCaseInsensitiveTopLevel(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+
+	record := map[string]any{
+		"ID":   int64(42),
+		"NAME": "alice",
+	}
+
+	shredder := NewRecordShredder(schema, false)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.NoError(t, err)
+	require.Len(t, sink.values, 2)
+	assert.Empty(t, sink.newFields, "case-only mismatches must not be reported as new fields")
+
+	assert.Equal(t, 1, sink.values[0].FieldID)
+	assert.Equal(t, int64(42), sink.values[0].Value.Int64())
+	assert.Equal(t, 2, sink.values[1].FieldID)
+	assert.Equal(t, "alice", string(sink.values[1].Value.ByteArray()))
+}
+
+// TestShredCaseInsensitiveMixedCase verifies matching works for arbitrary
+// case differences — not just full uppercase vs full lowercase.
+func TestShredCaseInsensitiveMixedCase(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "user_id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	record := map[string]any{"User_Id": int64(7)}
+
+	shredder := NewRecordShredder(schema, false)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.NoError(t, err)
+	require.Len(t, sink.values, 1)
+	assert.Empty(t, sink.newFields)
+	assert.Equal(t, int64(7), sink.values[0].Value.Int64())
+}
+
+// TestShredCaseInsensitiveNestedStruct verifies the case-insensitive lookup
+// works at every nesting depth, not only at the root.
+func TestShredCaseInsensitiveNestedStruct(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{
+			ID:   1,
+			Name: "user",
+			Type: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+					{ID: 3, Name: "age", Type: iceberg.PrimitiveTypes.Int32, Required: false},
+				},
+			},
+			Required: false,
+		},
+	)
+
+	record := map[string]any{
+		"USER": map[string]any{
+			"Name": "bob",
+			"AGE":  int32(30),
+		},
+	}
+
+	shredder := NewRecordShredder(schema, false)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.NoError(t, err)
+	require.Len(t, sink.values, 2)
+	assert.Empty(t, sink.newFields)
+	assert.Equal(t, "bob", string(sink.values[0].Value.ByteArray()))
+	assert.Equal(t, int32(30), sink.values[1].Value.Int32())
+}
+
+// TestShredAmbiguousCase verifies that when a message contains two keys that
+// differ only in case and both map to the same schema field, the shredder
+// errors rather than silently picking one. This protects against data loss
+// (the unselected key would be discarded) and aligns with iceberg's
+// case-insensitive uniqueness conventions.
+func TestShredAmbiguousCase(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	record := map[string]any{
+		"id": int64(1),
+		"ID": int64(2),
+	}
+
+	shredder := NewRecordShredder(schema, false)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+// TestShredCaseSensitivePreservesNewFieldDetection verifies that the
+// historical case-sensitive behavior is preserved when the flag is true: a
+// message keyed "ID" against a schema field "id" still misses and is reported
+// as a new field. This guards the backward-compatible default.
+func TestShredCaseSensitivePreservesNewFieldDetection(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	record := map[string]any{"ID": int64(42)}
+
+	shredder := NewRecordShredder(schema, true)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.NoError(t, err)
+	require.Len(t, sink.newFields, 1)
+	assert.Equal(t, "ID", sink.newFields[0].name)
+}
+
+// TestShredNewFieldStillDetectedWhenTrulyUnknown ensures the case-insensitive
+// match doesn't suppress legitimate new-field detection. A key that has no
+// case-insensitive match in the schema is still reported as a new field.
+func TestShredNewFieldStillDetectedWhenTrulyUnknown(t *testing.T) {
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	record := map[string]any{
+		"ID":    int64(1),
+		"EMAIL": "x@y.z",
+	}
+
+	shredder := NewRecordShredder(schema, false)
+	sink := &testSink{}
+	err := shredder.Shred(record, sink)
+	require.NoError(t, err)
+	require.Len(t, sink.newFields, 1)
+	assert.Equal(t, "EMAIL", sink.newFields[0].name)
 }

--- a/internal/impl/iceberg/type_inference.go
+++ b/internal/impl/iceberg/type_inference.go
@@ -17,14 +17,18 @@ import (
 )
 
 // typeInferrer holds state for inferring Iceberg types from Go values.
-// It tracks field IDs for nested structures to ensure unique IDs across the schema.
+// It tracks field IDs for nested structures to ensure unique IDs across the
+// schema. When caseSensitive is false, the inferrer rejects struct values
+// that contain two keys differing only in case so they don't materialise as
+// duplicate iceberg fields.
 type typeInferrer struct {
-	nextFieldID int
+	nextFieldID   int
+	caseSensitive bool
 }
 
 // newTypeInferrer creates a new type inferrer starting with field ID 1.
-func newTypeInferrer() *typeInferrer {
-	return &typeInferrer{nextFieldID: 1}
+func newTypeInferrer(caseSensitive bool) *typeInferrer {
+	return &typeInferrer{nextFieldID: 1, caseSensitive: caseSensitive}
 }
 
 // allocateFieldID returns the next available field ID and increments the counter.
@@ -51,8 +55,12 @@ func (ti *typeInferrer) allocateFieldID() int {
 //
 // Returns nil if the value is nil (the caller should skip this field).
 // Returns an error for unsupported types.
+//
+// This entry point uses case-sensitive struct construction. Callers that need
+// iceberg's case-insensitive convention should construct a typeInferrer
+// directly with caseSensitive=false.
 func InferIcebergType(value any) (iceberg.Type, error) {
-	ti := newTypeInferrer()
+	ti := newTypeInferrer(true)
 	return ti.inferType(value)
 }
 
@@ -157,6 +165,16 @@ func (ti *typeInferrer) inferStructType(m map[string]any) (*iceberg.StructType, 
 		return &iceberg.StructType{FieldList: []iceberg.NestedField{}}, nil
 	}
 
+	// In case-insensitive mode two keys differing only in case would each
+	// materialise as a struct field; subsequent reads or schema updates would
+	// then collide. Refuse here so the failure surfaces at the source rather
+	// than as a confusing iceberg-side error later.
+	if !ti.caseSensitive {
+		if a, b, ok := findCaseOnlyDuplicate(m); ok {
+			return nil, fmt.Errorf("ambiguous struct fields: %q and %q differ only in case", a, b)
+		}
+	}
+
 	fields := make([]iceberg.NestedField, 0, len(m))
 	for name, value := range m {
 		fieldType, err := ti.inferType(value)
@@ -180,10 +198,21 @@ func (ti *typeInferrer) inferStructType(m map[string]any) (*iceberg.StructType, 
 
 // InferIcebergTypeForAddColumn infers the type for a new column to be added via schema evolution.
 // This is similar to InferIcebergType but handles the special case where we need
-// to add a column at a specific path in the schema.
+// to add a column at a specific path in the schema. Uses case-sensitive struct
+// construction; internal callers that need the case-insensitive variant should
+// use inferIcebergTypeForAddColumn.
 func InferIcebergTypeForAddColumn(value any) (iceberg.Type, error) {
+	return inferIcebergTypeForAddColumn(value, true)
+}
+
+// inferIcebergTypeForAddColumn is the case-sensitivity-aware internal variant
+// used by the type resolver so that nested struct values with case-only
+// duplicate keys are rejected when iceberg's case-insensitive convention is
+// in effect.
+func inferIcebergTypeForAddColumn(value any, caseSensitive bool) (iceberg.Type, error) {
 	if value == nil {
 		return iceberg.StringType{}, nil // Default to string for nil
 	}
-	return InferIcebergType(value)
+	ti := newTypeInferrer(caseSensitive)
+	return ti.inferType(value)
 }

--- a/internal/impl/iceberg/type_inference_test.go
+++ b/internal/impl/iceberg/type_inference_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,5 +167,60 @@ func TestInferIcebergTypeForAddColumn(t *testing.T) {
 		typ, err := InferIcebergTypeForAddColumn(42)
 		require.NoError(t, err)
 		assert.Equal(t, "long", typ.Type())
+	})
+}
+
+// TestInferStructTypeRejectsCaseOnlyDuplicates covers the recursive fix: when
+// case-insensitive matching is enabled, a struct value containing two keys
+// that fold to the same lowercase string must be rejected at inference rather
+// than producing an iceberg struct that would later collide with itself.
+//
+// This applies to both top-level table creation and to nested struct
+// inference for new columns added via schema evolution. Without this guard,
+// a record like {"user": {"id": 1, "ID": 2}} would create a `user` struct
+// containing both `id` and `ID`, which is invalid under iceberg's
+// case-insensitive uniqueness convention.
+func TestInferStructTypeRejectsCaseOnlyDuplicates(t *testing.T) {
+	t.Run("case-insensitive flat struct rejects dup", func(t *testing.T) {
+		ti := newTypeInferrer(false)
+		_, err := ti.inferType(map[string]any{"id": 1, "ID": 2})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous struct fields")
+	})
+
+	t.Run("case-insensitive nested struct rejects dup", func(t *testing.T) {
+		ti := newTypeInferrer(false)
+		_, err := ti.inferType(map[string]any{
+			"user": map[string]any{"id": 1, "ID": 2},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous struct fields")
+	})
+
+	t.Run("case-insensitive struct in list element rejects dup", func(t *testing.T) {
+		ti := newTypeInferrer(false)
+		_, err := ti.inferType(map[string]any{
+			"items": []any{map[string]any{"sku": "x", "SKU": "y"}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous struct fields")
+	})
+
+	t.Run("case-sensitive mode admits both fields", func(t *testing.T) {
+		ti := newTypeInferrer(true)
+		typ, err := ti.inferType(map[string]any{"id": 1, "ID": 2})
+		require.NoError(t, err)
+		st, ok := typ.(*iceberg.StructType)
+		require.True(t, ok)
+		assert.Len(t, st.FieldList, 2)
+	})
+
+	t.Run("case-insensitive distinct names accepted", func(t *testing.T) {
+		ti := newTypeInferrer(false)
+		typ, err := ti.inferType(map[string]any{"id": 1, "name": "x"})
+		require.NoError(t, err)
+		st, ok := typ.(*iceberg.StructType)
+		require.True(t, ok)
+		assert.Len(t, st.FieldList, 2)
 	})
 }

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -31,13 +31,15 @@ import (
 type typeResolver struct {
 	schemaMetadataKey    string
 	newColumnTypeMapping *bloblang.Executor
+	caseSensitive        bool
 	logger               *service.Logger
 }
 
-func newTypeResolver(schemaMetadataKey string, newColumnTypeMapping *bloblang.Executor, logger *service.Logger) *typeResolver {
+func newTypeResolver(schemaMetadataKey string, newColumnTypeMapping *bloblang.Executor, caseSensitive bool, logger *service.Logger) *typeResolver {
 	return &typeResolver{
 		schemaMetadataKey:    schemaMetadataKey,
 		newColumnTypeMapping: newColumnTypeMapping,
+		caseSensitive:        caseSensitive,
 		logger:               logger,
 	}
 }
@@ -48,15 +50,18 @@ func (r *typeResolver) resolveTypeForAddColumn(
 	msg *service.Message,
 	namespace, table string,
 ) (iceberg.Type, error) {
-	// Stage 1: Default inference
-	inferredType, err := InferIcebergTypeForAddColumn(field.Value())
+	// Stage 1: Default inference. Use the resolver's case sensitivity so that
+	// new struct columns whose value carries case-only-duplicate keys are
+	// rejected at the inference step rather than producing an iceberg struct
+	// that would later collide with itself.
+	inferredType, err := inferIcebergTypeForAddColumn(field.Value(), r.caseSensitive)
 	if err != nil {
 		return nil, fmt.Errorf("inferring type for field %q: %w", field.FieldName(), err)
 	}
 
 	// Stage 2: schema_metadata override
 	if r.schemaMetadataKey != "" {
-		if metaType, err := r.resolveFromSchemaMetadata(msg, field.FullPath(), newTypeInferrer()); err != nil {
+		if metaType, err := r.resolveFromSchemaMetadata(msg, field.FullPath(), newTypeInferrer(r.caseSensitive)); err != nil {
 			return nil, fmt.Errorf("resolving type from schema metadata for field %v: %w", field.FullPath(), err)
 		} else if metaType != nil {
 			// If the metatype was not found then just stick with the default inferred type
@@ -138,7 +143,7 @@ func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath
 		return nil, fmt.Errorf("parsing schema metadata: %w", err)
 	}
 
-	field, found := findCommonField(commonSchema, fieldPath)
+	field, found := findCommonField(commonSchema, fieldPath, r.caseSensitive)
 	if !found {
 		return nil, nil
 	}
@@ -146,8 +151,11 @@ func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath
 	return commonTypeToIcebergType(field, ti)
 }
 
-// findCommonField walks a schema.Common tree to find the field at the given path.
-func findCommonField(root schema.Common, path icebergx.Path) (*schema.Common, bool) {
+// findCommonField walks a schema.Common tree to find the field at the given
+// path. When caseSensitive is false, name comparisons fold case so a metadata
+// schema authored with iceberg-canonical (typically lowercase) names still
+// matches paths derived from arbitrarily-cased input keys.
+func findCommonField(root schema.Common, path icebergx.Path, caseSensitive bool) (*schema.Common, bool) {
 	names := make([]string, 0, len(path))
 	for _, seg := range path {
 		if seg.Kind == icebergx.PathField {
@@ -156,6 +164,13 @@ func findCommonField(root schema.Common, path icebergx.Path) (*schema.Common, bo
 	}
 	if len(names) == 0 {
 		return nil, false
+	}
+
+	nameMatch := func(a, b string) bool {
+		if caseSensitive {
+			return a == b
+		}
+		return strings.EqualFold(a, b)
 	}
 
 	current := &root
@@ -170,7 +185,7 @@ func findCommonField(root schema.Common, path icebergx.Path) (*schema.Common, bo
 
 		found := false
 		for i := range children {
-			if children[i].Name == name {
+			if nameMatch(children[i].Name, name) {
 				current = &children[i]
 				found = true
 				break
@@ -226,6 +241,21 @@ func commonTypeToIcebergTypeRec(c *schema.Common, ti *typeInferrer) (iceberg.Typ
 }
 
 func commonObjectToIcebergStruct(c *schema.Common, ti *typeInferrer) (*iceberg.StructType, error) {
+	// Mirror the auto-inference path: when case-insensitive matching is in
+	// effect, refuse a metadata-supplied struct that contains two children
+	// differing only in case rather than producing an iceberg struct that
+	// would collide with itself under iceberg's case-folded uniqueness.
+	if !ti.caseSensitive {
+		seen := make(map[string]string, len(c.Children))
+		for _, child := range c.Children {
+			lower := strings.ToLower(child.Name)
+			if existing, ok := seen[lower]; ok {
+				return nil, fmt.Errorf("ambiguous struct fields in schema metadata for %q: %q and %q differ only in case", c.Name, existing, child.Name)
+			}
+			seen[lower] = child.Name
+		}
+	}
+
 	fields := make([]iceberg.NestedField, 0, len(c.Children))
 	for _, child := range c.Children {
 		childType, err := commonTypeToIcebergTypeRec(&child, ti)

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -120,7 +120,7 @@ func TestCommonTypeToIcebergType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := commonTypeToIcebergType(&tt.common, newTypeInferrer())
+			got, err := commonTypeToIcebergType(&tt.common, newTypeInferrer(true))
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -194,13 +194,81 @@ func TestFindCommonField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, found := findCommonField(root, tt.path)
+			got, found := findCommonField(root, tt.path, true)
 			assert.Equal(t, tt.want, found)
 			if found {
 				assert.Equal(t, tt.wType, got.Type)
 			}
 		})
 	}
+}
+
+// TestFindCommonFieldCaseInsensitive verifies that schema_metadata lookups
+// fold case when the resolver is configured for case-insensitive matching,
+// so a metadata schema authored with iceberg-canonical (typically lowercase)
+// names resolves types for paths derived from arbitrarily-cased input keys.
+func TestFindCommonFieldCaseInsensitive(t *testing.T) {
+	root := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "name", Type: schema.String},
+			{Name: "parent", Type: schema.Object, Children: []schema.Common{
+				{Name: "child", Type: schema.Int64},
+			}},
+		},
+	}
+
+	t.Run("uppercase path matches lowercase metadata", func(t *testing.T) {
+		got, found := findCommonField(root, icebergx.Path{
+			{Kind: icebergx.PathField, Name: "NAME"},
+		}, false)
+		require.True(t, found)
+		assert.Equal(t, schema.String, got.Type)
+	})
+
+	t.Run("mixed case nested path matches", func(t *testing.T) {
+		got, found := findCommonField(root, icebergx.Path{
+			{Kind: icebergx.PathField, Name: "Parent"},
+			{Kind: icebergx.PathField, Name: "CHILD"},
+		}, false)
+		require.True(t, found)
+		assert.Equal(t, schema.Int64, got.Type)
+	})
+
+	t.Run("case-sensitive mode preserves strict matching", func(t *testing.T) {
+		_, found := findCommonField(root, icebergx.Path{
+			{Kind: icebergx.PathField, Name: "NAME"},
+		}, true)
+		assert.False(t, found)
+	})
+}
+
+// TestCommonObjectToIcebergStructRejectsCaseOnlyDuplicates covers the
+// metadata-driven counterpart of TestInferStructTypeRejectsCaseOnlyDuplicates:
+// when a customer's schema_metadata declares two children that differ only in
+// case, the resulting iceberg struct would self-collide under iceberg's
+// case-insensitive convention. Refuse rather than silently produce a broken
+// struct.
+func TestCommonObjectToIcebergStructRejectsCaseOnlyDuplicates(t *testing.T) {
+	root := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "Foo", Type: schema.String},
+			{Name: "FOO", Type: schema.String},
+		},
+	}
+
+	t.Run("case-insensitive rejects", func(t *testing.T) {
+		_, err := commonTypeToIcebergType(&root, newTypeInferrer(false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous struct fields")
+	})
+
+	t.Run("case-sensitive admits", func(t *testing.T) {
+		got, err := commonTypeToIcebergType(&root, newTypeInferrer(true))
+		require.NoError(t, err)
+		assert.Equal(t, "struct", got.Type())
+	})
 }
 
 func TestIsPrimitiveType(t *testing.T) {
@@ -222,7 +290,7 @@ func mustParseBloblang(t *testing.T, mapping string) *bloblang.Executor {
 
 func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 	t.Run("default inference", func(t *testing.T) {
-		r := newTypeResolver("", nil, nil)
+		r := newTypeResolver("", nil, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"name": "hello"})
@@ -239,7 +307,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 	})
 
 	t.Run("schema_metadata override", func(t *testing.T) {
-		r := newTypeResolver("test_schema", nil, nil)
+		r := newTypeResolver("test_schema", nil, true, nil)
 
 		commonSchema := schema.Common{
 			Type: schema.Object,
@@ -259,7 +327,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 
 	t.Run("bloblang mapping override", func(t *testing.T) {
 		exec := mustParseBloblang(t, `root = "long"`)
-		r := newTypeResolver("", exec, nil)
+		r := newTypeResolver("", exec, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
@@ -272,7 +340,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 
 	t.Run("schema_metadata then mapping", func(t *testing.T) {
 		exec := mustParseBloblang(t, `root = "long"`)
-		r := newTypeResolver("test_schema", exec, nil)
+		r := newTypeResolver("test_schema", exec, true, nil)
 
 		commonSchema := schema.Common{
 			Type: schema.Object,
@@ -293,7 +361,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 
 	t.Run("struct type skips mapping", func(t *testing.T) {
 		exec := mustParseBloblang(t, `root = "string"`)
-		r := newTypeResolver("test_schema", exec, nil)
+		r := newTypeResolver("test_schema", exec, true, nil)
 
 		commonSchema := schema.Common{
 			Type: schema.Object,
@@ -315,7 +383,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 
 	t.Run("mapping receives inferred_type", func(t *testing.T) {
 		exec := mustParseBloblang(t, `root = if this.inferred_type == "long" { "decimal(10, 2)" } else { this.inferred_type }`)
-		r := newTypeResolver("", exec, nil)
+		r := newTypeResolver("", exec, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42, "name": "test"})
@@ -334,7 +402,7 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 	})
 
 	t.Run("schema_metadata configured but missing on message", func(t *testing.T) {
-		r := newTypeResolver("test_schema", nil, nil)
+		r := newTypeResolver("test_schema", nil, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
@@ -348,29 +416,29 @@ func TestTypeResolverResolveTypeForAddColumn(t *testing.T) {
 
 func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 	t.Run("default inference", func(t *testing.T) {
-		r := newTypeResolver("", nil, nil)
+		r := newTypeResolver("", nil, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"name": "hello"})
 
-		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", newTypeInferrer())
+		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "string", got.Type())
 	})
 
 	t.Run("nil value returns nil", func(t *testing.T) {
-		r := newTypeResolver("", nil, nil)
+		r := newTypeResolver("", nil, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{})
 
-		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", newTypeInferrer())
+		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
 
 	t.Run("schema_metadata override", func(t *testing.T) {
-		r := newTypeResolver("test_schema", nil, nil)
+		r := newTypeResolver("test_schema", nil, true, nil)
 
 		commonSchema := schema.Common{
 			Type: schema.Object,
@@ -382,37 +450,37 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg.SetStructuredMut(map[string]any{"count": 42})
 		msg.MetaSetMut("test_schema", commonSchema.ToAny())
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
 
 	t.Run("bloblang mapping override", func(t *testing.T) {
 		exec := mustParseBloblang(t, `root = "long"`)
-		r := newTypeResolver("", exec, nil)
+		r := newTypeResolver("", exec, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
 
 	t.Run("schema_metadata configured but missing on message", func(t *testing.T) {
-		r := newTypeResolver("test_schema", nil, nil)
+		r := newTypeResolver("test_schema", nil, true, nil)
 
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer())
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err, "should not error when schema_metadata is missing from message")
 		assert.Equal(t, "long", got.Type(), "should fall back to inference")
 	})
 
 	t.Run("shared allocator produces unique field IDs across nested structs", func(t *testing.T) {
-		r := newTypeResolver("", nil, nil)
-		ti := newTypeInferrer()
+		r := newTypeResolver("", nil, true, nil)
+		ti := newTypeInferrer(true)
 
 		record := map[string]any{
 			"id": int64(1),
@@ -476,8 +544,8 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 			},
 		}
 
-		r := newTypeResolver("test_schema", nil, nil)
-		ti := newTypeInferrer()
+		r := newTypeResolver("test_schema", nil, true, nil)
+		ti := newTypeInferrer(true)
 
 		record := map[string]any{
 			"source": map[string]any{

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"path"
 	"slices"
+	"strings"
 
 	"github.com/apache/iceberg-go"
 	icebergio "github.com/apache/iceberg-go/io"
@@ -29,19 +30,22 @@ import (
 
 // writer handles writing batches of messages to a single Iceberg table.
 type writer struct {
-	table     *table.Table
-	committer *committer
-	logger    *service.Logger
+	table         *table.Table
+	committer     *committer
+	caseSensitive bool
+	logger        *service.Logger
 }
 
 // NewWriter creates a new writer for a specific table.
 // The table and committer should use separate table references since they
 // operate in different goroutines and the table object is mutable.
-func NewWriter(tbl *table.Table, comm *committer, logger *service.Logger) *writer {
+// caseSensitive controls how message keys are matched against the schema.
+func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, logger *service.Logger) *writer {
 	return &writer{
-		table:     tbl,
-		committer: comm,
-		logger:    logger,
+		table:         tbl,
+		committer:     comm,
+		caseSensitive: caseSensitive,
+		logger:        logger,
 	}
 }
 
@@ -181,11 +185,11 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 	numPartitionFields := spec.NumFields()
 
 	// Create shredder for the schema
-	rs := shredder.NewRecordShredder(schema)
+	rs := shredder.NewRecordShredder(schema, w.caseSensitive)
 
 	// For unpartitioned tables, use a single writer
 	if spec.IsUnpartitioned() {
-		sink := newParquetSink(pqSchema, fieldToCol)
+		sink := newParquetSink(pqSchema, fieldToCol, w.caseSensitive)
 
 		for _, msg := range batch {
 			structured, err := msg.AsStructured()
@@ -229,7 +233,7 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 	var partitions []*partitionEntry
 
 	// Create a buffering sink to capture values and partition key
-	bufferSink := newBufferingSink(partitionSourceIDs, numPartitionFields)
+	bufferSink := newBufferingSink(partitionSourceIDs, numPartitionFields, w.caseSensitive)
 
 	for _, msg := range batch {
 		structured, err := msg.AsStructured()
@@ -264,7 +268,7 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 		} else {
 			entry = &partitionEntry{
 				key:  partitionKey,
-				sink: newParquetSink(pqSchema, fieldToCol),
+				sink: newParquetSink(pqSchema, fieldToCol, w.caseSensitive),
 			}
 			// Insert at sorted position
 			partitions = slices.Insert(partitions, idx, entry)
@@ -308,17 +312,18 @@ type parquetColumn struct {
 
 // parquetSink implements shredder.Sink and writes values directly to column writers.
 type parquetSink struct {
-	buffer   *bytes.Buffer
-	writer   *parquet.GenericWriter[any]
-	columns  map[int]*parquetColumn // field ID -> column state
-	rowCount int
+	buffer        *bytes.Buffer
+	writer        *parquet.GenericWriter[any]
+	columns       map[int]*parquetColumn // field ID -> column state
+	rowCount      int
+	caseSensitive bool
 
 	// newFields collects unknown fields discovered during shredding for schema evolution.
 	newFields  []*UnknownFieldError
 	seenFields map[string]struct{} // dedup by full path
 }
 
-func newParquetSink(pqSchema *parquet.Schema, fieldToCol map[int]int) *parquetSink {
+func newParquetSink(pqSchema *parquet.Schema, fieldToCol map[int]int, caseSensitive bool) *parquetSink {
 	buf := bytes.NewBuffer(nil)
 	pw := parquet.NewGenericWriter[any](buf, pqSchema)
 	colWriters := pw.ColumnWriters()
@@ -332,10 +337,11 @@ func newParquetSink(pqSchema *parquet.Schema, fieldToCol map[int]int) *parquetSi
 		}
 	}
 	return &parquetSink{
-		buffer:    buf,
-		writer:    pw,
-		columns:   columns,
-		newFields: nil, // allocated lazily
+		buffer:        buf,
+		writer:        pw,
+		columns:       columns,
+		caseSensitive: caseSensitive,
+		newFields:     nil, // allocated lazily
 	}
 }
 
@@ -354,7 +360,7 @@ func (s *parquetSink) EmitValue(sv shredder.ShreddedValue) error {
 
 func (s *parquetSink) OnNewField(parentPath icebergx.Path, name string, value any) {
 	fe := NewUnknownFieldError(parentPath, name, value)
-	key := fe.FullPath().String()
+	key := dedupKey(fe.FullPath().String(), s.caseSensitive)
 	if _, ok := s.seenFields[key]; ok {
 		return
 	}
@@ -399,17 +405,19 @@ type bufferingSink struct {
 	values             []shredder.ShreddedValue // buffered values in emission order
 	partitionSourceIDs map[int]int              // sourceFieldID -> partition field index
 	partitionValues    []parquet.Value          // captured partition values
+	caseSensitive      bool
 
 	// newFields collects unknown fields discovered during shredding for schema evolution.
 	newFields  []*UnknownFieldError
 	seenFields map[string]struct{} // dedup by full path
 }
 
-func newBufferingSink(partitionSourceIDs map[int]int, numPartitionFields int) *bufferingSink {
+func newBufferingSink(partitionSourceIDs map[int]int, numPartitionFields int, caseSensitive bool) *bufferingSink {
 	return &bufferingSink{
 		values:             make([]shredder.ShreddedValue, 0, 64),
 		partitionSourceIDs: partitionSourceIDs,
 		partitionValues:    make([]parquet.Value, numPartitionFields),
+		caseSensitive:      caseSensitive,
 		newFields:          nil, // allocated lazily
 	}
 }
@@ -436,7 +444,7 @@ func (s *bufferingSink) EmitValue(sv shredder.ShreddedValue) error {
 
 func (s *bufferingSink) OnNewField(parentPath icebergx.Path, name string, value any) {
 	fe := NewUnknownFieldError(parentPath, name, value)
-	key := fe.FullPath().String()
+	key := dedupKey(fe.FullPath().String(), s.caseSensitive)
 	if _, ok := s.seenFields[key]; ok {
 		return
 	}
@@ -445,6 +453,17 @@ func (s *bufferingSink) OnNewField(parentPath icebergx.Path, name string, value 
 	}
 	s.seenFields[key] = struct{}{}
 	s.newFields = append(s.newFields, fe)
+}
+
+// dedupKey returns the key used to dedup new-field errors across messages in
+// a batch. In case-insensitive mode it folds to lowercase so two messages
+// reporting new fields differing only in case (e.g. "FOO" and "foo") collapse
+// to a single schema-evolution attempt instead of racing each other.
+func dedupKey(path string, caseSensitive bool) string {
+	if caseSensitive {
+		return path
+	}
+	return strings.ToLower(path)
 }
 
 // newFieldErrors returns the collected new field errors.

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -359,6 +359,9 @@ func (s *parquetSink) EmitValue(sv shredder.ShreddedValue) error {
 }
 
 func (s *parquetSink) OnNewField(parentPath icebergx.Path, name string, value any) {
+	if !s.caseSensitive {
+		name = strings.ToLower(name)
+	}
 	fe := NewUnknownFieldError(parentPath, name, value)
 	key := dedupKey(fe.FullPath().String(), s.caseSensitive)
 	if _, ok := s.seenFields[key]; ok {
@@ -443,6 +446,9 @@ func (s *bufferingSink) EmitValue(sv shredder.ShreddedValue) error {
 }
 
 func (s *bufferingSink) OnNewField(parentPath icebergx.Path, name string, value any) {
+	if !s.caseSensitive {
+		name = strings.ToLower(name)
+	}
 	fe := NewUnknownFieldError(parentPath, name, value)
 	key := dedupKey(fe.FullPath().String(), s.caseSensitive)
 	if _, ok := s.seenFields[key]; ok {

--- a/internal/impl/iceberg/writer_test.go
+++ b/internal/impl/iceberg/writer_test.go
@@ -55,6 +55,40 @@ func TestBufferingSinkNewFieldDedup(t *testing.T) {
 	})
 }
 
+// TestSchemaEvolutionColumnNameNormalization verifies that when
+// case_sensitive_columns=false, new column names are normalised to lowercase
+// before being stored in the UnknownFieldError that drives AddColumn. Without
+// this, a message keyed "EMAIL" would add an uppercase column to an otherwise
+// lowercase schema, violating iceberg's recommended convention.
+func TestSchemaEvolutionColumnNameNormalization(t *testing.T) {
+	t.Run("buffering sink normalises to lowercase", func(t *testing.T) {
+		sink := newBufferingSink(nil, 0, false)
+		sink.OnNewField(icebergx.Path{}, "EMAIL", "a@x.z")
+
+		errs := sink.newFieldErrors()
+		require.Len(t, errs, 1)
+		assert.Equal(t, "email", errs[0].FieldName())
+	})
+
+	t.Run("parquet sink normalises to lowercase", func(t *testing.T) {
+		sink := &parquetSink{caseSensitive: false}
+		sink.OnNewField(icebergx.Path{}, "EMAIL", "a@x.z")
+
+		errs := sink.newFieldErrors()
+		require.Len(t, errs, 1)
+		assert.Equal(t, "email", errs[0].FieldName())
+	})
+
+	t.Run("case-sensitive mode preserves original capitalisation", func(t *testing.T) {
+		sink := newBufferingSink(nil, 0, true)
+		sink.OnNewField(icebergx.Path{}, "EMAIL", "a@x.z")
+
+		errs := sink.newFieldErrors()
+		require.Len(t, errs, 1)
+		assert.Equal(t, "EMAIL", errs[0].FieldName())
+	})
+}
+
 // TestParquetSinkNewFieldDedup mirrors TestBufferingSinkNewFieldDedup for the
 // non-buffering parquet sink, which is used for unpartitioned writes.
 func TestParquetSinkNewFieldDedup(t *testing.T) {

--- a/internal/impl/iceberg/writer_test.go
+++ b/internal/impl/iceberg/writer_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/icebergx"
+)
+
+// TestBufferingSinkNewFieldDedup verifies the case-aware dedup behaviour of
+// the buffering sink. Without folding, two messages reporting new fields that
+// differ only in case (e.g. "FOO" and "foo") would each yield a separate
+// UnknownFieldError; the router would then ask iceberg-go to add both, and
+// case-insensitive UpdateSchema would reject the second. Folding the dedup
+// key collapses them to a single schema-evolution attempt.
+func TestBufferingSinkNewFieldDedup(t *testing.T) {
+	t.Run("case-insensitive dedup folds case-only duplicates", func(t *testing.T) {
+		sink := newBufferingSink(nil, 0, false)
+		sink.OnNewField(icebergx.Path{}, "FOO", "x")
+		sink.OnNewField(icebergx.Path{}, "foo", "y")
+
+		errs := sink.newFieldErrors()
+		require.Len(t, errs, 1)
+		// Whichever arrived first wins; we only assert one survived.
+		assert.Contains(t, []string{"FOO", "foo"}, errs[0].FieldName())
+	})
+
+	t.Run("case-sensitive dedup keeps both", func(t *testing.T) {
+		sink := newBufferingSink(nil, 0, true)
+		sink.OnNewField(icebergx.Path{}, "FOO", "x")
+		sink.OnNewField(icebergx.Path{}, "foo", "y")
+
+		errs := sink.newFieldErrors()
+		assert.Len(t, errs, 2)
+	})
+
+	t.Run("case-insensitive dedup is path-aware", func(t *testing.T) {
+		// Same name at different parents must not collapse.
+		sink := newBufferingSink(nil, 0, false)
+		sink.OnNewField(icebergx.Path{{Kind: icebergx.PathField, Name: "user"}}, "FOO", "x")
+		sink.OnNewField(icebergx.Path{{Kind: icebergx.PathField, Name: "order"}}, "foo", "y")
+
+		errs := sink.newFieldErrors()
+		assert.Len(t, errs, 2)
+	})
+}
+
+// TestParquetSinkNewFieldDedup mirrors TestBufferingSinkNewFieldDedup for the
+// non-buffering parquet sink, which is used for unpartitioned writes.
+func TestParquetSinkNewFieldDedup(t *testing.T) {
+	t.Run("case-insensitive dedup folds case-only duplicates", func(t *testing.T) {
+		// The buffer/writer state is unused by OnNewField, so a zero-value
+		// sink with the caseSensitive flag set is sufficient for this test.
+		sink := &parquetSink{caseSensitive: false}
+		sink.OnNewField(icebergx.Path{}, "FOO", "x")
+		sink.OnNewField(icebergx.Path{}, "foo", "y")
+
+		require.Len(t, sink.newFieldErrors(), 1)
+	})
+
+	t.Run("case-sensitive dedup keeps both", func(t *testing.T) {
+		sink := &parquetSink{caseSensitive: true}
+		sink.OnNewField(icebergx.Path{}, "FOO", "x")
+		sink.OnNewField(icebergx.Path{}, "foo", "y")
+
+		assert.Len(t, sink.newFieldErrors(), 2)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds a top-level `case_sensitive_columns` boolean to the `iceberg` output (default `true`, preserving released behaviour). When set to `false`, column-name matching follows iceberg's recommended case-insensitive convention end-to-end.
- The flag is plumbed through every site that compares iceberg field names: shredder lookup, `schema_metadata` traversal, partition spec column references, struct inference (auto-inferred and metadata-driven), top-level table-creation duplicate detection, sink dedup keys for cross-message new fields, and the `caseSensitive` argument to iceberg-go's `UpdateSchema`. Ambiguous case-only duplicates in input records are rejected at shredding and creation.
- Resolves a customer-reported issue where messages with upper-case keys against a table with lower-case columns triggered spurious schema evolution rather than routing into the existing columns.

## Test plan

- [x] `task fmt`
- [x] `task lint` (0 issues)
- [x] `task test:unit`
- [x] New unit tests across the shredder, type inferrer/resolver, partition-spec parser, router, and writer sinks — covering both the case-insensitive path and the case-sensitive default
- [x] Integration tests (`internal/impl/iceberg/integration`):
  - [x] `CaseInsensitiveColumnMatching` — pre-created lowercase table, uppercase-keyed messages, no schema evolution, data lands in the right columns
  - [x] `CaseInsensitiveCreateTimeDuplicate` — record with `id` and `ID` rejected at create time
  - [x] `CaseInsensitiveNewFieldDedupAcrossBatch` — two messages with case-only-different new fields produce exactly one new column
  - [x] `CaseInsensitivePartitionSpecCreate` — partition spec with uppercase column reference resolves against schema inferred with lowercase keys