### PR TITLE
plugins: require cloud_unsupported_reason and reject placeholder versions

### DIFF
--- a/internal/plugins/alltest/plugins_test.go
+++ b/internal/plugins/alltest/plugins_test.go
@@ -67,3 +67,20 @@ func TestAllPluginsInInfoCSV(t *testing.T) {
 		check(name, plugins.TypeTracer)
 	})
 }
+
+// TestPluginCloudEnablement requires each plugin to either be enabled in the
+// cloud distribution or to document why it is not, via the
+// cloud_unsupported_reason column in internal/plugins/info.csv.
+func TestPluginCloudEnablement(t *testing.T) {
+	for key, info := range plugins.BaseInfo {
+		if info.Cloud {
+			if info.CloudUnsupportedReason != "" {
+				t.Errorf("plugin %q is cloud-enabled but has cloud_unsupported_reason %q set; clear that column", key, info.CloudUnsupportedReason)
+			}
+			continue
+		}
+		if info.CloudUnsupportedReason == "" {
+			t.Errorf("plugin %q is not cloud-enabled and is missing a cloud_unsupported_reason in internal/plugins/info.csv; either enable it for cloud or document why it cannot be", key)
+		}
+	}
+}

--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -1,324 +1,324 @@
-name                      ,type      ,commercial_name           ,version ,support    ,deprecated ,cloud ,cloud_with_gpu
-a2a_message               ,processor ,a2a_message               ,4.66.0  ,enterprise ,n          ,y     ,y
-amqp_0_9                  ,input     ,amqp_0_9                  ,0.0.0   ,certified  ,n          ,y     ,y
-amqp_0_9                  ,output    ,amqp_0_9                  ,0.0.0   ,certified  ,n          ,y     ,y
-amqp_1                    ,input     ,amqp_1                    ,0.0.0   ,community  ,n          ,n     ,n
-amqp_1                    ,output    ,amqp_1                    ,0.0.0   ,community  ,n          ,n     ,n
-arc                       ,output    ,arc                       ,4.88.0  ,community  ,n          ,y     ,y
-archive                   ,processor ,archive                   ,0.0.0   ,certified  ,n          ,y     ,y
-avro                      ,processor ,avro                      ,0.0.0   ,community  ,n          ,y     ,y
-avro                      ,scanner   ,avro                      ,0.0.0   ,community  ,n          ,y     ,y
-awk                       ,processor ,awk                       ,0.0.0   ,community  ,n          ,n     ,n
-aws_bedrock_chat          ,processor ,aws_bedrock_chat          ,4.34.0  ,certified  ,n          ,y     ,y
-aws_bedrock_embeddings    ,processor ,aws_bedrock_embeddings    ,4.37.0  ,certified  ,n          ,y     ,y
-aws_cloudwatch            ,metric    ,aws_cloudwatch            ,3.36.0  ,community  ,n          ,n     ,n
-aws_cloudwatch_logs       ,input     ,AWS CloudWatch Logs       ,4.81.0  ,community  ,n          ,y     ,y
-aws_dynamodb              ,cache     ,AWS DynamoDB              ,3.36.0  ,community  ,n          ,y     ,y
-aws_dynamodb              ,output    ,AWS DynamoDB              ,3.36.0  ,community  ,n          ,y     ,y
-aws_dynamodb_cdc          ,input     ,aws_dynamodb_cdc          ,4.79.0  ,enterprise ,n          ,y     ,y
-aws_dynamodb_partiql      ,processor ,aws_dynamodb_partiql      ,3.48.0  ,certified  ,n          ,y     ,y
-aws_kinesis               ,input     ,AWS Kinesis               ,3.36.0  ,certified  ,n          ,y     ,y
-aws_kinesis               ,output    ,AWS Kinesis               ,3.36.0  ,certified  ,n          ,y     ,y
-aws_kinesis_firehose      ,output    ,AWS Kinesis Firehose      ,3.36.0  ,certified  ,n          ,y     ,y
-aws_lambda                ,processor ,AWS Lambda                ,3.36.0  ,certified  ,n          ,y     ,y
-aws_s3                    ,cache     ,AWS S3                    ,3.36.0  ,certified  ,n          ,y     ,y
-aws_s3                    ,input     ,AWS S3                    ,0.0.0   ,certified  ,n          ,y     ,y
-aws_s3                    ,output    ,AWS S3                    ,3.36.0  ,certified  ,n          ,y     ,y
-aws_sns                   ,output    ,AWS SNS                   ,3.36.0  ,community  ,n          ,y     ,y
-aws_sqs                   ,input     ,AWS SQS                   ,0.0.0   ,certified  ,n          ,y     ,y
-aws_sqs                   ,output    ,AWS SQS                   ,3.36.0  ,certified  ,n          ,y     ,y
-azure_blob_storage        ,input     ,azure_blob_storage        ,3.36.0  ,certified  ,n          ,y     ,y
-azure_blob_storage        ,output    ,azure_blob_storage        ,3.36.0  ,certified  ,n          ,y     ,y
-azure_cosmosdb            ,input     ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
-azure_cosmosdb            ,output    ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
-azure_cosmosdb            ,processor ,azure_cosmosdb            ,4.25.0  ,certified  ,n          ,y     ,y
-azure_data_lake_gen2      ,output    ,azure_data_lake_gen2      ,4.38.0  ,certified  ,n          ,y     ,y
-azure_queue_storage       ,input     ,azure_queue_storage       ,3.42.0  ,certified  ,n          ,y     ,y
-azure_queue_storage       ,output    ,azure_queue_storage       ,3.36.0  ,certified  ,n          ,y     ,y
-azure_table_storage       ,input     ,azure_table_storage       ,4.10.0  ,certified  ,n          ,y     ,y
-azure_table_storage       ,output    ,azure_table_storage       ,3.36.0  ,certified  ,n          ,y     ,y
-batched                   ,input     ,batched                   ,4.11.0  ,certified  ,n          ,y     ,y
-beanstalkd                ,input     ,beanstalkd                ,4.7.0   ,community  ,n          ,n     ,n
-beanstalkd                ,output    ,beanstalkd                ,4.7.0   ,community  ,n          ,n     ,n
-benchmark                 ,processor ,benchmark                 ,4.40.0  ,certified  ,n          ,y     ,y
-bloblang                  ,processor ,bloblang                  ,0.0.0   ,certified  ,n          ,y     ,y
-bounds_check              ,processor ,bounds_check              ,0.0.0   ,certified  ,n          ,y     ,y
-branch                    ,processor ,branch                    ,0.0.0   ,certified  ,n          ,y     ,y
-broker                    ,input     ,broker                    ,0.0.0   ,certified  ,n          ,y     ,y
-broker                    ,output    ,broker                    ,0.0.0   ,certified  ,n          ,y     ,y
-cache                     ,output    ,cache                     ,0.0.0   ,certified  ,n          ,y     ,y
-cache                     ,processor ,cache                     ,0.0.0   ,certified  ,n          ,y     ,y
-cached                    ,processor ,cached                    ,4.3.0   ,certified  ,n          ,y     ,y
-cassandra                 ,input     ,cassandra                 ,0.0.0   ,community  ,n          ,n     ,n
-cassandra                 ,output    ,cassandra                 ,0.0.0   ,community  ,n          ,n     ,n
-catch                     ,processor ,catch                     ,0.0.0   ,certified  ,n          ,y     ,y
-chunker                   ,scanner   ,chunker                   ,0.0.0   ,certified  ,n          ,y     ,y
-cockroachdb_changefeed    ,input     ,cockroachdb_changefeed    ,0.0.0   ,community  ,n          ,n     ,n
-cohere_chat               ,processor ,cohere_chat               ,4.37.0  ,certified  ,n          ,y     ,y
-cohere_embeddings         ,processor ,cohere_embeddings         ,4.37.0  ,certified  ,n          ,y     ,y
-cohere_rerank             ,processor ,cohere_rerank             ,4.53.0  ,certified  ,n          ,y     ,y
-command                   ,processor ,command                   ,4.21.0  ,certified  ,n          ,n     ,n
-compress                  ,processor ,compress                  ,0.0.0   ,certified  ,n          ,y     ,y
-couchbase                 ,cache     ,Couchbase                 ,4.12.0  ,community  ,n          ,n     ,n
-couchbase                 ,output    ,Couchbase                 ,4.37.0  ,community  ,n          ,n     ,n
-couchbase                 ,processor ,Couchbase                 ,4.11.0  ,community  ,n          ,n     ,n
-crash                     ,processor ,crash                     ,4.47.0  ,certified  ,n          ,n     ,n
-csv                       ,input     ,csv                       ,0.0.0   ,certified  ,n          ,n     ,n
-csv                       ,scanner   ,csv                       ,0.0.0   ,certified  ,n          ,y     ,y
-cyborgdb                  ,output    ,cyborgdb                  ,4.66.0  ,community  ,n          ,y     ,y
-cypher                    ,output    ,cypher                    ,4.37.0  ,community  ,n          ,n     ,n
-decompress                ,processor ,decompress                ,0.0.0   ,certified  ,n          ,y     ,y
-decompress                ,scanner   ,decompress                ,0.0.0   ,certified  ,n          ,y     ,y
-dedupe                    ,processor ,dedupe                    ,0.0.0   ,certified  ,n          ,y     ,y
-discord                   ,input     ,discord                   ,0.0.0   ,community  ,n          ,n     ,n
-discord                   ,output    ,discord                   ,0.0.0   ,community  ,n          ,n     ,n
-drop                      ,output    ,drop                      ,0.0.0   ,certified  ,n          ,y     ,y
-drop_on                   ,output    ,drop_on                   ,0.0.0   ,certified  ,n          ,y     ,y
-dynamic                   ,input     ,dynamic                   ,0.0.0   ,community  ,n          ,n     ,n
-dynamic                   ,output    ,dynamic                   ,0.0.0   ,community  ,n          ,n     ,n
-elasticsearch_v8          ,output    ,elasticsearch_v8          ,4.47.0  ,certified  ,n          ,y     ,y
-elasticsearch_v9          ,output    ,elasticsearch_v9          ,0.0.0   ,community  ,n          ,n     ,n
-fallback                  ,output    ,fallback                  ,3.58.0  ,certified  ,n          ,y     ,y
-ffi                       ,processor ,Foreign Function Interface,4.69.0  ,certified  ,n          ,n     ,n
-file                      ,cache     ,File                      ,0.0.0   ,certified  ,n          ,n     ,n
-file                      ,input     ,File                      ,0.0.0   ,certified  ,n          ,n     ,n
-file                      ,output    ,File                      ,0.0.0   ,certified  ,n          ,n     ,n
-for_each                  ,processor ,for_each                  ,0.0.0   ,certified  ,n          ,y     ,y
-gateway                   ,input     ,gateway                   ,4.51.0  ,enterprise ,n          ,y     ,y
-gcp_bigquery              ,output    ,GCP BigQuery              ,3.55.0  ,certified  ,n          ,y     ,y
-gcp_bigquery_select       ,input     ,GCP BigQuery              ,3.63.0  ,certified  ,n          ,y     ,y
-gcp_bigquery_select       ,processor ,GCP BigQuery              ,3.64.0  ,certified  ,n          ,y     ,y
-gcp_bigquery_write_api    ,output    ,GCP BigQuery              ,4.90.0  ,enterprise ,n          ,y     ,y
-gcp_cloud_storage         ,cache     ,GCP Cloud Storage         ,0.0.0   ,certified  ,n          ,y     ,y
-gcp_cloud_storage         ,input     ,GCP Cloud Storage         ,3.43.0  ,certified  ,n          ,y     ,y
-gcp_cloud_storage         ,output    ,GCP Cloud Storage         ,3.43.0  ,certified  ,n          ,y     ,y
-gcp_cloudtrace            ,tracer    ,GCP Cloud Trace           ,4.2.0   ,certified  ,n          ,y     ,y
-gcp_pubsub                ,input     ,GCP PubSub                ,0.0.0   ,certified  ,n          ,y     ,y
-gcp_pubsub                ,output    ,GCP PubSub                ,0.0.0   ,certified  ,n          ,y     ,y
-gcp_spanner_cdc           ,input     ,gcp_spanner_cdc           ,0.0.0   ,enterprise ,n          ,y     ,y
-gcp_vertex_ai_chat        ,processor ,GCP Vertex AI             ,4.34.0  ,certified  ,n          ,y     ,y
-gcp_vertex_ai_embeddings  ,processor ,gcp_vertex_ai_embeddings  ,4.37.0  ,certified  ,n          ,y     ,y
-generate                  ,input     ,generate                  ,3.40.0  ,certified  ,n          ,y     ,y
-git                       ,input     ,git                       ,4.51.0  ,certified  ,n          ,y     ,y
-google_drive_download     ,processor ,google_drive_download     ,4.53.0  ,enterprise ,n          ,y     ,y
-google_drive_list_labels  ,processor ,google_drive_list_labels  ,4.53.0  ,enterprise ,n          ,y     ,y
-google_drive_search       ,processor ,google_drive_search       ,4.53.0  ,enterprise ,n          ,y     ,y
-grok                      ,processor ,grok                      ,0.0.0   ,community  ,n          ,n     ,n
-group_by                  ,processor ,group_by                  ,0.0.0   ,certified  ,n          ,y     ,y
-group_by_value            ,processor ,group_by_value            ,0.0.0   ,certified  ,n          ,y     ,y
-hdfs                      ,input     ,hdfs                      ,0.0.0   ,community  ,n          ,n     ,n
-hdfs                      ,output    ,hdfs                      ,0.0.0   ,community  ,n          ,n     ,n
-http                      ,processor ,HTTP                      ,0.0.0   ,certified  ,n          ,y     ,y
-http_client               ,input     ,http_client               ,0.0.0   ,certified  ,n          ,y     ,y
-http_client               ,output    ,http_client               ,0.0.0   ,certified  ,n          ,y     ,y
-http_server               ,input     ,http_server               ,0.0.0   ,certified  ,n          ,y     ,y
-http_server               ,output    ,http_server               ,0.0.0   ,certified  ,n          ,n     ,n
-iceberg                   ,output    ,Apache Iceberg            ,4.80.0  ,enterprise ,n          ,y     ,y
-influxdb                  ,metric    ,influxdb                  ,3.36.0  ,community  ,n          ,n     ,n
-inproc                    ,input     ,inproc                    ,0.0.0   ,certified  ,n          ,y     ,y
-inproc                    ,output    ,inproc                    ,0.0.0   ,certified  ,n          ,y     ,y
-insert_part               ,processor ,insert_part               ,0.0.0   ,certified  ,n          ,y     ,y
-jaeger                    ,tracer    ,jaeger                    ,0.0.0   ,community  ,n          ,n     ,n
-javascript                ,processor ,javascript                ,4.14.0  ,certified  ,n          ,n     ,n
-jira                      ,processor ,jira                      ,4.68.0  ,certified  ,n          ,y     ,n
-jmespath                  ,processor ,JMESPath                  ,0.0.0   ,certified  ,n          ,y     ,y
-jq                        ,processor ,jq                        ,0.0.0   ,certified  ,n          ,y     ,y
-json_api                  ,metric    ,json_api                  ,0.0.0   ,certified  ,n          ,n     ,n
-json_array                ,scanner   ,json_array                ,4.65.0  ,community  ,n          ,y     ,y
-json_documents            ,scanner   ,json_documents            ,4.27.0  ,certified  ,n          ,y     ,y
-json_schema               ,processor ,JSON Schema               ,0.0.0   ,certified  ,n          ,y     ,y
-kafka                     ,input     ,Kafka                     ,0.0.0   ,certified  ,y          ,y     ,y
-kafka                     ,output    ,Kafka                     ,0.0.0   ,certified  ,n          ,y     ,y
-kafka_franz               ,input     ,kafka_franz               ,3.61.0  ,certified  ,y          ,y     ,y
-kafka_franz               ,output    ,kafka_franz               ,3.61.0  ,certified  ,n          ,y     ,y
-lines                     ,scanner   ,lines                     ,0.0.0   ,certified  ,n          ,y     ,y
-local                     ,rate_limit,local                     ,0.0.0   ,certified  ,n          ,y     ,y
-log                       ,processor ,log                       ,0.0.0   ,certified  ,n          ,y     ,y
-logger                    ,metric    ,logger                    ,0.0.0   ,certified  ,n          ,n     ,n
-lru                       ,cache     ,lru                       ,0.0.0   ,community  ,n          ,y     ,y
-mapping                   ,processor ,mapping                   ,4.5.0   ,certified  ,n          ,y     ,y
-memcached                 ,cache     ,Memcached                 ,0.0.0   ,community  ,n          ,y     ,y
-memory                    ,buffer    ,Memory                    ,0.0.0   ,certified  ,n          ,y     ,y
-memory                    ,cache     ,Memory                    ,0.0.0   ,certified  ,n          ,y     ,y
-metric                    ,processor ,metric                    ,0.0.0   ,certified  ,n          ,y     ,y
-microsoft_sql_server_cdc  ,input     ,microsoft_sql_server_cdc  ,0.0.0   ,enterprise ,n          ,y     ,y
-mongodb                   ,cache     ,MongoDB                   ,3.43.0  ,certified  ,n          ,y     ,y
-mongodb                   ,input     ,MongoDB                   ,3.64.0  ,certified  ,n          ,y     ,y
-mongodb                   ,output    ,MongoDB                   ,3.43.0  ,certified  ,n          ,y     ,y
-mongodb                   ,processor ,MongoDB                   ,3.43.0  ,certified  ,n          ,y     ,y
-mongodb_cdc               ,input     ,MongoDB CDC               ,4.48.0  ,enterprise ,n          ,y     ,y
-mqtt                      ,input     ,mqtt                      ,4.37.0  ,certified  ,n          ,y     ,y
-mqtt                      ,output    ,mqtt                      ,4.37.0  ,certified  ,n          ,y     ,y
-msgpack                   ,processor ,msgpack                   ,3.59.0  ,community  ,n          ,n     ,n
-multilevel                ,cache     ,Multilevel                ,0.0.0   ,certified  ,n          ,y     ,y
-mutation                  ,processor ,mutation                  ,4.5.0   ,certified  ,n          ,y     ,y
-mysql_cdc                 ,input     ,mysql_cdc                 ,4.45.0  ,enterprise ,n          ,y     ,y
-nanomsg                   ,input     ,nanomsg                   ,0.0.0   ,community  ,n          ,n     ,n
-nanomsg                   ,output    ,nanomsg                   ,0.0.0   ,community  ,n          ,n     ,n
-nats                      ,input     ,NATS                      ,0.0.0   ,certified  ,n          ,y     ,y
-nats                      ,output    ,NATS                      ,0.0.0   ,certified  ,n          ,y     ,y
-nats_jetstream            ,input     ,NATS JetStream            ,3.46.0  ,certified  ,n          ,y     ,y
-nats_jetstream            ,output    ,NATS JetStream            ,3.46.0  ,certified  ,n          ,y     ,y
-nats_kv                   ,cache     ,NATS KV                   ,4.27.0  ,certified  ,n          ,y     ,y
-nats_kv                   ,input     ,NATS KV                   ,4.12.0  ,certified  ,n          ,y     ,y
-nats_kv                   ,output    ,NATS KV                   ,4.12.0  ,certified  ,n          ,y     ,y
-nats_kv                   ,processor ,NATS KV                   ,4.12.0  ,certified  ,n          ,y     ,y
-nats_request_reply        ,processor ,NATS Request Reply        ,4.27.0  ,certified  ,n          ,y     ,y
-nats_stream               ,input     ,NATS Stream               ,0.0.0   ,community  ,n          ,n     ,n
-nats_stream               ,output    ,NATS Stream               ,0.0.0   ,community  ,n          ,n     ,n
-none                      ,buffer    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
-none                      ,metric    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
-none                      ,tracer    ,none                      ,0.0.0   ,certified  ,n          ,y     ,y
-noop                      ,cache     ,noop                      ,4.27.0  ,certified  ,n          ,y     ,y
-noop                      ,processor ,noop                      ,0.0.0   ,certified  ,n          ,y     ,y
-nsq                       ,input     ,nsq                       ,0.0.0   ,community  ,n          ,n     ,n
-nsq                       ,output    ,nsq                       ,0.0.0   ,community  ,n          ,n     ,n
-ockam_kafka               ,input     ,ockam_kafka               ,0.0.0   ,community  ,n          ,n     ,n
-ockam_kafka               ,output    ,ockam_kafka               ,0.0.0   ,community  ,n          ,n     ,n
-ollama_chat               ,processor ,ollama_chat               ,4.32.0  ,certified  ,n          ,n     ,y
-ollama_embeddings         ,processor ,ollama_embeddings         ,4.32.0  ,certified  ,n          ,n     ,y
-ollama_moderation         ,processor ,ollama_moderation         ,4.42.0  ,certified  ,n          ,n     ,y
-open_telemetry_collector  ,metric    ,open_telemetry_collector  ,4.88.0  ,enterprise ,n          ,y     ,y
-open_telemetry_collector  ,tracer    ,open_telemetry_collector  ,4.26.0  ,enterprise ,n          ,y     ,y
-openai_chat_completion    ,processor ,openai_chat_completion    ,4.32.0  ,certified  ,n          ,y     ,y
-openai_embeddings         ,processor ,openai_embeddings         ,4.32.0  ,certified  ,n          ,y     ,y
-openai_image_generation   ,processor ,openai_image_generation   ,4.32.0  ,certified  ,n          ,y     ,y
-openai_speech             ,processor ,openai_speech             ,4.32.0  ,certified  ,n          ,y     ,y
-openai_transcription      ,processor ,openai_transcription      ,4.32.0  ,certified  ,n          ,y     ,y
-openai_translation        ,processor ,openai_translation        ,4.32.0  ,certified  ,n          ,y     ,y
-opensearch                ,output    ,OpenSearch                ,0.0.0   ,certified  ,n          ,y     ,y
-oracledb_cdc              ,input     ,oracledb_cdc              ,4.83.0  ,enterprise ,n          ,y     ,y
-otlp_grpc                 ,input     ,otlp_grpc                 ,4.78.0  ,enterprise ,n          ,y     ,y
-otlp_grpc                 ,output    ,otlp_grpc                 ,4.78.0  ,enterprise ,n          ,y     ,y
-otlp_http                 ,input     ,otlp_http                 ,4.78.0  ,enterprise ,n          ,y     ,y
-otlp_http                 ,output    ,otlp_http                 ,4.78.0  ,enterprise ,n          ,y     ,y
-parallel                  ,processor ,parallel                  ,0.0.0   ,certified  ,n          ,y     ,y
-parquet                   ,input     ,parquet                   ,4.8.0   ,certified  ,n          ,n     ,n
-parquet                   ,processor ,parquet                   ,3.62.0  ,community  ,y          ,n     ,n
-parquet_decode            ,processor ,parquet_decode            ,4.4.0   ,certified  ,n          ,y     ,y
-parquet_encode            ,processor ,parquet_encode            ,4.4.0   ,certified  ,n          ,y     ,y
-parse_log                 ,processor ,parse_log                 ,0.0.0   ,community  ,n          ,y     ,y
-pg_stream                 ,input     ,pg_stream                 ,4.43.0  ,enterprise ,y          ,y     ,y
-pinecone                  ,output    ,pinecone                  ,4.31.0  ,certified  ,n          ,y     ,y
-postgres_cdc              ,input     ,postgres_cdc              ,4.43.0  ,enterprise ,n          ,y     ,y
-processors                ,processor ,processors                ,0.0.0   ,certified  ,n          ,y     ,y
-prometheus                ,metric    ,prometheus                ,0.0.0   ,certified  ,n          ,y     ,y
-protobuf                  ,processor ,Protobuf                  ,0.0.0   ,certified  ,n          ,n     ,n
-pulsar                    ,input     ,pulsar                    ,3.43.0  ,community  ,n          ,n     ,n
-pulsar                    ,output    ,pulsar                    ,3.43.0  ,community  ,n          ,n     ,n
-pusher                    ,output    ,pusher                    ,4.3.0   ,community  ,n          ,n     ,n
-qdrant                    ,output    ,qdrant                    ,4.33.0  ,certified  ,n          ,y     ,y
-qdrant                    ,processor ,qdrant                    ,4.54.0  ,certified  ,n          ,y     ,y
-questdb                   ,output    ,questdb                   ,4.37.0  ,certified  ,n          ,y     ,y
-rate_limit                ,processor ,rate_limit                ,0.0.0   ,certified  ,n          ,y     ,y
-re_match                  ,scanner   ,re_match                  ,0.0.0   ,certified  ,n          ,y     ,y
-read_until                ,input     ,read_until                ,0.0.0   ,certified  ,n          ,y     ,y
-redis                     ,cache     ,Redis                     ,0.0.0   ,certified  ,n          ,y     ,y
-redis                     ,processor ,Redis                     ,0.0.0   ,certified  ,n          ,y     ,y
-redis                     ,rate_limit,Redis                     ,4.12.0  ,certified  ,n          ,y     ,y
-redis_hash                ,output    ,Redis Hash                ,0.0.0   ,certified  ,n          ,y     ,y
-redis_list                ,input     ,Redis List                ,0.0.0   ,certified  ,n          ,y     ,y
-redis_list                ,output    ,Redis List                ,0.0.0   ,certified  ,n          ,y     ,y
-redis_pubsub              ,input     ,Redis PubSub              ,0.0.0   ,certified  ,n          ,y     ,y
-redis_pubsub              ,output    ,Redis PubSub              ,0.0.0   ,certified  ,n          ,y     ,y
-redis_scan                ,input     ,Redis                     ,4.27.0  ,certified  ,n          ,y     ,y
-redis_script              ,processor ,Redis Script              ,4.11.0  ,certified  ,n          ,y     ,y
-redis_streams             ,input     ,Redis Streams             ,0.0.0   ,certified  ,n          ,y     ,y
-redis_streams             ,output    ,Redis Streams             ,0.0.0   ,certified  ,n          ,y     ,y
-redpanda                  ,cache     ,redpanda                  ,4.55.0  ,certified  ,n          ,y     ,y
-redpanda                  ,input     ,redpanda                  ,4.39.0  ,certified  ,n          ,y     ,y
-redpanda                  ,output    ,redpanda                  ,4.39.0  ,certified  ,n          ,y     ,y
-redpanda                  ,tracer    ,redpanda                  ,4.71.0  ,certified  ,n          ,y     ,y
-redpanda_common           ,input     ,redpanda_common           ,4.39.0  ,enterprise ,y          ,y     ,y
-redpanda_common           ,output    ,redpanda_common           ,4.39.0  ,enterprise ,y          ,y     ,y
-redpanda_data_transform   ,processor ,redpanda_data_transform   ,4.31.0  ,certified  ,n          ,n     ,n
-redpanda_migrator         ,input     ,redpanda_migrator         ,4.66.0  ,certified  ,n          ,y     ,y
-redpanda_migrator         ,output    ,redpanda_migrator         ,4.66.0  ,certified  ,n          ,y     ,y
-reject                    ,output    ,reject                    ,0.0.0   ,certified  ,n          ,y     ,y
-reject_errored            ,output    ,reject_errored            ,0.0.0   ,certified  ,n          ,y     ,y
-resource                  ,input     ,resource                  ,0.0.0   ,certified  ,n          ,y     ,y
-resource                  ,output    ,resource                  ,0.0.0   ,certified  ,n          ,y     ,y
-resource                  ,processor ,resource                  ,0.0.0   ,certified  ,n          ,y     ,y
-retry                     ,output    ,retry                     ,0.0.0   ,certified  ,n          ,y     ,y
-retry                     ,processor ,retry                     ,4.27.0  ,certified  ,n          ,y     ,y
-ristretto                 ,cache     ,Ristretto                 ,0.0.0   ,community  ,n          ,y     ,y
-salesforce                ,input     ,Salesforce                ,4.92.0  ,enterprise ,n          ,y     ,y
-salesforce_cdc            ,input     ,Salesforce                ,4.92.0  ,enterprise ,n          ,y     ,y
-salesforce_graphql        ,input     ,Salesforce                ,4.92.0  ,enterprise ,n          ,y     ,y
-salesforce_sink           ,output    ,Salesforce                ,4.85.0  ,enterprise ,n          ,y     ,y
-schema_registry           ,input     ,schema_registry           ,4.33.0  ,certified  ,n          ,y     ,y
-schema_registry           ,output    ,schema_registry           ,4.33.0  ,certified  ,n          ,y     ,y
-schema_registry_decode    ,processor ,schema_registry_decode    ,0.0.0   ,certified  ,n          ,y     ,y
-schema_registry_encode    ,processor ,schema_registry_encode    ,3.58.0  ,certified  ,n          ,y     ,y
-select_parts              ,processor ,select_parts              ,0.0.0   ,certified  ,n          ,y     ,y
-sentry_capture            ,processor ,sentry_capture            ,4.16.0  ,community  ,n          ,n     ,n
-sequence                  ,input     ,sequence                  ,0.0.0   ,certified  ,n          ,y     ,y
-sftp                      ,input     ,sftp                      ,3.39.0  ,certified  ,n          ,y     ,y
-sftp                      ,output    ,sftp                      ,3.39.0  ,certified  ,n          ,y     ,y
-skip_bom                  ,scanner   ,skip_bom                  ,0.0.0   ,certified  ,n          ,y     ,y
-slack                     ,input     ,Slack                     ,4.51.0  ,enterprise ,n          ,y     ,y
-slack_post                ,output    ,Slack Post                ,4.52.0  ,enterprise ,n          ,y     ,y
-slack_reaction            ,output    ,Slack Reaction            ,4.58.0  ,enterprise ,n          ,y     ,y
-slack_thread              ,processor ,Slack Thread              ,4.52.0  ,enterprise ,n          ,y     ,y
-slack_users               ,input     ,Slack Users               ,4.52.0  ,enterprise ,n          ,y     ,y
-sleep                     ,processor ,sleep                     ,0.0.0   ,certified  ,n          ,y     ,y
-snowflake_put             ,output    ,Snowflake                 ,4.0.0   ,enterprise ,n          ,y     ,y
-snowflake_streaming       ,output    ,Snowflake Streaming       ,4.39.0  ,enterprise ,n          ,y     ,y
-socket                    ,input     ,Socket                    ,0.0.0   ,certified  ,n          ,n     ,n
-socket                    ,output    ,Socket                    ,0.0.0   ,certified  ,n          ,n     ,n
-socket_server             ,input     ,socket_server             ,0.0.0   ,certified  ,n          ,n     ,n
-spicedb_watch             ,input     ,spicedb_watch             ,0.0.0   ,community  ,n          ,y     ,y
-split                     ,processor ,split                     ,0.0.0   ,certified  ,n          ,y     ,y
-splunk                    ,input     ,Splunk                    ,4.30.0  ,enterprise ,n          ,y     ,y
-splunk_hec                ,output    ,Splunk                    ,4.30.0  ,enterprise ,n          ,y     ,y
-sql                       ,cache     ,SQL                       ,4.26.0  ,certified  ,n          ,y     ,y
-sql                       ,output    ,SQL                       ,3.65.0  ,community  ,y          ,n     ,n
-sql                       ,processor ,SQL                       ,3.65.0  ,community  ,y          ,n     ,n
-sql_driver_clickhouse     ,sql_driver,ClickHouse                ,0.0.0   ,community  ,n          ,y     ,y
-sql_driver_gocosmos       ,sql_driver,Azure Cosmos DB           ,0.0.0   ,community  ,n          ,n     ,n
-sql_driver_mssql          ,sql_driver,Microsoft SQL Server      ,0.0.0   ,community  ,n          ,n     ,n
-sql_driver_mysql          ,sql_driver,MYSQL                     ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_oracle         ,sql_driver,Oracle                    ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_postgres       ,sql_driver,PostgreSQL                ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_snowflake      ,sql_driver,Snowflake                 ,0.0.0   ,community  ,n          ,n     ,n
-sql_driver_sqlite         ,sql_driver,SQLite                    ,0.0.0   ,certified  ,n          ,y     ,y
-sql_driver_trino          ,sql_driver,Trino                     ,0.0.0   ,community  ,n          ,n     ,n
-sql_insert                ,output    ,sql_insert                ,3.59.0  ,certified  ,n          ,y     ,y
-sql_insert                ,processor ,sql_insert                ,3.59.0  ,certified  ,n          ,y     ,y
-sql_raw                   ,input     ,sql_raw                   ,4.10.0  ,certified  ,n          ,y     ,y
-sql_raw                   ,output    ,sql_raw                   ,3.65.0  ,certified  ,n          ,y     ,y
-sql_raw                   ,processor ,sql_raw                   ,3.65.0  ,certified  ,n          ,y     ,y
-sql_select                ,input     ,sql_select                ,3.59.0  ,certified  ,n          ,y     ,y
-sql_select                ,processor ,sql_select                ,3.59.0  ,certified  ,n          ,y     ,y
-sqlite                    ,buffer    ,sqlite                    ,0.0.0   ,community  ,n          ,n     ,n
-statsd                    ,metric    ,statsd                    ,0.0.0   ,certified  ,n          ,n     ,n
-stdin                     ,input     ,stdin                     ,0.0.0   ,certified  ,n          ,n     ,n
-stdout                    ,output    ,stdout                    ,0.0.0   ,certified  ,n          ,n     ,n
-string_split              ,processor ,string_split              ,4.86.0  ,certified  ,n          ,y     ,y
-subprocess                ,input     ,subprocess                ,0.0.0   ,community  ,n          ,n     ,n
-subprocess                ,output    ,subprocess                ,0.0.0   ,community  ,n          ,n     ,n
-subprocess                ,processor ,subprocess                ,0.0.0   ,community  ,n          ,n     ,n
-switch                    ,output    ,switch                    ,0.0.0   ,certified  ,n          ,y     ,y
-switch                    ,processor ,switch                    ,0.0.0   ,certified  ,n          ,y     ,y
-switch                    ,scanner   ,switch                    ,0.0.0   ,certified  ,n          ,y     ,y
-sync_response             ,output    ,sync_response             ,0.0.0   ,certified  ,n          ,y     ,y
-sync_response             ,processor ,sync_response             ,0.0.0   ,certified  ,n          ,y     ,y
-system_window             ,buffer    ,system_window             ,3.53.0  ,certified  ,n          ,y     ,y
-tar                       ,scanner   ,tar                       ,0.0.0   ,certified  ,n          ,y     ,y
-text_chunker              ,processor ,text_chunker              ,4.51.0  ,certified  ,n          ,y     ,y
-tigerbeetle_cdc           ,input     ,tigerbeetle_cdc           ,4.65.0  ,certified  ,n          ,n     ,n
-timeplus                  ,input     ,timeplus                  ,4.39.0  ,community  ,n          ,y     ,y
-timeplus                  ,output    ,timeplus                  ,4.38.0  ,community  ,n          ,y     ,y
-to_the_end                ,scanner   ,to_the_end                ,0.0.0   ,certified  ,n          ,y     ,y
-try                       ,processor ,try                       ,0.0.0   ,certified  ,n          ,y     ,y
-ttlru                     ,cache     ,ttlru                     ,0.0.0   ,community  ,n          ,y     ,y
-twitter_search            ,input     ,twitter_search            ,0.0.0   ,community  ,n          ,n     ,n
-unarchive                 ,processor ,unarchive                 ,0.0.0   ,certified  ,n          ,y     ,y
-wasm                      ,processor ,wasm                      ,4.11.0  ,community  ,n          ,n     ,n
-websocket                 ,input     ,websocket                 ,0.0.0   ,certified  ,n          ,n     ,n
-websocket                 ,output    ,websocket                 ,0.0.0   ,certified  ,n          ,n     ,n
-while                     ,processor ,while                     ,0.0.0   ,certified  ,n          ,y     ,y
-workflow                  ,processor ,workflow                  ,0.0.0   ,certified  ,n          ,y     ,y
-xml                       ,processor ,xml                       ,0.0.0   ,community  ,n          ,y     ,y
-zmq4                      ,input     ,zmq4                      ,0.0.0   ,community  ,n          ,n     ,n
-zmq4                      ,output    ,zmq4                      ,0.0.0   ,community  ,n          ,n     ,n
+name                      ,type      ,commercial_name           ,support    ,deprecated ,cloud ,cloud_with_gpu ,cloud_unsupported_reason
+a2a_message               ,processor ,a2a_message               ,enterprise ,n          ,y     ,y              ,
+amqp_0_9                  ,input     ,amqp_0_9                  ,certified  ,n          ,y     ,y              ,
+amqp_0_9                  ,output    ,amqp_0_9                  ,certified  ,n          ,y     ,y              ,
+amqp_1                    ,input     ,amqp_1                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+amqp_1                    ,output    ,amqp_1                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+arc                       ,output    ,arc                       ,community  ,n          ,y     ,y              ,
+archive                   ,processor ,archive                   ,certified  ,n          ,y     ,y              ,
+avro                      ,processor ,avro                      ,community  ,n          ,y     ,y              ,
+avro                      ,scanner   ,avro                      ,community  ,n          ,y     ,y              ,
+awk                       ,processor ,awk                       ,community  ,n          ,n     ,n              ,security: arbitrary code execution
+aws_bedrock_chat          ,processor ,aws_bedrock_chat          ,certified  ,n          ,y     ,y              ,
+aws_bedrock_embeddings    ,processor ,aws_bedrock_embeddings    ,certified  ,n          ,y     ,y              ,
+aws_cloudwatch            ,metric    ,aws_cloudwatch            ,community  ,n          ,n     ,n              ,cloud uses a managed metrics integration
+aws_cloudwatch_logs       ,input     ,AWS CloudWatch Logs       ,community  ,n          ,y     ,y              ,
+aws_dynamodb              ,cache     ,AWS DynamoDB              ,community  ,n          ,y     ,y              ,
+aws_dynamodb              ,output    ,AWS DynamoDB              ,community  ,n          ,y     ,y              ,
+aws_dynamodb_cdc          ,input     ,aws_dynamodb_cdc          ,enterprise ,n          ,y     ,y              ,
+aws_dynamodb_partiql      ,processor ,aws_dynamodb_partiql      ,certified  ,n          ,y     ,y              ,
+aws_kinesis               ,input     ,AWS Kinesis               ,certified  ,n          ,y     ,y              ,
+aws_kinesis               ,output    ,AWS Kinesis               ,certified  ,n          ,y     ,y              ,
+aws_kinesis_firehose      ,output    ,AWS Kinesis Firehose      ,certified  ,n          ,y     ,y              ,
+aws_lambda                ,processor ,AWS Lambda                ,certified  ,n          ,y     ,y              ,
+aws_s3                    ,cache     ,AWS S3                    ,certified  ,n          ,y     ,y              ,
+aws_s3                    ,input     ,AWS S3                    ,certified  ,n          ,y     ,y              ,
+aws_s3                    ,output    ,AWS S3                    ,certified  ,n          ,y     ,y              ,
+aws_sns                   ,output    ,AWS SNS                   ,community  ,n          ,y     ,y              ,
+aws_sqs                   ,input     ,AWS SQS                   ,certified  ,n          ,y     ,y              ,
+aws_sqs                   ,output    ,AWS SQS                   ,certified  ,n          ,y     ,y              ,
+azure_blob_storage        ,input     ,azure_blob_storage        ,certified  ,n          ,y     ,y              ,
+azure_blob_storage        ,output    ,azure_blob_storage        ,certified  ,n          ,y     ,y              ,
+azure_cosmosdb            ,input     ,azure_cosmosdb            ,certified  ,n          ,y     ,y              ,
+azure_cosmosdb            ,output    ,azure_cosmosdb            ,certified  ,n          ,y     ,y              ,
+azure_cosmosdb            ,processor ,azure_cosmosdb            ,certified  ,n          ,y     ,y              ,
+azure_data_lake_gen2      ,output    ,azure_data_lake_gen2      ,certified  ,n          ,y     ,y              ,
+azure_queue_storage       ,input     ,azure_queue_storage       ,certified  ,n          ,y     ,y              ,
+azure_queue_storage       ,output    ,azure_queue_storage       ,certified  ,n          ,y     ,y              ,
+azure_table_storage       ,input     ,azure_table_storage       ,certified  ,n          ,y     ,y              ,
+azure_table_storage       ,output    ,azure_table_storage       ,certified  ,n          ,y     ,y              ,
+batched                   ,input     ,batched                   ,certified  ,n          ,y     ,y              ,
+beanstalkd                ,input     ,beanstalkd                ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+beanstalkd                ,output    ,beanstalkd                ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+benchmark                 ,processor ,benchmark                 ,certified  ,n          ,y     ,y              ,
+bloblang                  ,processor ,bloblang                  ,certified  ,n          ,y     ,y              ,
+bounds_check              ,processor ,bounds_check              ,certified  ,n          ,y     ,y              ,
+branch                    ,processor ,branch                    ,certified  ,n          ,y     ,y              ,
+broker                    ,input     ,broker                    ,certified  ,n          ,y     ,y              ,
+broker                    ,output    ,broker                    ,certified  ,n          ,y     ,y              ,
+cache                     ,output    ,cache                     ,certified  ,n          ,y     ,y              ,
+cache                     ,processor ,cache                     ,certified  ,n          ,y     ,y              ,
+cached                    ,processor ,cached                    ,certified  ,n          ,y     ,y              ,
+cassandra                 ,input     ,cassandra                 ,community  ,n          ,n     ,n              ,not yet certified for cloud
+cassandra                 ,output    ,cassandra                 ,community  ,n          ,n     ,n              ,not yet certified for cloud
+catch                     ,processor ,catch                     ,certified  ,n          ,y     ,y              ,
+chunker                   ,scanner   ,chunker                   ,certified  ,n          ,y     ,y              ,
+cockroachdb_changefeed    ,input     ,cockroachdb_changefeed    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+cohere_chat               ,processor ,cohere_chat               ,certified  ,n          ,y     ,y              ,
+cohere_embeddings         ,processor ,cohere_embeddings         ,certified  ,n          ,y     ,y              ,
+cohere_rerank             ,processor ,cohere_rerank             ,certified  ,n          ,y     ,y              ,
+command                   ,processor ,command                   ,certified  ,n          ,n     ,n              ,security: arbitrary code execution
+compress                  ,processor ,compress                  ,certified  ,n          ,y     ,y              ,
+couchbase                 ,cache     ,Couchbase                 ,community  ,n          ,n     ,n              ,not yet certified for cloud
+couchbase                 ,output    ,Couchbase                 ,community  ,n          ,n     ,n              ,not yet certified for cloud
+couchbase                 ,processor ,Couchbase                 ,community  ,n          ,n     ,n              ,not yet certified for cloud
+crash                     ,processor ,crash                     ,certified  ,n          ,n     ,n              ,intentionally crashes the pipeline; testing only
+csv                       ,input     ,csv                       ,certified  ,n          ,n     ,n              ,reads from local filesystem
+csv                       ,scanner   ,csv                       ,certified  ,n          ,y     ,y              ,
+cyborgdb                  ,output    ,cyborgdb                  ,community  ,n          ,y     ,y              ,
+cypher                    ,output    ,cypher                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+decompress                ,processor ,decompress                ,certified  ,n          ,y     ,y              ,
+decompress                ,scanner   ,decompress                ,certified  ,n          ,y     ,y              ,
+dedupe                    ,processor ,dedupe                    ,certified  ,n          ,y     ,y              ,
+discord                   ,input     ,discord                   ,community  ,n          ,n     ,n              ,not yet certified for cloud
+discord                   ,output    ,discord                   ,community  ,n          ,n     ,n              ,not yet certified for cloud
+drop                      ,output    ,drop                      ,certified  ,n          ,y     ,y              ,
+drop_on                   ,output    ,drop_on                   ,certified  ,n          ,y     ,y              ,
+dynamic                   ,input     ,dynamic                   ,community  ,n          ,n     ,n              ,security: opens a listener unreachable from cloud
+dynamic                   ,output    ,dynamic                   ,community  ,n          ,n     ,n              ,security: opens a listener unreachable from cloud
+elasticsearch_v8          ,output    ,elasticsearch_v8          ,certified  ,n          ,y     ,y              ,
+elasticsearch_v9          ,output    ,elasticsearch_v9          ,community  ,n          ,n     ,n              ,not yet certified for cloud
+fallback                  ,output    ,fallback                  ,certified  ,n          ,y     ,y              ,
+ffi                       ,processor ,Foreign Function Interface,certified  ,n          ,n     ,n              ,security: arbitrary code execution
+file                      ,cache     ,File                      ,certified  ,n          ,n     ,n              ,security: local filesystem access
+file                      ,input     ,File                      ,certified  ,n          ,n     ,n              ,security: local filesystem access
+file                      ,output    ,File                      ,certified  ,n          ,n     ,n              ,security: local filesystem access
+for_each                  ,processor ,for_each                  ,certified  ,n          ,y     ,y              ,
+gateway                   ,input     ,gateway                   ,enterprise ,n          ,y     ,y              ,
+gcp_bigquery              ,output    ,GCP BigQuery              ,certified  ,n          ,y     ,y              ,
+gcp_bigquery_select       ,input     ,GCP BigQuery              ,certified  ,n          ,y     ,y              ,
+gcp_bigquery_select       ,processor ,GCP BigQuery              ,certified  ,n          ,y     ,y              ,
+gcp_bigquery_write_api    ,output    ,GCP BigQuery              ,enterprise ,n          ,y     ,y              ,
+gcp_cloud_storage         ,cache     ,GCP Cloud Storage         ,certified  ,n          ,y     ,y              ,
+gcp_cloud_storage         ,input     ,GCP Cloud Storage         ,certified  ,n          ,y     ,y              ,
+gcp_cloud_storage         ,output    ,GCP Cloud Storage         ,certified  ,n          ,y     ,y              ,
+gcp_cloudtrace            ,tracer    ,GCP Cloud Trace           ,certified  ,n          ,y     ,y              ,
+gcp_pubsub                ,input     ,GCP PubSub                ,certified  ,n          ,y     ,y              ,
+gcp_pubsub                ,output    ,GCP PubSub                ,certified  ,n          ,y     ,y              ,
+gcp_spanner_cdc           ,input     ,gcp_spanner_cdc           ,enterprise ,n          ,y     ,y              ,
+gcp_vertex_ai_chat        ,processor ,GCP Vertex AI             ,certified  ,n          ,y     ,y              ,
+gcp_vertex_ai_embeddings  ,processor ,gcp_vertex_ai_embeddings  ,certified  ,n          ,y     ,y              ,
+generate                  ,input     ,generate                  ,certified  ,n          ,y     ,y              ,
+git                       ,input     ,git                       ,certified  ,n          ,y     ,y              ,
+google_drive_download     ,processor ,google_drive_download     ,enterprise ,n          ,y     ,y              ,
+google_drive_list_labels  ,processor ,google_drive_list_labels  ,enterprise ,n          ,y     ,y              ,
+google_drive_search       ,processor ,google_drive_search       ,enterprise ,n          ,y     ,y              ,
+grok                      ,processor ,grok                      ,community  ,n          ,n     ,n              ,not yet certified for cloud
+group_by                  ,processor ,group_by                  ,certified  ,n          ,y     ,y              ,
+group_by_value            ,processor ,group_by_value            ,certified  ,n          ,y     ,y              ,
+hdfs                      ,input     ,hdfs                      ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+hdfs                      ,output    ,hdfs                      ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+http                      ,processor ,HTTP                      ,certified  ,n          ,y     ,y              ,
+http_client               ,input     ,http_client               ,certified  ,n          ,y     ,y              ,
+http_client               ,output    ,http_client               ,certified  ,n          ,y     ,y              ,
+http_server               ,input     ,http_server               ,certified  ,n          ,y     ,y              ,
+http_server               ,output    ,http_server               ,certified  ,n          ,n     ,n              ,requires inbound listener; cloud is outbound only
+iceberg                   ,output    ,Apache Iceberg            ,enterprise ,n          ,y     ,y              ,
+influxdb                  ,metric    ,influxdb                  ,community  ,n          ,n     ,n              ,cloud uses a managed metrics integration
+inproc                    ,input     ,inproc                    ,certified  ,n          ,y     ,y              ,
+inproc                    ,output    ,inproc                    ,certified  ,n          ,y     ,y              ,
+insert_part               ,processor ,insert_part               ,certified  ,n          ,y     ,y              ,
+jaeger                    ,tracer    ,jaeger                    ,community  ,n          ,n     ,n              ,cloud uses a managed tracing integration
+javascript                ,processor ,javascript                ,certified  ,n          ,n     ,n              ,security: arbitrary code execution
+jira                      ,processor ,jira                      ,certified  ,n          ,y     ,n              ,
+jmespath                  ,processor ,JMESPath                  ,certified  ,n          ,y     ,y              ,
+jq                        ,processor ,jq                        ,certified  ,n          ,y     ,y              ,
+json_api                  ,metric    ,json_api                  ,certified  ,n          ,n     ,n              ,cloud uses a managed metrics integration
+json_array                ,scanner   ,json_array                ,community  ,n          ,y     ,y              ,
+json_documents            ,scanner   ,json_documents            ,certified  ,n          ,y     ,y              ,
+json_schema               ,processor ,JSON Schema               ,certified  ,n          ,y     ,y              ,
+kafka                     ,input     ,Kafka                     ,certified  ,y          ,y     ,y              ,
+kafka                     ,output    ,Kafka                     ,certified  ,n          ,y     ,y              ,
+kafka_franz               ,input     ,kafka_franz               ,certified  ,y          ,y     ,y              ,
+kafka_franz               ,output    ,kafka_franz               ,certified  ,n          ,y     ,y              ,
+lines                     ,scanner   ,lines                     ,certified  ,n          ,y     ,y              ,
+local                     ,rate_limit,local                     ,certified  ,n          ,y     ,y              ,
+log                       ,processor ,log                       ,certified  ,n          ,y     ,y              ,
+logger                    ,metric    ,logger                    ,certified  ,n          ,n     ,n              ,cloud uses a managed metrics integration
+lru                       ,cache     ,lru                       ,community  ,n          ,y     ,y              ,
+mapping                   ,processor ,mapping                   ,certified  ,n          ,y     ,y              ,
+memcached                 ,cache     ,Memcached                 ,community  ,n          ,y     ,y              ,
+memory                    ,buffer    ,Memory                    ,certified  ,n          ,y     ,y              ,
+memory                    ,cache     ,Memory                    ,certified  ,n          ,y     ,y              ,
+metric                    ,processor ,metric                    ,certified  ,n          ,y     ,y              ,
+microsoft_sql_server_cdc  ,input     ,microsoft_sql_server_cdc  ,enterprise ,n          ,y     ,y              ,
+mongodb                   ,cache     ,MongoDB                   ,certified  ,n          ,y     ,y              ,
+mongodb                   ,input     ,MongoDB                   ,certified  ,n          ,y     ,y              ,
+mongodb                   ,output    ,MongoDB                   ,certified  ,n          ,y     ,y              ,
+mongodb                   ,processor ,MongoDB                   ,certified  ,n          ,y     ,y              ,
+mongodb_cdc               ,input     ,MongoDB CDC               ,enterprise ,n          ,y     ,y              ,
+mqtt                      ,input     ,mqtt                      ,certified  ,n          ,y     ,y              ,
+mqtt                      ,output    ,mqtt                      ,certified  ,n          ,y     ,y              ,
+msgpack                   ,processor ,msgpack                   ,community  ,n          ,n     ,n              ,not yet certified for cloud
+multilevel                ,cache     ,Multilevel                ,certified  ,n          ,y     ,y              ,
+mutation                  ,processor ,mutation                  ,certified  ,n          ,y     ,y              ,
+mysql_cdc                 ,input     ,mysql_cdc                 ,enterprise ,n          ,y     ,y              ,
+nanomsg                   ,input     ,nanomsg                   ,community  ,n          ,n     ,n              ,deprecated upstream protocol
+nanomsg                   ,output    ,nanomsg                   ,community  ,n          ,n     ,n              ,deprecated upstream protocol
+nats                      ,input     ,NATS                      ,certified  ,n          ,y     ,y              ,
+nats                      ,output    ,NATS                      ,certified  ,n          ,y     ,y              ,
+nats_jetstream            ,input     ,NATS JetStream            ,certified  ,n          ,y     ,y              ,
+nats_jetstream            ,output    ,NATS JetStream            ,certified  ,n          ,y     ,y              ,
+nats_kv                   ,cache     ,NATS KV                   ,certified  ,n          ,y     ,y              ,
+nats_kv                   ,input     ,NATS KV                   ,certified  ,n          ,y     ,y              ,
+nats_kv                   ,output    ,NATS KV                   ,certified  ,n          ,y     ,y              ,
+nats_kv                   ,processor ,NATS KV                   ,certified  ,n          ,y     ,y              ,
+nats_request_reply        ,processor ,NATS Request Reply        ,certified  ,n          ,y     ,y              ,
+nats_stream               ,input     ,NATS Stream               ,community  ,n          ,n     ,n              ,NATS Streaming Server is end-of-life; use nats_jetstream
+nats_stream               ,output    ,NATS Stream               ,community  ,n          ,n     ,n              ,NATS Streaming Server is end-of-life; use nats_jetstream
+none                      ,buffer    ,none                      ,certified  ,n          ,y     ,y              ,
+none                      ,metric    ,none                      ,certified  ,n          ,y     ,y              ,
+none                      ,tracer    ,none                      ,certified  ,n          ,y     ,y              ,
+noop                      ,cache     ,noop                      ,certified  ,n          ,y     ,y              ,
+noop                      ,processor ,noop                      ,certified  ,n          ,y     ,y              ,
+nsq                       ,input     ,nsq                       ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+nsq                       ,output    ,nsq                       ,community  ,n          ,n     ,n              ,low cloud demand; not yet certified
+ockam_kafka               ,input     ,ockam_kafka               ,community  ,n          ,n     ,n              ,not yet certified for cloud
+ockam_kafka               ,output    ,ockam_kafka               ,community  ,n          ,n     ,n              ,not yet certified for cloud
+ollama_chat               ,processor ,ollama_chat               ,certified  ,n          ,n     ,y              ,requires a local Ollama runtime; AI build only
+ollama_embeddings         ,processor ,ollama_embeddings         ,certified  ,n          ,n     ,y              ,requires a local Ollama runtime; AI build only
+ollama_moderation         ,processor ,ollama_moderation         ,certified  ,n          ,n     ,y              ,requires a local Ollama runtime; AI build only
+open_telemetry_collector  ,metric    ,open_telemetry_collector  ,enterprise ,n          ,y     ,y              ,
+open_telemetry_collector  ,tracer    ,open_telemetry_collector  ,enterprise ,n          ,y     ,y              ,
+openai_chat_completion    ,processor ,openai_chat_completion    ,certified  ,n          ,y     ,y              ,
+openai_embeddings         ,processor ,openai_embeddings         ,certified  ,n          ,y     ,y              ,
+openai_image_generation   ,processor ,openai_image_generation   ,certified  ,n          ,y     ,y              ,
+openai_speech             ,processor ,openai_speech             ,certified  ,n          ,y     ,y              ,
+openai_transcription      ,processor ,openai_transcription      ,certified  ,n          ,y     ,y              ,
+openai_translation        ,processor ,openai_translation        ,certified  ,n          ,y     ,y              ,
+opensearch                ,output    ,OpenSearch                ,certified  ,n          ,y     ,y              ,
+oracledb_cdc              ,input     ,oracledb_cdc              ,enterprise ,n          ,y     ,y              ,
+otlp_grpc                 ,input     ,otlp_grpc                 ,enterprise ,n          ,y     ,y              ,
+otlp_grpc                 ,output    ,otlp_grpc                 ,enterprise ,n          ,y     ,y              ,
+otlp_http                 ,input     ,otlp_http                 ,enterprise ,n          ,y     ,y              ,
+otlp_http                 ,output    ,otlp_http                 ,enterprise ,n          ,y     ,y              ,
+parallel                  ,processor ,parallel                  ,certified  ,n          ,y     ,y              ,
+parquet                   ,input     ,parquet                   ,certified  ,n          ,n     ,n              ,reads from local filesystem
+parquet                   ,processor ,parquet                   ,community  ,y          ,n     ,n              ,not yet certified for cloud
+parquet_decode            ,processor ,parquet_decode            ,certified  ,n          ,y     ,y              ,
+parquet_encode            ,processor ,parquet_encode            ,certified  ,n          ,y     ,y              ,
+parse_log                 ,processor ,parse_log                 ,community  ,n          ,y     ,y              ,
+pg_stream                 ,input     ,pg_stream                 ,enterprise ,y          ,y     ,y              ,
+pinecone                  ,output    ,pinecone                  ,certified  ,n          ,y     ,y              ,
+postgres_cdc              ,input     ,postgres_cdc              ,enterprise ,n          ,y     ,y              ,
+processors                ,processor ,processors                ,certified  ,n          ,y     ,y              ,
+prometheus                ,metric    ,prometheus                ,certified  ,n          ,y     ,y              ,
+protobuf                  ,processor ,Protobuf                  ,certified  ,n          ,n     ,n              ,loads schemas from local filesystem
+pulsar                    ,input     ,pulsar                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+pulsar                    ,output    ,pulsar                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+pusher                    ,output    ,pusher                    ,community  ,n          ,n     ,n              ,not yet certified for cloud
+qdrant                    ,output    ,qdrant                    ,certified  ,n          ,y     ,y              ,
+qdrant                    ,processor ,qdrant                    ,certified  ,n          ,y     ,y              ,
+questdb                   ,output    ,questdb                   ,certified  ,n          ,y     ,y              ,
+rate_limit                ,processor ,rate_limit                ,certified  ,n          ,y     ,y              ,
+re_match                  ,scanner   ,re_match                  ,certified  ,n          ,y     ,y              ,
+read_until                ,input     ,read_until                ,certified  ,n          ,y     ,y              ,
+redis                     ,cache     ,Redis                     ,certified  ,n          ,y     ,y              ,
+redis                     ,processor ,Redis                     ,certified  ,n          ,y     ,y              ,
+redis                     ,rate_limit,Redis                     ,certified  ,n          ,y     ,y              ,
+redis_hash                ,output    ,Redis Hash                ,certified  ,n          ,y     ,y              ,
+redis_list                ,input     ,Redis List                ,certified  ,n          ,y     ,y              ,
+redis_list                ,output    ,Redis List                ,certified  ,n          ,y     ,y              ,
+redis_pubsub              ,input     ,Redis PubSub              ,certified  ,n          ,y     ,y              ,
+redis_pubsub              ,output    ,Redis PubSub              ,certified  ,n          ,y     ,y              ,
+redis_scan                ,input     ,Redis                     ,certified  ,n          ,y     ,y              ,
+redis_script              ,processor ,Redis Script              ,certified  ,n          ,y     ,y              ,
+redis_streams             ,input     ,Redis Streams             ,certified  ,n          ,y     ,y              ,
+redis_streams             ,output    ,Redis Streams             ,certified  ,n          ,y     ,y              ,
+redpanda                  ,cache     ,redpanda                  ,certified  ,n          ,y     ,y              ,
+redpanda                  ,input     ,redpanda                  ,certified  ,n          ,y     ,y              ,
+redpanda                  ,output    ,redpanda                  ,certified  ,n          ,y     ,y              ,
+redpanda                  ,tracer    ,redpanda                  ,certified  ,n          ,y     ,y              ,
+redpanda_common           ,input     ,redpanda_common           ,enterprise ,y          ,y     ,y              ,
+redpanda_common           ,output    ,redpanda_common           ,enterprise ,y          ,y     ,y              ,
+redpanda_data_transform   ,processor ,redpanda_data_transform   ,certified  ,n          ,n     ,n              ,WASM runtime not enabled in cloud
+redpanda_migrator         ,input     ,redpanda_migrator         ,certified  ,n          ,y     ,y              ,
+redpanda_migrator         ,output    ,redpanda_migrator         ,certified  ,n          ,y     ,y              ,
+reject                    ,output    ,reject                    ,certified  ,n          ,y     ,y              ,
+reject_errored            ,output    ,reject_errored            ,certified  ,n          ,y     ,y              ,
+resource                  ,input     ,resource                  ,certified  ,n          ,y     ,y              ,
+resource                  ,output    ,resource                  ,certified  ,n          ,y     ,y              ,
+resource                  ,processor ,resource                  ,certified  ,n          ,y     ,y              ,
+retry                     ,output    ,retry                     ,certified  ,n          ,y     ,y              ,
+retry                     ,processor ,retry                     ,certified  ,n          ,y     ,y              ,
+ristretto                 ,cache     ,Ristretto                 ,community  ,n          ,y     ,y              ,
+salesforce                ,input     ,Salesforce                ,enterprise ,n          ,y     ,y              ,
+salesforce_cdc            ,input     ,Salesforce                ,enterprise ,n          ,y     ,y              ,
+salesforce_graphql        ,input     ,Salesforce                ,enterprise ,n          ,y     ,y              ,
+salesforce_sink           ,output    ,Salesforce                ,enterprise ,n          ,y     ,y              ,
+schema_registry           ,input     ,schema_registry           ,certified  ,n          ,y     ,y              ,
+schema_registry           ,output    ,schema_registry           ,certified  ,n          ,y     ,y              ,
+schema_registry_decode    ,processor ,schema_registry_decode    ,certified  ,n          ,y     ,y              ,
+schema_registry_encode    ,processor ,schema_registry_encode    ,certified  ,n          ,y     ,y              ,
+select_parts              ,processor ,select_parts              ,certified  ,n          ,y     ,y              ,
+sentry_capture            ,processor ,sentry_capture            ,community  ,n          ,n     ,n              ,not yet certified for cloud
+sequence                  ,input     ,sequence                  ,certified  ,n          ,y     ,y              ,
+sftp                      ,input     ,sftp                      ,certified  ,n          ,y     ,y              ,
+sftp                      ,output    ,sftp                      ,certified  ,n          ,y     ,y              ,
+skip_bom                  ,scanner   ,skip_bom                  ,certified  ,n          ,y     ,y              ,
+slack                     ,input     ,Slack                     ,enterprise ,n          ,y     ,y              ,
+slack_post                ,output    ,Slack Post                ,enterprise ,n          ,y     ,y              ,
+slack_reaction            ,output    ,Slack Reaction            ,enterprise ,n          ,y     ,y              ,
+slack_thread              ,processor ,Slack Thread              ,enterprise ,n          ,y     ,y              ,
+slack_users               ,input     ,Slack Users               ,enterprise ,n          ,y     ,y              ,
+sleep                     ,processor ,sleep                     ,certified  ,n          ,y     ,y              ,
+snowflake_put             ,output    ,Snowflake                 ,enterprise ,n          ,y     ,y              ,
+snowflake_streaming       ,output    ,Snowflake Streaming       ,enterprise ,n          ,y     ,y              ,
+socket                    ,input     ,Socket                    ,certified  ,n          ,n     ,n              ,security: raw socket access
+socket                    ,output    ,Socket                    ,certified  ,n          ,n     ,n              ,security: raw socket access
+socket_server             ,input     ,socket_server             ,certified  ,n          ,n     ,n              ,security: opens a listener unreachable from cloud
+spicedb_watch             ,input     ,spicedb_watch             ,community  ,n          ,y     ,y              ,
+split                     ,processor ,split                     ,certified  ,n          ,y     ,y              ,
+splunk                    ,input     ,Splunk                    ,enterprise ,n          ,y     ,y              ,
+splunk_hec                ,output    ,Splunk                    ,enterprise ,n          ,y     ,y              ,
+sql                       ,cache     ,SQL                       ,certified  ,n          ,y     ,y              ,
+sql                       ,output    ,SQL                       ,community  ,y          ,n     ,n              ,use cloud-specific SQL connectors
+sql                       ,processor ,SQL                       ,community  ,y          ,n     ,n              ,use cloud-specific SQL connectors
+sql_driver_clickhouse     ,sql_driver,ClickHouse                ,community  ,n          ,y     ,y              ,
+sql_driver_gocosmos       ,sql_driver,Azure Cosmos DB           ,community  ,n          ,n     ,n              ,not yet certified for cloud
+sql_driver_mssql          ,sql_driver,Microsoft SQL Server      ,community  ,n          ,n     ,n              ,not yet certified for cloud
+sql_driver_mysql          ,sql_driver,MYSQL                     ,certified  ,n          ,y     ,y              ,
+sql_driver_oracle         ,sql_driver,Oracle                    ,certified  ,n          ,y     ,y              ,
+sql_driver_postgres       ,sql_driver,PostgreSQL                ,certified  ,n          ,y     ,y              ,
+sql_driver_snowflake      ,sql_driver,Snowflake                 ,community  ,n          ,n     ,n              ,use the snowflake_put output in cloud
+sql_driver_sqlite         ,sql_driver,SQLite                    ,certified  ,n          ,y     ,y              ,
+sql_driver_trino          ,sql_driver,Trino                     ,community  ,n          ,n     ,n              ,not yet certified for cloud
+sql_insert                ,output    ,sql_insert                ,certified  ,n          ,y     ,y              ,
+sql_insert                ,processor ,sql_insert                ,certified  ,n          ,y     ,y              ,
+sql_raw                   ,input     ,sql_raw                   ,certified  ,n          ,y     ,y              ,
+sql_raw                   ,output    ,sql_raw                   ,certified  ,n          ,y     ,y              ,
+sql_raw                   ,processor ,sql_raw                   ,certified  ,n          ,y     ,y              ,
+sql_select                ,input     ,sql_select                ,certified  ,n          ,y     ,y              ,
+sql_select                ,processor ,sql_select                ,certified  ,n          ,y     ,y              ,
+sqlite                    ,buffer    ,sqlite                    ,community  ,n          ,n     ,n              ,security: local filesystem access
+statsd                    ,metric    ,statsd                    ,certified  ,n          ,n     ,n              ,cloud uses a managed metrics integration
+stdin                     ,input     ,stdin                     ,certified  ,n          ,n     ,n              ,security: pipeline stdio not exposed in cloud
+stdout                    ,output    ,stdout                    ,certified  ,n          ,n     ,n              ,security: pipeline stdio not exposed in cloud
+string_split              ,processor ,string_split              ,certified  ,n          ,y     ,y              ,
+subprocess                ,input     ,subprocess                ,community  ,n          ,n     ,n              ,security: arbitrary code execution
+subprocess                ,output    ,subprocess                ,community  ,n          ,n     ,n              ,security: arbitrary code execution
+subprocess                ,processor ,subprocess                ,community  ,n          ,n     ,n              ,security: arbitrary code execution
+switch                    ,output    ,switch                    ,certified  ,n          ,y     ,y              ,
+switch                    ,processor ,switch                    ,certified  ,n          ,y     ,y              ,
+switch                    ,scanner   ,switch                    ,certified  ,n          ,y     ,y              ,
+sync_response             ,output    ,sync_response             ,certified  ,n          ,y     ,y              ,
+sync_response             ,processor ,sync_response             ,certified  ,n          ,y     ,y              ,
+system_window             ,buffer    ,system_window             ,certified  ,n          ,y     ,y              ,
+tar                       ,scanner   ,tar                       ,certified  ,n          ,y     ,y              ,
+text_chunker              ,processor ,text_chunker              ,certified  ,n          ,y     ,y              ,
+tigerbeetle_cdc           ,input     ,tigerbeetle_cdc           ,certified  ,n          ,n     ,n              ,not yet certified for cloud
+timeplus                  ,input     ,timeplus                  ,community  ,n          ,y     ,y              ,
+timeplus                  ,output    ,timeplus                  ,community  ,n          ,y     ,y              ,
+to_the_end                ,scanner   ,to_the_end                ,certified  ,n          ,y     ,y              ,
+try                       ,processor ,try                       ,certified  ,n          ,y     ,y              ,
+ttlru                     ,cache     ,ttlru                     ,community  ,n          ,y     ,y              ,
+twitter_search            ,input     ,twitter_search            ,community  ,n          ,n     ,n              ,not yet certified for cloud
+unarchive                 ,processor ,unarchive                 ,certified  ,n          ,y     ,y              ,
+wasm                      ,processor ,wasm                      ,community  ,n          ,n     ,n              ,WASM runtime not enabled in cloud
+websocket                 ,input     ,websocket                 ,certified  ,n          ,n     ,n              ,long-lived persistent connection not suitable for cloud
+websocket                 ,output    ,websocket                 ,certified  ,n          ,n     ,n              ,long-lived persistent connection not suitable for cloud
+while                     ,processor ,while                     ,certified  ,n          ,y     ,y              ,
+workflow                  ,processor ,workflow                  ,certified  ,n          ,y     ,y              ,
+xml                       ,processor ,xml                       ,community  ,n          ,y     ,y              ,
+zmq4                      ,input     ,zmq4                      ,community  ,n          ,n     ,n              ,requires libzmq; excluded from cloud build
+zmq4                      ,output    ,zmq4                      ,community  ,n          ,n     ,n              ,requires libzmq; excluded from cloud build

--- a/internal/plugins/info.go
+++ b/internal/plugins/info.go
@@ -65,14 +65,14 @@ var baseInfoCSV []byte
 
 // PluginInfo describes a given component
 type PluginInfo struct {
-	Name           string
-	Type           TypeName
-	CommercialName string
-	Support        string
-	Version        string
-	Deprecated     bool
-	Cloud          bool
-	CloudWithGPU   bool
+	Name                   string
+	Type                   TypeName
+	CommercialName         string
+	Support                string
+	Deprecated             bool
+	Cloud                  bool
+	CloudWithGPU           bool
+	CloudUnsupportedReason string
 }
 
 func basePluginInfo(name string, typeStr TypeName, view *service.ConfigView) PluginInfo {
@@ -80,7 +80,6 @@ func basePluginInfo(name string, typeStr TypeName, view *service.ConfigView) Plu
 		Name:           name,
 		Type:           typeStr,
 		CommercialName: name,
-		Version:        "0.0.0",
 		Deprecated:     view.IsDeprecated(),
 		Support:        "community",
 	}
@@ -95,19 +94,15 @@ func pluginInfoFromMap(m map[string]string) PluginInfo {
 	if supportStr == "" {
 		supportStr = "community"
 	}
-	version := m["version"]
-	if version == "" {
-		version = "0.0.0"
-	}
 	return PluginInfo{
-		Name:           m["name"],
-		Type:           TypeName(m["type"]),
-		CommercialName: m["commercial_name"],
-		Version:        version,
-		Support:        supportStr,
-		Deprecated:     m["deprecated"] == "y",
-		Cloud:          m["cloud"] == "y",
-		CloudWithGPU:   m["cloud_with_gpu"] == "y",
+		Name:                   m["name"],
+		Type:                   TypeName(m["type"]),
+		CommercialName:         m["commercial_name"],
+		Support:                supportStr,
+		Deprecated:             m["deprecated"] == "y",
+		Cloud:                  m["cloud"] == "y",
+		CloudWithGPU:           m["cloud_with_gpu"] == "y",
+		CloudUnsupportedReason: m["cloud_unsupported_reason"],
 	}
 }
 
@@ -117,19 +112,19 @@ type columnInfo struct {
 }
 
 func pluginInfoMapColumns() []columnInfo {
-	return []columnInfo{{"name", 26}, {"type", 10}, {"commercial_name", 26}, {"version", 8}, {"support", 11}, {"deprecated", 11}, {"cloud", 6}, {"cloud_with_gpu", 0}}
+	return []columnInfo{{"name", 26}, {"type", 10}, {"commercial_name", 26}, {"support", 11}, {"deprecated", 11}, {"cloud", 6}, {"cloud_with_gpu", 15}, {"cloud_unsupported_reason", 0}}
 }
 
 func (c PluginInfo) toMap() map[string]string {
 	return map[string]string{
-		"name":            c.Name,
-		"type":            string(c.Type),
-		"commercial_name": c.CommercialName,
-		"version":         c.Version,
-		"support":         c.Support,
-		"deprecated":      formatBool(c.Deprecated),
-		"cloud":           formatBool(c.Cloud),
-		"cloud_with_gpu":  formatBool(c.CloudWithGPU),
+		"name":                     c.Name,
+		"type":                     string(c.Type),
+		"commercial_name":          c.CommercialName,
+		"support":                  c.Support,
+		"deprecated":               formatBool(c.Deprecated),
+		"cloud":                    formatBool(c.Cloud),
+		"cloud_with_gpu":           formatBool(c.CloudWithGPU),
+		"cloud_unsupported_reason": c.CloudUnsupportedReason,
 	}
 }
 


### PR DESCRIPTION
Adds a cloud_unsupported_reason column to internal/plugins/info.csv so that every connector excluded from the cloud distribution carries a one-line rationale alongside the cloud=n flag, and drops the version column entirely (157 of 320 rows carried the 0.0.0 placeholder, and nothing in the runtime, docs, or cloud bundling consumed the value).

A new TestPluginCloudEnablement in internal/plugins/alltest enforces the invariant going forward: every plugin must either be cloud-enabled or carry a non-empty cloud_unsupported_reason.

The reasons for connectors deliberately gated on security review are bucketed into "security: arbitrary code execution", "security: local filesystem access", "security: raw socket access", "security: opens a listener unreachable from cloud", and "security: pipeline stdio not exposed in cloud". The remaining reasons cover deprecated upstream protocols, managed metrics/tracing in cloud, missing certification, and a few connector-specific limitations.