### PR TITLE
aws_s3: Don't set ACL by default since ACLs are disabled by default in S3

### DIFF
--- a/docs/modules/components/pages/outputs/aws_s3.adoc
+++ b/docs/modules/components/pages/outputs/aws_s3.adoc
@@ -81,7 +81,7 @@ output:
     force_path_style_urls: false
     max_in_flight: 64
     timeout: 5s
-    object_canned_acl: private
+    object_canned_acl: ""
     batching:
       count: 0
       byte_size: 0
@@ -387,7 +387,7 @@ The object canned ACL value.
 
 *Type*: `string`
 
-*Default*: `"private"`
+*Default*: `""`
 
 Options:
 `private`

--- a/internal/impl/aws/s3/output.go
+++ b/internal/impl/aws/s3/output.go
@@ -313,7 +313,7 @@ output:
 					}
 				})...).
 				Description("The object canned ACL value.").
-				Default(string(types.ObjectCannedACLPrivate)).
+				Default("").
 				Advanced(),
 			service.NewBatchPolicyField(s3oFieldBatching),
 		).
@@ -473,7 +473,6 @@ func (a *amazonS3Writer) WriteBatch(wctx context.Context, msg service.MessageBat
 			WebsiteRedirectLocation: websiteRedirectLocation,
 			StorageClass:            tmtypes.StorageClass(storageClass),
 			Metadata:                metadata,
-			ACL:                     tmtypes.ObjectCannedACL(a.conf.ObjectCannedACL),
 		}
 
 		// Prepare tags, escaping keys and values to ensure they're valid query string parameters.
@@ -496,6 +495,10 @@ func (a *amazonS3Writer) WriteBatch(wctx context.Context, msg service.MessageBat
 
 		if a.conf.ChecksumAlgorithm != "" {
 			uploadInput.ChecksumAlgorithm = tmtypes.ChecksumAlgorithm(a.conf.ChecksumAlgorithm)
+		}
+
+		if a.conf.ObjectCannedACL != "" {
+			uploadInput.ACL = tmtypes.ObjectCannedACL(a.conf.ObjectCannedACL)
 		}
 
 		// NOTE: This overrides the ServerSideEncryption set above. We need this to preserve


### PR DESCRIPTION
Setting an ACL throws an error when uploading to a bucket with ACLs disabled (default since 2023) when the bucket is in another account. The former default 'private' is accepted by buckets in the same account but is a no-op.

This change should not affect cases where users are writing to a bucket with ACLs enabled, since the default ACL applied by AWS is 'private', which matches the expected behavior when `object_canned_acl` is not specified. If a user is writing to a bucket with ACLs enabled and is specifying a different canned ACL, that will continue to work with this change.

Fixes #4371 