### PR TITLE
fix(iceberg): apply schema_metadata for nil fields during table creation

### DIFF
--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -325,3 +325,37 @@ func TestBuildSchemaWithResolverNewColumnTypeMappingSeesMetadataCasing(t *testin
 	assert.Equal(t, "long", fields[0].Type.Type(),
 		"mapping returns long only when name+path match metadata casing; any other casing means the rename path is broken")
 }
+
+// TestBuildSchemaWithResolverUsesMetadataTypeForNilValue verifies that
+// table-creation type resolution still applies schema metadata when the
+// observed record value is nil. Without this, nil values would be skipped
+// before metadata lookup and columns would appear later only after a non-nil
+// value is seen.
+func TestBuildSchemaWithResolverUsesMetadataTypeForNilValue(t *testing.T) {
+	router := &Router{
+		caseSensitive: true,
+		resolver:      newTypeResolver("schema_key", nil, true, nil),
+	}
+
+	schemaMeta := schema.Common{
+		Type: schema.Object,
+		Children: []schema.Common{
+			{Name: "count", Type: schema.Int32},
+		},
+	}
+
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("schema_key", schemaMeta.ToAny())
+
+	record := map[string]any{
+		"count": nil,
+	}
+
+	icebergSchema, err := router.buildSchemaWithResolver(record, msg, tableKey{namespace: "ns", table: "t"})
+	require.NoError(t, err)
+
+	fields := icebergSchema.Fields()
+	require.Len(t, fields, 1)
+	assert.Equal(t, "count", fields[0].Name)
+	assert.Equal(t, "int", fields[0].Type.Type())
+}

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -103,17 +103,18 @@ func (r *typeResolver) resolveTypeForCreateTable(
 	if err != nil {
 		return nil, err
 	}
-	if inferredType == nil {
-		return nil, nil // nil value, skip
-	}
 
 	// Stage 2: schema_metadata override (uses shared ti so override structs share the ID space)
 	path := icebergx.Path{{Kind: icebergx.PathField, Name: fieldName}}
 	if metaType, err := r.resolveFromCommon(common, path, ti); err != nil {
 		return nil, fmt.Errorf("resolving type from schema metadata for field %q: %w", fieldName, err)
 	} else if metaType != nil {
-		// If the metatype was not found then just stick with the default inferred type
+		// Metadata takes precedence over runtime inference. This also ensures
+		// metadata-declared columns are created even when the observed value is nil.
 		inferredType = metaType
+	}
+	if inferredType == nil {
+		return nil, nil // nil value with no metadata type, skip
 	}
 
 	// Stage 3: Bloblang mapping override (only for primitive/leaf types)


### PR DESCRIPTION
Issue:
Using Iceberg with AWS Glue and an explicit schema from the registry, some columns were not created initially if their first observed value was null, even though they were present in the only schema version. Those columns were added later once non-null values appeared.

Changes:

* move the nil-skip check to run after schema_metadata override
* preserve existing behavior for fields with neither inferred type nor metadata type
* add a regression test covering metadata-defined type + nil record value