### PR TITLE
mssqlserver: store checkpoint LSN as varbinary

### DIFF
--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -160,14 +160,16 @@ func (c *checkpointCache) Close(ctx context.Context) error {
 }
 
 func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, error) {
-	// cache_key length is based on default (fixed) cache key
+	// LSNs are varbinary(10); storing them as varchar would trigger an implicit
+	// binary-to-hex-string conversion by the driver and corrupt the value on
+	// read-back.
 	q := `
 	DECLARE @created BIT = 0;
 	IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE schema_id = SCHEMA_ID('%s') AND name = '%s')
 	BEGIN
 		CREATE TABLE %s (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
-			cache_val varchar(100)
+			cache_val varbinary(10)
 		);
 		SET @created = 1;
 	END;
@@ -186,7 +188,7 @@ func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTab
 	q := `
 	CREATE OR ALTER PROCEDURE %s
 		@Key varchar(7),
-		@Value varchar(100)
+		@Value varbinary(10)
 	AS
 	BEGIN
 		SET NOCOUNT ON;

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -59,9 +59,9 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache(t *testing.T) {
 		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
 		require.NoError(t, err)
 
-		// verify set
+		// verify set: LSN is a 10-byte varbinary value
 		var wanted replication.LSN
-		require.NoError(t, wanted.Scan([]byte("0x0000002d000004b00003")))
+		require.NoError(t, wanted.Scan([]byte{0x00, 0x00, 0x00, 0x2d, 0x00, 0x00, 0x04, 0xb0, 0x00, 0x03}))
 		require.NoError(t, cache.Set(t.Context(), "", wanted, nil))
 
 		// verify get


### PR DESCRIPTION
The CDC checkpoint cache stored LSNs in a varchar(100) column. When
writing a []byte to a varchar, go-mssqldb performs an implicit
binary-to-hex-string conversion (e.g. "0x0000002d00000bc3b80003"), so
reads returned the ASCII representation of the LSN rather than the
original binary value. On resume, those ASCII bytes were passed as a
varbinary parameter to the change-table query and, starting with 0x30,
sorted above any real LSN (which starts with 0x00), leaving the stream
spinning with no rows matched.

Change the cache column and stored procedure parameter to varbinary(10)
so the driver transfers the LSN as-is.

Fixes CON-382

Cherry picked from https://github.com/redpanda-data/connect/pull/4304 so I can verify backwards compatibility.
