### PR TITLE
iceberg: fix schema column ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - iceberg: fix decimal min/max stats extraction for parquet files ([@josephwoodward](https://github.com/josephwoodward), [#4368](https://github.com/redpanda-data/connect/pull/4368))
+- iceberg: Preserve schema-registry column order when auto-creating tables. Build-time ordering now follows `schema_metadata` when present and falls back to sorted record keys otherwise, replacing Go's randomised map iteration. In case-insensitive mode, top-level column names use the metadata's casing — record keys are matched by case-folding and the metadata's name lands in the table, mirroring how nested struct fields supplied via metadata are named. ([@josephwoodward](https://github.com/josephwoodward), [#4373](https://github.com/redpanda-data/connect/pull/4373))
 
 ### Added
 

--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -875,7 +875,7 @@ table_location: s3://my-iceberg-bucket/
 
 === `schema_evolution.schema_metadata`
 
-The name of a message metadata field containing a schema definition. When set, the schema is used to determine column types during schema evolution and table creation instead of inferring types from values. The schema must be in the standard common schema format (the same format used by the `parquet_encode` processor's `schema_metadata` field). For batches of messages, the first message's schema is used.
+The name of a message metadata field containing a schema definition. When set, the schema is used to determine column types during schema evolution and table creation instead of inferring types from values. The schema must be in the standard common schema format (the same format used by the `parquet_encode` processor's `schema_metadata` field). For batches of messages, the first message's schema is used. Record presence drives schema shape: fields declared in the schema metadata that are absent from the record are not added to the table, while the metadata controls column ordering, naming, and types for fields that are present. In case-insensitive mode, top-level column names use the metadata's casing — record keys are matched by case-folding and the metadata's name is what lands in the table.
 
 
 *Type*: `string`

--- a/internal/impl/iceberg/config.go
+++ b/internal/impl/iceberg/config.go
@@ -320,7 +320,7 @@ array:list
 					Example("s3://my-iceberg-bucket/").
 					Optional(),
 				service.NewStringField(ioFieldSchemaEvolutionSchemaMetadata).
-					Description("The name of a message metadata field containing a schema definition. When set, the schema is used to determine column types during schema evolution and table creation instead of inferring types from values. The schema must be in the standard common schema format (the same format used by the `parquet_encode` processor's `schema_metadata` field). For batches of messages, the first message's schema is used.").
+					Description("The name of a message metadata field containing a schema definition. When set, the schema is used to determine column types during schema evolution and table creation instead of inferring types from values. The schema must be in the standard common schema format (the same format used by the `parquet_encode` processor's `schema_metadata` field). For batches of messages, the first message's schema is used. Record presence drives schema shape: fields declared in the schema metadata that are absent from the record are not added to the table, while the metadata controls column ordering, naming, and types for fields that are present. In case-insensitive mode, top-level column names use the metadata's casing — record keys are matched by case-folding and the metadata's name is what lands in the table.").
 					Default("").
 					Optional().
 					Advanced(),

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 
@@ -388,7 +390,15 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	ti := newTypeInferrer(r.caseSensitive)
 	fields := make([]iceberg.NestedField, 0, len(record))
 
-	for name, value := range record {
+	orderedNames := r.resolver.topLevelFieldOrder(msg)
+	if orderedNames == nil {
+		orderedNames = slices.Sorted(maps.Keys(record))
+	}
+	for _, name := range orderedNames {
+		value, exists := record[name]
+		if !exists {
+			continue
+		}
 		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, key.namespace, key.table, ti)
 		if err != nil {
 			return nil, fmt.Errorf("resolving type for field %q: %w", name, err)

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -390,16 +390,45 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	ti := newTypeInferrer(r.caseSensitive)
 	fields := make([]iceberg.NestedField, 0, len(record))
 
-	orderedNames := r.resolver.topLevelFieldOrder(msg)
-	if orderedNames == nil {
-		orderedNames = slices.Sorted(maps.Keys(record))
+	// Parse the schema metadata once; it's used for both column ordering and
+	// per-field type resolution.
+	common, err := r.resolver.parseSchemaMetadata(msg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing schema metadata: %w", err)
 	}
-	for _, name := range orderedNames {
-		value, exists := record[name]
-		if !exists {
+
+	// Build the final column ordering. Metadata-declared fields come first in
+	// the order they appear there, with case-folded matching against record
+	// keys when caseSensitive is false. Any record keys not declared in the
+	// metadata are appended in sorted order so create-table is deterministic
+	// and never silently drops record fields.
+	orderedMetaNames, err := r.resolver.topLevelFieldOrder(common)
+	if err != nil {
+		return nil, err
+	}
+	used := make(map[string]struct{}, len(record))
+	finalOrder := make([]string, 0, len(record))
+	for _, metaName := range orderedMetaNames {
+		recordKey, ok := matchRecordKey(record, metaName, r.caseSensitive)
+		if !ok {
 			continue
 		}
-		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, key.namespace, key.table, ti)
+		if _, seen := used[recordKey]; seen {
+			continue
+		}
+		finalOrder = append(finalOrder, recordKey)
+		used[recordKey] = struct{}{}
+	}
+	for _, k := range slices.Sorted(maps.Keys(record)) {
+		if _, seen := used[k]; seen {
+			continue
+		}
+		finalOrder = append(finalOrder, k)
+	}
+
+	for _, name := range finalOrder {
+		value := record[name]
+		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, common, key.namespace, key.table, ti)
 		if err != nil {
 			return nil, fmt.Errorf("resolving type for field %q: %w", name, err)
 		}
@@ -415,6 +444,25 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	}
 
 	return iceberg.NewSchema(0, fields...), nil
+}
+
+// matchRecordKey returns the actual key from record matching name, preserving
+// the record's casing. When caseSensitive is false, falls back to a case-folded
+// scan so schema-registry metadata authored with iceberg-canonical (typically
+// lowercase) names still matches arbitrarily-cased record keys.
+func matchRecordKey(record map[string]any, name string, caseSensitive bool) (string, bool) {
+	if _, ok := record[name]; ok {
+		return name, true
+	}
+	if caseSensitive {
+		return "", false
+	}
+	for k := range record {
+		if strings.EqualFold(k, name) {
+			return k, true
+		}
+	}
+	return "", false
 }
 
 // findCaseOnlyDuplicate returns the first pair of map keys that fold to the

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -402,12 +402,17 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 	// keys when caseSensitive is false. Any record keys not declared in the
 	// metadata are appended in sorted order so create-table is deterministic
 	// and never silently drops record fields.
+	//
+	// When a record key matches a metadata field, the metadata's casing is
+	// what lands in the iceberg column — the record key is only used to look
+	// up the value. This keeps top-level naming consistent with how nested
+	// struct fields supplied via metadata are named.
 	orderedMetaNames, err := r.resolver.topLevelFieldOrder(common)
 	if err != nil {
 		return nil, err
 	}
 	used := make(map[string]struct{}, len(record))
-	finalOrder := make([]string, 0, len(record))
+	finalOrder := make([]orderedField, 0, len(record))
 	for _, metaName := range orderedMetaNames {
 		recordKey, ok := matchRecordKey(record, metaName, r.caseSensitive)
 		if !ok {
@@ -416,34 +421,44 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 		if _, seen := used[recordKey]; seen {
 			continue
 		}
-		finalOrder = append(finalOrder, recordKey)
+		finalOrder = append(finalOrder, orderedField{recordKey: recordKey, emitName: metaName})
 		used[recordKey] = struct{}{}
 	}
 	for _, k := range slices.Sorted(maps.Keys(record)) {
 		if _, seen := used[k]; seen {
 			continue
 		}
-		finalOrder = append(finalOrder, k)
+		finalOrder = append(finalOrder, orderedField{recordKey: k, emitName: k})
 	}
 
-	for _, name := range finalOrder {
-		value := record[name]
-		fieldType, err := r.resolver.resolveTypeForCreateTable(name, value, msg, common, key.namespace, key.table, ti)
+	for _, f := range finalOrder {
+		value := record[f.recordKey]
+		fieldType, err := r.resolver.resolveTypeForCreateTable(f.emitName, value, msg, common, key.namespace, key.table, ti)
 		if err != nil {
-			return nil, fmt.Errorf("resolving type for field %q: %w", name, err)
+			return nil, fmt.Errorf("resolving type for field %q: %w", f.emitName, err)
 		}
 		if fieldType == nil {
 			continue // nil value, skip
 		}
 		fields = append(fields, iceberg.NestedField{
 			ID:       ti.allocateFieldID(), // For primitives this is the only allocation; for nested structs, inner IDs were already assigned by ti
-			Name:     name,
+			Name:     f.emitName,
 			Type:     fieldType,
 			Required: false,
 		})
 	}
 
 	return iceberg.NewSchema(0, fields...), nil
+}
+
+// orderedField pairs the key used to look up a value in the record with the
+// name that should land on the iceberg column. They differ in case-insensitive
+// mode when a metadata field matches a record key with different casing — the
+// metadata casing wins for the column, the record casing is needed to find the
+// value.
+type orderedField struct {
+	recordKey string
+	emitName  string
 }
 
 // matchRecordKey returns the actual key from record matching name, preserving

--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -12,7 +12,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/redpanda-data/benthos/v4/public/schema"
+	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestFindCaseOnlyDuplicate covers the create-time guard that prevents an
@@ -46,4 +49,43 @@ func TestFindCaseOnlyDuplicate(t *testing.T) {
 		_, _, ok := findCaseOnlyDuplicate(map[string]any{})
 		assert.False(t, ok)
 	})
+}
+
+// TestBuildSchemaWithResolverPreservesColumnOrder verifies that columns in the
+// resulting Iceberg schema appear in the order defined by the schema registry
+// metadata, not in Go map iteration order.
+func TestBuildSchemaWithResolverPreservesColumnOrder(t *testing.T) {
+	router := &Router{
+		caseSensitive: true,
+		resolver:      newTypeResolver("schema_key", nil, true, nil),
+	}
+
+	// Build a schema.Common with fields in a specific order that differs from
+	// alphabetical to make the test deterministic and meaningful.
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "zebra", Type: schema.String},
+			{Name: "alpha", Type: schema.String},
+			{Name: "mango", Type: schema.String},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"zebra": "z-value",
+		"alpha": "a-value",
+		"mango": "m-value",
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 3)
+	assert.Equal(t, "zebra", fields[0].Name)
+	assert.Equal(t, "alpha", fields[1].Name)
+	assert.Equal(t, "mango", fields[2].Name)
 }

--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redpanda-data/benthos/v4/public/schema"
-	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 // TestFindCaseOnlyDuplicate covers the create-time guard that prevents an
@@ -88,4 +89,155 @@ func TestBuildSchemaWithResolverPreservesColumnOrder(t *testing.T) {
 	assert.Equal(t, "zebra", fields[0].Name)
 	assert.Equal(t, "alpha", fields[1].Name)
 	assert.Equal(t, "mango", fields[2].Name)
+}
+
+// TestBuildSchemaWithResolverAppendsRecordOnlyFields verifies that record fields
+// not declared in the schema metadata are still included in the iceberg schema.
+// Without this, an enriched record with extra keys would silently lose columns
+// the moment metadata-driven ordering kicks in.
+func TestBuildSchemaWithResolverAppendsRecordOnlyFields(t *testing.T) {
+	router := &Router{
+		caseSensitive: true,
+		resolver:      newTypeResolver("schema_key", nil, true, nil),
+	}
+
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "zebra", Type: schema.String},
+			{Name: "alpha", Type: schema.String},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"zebra":  "z",
+		"alpha":  "a",
+		"extra2": "e2",
+		"extra1": "e1",
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 4)
+	// Metadata order first.
+	assert.Equal(t, "zebra", fields[0].Name)
+	assert.Equal(t, "alpha", fields[1].Name)
+	// Record-only keys appended in sorted order for determinism.
+	assert.Equal(t, "extra1", fields[2].Name)
+	assert.Equal(t, "extra2", fields[3].Name)
+}
+
+// TestBuildSchemaWithResolverCaseInsensitiveOrdering verifies that when
+// caseSensitive is false, schema metadata field names match record keys with
+// case folding, and the iceberg column name preserves the record's original
+// casing. Without case-folded matching, lowercase canonical metadata against
+// mixed-case record keys would drop every column.
+func TestBuildSchemaWithResolverCaseInsensitiveOrdering(t *testing.T) {
+	router := &Router{
+		caseSensitive: false,
+		resolver:      newTypeResolver("schema_key", nil, false, nil),
+	}
+
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "zebra", Type: schema.String},
+			{Name: "alpha", Type: schema.String},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"Zebra": "z",
+		"ALPHA": "a",
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 2)
+	assert.Equal(t, "Zebra", fields[0].Name)
+	assert.Equal(t, "ALPHA", fields[1].Name)
+}
+
+// TestBuildSchemaWithResolverCaseInsensitiveWithRecordOnlyFields combines
+// case-insensitive metadata-driven ordering with record-only leftover fields
+// to exercise the full merge path: lowercase canonical metadata, mixed-case
+// record keys, plus extras absent from metadata that should appear sorted at
+// the end with their original casing preserved.
+func TestBuildSchemaWithResolverCaseInsensitiveWithRecordOnlyFields(t *testing.T) {
+	router := &Router{
+		caseSensitive: false,
+		resolver:      newTypeResolver("schema_key", nil, false, nil),
+	}
+
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "alpha", Type: schema.String},
+			{Name: "beta", Type: schema.String},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"Alpha": "a", // case-folded match for metadata "alpha"
+		"BETA":  "b", // case-folded match for metadata "beta"
+		"gamma": "g", // record-only
+		"Delta": "d", // record-only
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 4)
+	// Metadata-ordered first, with the record's original casing preserved.
+	assert.Equal(t, "Alpha", fields[0].Name)
+	assert.Equal(t, "BETA", fields[1].Name)
+	// Record-only keys appended in bytewise sorted order ("Delta" precedes
+	// "gamma" because uppercase 'D' < lowercase 'g').
+	assert.Equal(t, "Delta", fields[2].Name)
+	assert.Equal(t, "gamma", fields[3].Name)
+}
+
+// TestBuildSchemaWithResolverRejectsCaseOnlyDuplicateMetadata verifies that
+// metadata declaring two top-level children differing only in case is rejected
+// at create time when case-insensitive matching is in effect, mirroring the
+// same guard applied to nested struct metadata. Without this, the override
+// path would silently dedupe and admit one child arbitrarily.
+func TestBuildSchemaWithResolverRejectsCaseOnlyDuplicateMetadata(t *testing.T) {
+	router := &Router{
+		caseSensitive: false,
+		resolver:      newTypeResolver("schema_key", nil, false, nil),
+	}
+
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "alpha", Type: schema.String},
+			{Name: "ALPHA", Type: schema.String},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"alpha": "a",
+	}
+
+	_, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "differ only in case")
 }

--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -134,9 +135,9 @@ func TestBuildSchemaWithResolverAppendsRecordOnlyFields(t *testing.T) {
 
 // TestBuildSchemaWithResolverCaseInsensitiveOrdering verifies that when
 // caseSensitive is false, schema metadata field names match record keys with
-// case folding, and the iceberg column name preserves the record's original
-// casing. Without case-folded matching, lowercase canonical metadata against
-// mixed-case record keys would drop every column.
+// case folding, and the metadata's casing is what lands in the iceberg column.
+// This keeps top-level naming consistent with how nested struct fields supplied
+// via metadata are named — metadata is the source of truth for column names.
 func TestBuildSchemaWithResolverCaseInsensitiveOrdering(t *testing.T) {
 	router := &Router{
 		caseSensitive: false,
@@ -164,15 +165,15 @@ func TestBuildSchemaWithResolverCaseInsensitiveOrdering(t *testing.T) {
 
 	fields := icebergSchema.Fields()
 	require.Len(t, fields, 2)
-	assert.Equal(t, "Zebra", fields[0].Name)
-	assert.Equal(t, "ALPHA", fields[1].Name)
+	assert.Equal(t, "zebra", fields[0].Name)
+	assert.Equal(t, "alpha", fields[1].Name)
 }
 
 // TestBuildSchemaWithResolverCaseInsensitiveWithRecordOnlyFields combines
 // case-insensitive metadata-driven ordering with record-only leftover fields
 // to exercise the full merge path: lowercase canonical metadata, mixed-case
-// record keys, plus extras absent from metadata that should appear sorted at
-// the end with their original casing preserved.
+// record keys, plus extras absent from metadata. Metadata-matched fields land
+// in the table with the metadata's casing; record-only fields keep their own.
 func TestBuildSchemaWithResolverCaseInsensitiveWithRecordOnlyFields(t *testing.T) {
 	router := &Router{
 		caseSensitive: false,
@@ -202,9 +203,9 @@ func TestBuildSchemaWithResolverCaseInsensitiveWithRecordOnlyFields(t *testing.T
 
 	fields := icebergSchema.Fields()
 	require.Len(t, fields, 4)
-	// Metadata-ordered first, with the record's original casing preserved.
-	assert.Equal(t, "Alpha", fields[0].Name)
-	assert.Equal(t, "BETA", fields[1].Name)
+	// Metadata-ordered first, named in the metadata's casing.
+	assert.Equal(t, "alpha", fields[0].Name)
+	assert.Equal(t, "beta", fields[1].Name)
 	// Record-only keys appended in bytewise sorted order ("Delta" precedes
 	// "gamma" because uppercase 'D' < lowercase 'g').
 	assert.Equal(t, "Delta", fields[2].Name)
@@ -240,4 +241,87 @@ func TestBuildSchemaWithResolverRejectsCaseOnlyDuplicateMetadata(t *testing.T) {
 	_, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "differ only in case")
+}
+
+// TestBuildSchemaWithResolverTypeOverrideAcrossCaseMismatch verifies that a
+// metadata-supplied type override still flows through when the metadata's
+// field name differs in casing from the record's key. Without this, the
+// metadata path lookup could silently miss and quietly fall back to type
+// inference — and tests that use String-on-String would never notice because
+// inference and metadata would agree.
+func TestBuildSchemaWithResolverTypeOverrideAcrossCaseMismatch(t *testing.T) {
+	router := &Router{
+		caseSensitive: false,
+		resolver:      newTypeResolver("schema_key", nil, false, nil),
+	}
+
+	// Metadata declares Customer_ID as int32. The record carries customer_id
+	// as a Go int, which would otherwise be inferred as int64. If the override
+	// reaches the resolver, the column should be int32.
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "Customer_ID", Type: schema.Int32},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"customer_id": 42,
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 1)
+	assert.Equal(t, "Customer_ID", fields[0].Name, "metadata casing should win")
+	assert.Equal(t, "int", fields[0].Type.Type(), "metadata-supplied int32 type should be applied, not inferred int64")
+}
+
+// TestBuildSchemaWithResolverNewColumnTypeMappingSeesMetadataCasing verifies
+// that when the bloblang new_column_type_mapping runs against a column where
+// the metadata's casing differs from the record's key, the mapping receives
+// the metadata's casing as `name` and `path`. This pins down the user-visible
+// behaviour of the metadata-wins-everywhere rule for the Bloblang surface.
+func TestBuildSchemaWithResolverNewColumnTypeMappingSeesMetadataCasing(t *testing.T) {
+	// The mapping returns "long" only when invoked with the metadata casing.
+	// Any other observed name produces "string", which would surface as a
+	// type mismatch in the assertion below.
+	exec, err := bloblang.Parse(`root = if this.name == "Customer_ID" && this.path == "Customer_ID" { "long" } else { "string" }`)
+	require.NoError(t, err)
+
+	router := &Router{
+		caseSensitive: false,
+		resolver:      newTypeResolver("schema_key", exec, false, nil),
+	}
+
+	// Metadata is intentionally omitted for this column so type inference
+	// reaches Stage 3 (the bloblang mapping). The metadata still carries the
+	// canonical name so the casing-rename path is exercised.
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "Customer_ID", Type: schema.String}, // metadata says String, mapping overrides to long
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.SetStructuredMut(map[string]any{"customer_id": "anything"})
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"customer_id": "anything",
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 1)
+	assert.Equal(t, "Customer_ID", fields[0].Name)
+	assert.Equal(t, "long", fields[0].Type.Type(),
+		"mapping returns long only when name+path match metadata casing; any other casing means the rename path is broken")
 }

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -398,3 +398,27 @@ func parseIcebergTypeString(s string) (iceberg.Type, error) {
 
 	return nil, fmt.Errorf("unrecognized iceberg type: %q", s)
 }
+
+// topLevelFieldOrder returns the top-level field names from the schema metadata
+// in the order they appear there, or nil if no schema metadata is present.
+func (r *typeResolver) topLevelFieldOrder(msg *service.Message) []string {
+	if r.schemaMetadataKey == "" {
+		return nil
+	}
+	raw, exists := msg.MetaGetMut(r.schemaMetadataKey)
+	if !exists {
+		return nil
+	}
+	c, err := schema.ParseFromAny(raw)
+	if err != nil {
+		return nil
+	}
+	if c.Type != schema.Object {
+		return nil
+	}
+	names := make([]string, 0, len(c.Children))
+	for _, child := range c.Children {
+		names = append(names, child.Name)
+	}
+	return names
+}

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -60,13 +60,15 @@ func (r *typeResolver) resolveTypeForAddColumn(
 	}
 
 	// Stage 2: schema_metadata override
-	if r.schemaMetadataKey != "" {
-		if metaType, err := r.resolveFromSchemaMetadata(msg, field.FullPath(), newTypeInferrer(r.caseSensitive)); err != nil {
-			return nil, fmt.Errorf("resolving type from schema metadata for field %v: %w", field.FullPath(), err)
-		} else if metaType != nil {
-			// If the metatype was not found then just stick with the default inferred type
-			inferredType = metaType
-		}
+	common, err := r.parseSchemaMetadata(msg)
+	if err != nil {
+		return nil, fmt.Errorf("resolving type from schema metadata for field %v: %w", field.FullPath(), err)
+	}
+	if metaType, err := r.resolveFromCommon(common, field.FullPath(), newTypeInferrer(r.caseSensitive)); err != nil {
+		return nil, fmt.Errorf("resolving type from schema metadata for field %v: %w", field.FullPath(), err)
+	} else if metaType != nil {
+		// If the metatype was not found then just stick with the default inferred type
+		inferredType = metaType
 	}
 
 	// Stage 3: Bloblang mapping override (only for primitive/leaf types)
@@ -85,10 +87,14 @@ func (r *typeResolver) resolveTypeForAddColumn(
 // ti is a shared field ID allocator so that nested struct field IDs are unique across the entire
 // schema, including IDs assigned by the schema_metadata override path. If stage 2 or 3 overrides
 // replace a nested struct, IDs allocated during stage 1 inference become harmless gaps.
+//
+// common is the pre-parsed schema metadata for the message, or nil when no metadata is present.
+// Parsing once at the call site avoids re-parsing per field across a wide schema.
 func (r *typeResolver) resolveTypeForCreateTable(
 	fieldName string,
 	value any,
 	msg *service.Message,
+	common *schema.Common,
 	namespace, table string,
 	ti *typeInferrer,
 ) (iceberg.Type, error) {
@@ -102,14 +108,12 @@ func (r *typeResolver) resolveTypeForCreateTable(
 	}
 
 	// Stage 2: schema_metadata override (uses shared ti so override structs share the ID space)
-	if r.schemaMetadataKey != "" {
-		path := icebergx.Path{{Kind: icebergx.PathField, Name: fieldName}}
-		if metaType, err := r.resolveFromSchemaMetadata(msg, path, ti); err != nil {
-			return nil, fmt.Errorf("resolving type from schema metadata for field %q: %w", fieldName, err)
-		} else if metaType != nil {
-			// If the metatype was not found then just stick with the default inferred type
-			inferredType = metaType
-		}
+	path := icebergx.Path{{Kind: icebergx.PathField, Name: fieldName}}
+	if metaType, err := r.resolveFromCommon(common, path, ti); err != nil {
+		return nil, fmt.Errorf("resolving type from schema metadata for field %q: %w", fieldName, err)
+	} else if metaType != nil {
+		// If the metatype was not found then just stick with the default inferred type
+		inferredType = metaType
 	}
 
 	// Stage 3: Bloblang mapping override (only for primitive/leaf types)
@@ -125,11 +129,15 @@ func (r *typeResolver) resolveTypeForCreateTable(
 	return inferredType, nil
 }
 
-// resolveFromSchemaMetadata looks up the type for a field path in the schema.Common
-// structure found in message metadata. ti is the field ID allocator used when the
-// resolved type is a struct or list; pass the schema's shared allocator to keep IDs
-// unique across the whole schema, or a fresh one when the result is single-column.
-func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath icebergx.Path, ti *typeInferrer) (iceberg.Type, error) {
+// parseSchemaMetadata reads the schema.Common from message metadata. Returns
+// (nil, nil) when no metadata key is configured or the key is absent on the
+// message — in both cases callers should fall back to default type inference.
+// A parse error is surfaced so a malformed schema is rejected loudly rather
+// than silently degrading to inference.
+func (r *typeResolver) parseSchemaMetadata(msg *service.Message) (*schema.Common, error) {
+	if r.schemaMetadataKey == "" {
+		return nil, nil
+	}
 	metaAny, exists := msg.MetaGetMut(r.schemaMetadataKey)
 	if !exists {
 		if r.logger != nil {
@@ -137,17 +145,25 @@ func (r *typeResolver) resolveFromSchemaMetadata(msg *service.Message, fieldPath
 		}
 		return nil, nil
 	}
-
-	commonSchema, err := schema.ParseFromAny(metaAny)
+	c, err := schema.ParseFromAny(metaAny)
 	if err != nil {
 		return nil, fmt.Errorf("parsing schema metadata: %w", err)
 	}
+	return &c, nil
+}
 
-	field, found := findCommonField(commonSchema, fieldPath, r.caseSensitive)
+// resolveFromCommon looks up the type for a field path in a pre-parsed schema.Common.
+// ti is the field ID allocator used when the resolved type is a struct or list; pass
+// the schema's shared allocator to keep IDs unique across the whole schema, or a
+// fresh one when the result is single-column.
+func (r *typeResolver) resolveFromCommon(common *schema.Common, fieldPath icebergx.Path, ti *typeInferrer) (iceberg.Type, error) {
+	if common == nil {
+		return nil, nil
+	}
+	field, found := findCommonField(*common, fieldPath, r.caseSensitive)
 	if !found {
 		return nil, nil
 	}
-
 	return commonTypeToIcebergType(field, ti)
 }
 
@@ -399,26 +415,29 @@ func parseIcebergTypeString(s string) (iceberg.Type, error) {
 	return nil, fmt.Errorf("unrecognized iceberg type: %q", s)
 }
 
-// topLevelFieldOrder returns the top-level field names from the schema metadata
-// in the order they appear there, or nil if no schema metadata is present.
-func (r *typeResolver) topLevelFieldOrder(msg *service.Message) []string {
-	if r.schemaMetadataKey == "" {
-		return nil
+// topLevelFieldOrder returns the top-level field names from the pre-parsed
+// schema metadata in the order they appear there, or nil if common is absent
+// or is not a top-level object. When case-insensitive matching is in effect,
+// metadata that declares two top-level children differing only in case is
+// rejected — mirroring the same guard that commonObjectToIcebergStruct
+// applies to nested struct metadata.
+func (r *typeResolver) topLevelFieldOrder(common *schema.Common) ([]string, error) {
+	if common == nil || common.Type != schema.Object {
+		return nil, nil
 	}
-	raw, exists := msg.MetaGetMut(r.schemaMetadataKey)
-	if !exists {
-		return nil
+	if !r.caseSensitive {
+		seen := make(map[string]string, len(common.Children))
+		for _, child := range common.Children {
+			lower := strings.ToLower(child.Name)
+			if existing, ok := seen[lower]; ok {
+				return nil, fmt.Errorf("ambiguous top-level fields in schema metadata: %q and %q differ only in case", existing, child.Name)
+			}
+			seen[lower] = child.Name
+		}
 	}
-	c, err := schema.ParseFromAny(raw)
-	if err != nil {
-		return nil
-	}
-	if c.Type != schema.Object {
-		return nil
-	}
-	names := make([]string, 0, len(c.Children))
-	for _, child := range c.Children {
+	names := make([]string, 0, len(common.Children))
+	for _, child := range common.Children {
 		names = append(names, child.Name)
 	}
-	return names
+	return names, nil
 }

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -421,7 +421,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"name": "hello"})
 
-		got, err := r.resolveTypeForCreateTable("name", "hello", msg, "ns", "tbl", newTypeInferrer(true))
+		got, err := r.resolveTypeForCreateTable("name", "hello", msg, nil, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "string", got.Type())
 	})
@@ -432,7 +432,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{})
 
-		got, err := r.resolveTypeForCreateTable("name", nil, msg, "ns", "tbl", newTypeInferrer(true))
+		got, err := r.resolveTypeForCreateTable("name", nil, msg, nil, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
@@ -450,7 +450,9 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg.SetStructuredMut(map[string]any{"count": 42})
 		msg.MetaSetMut("test_schema", commonSchema.ToAny())
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
+		common, err := r.parseSchemaMetadata(msg)
+		require.NoError(t, err)
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, common, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -462,7 +464,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, nil, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err)
 		assert.Equal(t, "long", got.Type())
 	})
@@ -473,7 +475,9 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg := service.NewMessage(nil)
 		msg.SetStructuredMut(map[string]any{"count": 42})
 
-		got, err := r.resolveTypeForCreateTable("count", 42, msg, "ns", "tbl", newTypeInferrer(true))
+		common, err := r.parseSchemaMetadata(msg)
+		require.NoError(t, err)
+		got, err := r.resolveTypeForCreateTable("count", 42, msg, common, "ns", "tbl", newTypeInferrer(true))
 		require.NoError(t, err, "should not error when schema_metadata is missing from message")
 		assert.Equal(t, "long", got.Type(), "should fall back to inference")
 	})
@@ -500,7 +504,7 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		// Build fields the same way buildSchemaWithResolver does.
 		var allIDs []int
 		for name, value := range record {
-			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, "ns", "tbl", ti)
+			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, nil, "ns", "tbl", ti)
 			require.NoError(t, err)
 			if fieldType == nil {
 				continue
@@ -561,9 +565,12 @@ func TestTypeResolverResolveTypeForCreateTable(t *testing.T) {
 		msg.SetStructuredMut(record)
 		msg.MetaSetMut("test_schema", commonRoot.ToAny())
 
+		common, err := r.parseSchemaMetadata(msg)
+		require.NoError(t, err)
+
 		var allIDs []int
 		for name, value := range record {
-			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, "ns", "tbl", ti)
+			fieldType, err := r.resolveTypeForCreateTable(name, value, msg, common, "ns", "tbl", ti)
 			require.NoError(t, err)
 			require.NotNil(t, fieldType)
 			topID := ti.allocateFieldID()


### PR DESCRIPTION
Preserve schema registry column order when creating Iceberg tables. Column order was lost because `buildSchemaWithResolver` iterated over a `map[string]any`, which Go randomises. The fix reads the ordered field list from `schema.Common` metadata when present, falling back to sorted keys for determinism when it isn't.

<img width="1208" height="775" alt="image" src="https://github.com/user-attachments/assets/9de5f2d9-6ce4-402e-abc0-694a9830da2c" />
