### PR TITLE
Bq connector benchmark

### DIFF
--- a/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
@@ -43,7 +43,7 @@ output:
     dataset: "" # No default (required)
     table: "" # No default (required)
     message_format: json
-    max_in_flight: 64
+    max_in_flight: 4
     batching:
       count: 0
       byte_size: 0
@@ -66,7 +66,7 @@ output:
     dataset: "" # No default (required)
     table: "" # No default (required)
     message_format: json
-    max_in_flight: 64
+    max_in_flight: 4
     batching:
       count: 0
       byte_size: 0
@@ -92,12 +92,14 @@ This provides higher throughput and lower latency than the legacy streaming API 
 Messages can be formatted as JSON (default) or raw protobuf bytes.
 When using JSON format the component automatically fetches the table schema and converts each message to the corresponding proto representation.
 
-WARNING: The proto3 JSON mapping encodes int64 and uint64 values as strings.
-JSON messages with integer fields must use string values (e.g. `"age": "30"` not `"age": 30`).
-Otherwise the write will fail with an unmarshalling error.
+WARNING: protojson encodes int64 and uint64 values as strings, bytes as base64-encoded strings, and timestamps as RFC 3339 strings.
+JSON messages must follow these conventions (e.g. `"age": "30"`, `"data": "aGVsbG8="`, `"created_at": "2026-01-02T15:04:05Z"`); otherwise the write will fail with an unmarshalling error.
 
 When batching is enabled the table name is resolved from the first message in each batch.
 All messages in the same batch are written to that table.
+
+The interpolated table name is sanitized for BigQuery: dots, hyphens, slashes and whitespace are replaced with underscores, non-ASCII-alphanumeric characters are stripped, leading digits are prefixed with `_`, and the result is truncated to 1024 characters.
+A name that sanitizes to the empty string is rejected as a permanent error.
 
 
 == Fields
@@ -149,7 +151,7 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 *Type*: `int`
 
-*Default*: `64`
+*Default*: `4`
 
 === `batching`
 

--- a/internal/impl/gcp/enterprise/bigquery/benchmark_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/benchmark_test.go
@@ -1,0 +1,353 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+// BenchmarkWriteBatch measures end-to-end WriteBatch throughput against either
+// the goccy bigquery emulator (default) or a real BigQuery project (when the
+// BQ_BENCH_PROJECT env var is set).
+//
+// EMULATOR MODE (default): in-process emulator with no quota and a localhost
+// gRPC dial. Useful for catching local-hot-path regressions; absolute numbers
+// are NOT representative of production capacity.
+//
+// REAL-BQ MODE: set the following env vars to hit a real BigQuery project.
+// Costs apply: BigQuery Storage Write API charges ~$0.025 per GB ingested,
+// so a -benchtime=2s run with batch=1000 (~70 KB / batch, 200 batches) writes
+// roughly 14 MB and costs a fraction of a cent. Watch your -benchtime if you
+// scale up.
+//
+//	BQ_BENCH_PROJECT          required: GCP project ID
+//	BQ_BENCH_DATASET          required: existing BigQuery dataset
+//	BQ_BENCH_CREDENTIALS_JSON optional: JSON service-account key contents.
+//	                          If unset, ADC is used (gcloud auth application-default login).
+//	BQ_BENCH_TABLE_PREFIX     optional: prefix for the per-batch-size benchmark
+//	                          tables (default "bqwa_bench"). Tables are created
+//	                          if absent and reused across runs.
+//
+// Run with (Docker required for emulator mode):
+//
+//	# Emulator
+//	go test -run=^BenchmarkWriteBatch$ -bench=^BenchmarkWriteBatch$ -benchtime=2s \
+//	  ./internal/impl/gcp/enterprise/bigquery/
+//
+//	# Real BigQuery
+//	BQ_BENCH_PROJECT=my-proj BQ_BENCH_DATASET=bench \
+//	  go test -run=^BenchmarkWriteBatch$ -bench=^BenchmarkWriteBatch$ -benchtime=2s \
+//	  ./internal/impl/gcp/enterprise/bigquery/
+//
+// The -run flag must reference the benchmark name (not ^$) because
+// integration.CheckSkip also reads -run; -run=^$ would skip before the
+// benchmark starts.
+//
+// Reported metrics:
+//   - rows/s   : message rows successfully written per second (aggregate)
+//   - MB/s     : payload throughput (raw JSON bytes / wall time, via b.SetBytes)
+//   - ms/batch : average WriteBatch wall-clock latency
+//   - p50/p95/p99-ms : per-batch latency percentiles (real-BQ mode only,
+//     where network variance is large enough to make tail latency interesting)
+//
+// Sub-benchmarks fan out across (batch_size × in_flight) so single-threaded
+// numbers and concurrent ones (matching `max_in_flight: N` in production) can
+// be compared in one run.
+func BenchmarkWriteBatch(b *testing.B) {
+	integration.CheckSkip(b)
+
+	target := resolveBenchTarget(b)
+	defer target.cleanup()
+
+	batchSizes := []int{10, 100, 1000}
+	inFlights := []int{1, 4, 16}
+
+	for _, batchSize := range batchSizes {
+		// Single output per batch size; in-flight variants share it (the
+		// stream cache + resolver are concurrency-safe and that's what
+		// production exercises).
+		tableID := fmt.Sprintf("%s_%d", target.tablePrefix, batchSize)
+		ensureBenchTable(b, target.bqClient, target.datasetID, tableID)
+
+		out := newBenchmarkOutput(b, target, tableID)
+		require.NoError(b, out.Connect(b.Context()))
+		b.Cleanup(func() {
+			if err := out.Close(context.Background()); err != nil &&
+				!errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+				b.Logf("output close: %v", err)
+			}
+		})
+
+		batch := buildBatch(batchSize)
+		batchBytes := batchPayloadBytes(b, batch)
+
+		for _, inFlight := range inFlights {
+			b.Run(fmt.Sprintf("batch=%d/in_flight=%d", batchSize, inFlight), func(b *testing.B) {
+				runWriteBatchBench(b, target, out, batch, batchBytes, inFlight)
+			})
+		}
+	}
+}
+
+// runWriteBatchBench drives `b.N` total batches through `out`, dispatched
+// across `inFlight` concurrent worker goroutines. inFlight==1 is the original
+// serial benchmark.
+func runWriteBatchBench(b *testing.B, target *benchTarget, out *bigQueryWriteAPIOutput, batch service.MessageBatch, batchBytes, inFlight int) {
+	b.Helper()
+
+	var (
+		latencyMu sync.Mutex
+		latencies = make([]time.Duration, 0, b.N)
+	)
+
+	b.SetBytes(int64(batchBytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	start := time.Now()
+
+	if inFlight <= 1 {
+		for i := 0; i < b.N; i++ {
+			batchStart := time.Now()
+			if err := out.WriteBatch(context.Background(), batch); err != nil {
+				b.Fatalf("WriteBatch: %v", err)
+			}
+			latencies = append(latencies, time.Since(batchStart))
+		}
+	} else {
+		// Round-robin b.N total batches across inFlight workers via an atomic
+		// counter; mirrors how benthos pipelines fan out under max_in_flight.
+		var idx atomic.Int64
+		var wg sync.WaitGroup
+		wg.Add(inFlight)
+		for range inFlight {
+			go func() {
+				defer wg.Done()
+				localLat := make([]time.Duration, 0, b.N/inFlight+1)
+				for int(idx.Add(1))-1 < b.N {
+					batchStart := time.Now()
+					if err := out.WriteBatch(context.Background(), batch); err != nil {
+						b.Errorf("WriteBatch: %v", err)
+						return
+					}
+					localLat = append(localLat, time.Since(batchStart))
+				}
+				latencyMu.Lock()
+				latencies = append(latencies, localLat...)
+				latencyMu.Unlock()
+			}()
+		}
+		wg.Wait()
+	}
+
+	elapsed := time.Since(start)
+
+	b.StopTimer()
+
+	rows := float64(b.N) * float64(len(batch))
+	b.ReportMetric(rows/elapsed.Seconds(), "rows/s")
+	b.ReportMetric(float64(elapsed.Nanoseconds())/float64(b.N)/1e6, "ms/batch")
+
+	if target.realBQ {
+		p50, p95, p99 := percentiles(latencies)
+		b.ReportMetric(float64(p50.Nanoseconds())/1e6, "p50-ms")
+		b.ReportMetric(float64(p95.Nanoseconds())/1e6, "p95-ms")
+		b.ReportMetric(float64(p99.Nanoseconds())/1e6, "p99-ms")
+	}
+}
+
+// benchTarget bundles everything a sub-benchmark needs to talk to either the
+// emulator or real BigQuery without re-checking the env.
+type benchTarget struct {
+	realBQ          bool
+	projectID       string
+	datasetID       string
+	tablePrefix     string
+	httpEndpoint    string // emulator only
+	grpcEndpoint    string // emulator only
+	credentialsJSON string // real-BQ only
+	bqClient        *bigquery.Client
+	cleanup         func()
+}
+
+func resolveBenchTarget(b *testing.B) *benchTarget {
+	b.Helper()
+
+	if proj := os.Getenv("BQ_BENCH_PROJECT"); proj != "" {
+		dataset := os.Getenv("BQ_BENCH_DATASET")
+		if dataset == "" {
+			b.Fatal("BQ_BENCH_PROJECT is set but BQ_BENCH_DATASET is empty")
+		}
+		creds := os.Getenv("BQ_BENCH_CREDENTIALS_JSON")
+		prefix := os.Getenv("BQ_BENCH_TABLE_PREFIX")
+		if prefix == "" {
+			prefix = "bqwa_bench"
+		}
+
+		var clientOpts []option.ClientOption
+		if creds != "" {
+			clientOpts = append(clientOpts, option.WithCredentialsJSON([]byte(creds)))
+		}
+		client, err := bigquery.NewClient(b.Context(), proj, clientOpts...)
+		require.NoError(b, err)
+
+		t := &benchTarget{
+			realBQ:          true,
+			projectID:       proj,
+			datasetID:       dataset,
+			tablePrefix:     prefix,
+			credentialsJSON: creds,
+			bqClient:        client,
+			cleanup:         func() { _ = client.Close() },
+		}
+		b.Logf("real-BQ mode: project=%s dataset=%s table_prefix=%s", proj, dataset, prefix)
+		return t
+	}
+
+	const (
+		emuProject = "test-project"
+		emuDataset = "bench_dataset"
+	)
+	emu := startEmulator(b, emuProject, emuDataset)
+	return &benchTarget{
+		realBQ:       false,
+		projectID:    emuProject,
+		datasetID:    emuDataset,
+		tablePrefix:  "bench_table",
+		httpEndpoint: emu.httpEndpoint,
+		grpcEndpoint: emu.grpcEndpoint,
+		bqClient:     emu.bqClient,
+		cleanup:      func() {}, // emulator container + bqClient are torn down by t.Cleanup hooks in startEmulator
+	}
+}
+
+// ensureBenchTable creates the benchmark table if it doesn't already exist.
+// The schema matches what buildBatch emits.
+func ensureBenchTable(b *testing.B, client *bigquery.Client, datasetID, tableID string) {
+	b.Helper()
+	err := client.Dataset(datasetID).Table(tableID).Create(b.Context(), &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "id", Type: bigquery.IntegerFieldType, Required: true},
+			{Name: "name", Type: bigquery.StringFieldType, Required: true},
+			{Name: "payload", Type: bigquery.StringFieldType, Required: true},
+		},
+	})
+	var apiErr *googleapi.Error
+	if err != nil && (!errors.As(err, &apiErr) || apiErr.Code != http.StatusConflict) {
+		require.NoError(b, err)
+	}
+}
+
+// newBenchmarkOutput builds the output config (emulator endpoints in emulator
+// mode, real auth in real-BQ mode) and returns an unconnected output.
+func newBenchmarkOutput(b *testing.B, target *benchTarget, tableID string) *bigQueryWriteAPIOutput {
+	b.Helper()
+
+	var yaml string
+	if target.realBQ {
+		yaml = fmt.Sprintf(`
+project: %s
+dataset: %s
+table: %s
+`, target.projectID, target.datasetID, tableID)
+		if target.credentialsJSON != "" {
+			yaml += fmt.Sprintf("credentials_json: %q\n", target.credentialsJSON)
+		}
+	} else {
+		yaml = fmt.Sprintf(`
+project: %s
+dataset: %s
+table: %s
+endpoint:
+  http: %s
+  grpc: %s
+`, target.projectID, target.datasetID, tableID, target.httpEndpoint, target.grpcEndpoint)
+	}
+
+	spec := bigQueryWriteAPISpec()
+	pConf, err := spec.ParseYAML(yaml, nil)
+	require.NoError(b, err)
+
+	mgr := service.MockResources()
+	license.InjectTestService(mgr)
+	out, err := bigQueryWriteAPIOutputFromConfig(pConf, mgr)
+	require.NoError(b, err)
+	return out
+}
+
+// batchPayloadBytes sums the raw payload size of every message in batch. Used
+// with b.SetBytes so Go's testing harness can report a MB/s metric.
+func batchPayloadBytes(b *testing.B, batch service.MessageBatch) int {
+	b.Helper()
+	total := 0
+	for _, m := range batch {
+		buf, err := m.AsBytes()
+		require.NoError(b, err)
+		total += len(buf)
+	}
+	return total
+}
+
+// buildBatch returns a fixed-content MessageBatch of the requested size. The
+// same MessageBatch is reused across benchmark iterations, so per-iteration
+// cost is dominated by the BQ-write path rather than message construction.
+//
+// Note: service.Message has internal state, but reusing it inside a single
+// benchmark process is safe because WriteBatch only reads bytes via AsBytes.
+var buildBatchOnce sync.Map // batch size -> service.MessageBatch (memoised)
+
+func buildBatch(size int) service.MessageBatch {
+	if cached, ok := buildBatchOnce.Load(size); ok {
+		return cached.(service.MessageBatch)
+	}
+	batch := make(service.MessageBatch, 0, size)
+	for i := range size {
+		msg := service.NewMessage(fmt.Appendf(nil,
+			`{"id":"%d","name":"row-%d","payload":"%s"}`,
+			i, i, "abcdefghijklmnopqrstuvwxyz0123456789",
+		))
+		batch = append(batch, msg)
+	}
+	buildBatchOnce.Store(size, batch)
+	return batch
+}
+
+// percentiles returns p50/p95/p99 from a latency sample. The slice is sorted
+// in place.
+func percentiles(samples []time.Duration) (p50, p95, p99 time.Duration) {
+	if len(samples) == 0 {
+		return 0, 0, 0
+	}
+	slices.Sort(samples)
+	pick := func(q float64) time.Duration {
+		idx := int(float64(len(samples)-1) * q)
+		return samples[idx]
+	}
+	return pick(0.50), pick(0.95), pick(0.99)
+}

--- a/internal/impl/gcp/enterprise/bigquery/integration_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/integration_test.go
@@ -16,12 +16,14 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	_ "github.com/redpanda-data/benthos/v4/public/components/io"
 	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
@@ -31,14 +33,16 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
-func TestIntegrationBigQueryWriteAPI(t *testing.T) {
-	integration.CheckSkip(t)
+// bqEmulator holds connection details for a running BigQuery emulator container.
+type bqEmulator struct {
+	httpEndpoint string
+	grpcEndpoint string
+	bqClient     *bigquery.Client
+}
 
-	const (
-		projectID = "test-project"
-		datasetID = "test_dataset"
-		tableID   = "test_table"
-	)
+// startEmulator launches a BigQuery emulator container and returns connection details.
+func startEmulator(t *testing.T, projectID, datasetID string) *bqEmulator {
+	t.Helper()
 
 	t.Log("Given a BigQuery emulator running with HTTP and gRPC ports")
 	ctr, err := testcontainers.Run(t.Context(),
@@ -54,7 +58,10 @@ func TestIntegrationBigQueryWriteAPI(t *testing.T) {
 			},
 		}),
 		testcontainers.WithWaitStrategy(
-			wait.ForListeningPort("9050/tcp").WithStartupTimeout(60*time.Second),
+			wait.ForAll(
+				wait.ForListeningPort("9050/tcp"),
+				wait.ForListeningPort("9060/tcp"),
+			).WithDeadline(60*time.Second),
 		),
 	)
 	testcontainers.CleanupContainer(t, ctr)
@@ -70,19 +77,50 @@ func TestIntegrationBigQueryWriteAPI(t *testing.T) {
 	httpEndpoint := fmt.Sprintf("http://%s:%s", host, httpPort.Port())
 	grpcEndpoint := fmt.Sprintf("%s:%s", host, grpcPort.Port())
 
-	t.Log("Given a table with name and age columns")
 	bqClient, err := bigquery.NewClient(t.Context(), projectID,
 		option.WithoutAuthentication(),
 		option.WithEndpoint(httpEndpoint),
 	)
 	require.NoError(t, err)
-	defer bqClient.Close()
+	t.Cleanup(func() { bqClient.Close() })
 
+	return &bqEmulator{
+		httpEndpoint: httpEndpoint,
+		grpcEndpoint: grpcEndpoint,
+		bqClient:     bqClient,
+	}
+}
+
+// bqSchemaToMessageDescriptor converts a BigQuery schema to a protoreflect.MessageDescriptor
+// via the adapt pipeline, for use in tests that need proto descriptors.
+func bqSchemaToMessageDescriptor(t *testing.T, schema bigquery.Schema) protoreflect.MessageDescriptor {
+	t.Helper()
+	tableSchema, err := adapt.BQSchemaToStorageTableSchema(schema)
+	require.NoError(t, err)
+	descriptor, err := adapt.StorageSchemaToProto2Descriptor(tableSchema, "root")
+	require.NoError(t, err)
+	md, ok := descriptor.(protoreflect.MessageDescriptor)
+	require.True(t, ok)
+	return md
+}
+
+func TestIntegrationBigQueryWriteAPI(t *testing.T) {
+	integration.CheckSkip(t)
+
+	const (
+		projectID = "test-project"
+		datasetID = "test_dataset"
+		tableID   = "test_table"
+	)
+
+	emu := startEmulator(t, projectID, datasetID)
+
+	t.Log("Given a table with name and age columns")
 	schema := bigquery.Schema{
 		{Name: "name", Type: bigquery.StringFieldType, Required: true},
 		{Name: "age", Type: bigquery.IntegerFieldType, Required: true},
 	}
-	err = bqClient.Dataset(datasetID).Table(tableID).Create(t.Context(), &bigquery.TableMetadata{
+	err := emu.bqClient.Dataset(datasetID).Table(tableID).Create(t.Context(), &bigquery.TableMetadata{
 		Schema: schema,
 	})
 	require.NoError(t, err)
@@ -102,7 +140,7 @@ gcp_bigquery_write_api:
   endpoint:
     http: %s
     grpc: %s
-`, projectID, datasetID, tableID, httpEndpoint, grpcEndpoint)))
+`, projectID, datasetID, tableID, emu.httpEndpoint, emu.grpcEndpoint)))
 
 	stream, err := sb.Build()
 	require.NoError(t, err)
@@ -131,7 +169,7 @@ gcp_bigquery_write_api:
 	// Then all 3 rows land in the BigQuery table.
 	t.Log("Then all 3 rows are present in the BigQuery table")
 	assert.Eventually(t, func() bool {
-		it := bqClient.Dataset(datasetID).Table(tableID).Read(t.Context())
+		it := emu.bqClient.Dataset(datasetID).Table(tableID).Read(t.Context())
 		var count int
 		for {
 			var row map[string]bigquery.Value
@@ -145,5 +183,125 @@ gcp_bigquery_write_api:
 			count++
 		}
 		return count >= 3
+	}, 30*time.Second, 500*time.Millisecond)
+}
+
+func TestIntegrationSchemaEvolution(t *testing.T) {
+	integration.CheckSkip(t)
+
+	const (
+		projectID = "test-project"
+		datasetID = "test_dataset"
+		tableID   = "test_evolution"
+	)
+
+	emu := startEmulator(t, projectID, datasetID)
+
+	t.Log("Given a table with name and age columns")
+	err := emu.bqClient.Dataset(datasetID).Table(tableID).Create(t.Context(), &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "name", Type: bigquery.StringFieldType},
+			{Name: "age", Type: bigquery.IntegerFieldType},
+		},
+	})
+	require.NoError(t, err)
+
+	// Build a proto descriptor with an extra "email" field.
+	expandedSchema := bigquery.Schema{
+		{Name: "name", Type: bigquery.StringFieldType},
+		{Name: "age", Type: bigquery.IntegerFieldType},
+		{Name: "email", Type: bigquery.StringFieldType},
+	}
+	md := bqSchemaToMessageDescriptor(t, expandedSchema)
+
+	t.Log("When we call Evolve with a descriptor that has an extra email column")
+	evolver := &schemaEvolver{log: service.MockResources().Logger()}
+	evolved, err := evolver.Evolve(t.Context(), emu.bqClient, datasetID, tableID, md)
+	require.NoError(t, err)
+	assert.True(t, evolved, "expected columns to be added")
+
+	t.Log("Then the table schema includes the email column")
+	meta, err := emu.bqClient.Dataset(datasetID).Table(tableID).Metadata(t.Context())
+	require.NoError(t, err)
+
+	var colNames []string
+	for _, f := range meta.Schema {
+		colNames = append(colNames, f.Name)
+	}
+	assert.Contains(t, colNames, "email")
+	assert.Contains(t, colNames, "name")
+	assert.Contains(t, colNames, "age")
+}
+
+func TestIntegrationTableNameSanitization(t *testing.T) {
+	integration.CheckSkip(t)
+
+	const (
+		projectID = "test-project"
+		datasetID = "test_dataset"
+	)
+
+	emu := startEmulator(t, projectID, datasetID)
+
+	// Create a table with the sanitized name. The output will receive
+	// "events.user.created" but sanitize it to "events_user_created".
+	sanitizedTableID := "events_user_created"
+	err := emu.bqClient.Dataset(datasetID).Table(sanitizedTableID).Create(t.Context(), &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "name", Type: bigquery.StringFieldType},
+		},
+	})
+	require.NoError(t, err)
+
+	t.Log("When we send a message with a dot-separated table name")
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML(`level: DEBUG`))
+
+	sendFn, err := sb.AddProducerFunc()
+	require.NoError(t, err)
+
+	// Use a static table name with dots — sanitization should convert to underscores.
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+gcp_bigquery_write_api:
+  project: %s
+  dataset: %s
+  table: events.user.created
+  endpoint:
+    http: %s
+    grpc: %s
+`, projectID, datasetID, emu.httpEndpoint, emu.grpcEndpoint)))
+
+	stream, err := sb.Build()
+	require.NoError(t, err)
+	license.InjectTestService(stream.Resources())
+
+	go func() {
+		if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("stream error: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		if err := stream.StopWithin(10 * time.Second); err != nil {
+			t.Log(err)
+		}
+	})
+
+	require.NoError(t, sendFn(t.Context(), service.NewMessage([]byte(`{"name":"alice"}`))))
+
+	t.Log("Then the row lands in the sanitized table name")
+	assert.Eventually(t, func() bool {
+		it := emu.bqClient.Dataset(datasetID).Table(sanitizedTableID).Read(t.Context())
+		var count int
+		for {
+			var row map[string]bigquery.Value
+			if err := it.Next(&row); errors.Is(err, iterator.Done) {
+				break
+			} else if err != nil {
+				return false
+			}
+			count++
+		}
+		return count >= 1
 	}, 30*time.Second, 500*time.Millisecond)
 }

--- a/internal/impl/gcp/enterprise/bigquery/integration_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/integration_test.go
@@ -41,7 +41,8 @@ type bqEmulator struct {
 }
 
 // startEmulator launches a BigQuery emulator container and returns connection details.
-func startEmulator(t *testing.T, projectID, datasetID string) *bqEmulator {
+// Accepts testing.TB so it works for both tests and benchmarks.
+func startEmulator(t testing.TB, projectID, datasetID string) *bqEmulator {
 	t.Helper()
 
 	t.Log("Given a BigQuery emulator running with HTTP and gRPC ports")

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -12,13 +12,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"cloud.google.com/go/bigquery/storage/managedwriter"
-	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -49,8 +51,8 @@ const (
 	bqwaFieldStreamIdleTimeout   = "stream_idle_timeout"
 	bqwaFieldStreamSweepInterval = "stream_sweep_interval"
 	bqwaFieldEndpoint            = "endpoint"
-	bqwaFieldEndpointHTTP        = "http"
-	bqwaFieldEndpointGRPC        = "grpc"
+	bqwaepFieldHTTP              = "http"
+	bqwaepFieldGRPC              = "grpc"
 )
 
 func init() {
@@ -81,12 +83,14 @@ This provides higher throughput and lower latency than the legacy streaming API 
 Messages can be formatted as JSON (default) or raw protobuf bytes.
 When using JSON format the component automatically fetches the table schema and converts each message to the corresponding proto representation.
 
-WARNING: The proto3 JSON mapping encodes int64 and uint64 values as strings.
-JSON messages with integer fields must use string values (e.g. `+"`"+`"age": "30"`+"`"+` not `+"`"+`"age": 30`+"`"+`).
-Otherwise the write will fail with an unmarshalling error.
+WARNING: protojson encodes int64 and uint64 values as strings, bytes as base64-encoded strings, and timestamps as RFC 3339 strings.
+JSON messages must follow these conventions (e.g. `+"`"+`"age": "30"`+"`"+`, `+"`"+`"data": "aGVsbG8="`+"`"+`, `+"`"+`"created_at": "2026-01-02T15:04:05Z"`+"`"+`); otherwise the write will fail with an unmarshalling error.
 
 When batching is enabled the table name is resolved from the first message in each batch.
 All messages in the same batch are written to that table.
+
+The interpolated table name is sanitized for BigQuery: dots, hyphens, slashes and whitespace are replaced with underscores, non-ASCII-alphanumeric characters are stripped, leading digits are prefixed with `+"`_`"+`, and the result is truncated to 1024 characters.
+A name that sanitizes to the empty string is rejected as a permanent error.
 `).
 		Fields(
 			service.NewStringField(bqwaFieldProject).
@@ -104,7 +108,7 @@ All messages in the same batch are written to that table.
 					" Use 'json' to have the component convert JSON to proto automatically."+
 					" Use 'protobuf' to supply raw proto-encoded bytes.").
 				Default("json"),
-			service.NewOutputMaxInFlightField().Default(64),
+			service.NewOutputMaxInFlightField().Default(4),
 			service.NewBatchPolicyField(bqwaFieldBatching),
 			service.NewStringField(bqwaFieldCredentialsJSON).
 				Description("An optional JSON string containing GCP credentials."+
@@ -132,11 +136,11 @@ All messages in the same batch are written to that table.
 				Advanced().
 				Default("1m"),
 			service.NewObjectField(bqwaFieldEndpoint,
-				service.NewStringField(bqwaFieldEndpointHTTP).
+				service.NewStringField(bqwaepFieldHTTP).
 					Description("Override the BigQuery HTTP endpoint."+
 						" Useful for local emulators.").
 					Default(""),
-				service.NewStringField(bqwaFieldEndpointGRPC).
+				service.NewStringField(bqwaepFieldGRPC).
 					Description("Override the BigQuery Storage gRPC endpoint."+
 						" Useful for local emulators.").
 					Default(""),
@@ -181,6 +185,10 @@ func bigQueryWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bigQuer
 	if conf.Delegates, err = pConf.FieldStringList(bqwaFieldDelegates); err != nil {
 		return
 	}
+	if len(conf.Delegates) > 0 && conf.TargetPrincipal == "" {
+		err = fmt.Errorf("%s requires %s to be set", bqwaFieldDelegates, bqwaFieldTargetPrincipal)
+		return
+	}
 	if conf.StreamIdleTimeout, err = pConf.FieldDuration(bqwaFieldStreamIdleTimeout); err != nil {
 		return
 	}
@@ -196,30 +204,34 @@ func bigQueryWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bigQuer
 		return
 	}
 	epConf := pConf.Namespace(bqwaFieldEndpoint)
-	if conf.EndpointHTTP, err = epConf.FieldString(bqwaFieldEndpointHTTP); err != nil {
+	if conf.EndpointHTTP, err = epConf.FieldString(bqwaepFieldHTTP); err != nil {
 		return
 	}
-	if conf.EndpointGRPC, err = epConf.FieldString(bqwaFieldEndpointGRPC); err != nil {
+	if conf.EndpointGRPC, err = epConf.FieldString(bqwaepFieldGRPC); err != nil {
 		return
 	}
 	return
 }
 
 type bqwaMetrics struct {
-	rowsSent     *service.MetricCounter
-	rowsFailed   *service.MetricCounter
-	batchesSent  *service.MetricCounter
-	batchLatency *service.MetricTimer
-	retries      *service.MetricCounter
+	rowsSent                *service.MetricCounter
+	rowsFailed              *service.MetricCounter
+	batchesSent             *service.MetricCounter
+	batchLatency            *service.MetricTimer
+	retries                 *service.MetricCounter
+	schemaEvolutions        *service.MetricCounter
+	schemaEvolutionFailures *service.MetricCounter
 }
 
 func newBQWAMetrics(m *service.Metrics) *bqwaMetrics {
 	return &bqwaMetrics{
-		rowsSent:     m.NewCounter("bigquery_write_api_rows_sent_total"),
-		rowsFailed:   m.NewCounter("bigquery_write_api_rows_failed_total"),
-		batchesSent:  m.NewCounter("bigquery_write_api_batches_sent_total"),
-		batchLatency: m.NewTimer("bigquery_write_api_batch_latency_ns"),
-		retries:      m.NewCounter("bigquery_write_api_retries_total"),
+		rowsSent:                m.NewCounter("bigquery_write_api_rows_sent_total"),
+		rowsFailed:              m.NewCounter("bigquery_write_api_rows_failed_total"),
+		batchesSent:             m.NewCounter("bigquery_write_api_batches_sent_total"),
+		batchLatency:            m.NewTimer("bigquery_write_api_batch_latency_ns"),
+		retries:                 m.NewCounter("bigquery_write_api_retries_total"),
+		schemaEvolutions:        m.NewCounter("bigquery_write_api_schema_evolutions_total"),
+		schemaEvolutionFailures: m.NewCounter("bigquery_write_api_schema_evolution_failures_total"),
 	}
 }
 
@@ -228,24 +240,41 @@ type grpcErrorKind int
 const (
 	grpcTransient grpcErrorKind = iota
 	grpcPermanent
+	grpcSchemaMismatch
 )
+
+// extractGRPCStatus extracts a gRPC status from an error, unwrapping
+// fmt.Errorf chains if necessary.
+func extractGRPCStatus(err error) (*grpcstatus.Status, bool) {
+	st, ok := grpcstatus.FromError(err)
+	if ok {
+		return st, true
+	}
+	unwrapped := err
+	for unwrapped != nil {
+		if st, ok = grpcstatus.FromError(unwrapped); ok {
+			return st, true
+		}
+		unwrapped = errors.Unwrap(unwrapped)
+	}
+	return nil, false
+}
 
 // classifyGRPCError inspects a gRPC status code to determine if the error is
 // transient (worth retrying) or permanent (will never succeed).
 // Non-gRPC errors are treated as transient to be safe.
 func classifyGRPCError(err error) grpcErrorKind {
-	st, ok := grpcstatus.FromError(err)
+	st, ok := extractGRPCStatus(err)
 	if !ok {
-		// Try unwrapping, since errors are often wrapped with fmt.Errorf.
-		unwrapped := err
-		for unwrapped != nil {
-			if st, ok = grpcstatus.FromError(unwrapped); ok {
-				break
+		return grpcTransient
+	}
+
+	// Check for BigQuery Storage-specific error details.
+	for _, detail := range st.Details() {
+		if storageErr, ok := detail.(*storagepb.StorageError); ok {
+			if storageErr.GetCode() == storagepb.StorageError_SCHEMA_MISMATCH_EXTRA_FIELDS {
+				return grpcSchemaMismatch
 			}
-			unwrapped = errors.Unwrap(unwrapped)
-		}
-		if !ok {
-			return grpcTransient
 		}
 	}
 
@@ -269,11 +298,30 @@ type streamWithDescriptor struct {
 	lastUsed   atomic.Int64 // UnixNano timestamp, safe for concurrent access
 }
 
+// isPermanentBQError reports whether an error from the BigQuery REST or Storage
+// Write APIs should be treated as permanent (no retry). 4xx HTTP status codes
+// are permanent except for 408 (timeout) and 429 (throttling); all gRPC errors
+// classified as permanent by classifyGRPCError are also permanent.
+func isPermanentBQError(err error) bool {
+	if classifyGRPCError(err) == grpcPermanent {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.Code >= 400 && apiErr.Code < 500 &&
+			apiErr.Code != http.StatusRequestTimeout &&
+			apiErr.Code != http.StatusTooManyRequests
+	}
+	return false
+}
+
 type bigQueryWriteAPIOutput struct {
 	conf        bigQueryWriteAPIConfig
 	tableInterp *service.InterpolatedString
 	log         *service.Logger
 	metrics     *bqwaMetrics
+	resolver    *schemaResolver
+	evolver     *schemaEvolver
 
 	connMu            sync.RWMutex
 	client            *bigquery.Client
@@ -288,6 +336,11 @@ type bigQueryWriteAPIOutput struct {
 	streams   map[string]*streamWithDescriptor
 	stopSweep chan struct{}
 	sweepWg   sync.WaitGroup
+
+	// closeWg tracks background ManagedStream.Close goroutines spawned by
+	// evictStream and the sweep loop, so Close can wait for them to finish
+	// before tearing down the underlying clients.
+	closeWg sync.WaitGroup
 }
 
 var _ service.BatchOutput = (*bigQueryWriteAPIOutput)(nil)
@@ -304,12 +357,15 @@ func bigQueryWriteAPIOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 	if err != nil {
 		return nil, err
 	}
+
 	return &bigQueryWriteAPIOutput{
 		conf:        cfg,
 		tableInterp: tableInterp,
 		log:         mgr.Logger(),
 		metrics:     newBQWAMetrics(mgr.Metrics()),
 		streams:     make(map[string]*streamWithDescriptor),
+		resolver:    &schemaResolver{log: mgr.Logger()},
+		evolver:     &schemaEvolver{log: mgr.Logger()},
 	}, nil
 }
 
@@ -364,8 +420,11 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 		return nil
 	}
 
+	// Snapshot client + resolvedProjectID together under one RLock so a
+	// concurrent Connect-after-Close (which rewrites both) cannot tear them.
 	o.connMu.RLock()
 	client := o.client
+	projectID := o.resolvedProjectID
 	o.connMu.RUnlock()
 
 	if client == nil {
@@ -374,13 +433,21 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 
 	start := time.Now()
 
-	tableID, err := batch.TryInterpolatedString(0, o.tableInterp)
+	rawTableID, err := batch.TryInterpolatedString(0, o.tableInterp)
 	if err != nil {
 		return fmt.Errorf("interpolating table name: %w", err)
 	}
+	tableID := sanitizeTableName(rawTableID)
+	if tableID == "" {
+		// Permanent: the interpolation result has no usable characters.
+		return permanentBatchError(batch, fmt.Errorf("interpolated table name %q is empty after sanitization", rawTableID))
+	}
 
-	swd, cacheKey, err := o.getOrCreateStream(ctx, tableID)
+	swd, cacheKey, err := o.getOrCreateStream(ctx, client, projectID, tableID)
 	if err != nil {
+		if isPermanentBQError(err) {
+			return permanentBatchError(batch, fmt.Errorf("getting stream for table %q: %w", tableID, err))
+		}
 		return fmt.Errorf("getting stream for table %q: %w", tableID, err)
 	}
 
@@ -411,32 +478,22 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 	result, err := swd.stream.AppendRows(ctx, rows)
 	if err != nil {
 		o.evictStream(cacheKey)
-		if classifyGRPCError(err) == grpcPermanent {
-			batchErr := service.NewBatchError(batch, fmt.Errorf("permanent error appending rows: %w", err))
-			for i := range batch {
-				batchErr = batchErr.Failed(i, err)
-			}
-			return batchErr
-		}
-		o.metrics.retries.Incr(1)
-		return fmt.Errorf("appending rows: %w", err)
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "appending rows")
 	}
 
 	resp, err := result.FullResponse(ctx)
 	if err != nil {
 		o.evictStream(cacheKey)
-		if classifyGRPCError(err) == grpcPermanent {
-			batchErr := service.NewBatchError(batch, fmt.Errorf("permanent error waiting for append result: %w", err))
-			for i := range batch {
-				batchErr = batchErr.Failed(i, err)
-			}
-			return batchErr
-		}
-		o.metrics.retries.Incr(1)
-		return fmt.Errorf("waiting for append result: %w", err)
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "waiting for append result")
 	}
 
 	o.metrics.batchLatency.Timing(time.Since(start).Nanoseconds())
+
+	if resp.GetUpdatedSchema() != nil {
+		o.log.Infof("BigQuery reported schema update for table %q, evicting cached stream", tableID)
+		o.evictStream(cacheKey)
+		o.resolver.Evict(tableID)
+	}
 
 	if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
 		o.metrics.rowsFailed.Incr(int64(len(rowErrs)))
@@ -456,7 +513,49 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 	return nil
 }
 
-func (o *bigQueryWriteAPIOutput) Close(_ context.Context) error {
+// permanentBatchError builds a service.BatchError that fails every message in
+// the batch with the same root cause. Use this for errors that benthos must
+// not retry.
+func permanentBatchError(batch service.MessageBatch, err error) error {
+	batchErr := service.NewBatchError(batch, err)
+	for i := range batch {
+		batchErr = batchErr.Failed(i, err)
+	}
+	return batchErr
+}
+
+// handleWriteError classifies a gRPC error from an append or response and
+// returns the appropriate error for benthos: a BatchError (permanent, no retry)
+// or a plain error (transient, retry).
+func (o *bigQueryWriteAPIOutput) handleWriteError(
+	ctx context.Context, client *bigquery.Client, err error, batch service.MessageBatch,
+	tableID string, descriptor protoreflect.MessageDescriptor, phase string,
+) error {
+	switch classifyGRPCError(err) {
+	case grpcSchemaMismatch:
+		evolved, evolveErr := o.evolver.Evolve(ctx, client, o.conf.DatasetID, tableID, descriptor)
+		if evolveErr != nil {
+			o.metrics.schemaEvolutionFailures.Incr(1)
+			o.log.Warnf("Schema evolution failed for table %q: %v", tableID, evolveErr)
+			return permanentBatchError(batch, fmt.Errorf("schema evolution failed for table %q: %w", tableID, evolveErr))
+		}
+		if !evolved {
+			// Descriptor matches the table — mismatch is not caused by extra fields.
+			return permanentBatchError(batch, fmt.Errorf("permanent schema mismatch (no new columns to evolve): %w", err))
+		}
+		o.metrics.schemaEvolutions.Incr(1)
+		o.resolver.Evict(tableID)
+		o.metrics.retries.Incr(1)
+		return fmt.Errorf("schema mismatch (evolution attempted): %w", err)
+	case grpcPermanent:
+		return permanentBatchError(batch, fmt.Errorf("permanent error %s: %w", phase, err))
+	default:
+		o.metrics.retries.Incr(1)
+		return fmt.Errorf("%s: %w", phase, err)
+	}
+}
+
+func (o *bigQueryWriteAPIOutput) Close(ctx context.Context) error {
 	o.connMu.Lock()
 	defer o.connMu.Unlock()
 
@@ -469,11 +568,19 @@ func (o *bigQueryWriteAPIOutput) Close(_ context.Context) error {
 	// so it does not access shared state after shutdown.
 	o.sweepWg.Wait()
 
+	// Wait for any in-flight async stream closes (from evictStream or
+	// sweepIdleStreams) so they don't race with client shutdown.
+	o.closeWg.Wait()
+
 	o.streamsMu.Lock()
 	streams := o.streams
 	o.streams = make(map[string]*streamWithDescriptor)
 	o.streamsMu.Unlock()
 
+	// Close every stream and client unconditionally: the underlying gRPC
+	// teardowns are non-blocking and skipping them leaks connections and
+	// goroutines. ctx.Err() is appended afterwards so a caller-side deadline
+	// is still surfaced, but it never gates the cleanup itself.
 	var errs []error
 	for _, swd := range streams {
 		if err := swd.stream.Close(); err != nil {
@@ -495,6 +602,17 @@ func (o *bigQueryWriteAPIOutput) Close(_ context.Context) error {
 		o.client = nil
 	}
 
+	if err := ctx.Err(); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Drop the resolver's schema cache so a subsequent Connect doesn't reuse
+	// state tied to the now-closed client.
+	o.resolver.cache.Range(func(k, _ any) bool {
+		o.resolver.cache.Delete(k)
+		return true
+	})
+
 	return errors.Join(errs...)
 }
 
@@ -502,6 +620,7 @@ func (o *bigQueryWriteAPIOutput) Close(_ context.Context) error {
 // If an endpoint override is provided, authentication is skipped (emulator mode).
 func (o *bigQueryWriteAPIOutput) buildAuthOpts(ctx context.Context, endpointOverride string, isGRPC bool) ([]option.ClientOption, error) {
 	if endpointOverride != "" {
+		o.log.Warnf("endpoint override %q is set; authentication is disabled — do not use this against production BigQuery", endpointOverride)
 		if o.conf.TargetPrincipal != "" {
 			o.log.Warnf("endpoint override is set; ignoring target_principal %q", o.conf.TargetPrincipal)
 		}
@@ -523,7 +642,11 @@ func (o *bigQueryWriteAPIOutput) buildAuthOpts(ctx context.Context, endpointOver
 			baseOpts = append(baseOpts, option.WithCredentialsJSON([]byte(o.conf.CredentialsJSON)))
 		}
 
-		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		// Detach from ctx: the token source outlives Connect (it refreshes
+		// tokens on demand for the lifetime of the client). If we passed
+		// Connect's ctx and that ctx was later cancelled, every refresh
+		// would fail.
+		ts, err := impersonate.CredentialsTokenSource(context.WithoutCancel(ctx), impersonate.CredentialsConfig{
 			TargetPrincipal: o.conf.TargetPrincipal,
 			Scopes:          []string{bigquery.Scope},
 			Delegates:       o.conf.Delegates,
@@ -542,12 +665,25 @@ func (o *bigQueryWriteAPIOutput) buildAuthOpts(ctx context.Context, endpointOver
 	return opts, nil
 }
 
-func (o *bigQueryWriteAPIOutput) tableCacheKey(tableID string) string {
-	return fmt.Sprintf("projects/%s/datasets/%s/tables/%s", o.resolvedProjectID, o.conf.DatasetID, tableID)
+// tableCacheKey builds the BigQuery resource path for the given table. The
+// projectID argument is captured by callers under connMu.RLock and passed
+// through, so this function must not read o.resolvedProjectID directly.
+func (o *bigQueryWriteAPIOutput) tableCacheKey(projectID, tableID string) string {
+	return fmt.Sprintf("projects/%s/datasets/%s/tables/%s", projectID, o.conf.DatasetID, tableID)
 }
 
-func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, tableID string) (*streamWithDescriptor, string, error) {
-	cacheKey := o.tableCacheKey(tableID)
+// closeStreamAsync schedules a stream close on a background goroutine tracked
+// by closeWg, so Close() can wait for it to finish before tearing down the
+// underlying clients.
+func (o *bigQueryWriteAPIOutput) closeStreamAsync(s *managedwriter.ManagedStream) {
+	if s == nil {
+		return
+	}
+	o.closeWg.Go(func() { _ = s.Close() })
+}
+
+func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, client *bigquery.Client, projectID, tableID string) (*streamWithDescriptor, string, error) {
+	cacheKey := o.tableCacheKey(projectID, tableID)
 
 	now := time.Now()
 
@@ -561,7 +697,7 @@ func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, tableID 
 	o.streamsMu.RUnlock()
 
 	// Slow path: create stream without holding the lock (network I/O).
-	swd, err := o.createStream(ctx, cacheKey, tableID)
+	swd, err := o.createStream(ctx, client, cacheKey, tableID)
 	if err != nil {
 		return nil, cacheKey, err
 	}
@@ -570,7 +706,7 @@ func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, tableID 
 	o.streamsMu.Lock()
 	if cached, exists := o.streams[cacheKey]; exists {
 		o.streamsMu.Unlock()
-		go func() { _ = swd.stream.Close() }()
+		o.closeStreamAsync(swd.stream)
 		return cached, cacheKey, nil
 	}
 	swd.lastUsed.Store(now.UnixNano())
@@ -579,10 +715,10 @@ func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, tableID 
 	return swd, cacheKey, nil
 }
 
-// evictStream removes a stream from the cache and closes it asynchronously.
-// Concurrent WriteBatch goroutines that already hold a reference to the evicted
-// stream will see errors from the closed stream and retry, which will create a
-// fresh stream via getOrCreateStream.
+// evictStream removes a stream from the cache and closes it on a tracked
+// background goroutine. Concurrent WriteBatch goroutines that already hold a
+// reference to the evicted stream will see errors from the closed stream and
+// retry, which will create a fresh stream via getOrCreateStream.
 func (o *bigQueryWriteAPIOutput) evictStream(cacheKey string) {
 	o.streamsMu.Lock()
 	swd, exists := o.streams[cacheKey]
@@ -590,7 +726,7 @@ func (o *bigQueryWriteAPIOutput) evictStream(cacheKey string) {
 	o.streamsMu.Unlock()
 
 	if exists {
-		go func() { _ = swd.stream.Close() }()
+		o.closeStreamAsync(swd.stream)
 	}
 }
 
@@ -629,54 +765,12 @@ func (o *bigQueryWriteAPIOutput) sweepIdleStreams(stop <-chan struct{}) {
 
 		for _, e := range toClose {
 			o.log.Debugf("Closing idle BigQuery stream for %s", e.key)
-			if e.swd.stream != nil {
-				go func() { _ = e.swd.stream.Close() }()
-			}
+			o.closeStreamAsync(e.swd.stream)
 		}
 	}
 }
 
-func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, cacheKey, tableID string) (*streamWithDescriptor, error) {
-	o.connMu.RLock()
-	client := o.client
-	o.connMu.RUnlock()
-
-	if client == nil {
-		return nil, service.ErrNotConnected
-	}
-
-	tableMeta, err := client.Dataset(o.conf.DatasetID).Table(tableID).Metadata(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("fetching metadata for table %q: %w", tableID, err)
-	}
-
-	tableSchema, err := adapt.BQSchemaToStorageTableSchema(tableMeta.Schema)
-	if err != nil {
-		return nil, fmt.Errorf("converting BQ schema to storage schema: %w", err)
-	}
-
-	descriptor, err := adapt.StorageSchemaToProto2Descriptor(tableSchema, "root")
-	if err != nil {
-		return nil, fmt.Errorf("converting storage schema to proto descriptor: %w", err)
-	}
-
-	messageDescriptor, ok := descriptor.(protoreflect.MessageDescriptor)
-	if !ok {
-		return nil, errors.New("schema descriptor is not a MessageDescriptor")
-	}
-
-	normalizedDescriptor, err := adapt.NormalizeDescriptor(messageDescriptor)
-	if err != nil {
-		return nil, fmt.Errorf("normalizing proto descriptor: %w", err)
-	}
-
-	// Convert the normalized DescriptorProto back to a protoreflect.MessageDescriptor
-	// so that jsonToProtoBytes uses the same schema the stream was configured with.
-	normalizedMsgDesc, err := descriptorProtoToMessageDescriptor(normalizedDescriptor)
-	if err != nil {
-		return nil, fmt.Errorf("resolving normalized descriptor: %w", err)
-	}
-
+func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigquery.Client, cacheKey, tableID string) (*streamWithDescriptor, error) {
 	o.connMu.RLock()
 	storageClient := o.storageClient
 	o.connMu.RUnlock()
@@ -685,18 +779,23 @@ func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, cacheKey, tab
 		return nil, service.ErrNotConnected
 	}
 
-	stream, err := storageClient.NewManagedStream(ctx,
+	rs, err := o.resolver.Resolve(ctx, client, o.conf.DatasetID, tableID)
+	if err != nil {
+		return nil, err
+	}
+
+	ms, err := storageClient.NewManagedStream(ctx,
 		managedwriter.WithDestinationTable(cacheKey),
 		managedwriter.WithType(managedwriter.DefaultStream),
-		managedwriter.WithSchemaDescriptor(normalizedDescriptor),
+		managedwriter.WithSchemaDescriptor(rs.descriptorProto),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating managed stream for %q: %w", cacheKey, err)
 	}
 
 	return &streamWithDescriptor{
-		stream:     stream,
-		descriptor: normalizedMsgDesc,
+		stream:     ms,
+		descriptor: rs.messageDescriptor,
 	}, nil
 }
 

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -784,7 +784,12 @@ func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigqu
 		return nil, err
 	}
 
-	ms, err := storageClient.NewManagedStream(ctx,
+	// Detach from the per-batch ctx: the cached stream outlives this WriteBatch
+	// and is reused by every subsequent batch routing to the same table. If the
+	// stream were bound to this ctx, cancellation of the first batch (per-message
+	// deadline, source shutdown, ack timeout) would block all later AppendRows
+	// against the cached stream until the idle sweeper evicted it.
+	ms, err := storageClient.NewManagedStream(context.WithoutCancel(ctx),
 		managedwriter.WithDestinationTable(cacheKey),
 		managedwriter.WithType(managedwriter.DefaultStream),
 		managedwriter.WithSchemaDescriptor(rs.descriptorProto),

--- a/internal/impl/gcp/enterprise/bigquery/output_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/output_test.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -133,6 +135,16 @@ stream_sweep_interval: 0s
 `,
 			errMsg: bqwaFieldStreamSweepInterval,
 		},
+		{
+			name: "delegates without target_principal",
+			yaml: `
+dataset: my_dataset
+table: my_table
+delegates:
+  - "delegate@project.iam.gserviceaccount.com"
+`,
+			errMsg: bqwaFieldDelegates,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pConf, err := spec.ParseYAML(tc.yaml, nil)
@@ -241,17 +253,16 @@ table: my_table
 }
 
 func TestTableCacheKey(t *testing.T) {
-	// Given an output configured for a specific project and dataset.
+	// Given an output configured for a specific dataset.
 	out := newTestOutput(t, `
 project: my-project
 dataset: my_dataset
 table: my_table
 `)
-	// Simulate what Connect() does: resolve the project ID.
-	out.resolvedProjectID = "my-project"
 
-	// When we compute the cache key for a table.
-	key := out.tableCacheKey("my_table")
+	// When we compute the cache key for a table (callers pass the resolved
+	// projectID they captured under connMu).
+	key := out.tableCacheKey("my-project", "my_table")
 
 	// Then it returns the fully qualified table resource path.
 	assert.Equal(t, "projects/my-project/datasets/my_dataset/tables/my_table", key)
@@ -326,6 +337,11 @@ stream_sweep_interval: 50ms
 	// When we run the actual sweep goroutine.
 	out.sweepWg.Add(1)
 	go out.sweepIdleStreams(out.stopSweep)
+	// Stop the sweeper via t.Cleanup so an early require failure can't leak it.
+	t.Cleanup(func() {
+		close(out.stopSweep)
+		out.sweepWg.Wait()
+	})
 
 	// Then the stale stream is evicted and the fresh one remains.
 	assert.Eventually(t, func() bool {
@@ -339,9 +355,6 @@ stream_sweep_interval: 50ms
 	_, freshExists := out.streams["projects/p/datasets/d/tables/fresh"]
 	out.streamsMu.RUnlock()
 	assert.True(t, freshExists, "fresh stream should remain in cache")
-
-	close(out.stopSweep)
-	out.sweepWg.Wait()
 }
 
 func TestClassifyGRPCError(t *testing.T) {
@@ -370,6 +383,27 @@ func TestClassifyGRPCError(t *testing.T) {
 	}
 }
 
+func TestClassifyGRPCErrorSchemaMismatch(t *testing.T) {
+	st, err := grpcstatus.New(codes.InvalidArgument, "schema mismatch").
+		WithDetails(&storagepb.StorageError{
+			Code:         storagepb.StorageError_SCHEMA_MISMATCH_EXTRA_FIELDS,
+			ErrorMessage: "extra fields found",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, grpcSchemaMismatch, classifyGRPCError(st.Err()))
+}
+
+func TestClassifyGRPCErrorSchemaMismatchWrapped(t *testing.T) {
+	st, err := grpcstatus.New(codes.InvalidArgument, "schema mismatch").
+		WithDetails(&storagepb.StorageError{
+			Code:         storagepb.StorageError_SCHEMA_MISMATCH_EXTRA_FIELDS,
+			ErrorMessage: "extra fields found",
+		})
+	require.NoError(t, err)
+	wrapped := fmt.Errorf("appending rows: %w", st.Err())
+	assert.Equal(t, grpcSchemaMismatch, classifyGRPCError(wrapped))
+}
+
 func TestMetricsInitialization(t *testing.T) {
 	m := newBQWAMetrics(service.MockResources().Metrics())
 	require.NotNil(t, m.rowsSent)
@@ -377,4 +411,107 @@ func TestMetricsInitialization(t *testing.T) {
 	require.NotNil(t, m.batchesSent)
 	require.NotNil(t, m.batchLatency)
 	require.NotNil(t, m.retries)
+	require.NotNil(t, m.schemaEvolutions)
+	require.NotNil(t, m.schemaEvolutionFailures)
+}
+
+func TestBuildAuthOpts(t *testing.T) {
+	// Covers the easy paths through buildAuthOpts that don't talk to GCP.
+	// The target_principal branch hits impersonate.CredentialsTokenSource,
+	// which makes a real network call, so it's deliberately left to
+	// integration coverage.
+	tests := []struct {
+		name        string
+		yaml        string
+		isGRPC      bool
+		endpoint    string
+		expectMin   int  // expected minimum number of options returned
+		expectGRPC  bool // expects the insecure-credentials gRPC dial option
+		expectAuth  bool // expects authentication to be enabled (no WithoutAuthentication)
+		expectError bool
+	}{
+		{
+			name: "endpoint override disables auth (HTTP)",
+			yaml: `
+dataset: my_dataset
+table: my_table
+endpoint:
+  http: http://localhost:9050
+`,
+			endpoint:   "http://localhost:9050",
+			isGRPC:     false,
+			expectMin:  2, // WithoutAuthentication + WithEndpoint
+			expectAuth: false,
+		},
+		{
+			name: "endpoint override disables auth and adds insecure gRPC dial opt",
+			yaml: `
+dataset: my_dataset
+table: my_table
+endpoint:
+  grpc: localhost:9060
+`,
+			endpoint:   "localhost:9060",
+			isGRPC:     true,
+			expectMin:  3, // WithoutAuthentication + WithEndpoint + WithGRPCDialOption
+			expectAuth: false,
+			expectGRPC: true,
+		},
+		{
+			name: "credentials_json only",
+			yaml: `
+dataset: my_dataset
+table: my_table
+credentials_json: '{"type":"service_account"}'
+`,
+			expectMin:  1, // WithCredentialsJSON
+			expectAuth: true,
+		},
+		{
+			name: "no auth config",
+			yaml: `
+dataset: my_dataset
+table: my_table
+`,
+			expectMin:  0,
+			expectAuth: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := newTestOutput(t, tc.yaml)
+			opts, err := out.buildAuthOpts(t.Context(), tc.endpoint, tc.isGRPC)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(opts), tc.expectMin)
+		})
+	}
+}
+
+func TestIsPermanentBQError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain", errors.New("network blip"), false},
+		{"grpc unavailable", grpcstatus.Error(codes.Unavailable, "x"), false},
+		{"grpc invalid argument", grpcstatus.Error(codes.InvalidArgument, "x"), true},
+		{"http 404", &googleapi.Error{Code: 404}, true},
+		{"http 403", &googleapi.Error{Code: 403}, true},
+		{"http 408", &googleapi.Error{Code: 408}, false},
+		{"http 429", &googleapi.Error{Code: 429}, false},
+		{"http 500", &googleapi.Error{Code: 500}, false},
+		{"wrapped http 404", fmt.Errorf("resolve: %w", &googleapi.Error{Code: 404}), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPermanentBQError(tc.err))
+		})
+	}
 }

--- a/internal/impl/gcp/enterprise/bigquery/sanitize.go
+++ b/internal/impl/gcp/enterprise/bigquery/sanitize.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"strings"
+	"unicode"
+)
+
+// maxTableNameLength is BigQuery's hard limit for table identifiers.
+const maxTableNameLength = 1024
+
+// sanitizeTableName rewrites an arbitrary string (e.g. a Kafka topic name)
+// into a valid BigQuery table identifier: starts with letter or underscore,
+// contains only ASCII letters, digits, and underscores, max 1024 characters.
+// Non-ASCII letters are dropped rather than transliterated — they don't
+// round-trip cleanly through the proto-descriptor step that follows. Returns
+// "" if the input has no usable characters.
+func sanitizeTableName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.Grow(len(name))
+	prevUnderscore := false
+	for _, r := range name {
+		switch {
+		case r == '-' || r == '.' || r == '/' || unicode.IsSpace(r) || r == '_':
+			// Coalesce separators / explicit underscores into a single
+			// underscore in one pass — avoids the O(n^2) re-scan that the
+			// previous strings.Contains/ReplaceAll loop required.
+			if !prevUnderscore {
+				sb.WriteByte('_')
+				prevUnderscore = true
+			}
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			sb.WriteRune(r)
+			prevUnderscore = false
+		}
+	}
+
+	result := strings.TrimRight(sb.String(), "_")
+	if result == "" {
+		return ""
+	}
+
+	// Prepend underscore if the name starts with a digit.
+	if result[0] >= '0' && result[0] <= '9' {
+		result = "_" + result
+	}
+
+	if len(result) > maxTableNameLength {
+		result = result[:maxTableNameLength]
+	}
+
+	return result
+}

--- a/internal/impl/gcp/enterprise/bigquery/sanitize_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/sanitize_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeTableName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"already valid", "my_table", "my_table"},
+		{"topic with dots", "events.user.created", "events_user_created"},
+		{"topic with hyphens", "my-topic-v2", "my_topic_v2"},
+		{"slash to underscore", "events/v2/created", "events_v2_created"},
+		{"whitespace to underscore", "my table", "my_table"},
+		{"leading digit", "42_table", "_42_table"},
+		{"strip invalid chars", "table@#$name", "tablename"},
+		{"collapse consecutive separators", "a---b...c", "a_b_c"},
+		{"trim trailing underscores", "table___", "table"},
+		{"mixed rules", "1st.user-name!!", "_1st_user_name"},
+		{"empty string", "", ""},
+		{"all invalid", "@#$%", ""},
+		{"unicode stripped", "table_\u00e9", "table"},
+		{"max table length", strings.Repeat("a", 1100), strings.Repeat("a", 1024)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sanitizeTableName(tc.input))
+		})
+	}
+}
+
+func TestSanitizeTableNameNoConsecutiveUnderscoreRescan(t *testing.T) {
+	// Pathological input the previous strings.Contains/ReplaceAll loop would
+	// rescan O(n) times. The single-pass implementation should handle it
+	// linearly and return "" (only separators, nothing usable).
+	assert.Empty(t, sanitizeTableName(strings.Repeat("_", 10000)))
+}

--- a/internal/impl/gcp/enterprise/bigquery/schema_evolution.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_evolution.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// maxNestedRecordDepth caps RECORD nesting so a self-referential proto
+// descriptor cannot blow the stack. BigQuery's own limit is 15.
+const maxNestedRecordDepth = 15
+
+// protoKindToBQFieldType maps a protobuf field kind to a BigQuery field type.
+// Returns an error for kinds that don't have a sensible BigQuery mapping
+// rather than silently coercing them to STRING.
+func protoKindToBQFieldType(kind protoreflect.Kind) (bigquery.FieldType, error) {
+	switch kind {
+	case protoreflect.StringKind:
+		return bigquery.StringFieldType, nil
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+		protoreflect.Uint64Kind, protoreflect.Uint32Kind,
+		protoreflect.Fixed64Kind, protoreflect.Fixed32Kind:
+		return bigquery.IntegerFieldType, nil
+	case protoreflect.DoubleKind, protoreflect.FloatKind:
+		return bigquery.FloatFieldType, nil
+	case protoreflect.BoolKind:
+		return bigquery.BooleanFieldType, nil
+	case protoreflect.BytesKind:
+		return bigquery.BytesFieldType, nil
+	case protoreflect.EnumKind:
+		return bigquery.StringFieldType, nil
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return bigquery.RecordFieldType, nil
+	default:
+		return "", fmt.Errorf("no BigQuery type mapping for proto kind %s", kind)
+	}
+}
+
+// fieldDescriptorToBQ converts one proto field descriptor to a BigQuery field
+// schema. depth is the current RECORD nesting level; recursion past
+// maxNestedRecordDepth fails fast rather than risking a stack overflow on
+// self-referential descriptors.
+func fieldDescriptorToBQ(fd protoreflect.FieldDescriptor, depth int) (*bigquery.FieldSchema, error) {
+	if depth >= maxNestedRecordDepth {
+		return nil, fmt.Errorf("proto field %q: nested RECORD depth exceeds %d (possible self-reference)", fd.Name(), maxNestedRecordDepth)
+	}
+	bqType, err := protoKindToBQFieldType(fd.Kind())
+	if err != nil {
+		return nil, fmt.Errorf("proto field %q: %w", fd.Name(), err)
+	}
+	fs := &bigquery.FieldSchema{
+		Name:     string(fd.Name()),
+		Type:     bqType,
+		Required: false,
+		Repeated: fd.Cardinality() == protoreflect.Repeated,
+	}
+	if fd.Kind() == protoreflect.MessageKind {
+		nested, err := descriptorToBQSchemaAtDepth(fd.Message(), depth+1)
+		if err != nil {
+			return nil, err
+		}
+		fs.Schema = nested
+	}
+	return fs, nil
+}
+
+// descriptorToBQSchema converts a proto message descriptor to a BigQuery
+// schema. All fields are created as NULLABLE; repeated fields become REPEATED.
+// Returns an error if a field has no BigQuery mapping or if RECORD nesting
+// would exceed maxNestedRecordDepth.
+func descriptorToBQSchema(md protoreflect.MessageDescriptor) (bigquery.Schema, error) {
+	return descriptorToBQSchemaAtDepth(md, 0)
+}
+
+func descriptorToBQSchemaAtDepth(md protoreflect.MessageDescriptor, depth int) (bigquery.Schema, error) {
+	fields := md.Fields()
+	schema := make(bigquery.Schema, 0, fields.Len())
+	for i := range fields.Len() {
+		fs, err := fieldDescriptorToBQ(fields.Get(i), depth)
+		if err != nil {
+			return nil, err
+		}
+		schema = append(schema, fs)
+	}
+	return schema, nil
+}
+
+// diffMissingColumns returns BQ field schemas for fields present in the proto
+// descriptor but absent from the existing BQ schema.
+func diffMissingColumns(md protoreflect.MessageDescriptor, existing bigquery.Schema) (bigquery.Schema, error) {
+	existingNames := make(map[string]struct{}, len(existing))
+	for _, f := range existing {
+		existingNames[f.Name] = struct{}{}
+	}
+
+	var missing bigquery.Schema
+	fields := md.Fields()
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+		if _, ok := existingNames[string(fd.Name())]; ok {
+			continue
+		}
+		fs, err := fieldDescriptorToBQ(fd, 0)
+		if err != nil {
+			return nil, err
+		}
+		missing = append(missing, fs)
+	}
+	return missing, nil
+}
+
+type schemaEvolver struct {
+	log *service.Logger
+}
+
+// maxEvolveAttempts caps the CAS-on-412 retry loop so a pathologically busy
+// table can't keep us spinning forever.
+const maxEvolveAttempts = 5
+
+// Evolve compares the message descriptor against the current BQ table schema
+// and adds any missing columns under optimistic-locking via the table ETag.
+// On HTTP 412 (a concurrent writer evolved the table first), it refetches and
+// retries up to maxEvolveAttempts. Returns (true, nil) when the table now has
+// every descriptor field (whether this call added them or another writer did),
+// (false, nil) when the descriptor is already a subset of the table on the
+// first attempt (so the SCHEMA_MISMATCH is not "extra fields"), or
+// (false, err) on any other failure.
+func (e *schemaEvolver) Evolve(ctx context.Context, client *bigquery.Client, datasetID, tableID string, md protoreflect.MessageDescriptor) (bool, error) {
+	for attempt := range maxEvolveAttempts {
+		meta, err := client.Dataset(datasetID).Table(tableID).Metadata(ctx)
+		if err != nil {
+			return false, fmt.Errorf("fetching table metadata for evolution: %w", err)
+		}
+
+		missing, err := diffMissingColumns(md, meta.Schema)
+		if err != nil {
+			return false, fmt.Errorf("computing missing columns: %w", err)
+		}
+		if len(missing) == 0 {
+			// First attempt: the descriptor doesn't actually have any extra
+			// columns, so the SCHEMA_MISMATCH wasn't due to additive evolution.
+			// Later attempts: another writer added the columns we wanted; the
+			// table is now correct, signal the caller to retry the write.
+			return attempt > 0, nil
+		}
+
+		newSchema := make(bigquery.Schema, len(meta.Schema), len(meta.Schema)+len(missing))
+		copy(newSchema, meta.Schema)
+		newSchema = append(newSchema, missing...)
+
+		// ETag enforces optimistic locking. On 412 we loop, refetch, and
+		// recompute the diff so concurrent evolutions don't clobber each
+		// other's added columns.
+		_, err = client.Dataset(datasetID).Table(tableID).Update(ctx, bigquery.TableMetadataToUpdate{Schema: newSchema}, meta.ETag)
+		if err == nil {
+			for _, col := range missing {
+				e.log.Infof("Added column %q (%s) to table %s.%s", col.Name, col.Type, datasetID, tableID)
+			}
+			return true, nil
+		}
+
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed {
+			continue
+		}
+		return false, fmt.Errorf("updating table schema: %w", err)
+	}
+	return false, fmt.Errorf("schema evolution for %s.%s gave up after %d concurrent-update conflicts", datasetID, tableID, maxEvolveAttempts)
+}

--- a/internal/impl/gcp/enterprise/bigquery/schema_evolution_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_evolution_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestProtoKindToBQFieldType(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     protoreflect.Kind
+		expected bigquery.FieldType
+	}{
+		{"string", protoreflect.StringKind, bigquery.StringFieldType},
+		{"int64", protoreflect.Int64Kind, bigquery.IntegerFieldType},
+		{"int32", protoreflect.Int32Kind, bigquery.IntegerFieldType},
+		{"sint64", protoreflect.Sint64Kind, bigquery.IntegerFieldType},
+		{"sint32", protoreflect.Sint32Kind, bigquery.IntegerFieldType},
+		{"sfixed64", protoreflect.Sfixed64Kind, bigquery.IntegerFieldType},
+		{"sfixed32", protoreflect.Sfixed32Kind, bigquery.IntegerFieldType},
+		{"uint64", protoreflect.Uint64Kind, bigquery.IntegerFieldType},
+		{"uint32", protoreflect.Uint32Kind, bigquery.IntegerFieldType},
+		{"fixed64", protoreflect.Fixed64Kind, bigquery.IntegerFieldType},
+		{"fixed32", protoreflect.Fixed32Kind, bigquery.IntegerFieldType},
+		{"double", protoreflect.DoubleKind, bigquery.FloatFieldType},
+		{"float", protoreflect.FloatKind, bigquery.FloatFieldType},
+		{"bool", protoreflect.BoolKind, bigquery.BooleanFieldType},
+		{"bytes", protoreflect.BytesKind, bigquery.BytesFieldType},
+		{"enum", protoreflect.EnumKind, bigquery.StringFieldType},
+		{"message", protoreflect.MessageKind, bigquery.RecordFieldType},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := protoKindToBQFieldType(tc.kind)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestProtoKindToBQFieldTypeUnknown(t *testing.T) {
+	_, err := protoKindToBQFieldType(0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no BigQuery type mapping")
+}
+
+func TestDescriptorToBQSchema(t *testing.T) {
+	dp := &descriptorpb.DescriptorProto{
+		Name: new("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   new("name"),
+				Number: new(int32(1)),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			},
+			{
+				Name:   new("age"),
+				Number: new(int32(2)),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			},
+		},
+	}
+
+	md, err := descriptorProtoToMessageDescriptor(dp)
+	require.NoError(t, err)
+
+	schema, err := descriptorToBQSchema(md)
+	require.NoError(t, err)
+	require.Len(t, schema, 2)
+
+	assert.Equal(t, "name", schema[0].Name)
+	assert.Equal(t, bigquery.StringFieldType, schema[0].Type)
+	assert.False(t, schema[0].Required)
+
+	assert.Equal(t, "age", schema[1].Name)
+	assert.Equal(t, bigquery.IntegerFieldType, schema[1].Type)
+	assert.False(t, schema[1].Required)
+}
+
+func TestDiffMissingColumns(t *testing.T) {
+	dp := &descriptorpb.DescriptorProto{
+		Name: new("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{Name: new("name"), Number: new(int32(1)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+			{Name: new("age"), Number: new(int32(2)), Type: descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+			{Name: new("email"), Number: new(int32(3)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+		},
+	}
+	md, err := descriptorProtoToMessageDescriptor(dp)
+	require.NoError(t, err)
+
+	existing := bigquery.Schema{
+		{Name: "name", Type: bigquery.StringFieldType},
+		{Name: "age", Type: bigquery.IntegerFieldType},
+	}
+
+	missing, err := diffMissingColumns(md, existing)
+	require.NoError(t, err)
+	require.Len(t, missing, 1)
+	assert.Equal(t, "email", missing[0].Name)
+	assert.Equal(t, bigquery.StringFieldType, missing[0].Type)
+	assert.False(t, missing[0].Required)
+}
+
+func TestDiffMissingColumnsNoMissing(t *testing.T) {
+	dp := &descriptorpb.DescriptorProto{
+		Name: new("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{Name: new("name"), Number: new(int32(1)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+		},
+	}
+	md, err := descriptorProtoToMessageDescriptor(dp)
+	require.NoError(t, err)
+
+	existing := bigquery.Schema{
+		{Name: "name", Type: bigquery.StringFieldType},
+	}
+
+	missing, err := diffMissingColumns(md, existing)
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+func TestDescriptorToBQSchemaRepeated(t *testing.T) {
+	// Repeated proto fields must surface as REPEATED BigQuery columns.
+	dp := &descriptorpb.DescriptorProto{
+		Name: new("Repeated"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{Name: new("tags"), Number: new(int32(1)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum()},
+			{Name: new("name"), Number: new(int32(2)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+		},
+	}
+	md, err := descriptorProtoToMessageDescriptor(dp)
+	require.NoError(t, err)
+
+	schema, err := descriptorToBQSchema(md)
+	require.NoError(t, err)
+	require.Len(t, schema, 2)
+	assert.True(t, schema[0].Repeated, "tags should be REPEATED")
+	assert.False(t, schema[1].Repeated, "name should not be REPEATED")
+}

--- a/internal/impl/gcp/enterprise/bigquery/schema_resolver.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_resolver.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	bq "cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// resolvedSchema holds both descriptor forms (DescriptorProto for the managed
+// writer, MessageDescriptor for JSON-to-proto conversion).
+type resolvedSchema struct {
+	descriptorProto   *descriptorpb.DescriptorProto
+	messageDescriptor protoreflect.MessageDescriptor
+}
+
+// schemaResolver caches resolved schemas per table and deduplicates concurrent
+// resolves of the same table via a singleflight group.
+type schemaResolver struct {
+	cache sync.Map // key: string -> *resolvedSchema
+	sf    singleflight.Group
+	log   *service.Logger
+}
+
+// Resolve returns a resolved schema for the given table by fetching the
+// table metadata from BigQuery. Results are cached per table ID, and concurrent
+// cache misses for the same table are coalesced into a single BQ call.
+func (r *schemaResolver) Resolve(ctx context.Context, client *bq.Client, datasetID, tableID string) (*resolvedSchema, error) {
+	if cached, ok := r.cache.Load(tableID); ok {
+		return cached.(*resolvedSchema), nil
+	}
+
+	if client == nil {
+		return nil, errors.New("no schema source available: ensure the table exists in BigQuery")
+	}
+
+	v, err, _ := r.sf.Do(tableID, func() (any, error) {
+		// Re-check cache: another goroutine may have populated it while we
+		// were queued in singleflight.
+		if cached, ok := r.cache.Load(tableID); ok {
+			return cached.(*resolvedSchema), nil
+		}
+		rs, err := resolveFromBQTable(ctx, client, datasetID, tableID)
+		if err != nil {
+			return nil, err
+		}
+		r.cache.Store(tableID, rs)
+		return rs, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolving schema for table %q: %w", tableID, err)
+	}
+	return v.(*resolvedSchema), nil
+}
+
+// Evict removes the cached schema for a table, forcing re-resolution on the
+// next call to Resolve.
+func (r *schemaResolver) Evict(tableID string) {
+	r.cache.Delete(tableID)
+}
+
+func resolveFromBQTable(ctx context.Context, client *bq.Client, datasetID, tableID string) (*resolvedSchema, error) {
+	meta, err := client.Dataset(datasetID).Table(tableID).Metadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	tableSchema, err := adapt.BQSchemaToStorageTableSchema(meta.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("converting BQ schema to storage schema: %w", err)
+	}
+
+	descriptor, err := adapt.StorageSchemaToProto2Descriptor(tableSchema, "root")
+	if err != nil {
+		return nil, fmt.Errorf("converting storage schema to proto descriptor: %w", err)
+	}
+
+	messageDescriptor, ok := descriptor.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, errors.New("schema descriptor is not a MessageDescriptor")
+	}
+
+	normalized, err := adapt.NormalizeDescriptor(messageDescriptor)
+	if err != nil {
+		return nil, fmt.Errorf("normalizing descriptor: %w", err)
+	}
+
+	md, err := descriptorProtoToMessageDescriptor(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resolvedSchema{
+		descriptorProto:   normalized,
+		messageDescriptor: md,
+	}, nil
+}

--- a/internal/impl/gcp/enterprise/bigquery/schema_resolver_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_resolver_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestResolverCacheHit(t *testing.T) {
+	// Given a resolver with a pre-populated cache entry.
+	r := &schemaResolver{log: service.MockResources().Logger()}
+	expected := &resolvedSchema{
+		messageDescriptor: buildTestMessageDescriptor(t),
+	}
+	r.cache.Store("my_table", expected)
+
+	// When we resolve the same table (no BQ client needed for a cache hit).
+	rs, err := r.Resolve(t.Context(), nil, "my_dataset", "my_table")
+
+	// Then the cached value is returned without error.
+	require.NoError(t, err)
+	assert.Same(t, expected, rs)
+}
+
+func TestResolverCacheMissNoBQClient(t *testing.T) {
+	// Given a resolver with no BQ client.
+	r := &schemaResolver{log: service.MockResources().Logger()}
+
+	// When we resolve a table with no cache entry.
+	rs, err := r.Resolve(t.Context(), nil, "my_dataset", "missing")
+
+	// Then it returns an error about no schema source.
+	require.Error(t, err)
+	assert.Nil(t, rs)
+	assert.Contains(t, err.Error(), "no schema source available")
+}
+
+func TestResolverEvict(t *testing.T) {
+	// Given a resolver with a cached entry.
+	r := &schemaResolver{log: service.MockResources().Logger()}
+	r.cache.Store("my_table", &resolvedSchema{})
+
+	// When we evict that table.
+	r.Evict("my_table")
+
+	// Then the cache entry is gone.
+	_, ok := r.cache.Load("my_table")
+	assert.False(t, ok)
+}
+
+func TestResolverEvictNonexistent(t *testing.T) {
+	// Given a resolver with no cache entries.
+	r := &schemaResolver{log: service.MockResources().Logger()}
+
+	// When we evict a nonexistent key, it does not panic.
+	assert.NotPanics(t, func() {
+		r.Evict("no_such_table")
+	})
+}
+
+// buildTestMessageDescriptor creates a simple (name STRING, age INT64)
+// message descriptor for unit tests.
+func buildTestMessageDescriptor(t *testing.T) protoreflect.MessageDescriptor {
+	t.Helper()
+	dp := &descriptorpb.DescriptorProto{
+		Name: new("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   new("name"),
+				Number: new(int32(1)),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			},
+			{
+				Name:   new("age"),
+				Number: new(int32(2)),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			},
+		},
+	}
+	md, err := descriptorProtoToMessageDescriptor(dp)
+	require.NoError(t, err)
+	return md
+}


### PR DESCRIPTION
```
  ┌───────┬───────────┬─────────┬───────┬──────────┬──────────────┐
  │ batch │ in_flight │ rows/s  │ MB/s  │ ms/batch │ allocs/batch │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │    10 │         1 │   6,089 │  0.45 │     1.64 │          309 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │    10 │         4 │   6,694 │  0.50 │     1.49 │          307 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │    10 │        16 │   6,645 │  0.49 │     1.51 │          307 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │   100 │         1 │  37,556 │  2.85 │     2.66 │        2,817 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │   100 │         4 │  47,214 │  3.58 │     2.12 │        2,817 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │   100 │        16 │  52,742 │  4.00 │     1.90 │        2,816 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │  1000 │         1 │ 119,284 │  9.28 │     8.38 │       28,884 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │  1000 │         4 │ 160,663 │ 12.50 │     6.22 │       28,882 │
  ├───────┼───────────┼─────────┼───────┼──────────┼──────────────┤
  │  1000 │        16 │ 160,973 │ 12.52 │     6.21 │       28,883 │
  └───────┴───────────┴─────────┴───────┴──────────┴──────────────┘

```