### PR TITLE
chore(cli): upgrade urfave/cli v2 → v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.26.2
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 
+replace github.com/redpanda-data/benthos/v4 => ../benthos-2
+
 ignore (
 	./bin
 	./config
@@ -176,6 +178,7 @@ require (
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	github.com/twmb/franz-go/pkg/sr v1.7.0
 	github.com/twmb/go-cache v1.3.0
+	github.com/urfave/cli/v3 v3.8.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/xdg-go/scram v1.2.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -419,7 +422,6 @@ require (
 	github.com/couchbase/goprotostellar v1.0.5 // indirect
 	github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -521,7 +523,6 @@ require (
 	github.com/rickb777/plural v1.4.10 // indirect
 	github.com/rivo/uniseg v0.4.7
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
@@ -533,13 +534,11 @@ require (
 	github.com/tilinna/z85 v1.0.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
-	github.com/urfave/cli/v2 v2.27.7
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	gitlab.com/golang-commonmark/markdown v0.0.0-20211110145824-bf3e522c626a // indirect

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,6 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0 h1:HU9DlAYYWR69jQnLN6cpg0fh0hxW/8
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
-github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -1553,8 +1551,6 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/redpanda-data/benthos/v4 v4.72.0 h1:Aj63fY6nZBGL17YDvHZV88caN2/jHlza9ZS57BGtxhs=
-github.com/redpanda-data/benthos/v4 v4.72.0/go.mod h1:if/3gnj/gIz3mKIiz2MGF7gNag/gv7ak0snVxP81BM4=
 github.com/redpanda-data/common-go/authz v0.2.1-0.20260319205134-242ab3c168b8 h1:hZTIp81OUDNOTCTD0gM01b1t821pDbToU9jWnZRnd/E=
 github.com/redpanda-data/common-go/authz v0.2.1-0.20260319205134-242ab3c168b8/go.mod h1:sHhzCYf64ZYUBi7snbopQl+wQaKySbFsKCvGhmSckhk=
 github.com/redpanda-data/common-go/license v0.0.0-20260318014216-2bbd72bde0a0 h1:xL2THs63tUTZmTiBfBm/mrjFMrwQaHKduvgQ6gIizXg=
@@ -1590,6 +1586,7 @@ github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OK
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
@@ -1786,8 +1783,8 @@ github.com/uptrace/bun/driver/sqliteshim v1.2.18 h1:fDCXp4L46A23OuUikDbL14SRmm3y
 github.com/uptrace/bun/driver/sqliteshim v1.2.18/go.mod h1:MqvqMCAAKNn6M0HF9YK/Z6xrnCP6sih5OZ37AxdAlHw=
 github.com/uptrace/bun/extra/bundebug v1.2.18 h1:5cgkqdvhpSHIEONazSytm4RWYFneNtcznaWLt6r8m4M=
 github.com/uptrace/bun/extra/bundebug v1.2.18/go.mod h1:M+U9YJVJcmk0RrszCb2Q1oskJiJ0LuC44FxDhZLP1ws=
-github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
-github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
+github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/vmihailenco/bufpool v0.1.11 h1:gOq2WmBrq0i2yW5QJ16ykccQ4wH9UyEsgLm6czKAd94=
 github.com/vmihailenco/bufpool v0.1.11/go.mod h1:AFf/MOy3l2CFTKbxwt0mp2MwnqjNEs5H/UxrkA5jxTQ=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
@@ -1829,8 +1826,6 @@ github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b/go.mod
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
-github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
-github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -9,12 +9,13 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
@@ -34,7 +35,7 @@ func agentCli(rpMgr *enterprise.GlobalRedpandaManager) *cli.Command {
 	return &cli.Command{
 		Name:  "agent",
 		Usage: "Redpanda Connect commands.",
-		Subcommands: []*cli.Command{
+		Commands: []*cli.Command{
 			{
 				Name:  "init",
 				Usage: "Initialize a Redpanda Connect agent",
@@ -48,7 +49,7 @@ Initialize a template for building a Redpanda Connect agent.
   {{.BinaryName}} agent init ./repo
   
   `[1:],
-				Action: func(c *cli.Context) error {
+				Action: func(_ context.Context, c *cli.Command) error {
 					repositoryDir := "."
 					if c.Args().Len() > 0 {
 						if c.Args().Len() > 1 {
@@ -82,7 +83,7 @@ Each resource in the mcp subdirectory will create tools that can be used, then t
   {{.BinaryName}} agent run ./repo
   
   `[1:],
-				Action: func(c *cli.Context) error {
+				Action: func(ctx context.Context, c *cli.Command) error {
 					repositoryDir := "."
 					if c.Args().Len() > 0 {
 						if c.Args().Len() > 1 {
@@ -103,7 +104,7 @@ Each resource in the mcp subdirectory will create tools that can be used, then t
 					// TODO: rpMgr.Init...
 					logger := slog.New(newTeeLogger(fallbackLogger.Handler(), rpMgr.SlogHandler()))
 
-					secretLookupFn, err := parseSecretsFlag(logger, c)
+					secretLookupFn, err := parseSecretsFlag(ctx, logger, c)
 					if err != nil {
 						return err
 					}

--- a/internal/cli/custom_lint.go
+++ b/internal/cli/custom_lint.go
@@ -9,13 +9,14 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/mcp/repository"
@@ -64,7 +65,7 @@ Exits with a status code 1 if any linting errors are detected in a directory:
 
   {{.BinaryName}} mcp-server lint . 
   {{.BinaryName}} mcp-server lint ./foo`[1:],
-		Action: func(c *cli.Context) error {
+		Action: func(ctx context.Context, c *cli.Command) error {
 			if err := applyEnvFileFlag(c); err != nil {
 				return err
 			}
@@ -77,17 +78,17 @@ Exits with a status code 1 if any linting errors are detected in a directory:
 				repositoryDir = c.Args().First()
 			}
 
-			return directoryMode(c, repositoryDir)
+			return directoryMode(ctx, c, repositoryDir)
 		},
 	}
 }
 
-func directoryMode(c *cli.Context, repositoryDir string) error {
+func directoryMode(ctx context.Context, c *cli.Command, repositoryDir string) error {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelError,
 	}))
 
-	secretLookupFn, err := parseSecretsFlag(logger, c)
+	secretLookupFn, err := parseSecretsFlag(ctx, logger, c)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/dry_run.go
+++ b/internal/cli/dry_run.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/rs/xid"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/impl/kafka/enterprise"
@@ -55,7 +55,7 @@ func dryRunCli(schema *service.ConfigSchema) *cli.Command {
 Exits with a status code 1 if any connection errors are detected in a directory:
 
   {{.BinaryName}} dry-run ./foo.yaml`[1:],
-		Action: func(c *cli.Context) error {
+		Action: func(ctx context.Context, c *cli.Command) error {
 			if err := applyEnvFileFlag(c); err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ Exits with a status code 1 if any connection errors are detected in a directory:
 			applyLicenseFlag(c, &r.licenseConfig)
 
 			var err error
-			if r.secretLookupFn, err = parseSecretsFlag(r.logger, c); err != nil {
+			if r.secretLookupFn, err = parseSecretsFlag(ctx, r.logger, c); err != nil {
 				return err
 			}
 
@@ -84,11 +84,11 @@ Exits with a status code 1 if any connection errors are detected in a directory:
 
 			for _, target := range targets {
 				if isDirectory(target) {
-					if err := r.dryRunDirectory(c, target); err != nil {
+					if err := r.dryRunDirectory(ctx, target); err != nil {
 						return err
 					}
 				} else {
-					if err := r.dryRunFile(c, target); err != nil {
+					if err := r.dryRunFile(ctx, target); err != nil {
 						return err
 					}
 				}
@@ -172,7 +172,7 @@ type dryRunner struct {
 	runLogger      *dryRunResultLogger
 }
 
-func (d *dryRunner) dryRunFile(c *cli.Context, filePath string) error {
+func (d *dryRunner) dryRunFile(ctx context.Context, filePath string) error {
 	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
@@ -214,9 +214,9 @@ func (d *dryRunner) dryRunFile(c *cli.Context, filePath string) error {
 		return err
 	}
 
-	connTestResults := rpMgr.ConnectionTest(c.Context)
+	connTestResults := rpMgr.ConnectionTest(ctx)
 
-	if tmpTestResults, err := strm.ConnectionTest(c.Context); err != nil {
+	if tmpTestResults, err := strm.ConnectionTest(ctx); err != nil {
 		return err
 	} else {
 		connTestResults = append(connTestResults, tmpTestResults...)
@@ -226,7 +226,7 @@ func (d *dryRunner) dryRunFile(c *cli.Context, filePath string) error {
 	return nil
 }
 
-func (d *dryRunner) dryRunDirectory(c *cli.Context, repositoryDir string) error {
+func (d *dryRunner) dryRunDirectory(ctx context.Context, repositoryDir string) error {
 	resBuilder := d.schema.Environment().NewResourceBuilder()
 
 	repoScanner := repository.NewScanner(os.DirFS(repositoryDir))
@@ -273,10 +273,10 @@ func (d *dryRunner) dryRunDirectory(c *cli.Context, repositoryDir string) error 
 	}
 
 	defer func() {
-		_ = closeFn(c.Context)
+		_ = closeFn(ctx)
 	}()
 
-	results, err := resources.ConnectionTest(c.Context)
+	results, err := resources.ConnectionTest(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/rs/xid"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/common-go/authz"
@@ -182,13 +182,13 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				redpandaFlags(),
 			),
 
-			func(c *cli.Context) error {
+			func(ctx context.Context, c *cli.Command) error {
 				applyLicenseFlag(c, &licenseConfig)
 				chrootPath = c.String("chroot")
 				chrootPassthrough = c.StringSlice("chroot-passthrough")
 				disableTelemetry = c.Bool("disable-telemetry")
 
-				if secretLookupFn, err = parseSecretsFlag(slog.New(rpLogger), c); err != nil {
+				if secretLookupFn, err = parseSecretsFlag(ctx, slog.New(rpLogger), c); err != nil {
 					return err
 				}
 
@@ -205,7 +205,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				}
 
 				// Parse and resolve cloud auth flags
-				if authzResourceName, authzPolicyFile, authzPolicyEndpoint, err = parseCloudAuthFlags(c.Context, c, secretLookupFn); err != nil {
+				if authzResourceName, authzPolicyFile, authzPolicyEndpoint, err = parseCloudAuthFlags(ctx, c, secretLookupFn); err != nil {
 					return err
 				}
 

--- a/internal/cli/flags_common.go
+++ b/internal/cli/flags_common.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -24,11 +24,11 @@ const (
 var envFileFlag = &cli.StringSliceFlag{
 	Name:    "env-file",
 	Aliases: []string{"e"},
-	Value:   cli.NewStringSlice(),
+	Value:   []string{},
 	Usage:   "import environment variables from a dotenv file",
 }
 
-func applyEnvFileFlag(c *cli.Context) error {
+func applyEnvFileFlag(c *cli.Command) error {
 	dotEnvPaths, err := service.Globs(service.OSFS(), c.StringSlice(cfEnvFile)...)
 	if err != nil {
 		return fmt.Errorf("resolving env file glob pattern: %w", err)

--- a/internal/cli/flags_redpanda.go
+++ b/internal/cli/flags_redpanda.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/twmb/franz-go/pkg/sasl/scram"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/benthos/v4/public/service/securetls"
@@ -51,12 +51,12 @@ const (
 var secretsFlag = &cli.StringSliceFlag{
 	Name:  "secrets",
 	Usage: "Attempt to load secrets from a provided URN. If more than one entry is specified they will be attempted in order until a value is found. Environment variable lookups are specified with the URN `env:`, which by default is the only entry. In order to disable all secret lookups specify a single entry of `none:`.",
-	Value: cli.NewStringSlice("env:"),
+	Value: []string{"env:"},
 }
 
-func parseSecretsFlag(logger *slog.Logger, c *cli.Context) (func(context.Context, string) (string, bool), error) {
+func parseSecretsFlag(ctx context.Context, logger *slog.Logger, c *cli.Command) (func(context.Context, string) (string, bool), error) {
 	if secretsURNs := c.StringSlice("secrets"); len(secretsURNs) > 0 {
-		return secrets.ParseLookupURNs(c.Context, logger, secretsURNs...)
+		return secrets.ParseLookupURNs(ctx, logger, secretsURNs...)
 	}
 	return func(_ context.Context, _ string) (string, bool) {
 		return "", false
@@ -75,7 +75,7 @@ func defaultLicenseConfig() license.Config {
 	}
 }
 
-func applyLicenseFlag(c *cli.Context, conf *license.Config) {
+func applyLicenseFlag(c *cli.Command, conf *license.Config) {
 	if inline := c.String("redpanda-license"); inline != "" {
 		conf.License = inline
 	}
@@ -119,7 +119,7 @@ func redpandaFlags() []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:   rfBrokers,
 			Hidden: true,
-			Value:  cli.NewStringSlice(),
+			Value:  []string{},
 		},
 		&cli.BoolFlag{
 			Name:   rfTLSEnabled,
@@ -181,7 +181,7 @@ func redpandaFlags() []cli.Flag {
 			Hidden: true,
 			Value:  "",
 		},
-		&cli.PathFlag{
+		&cli.StringFlag{
 			Name:   rfCloudAuthzPolicyFile,
 			Usage:  "Authorization policy file for enforcing permissions",
 			Hidden: true,
@@ -196,7 +196,7 @@ func redpandaFlags() []cli.Flag {
 	}
 }
 
-func parseRedpandaFlags(c *cli.Context) (pipelineID, logsTopic, statusTopic string, connDetails *kafka.FranzConnectionDetails, err error) {
+func parseRedpandaFlags(c *cli.Command) (pipelineID, logsTopic, statusTopic string, connDetails *kafka.FranzConnectionDetails, err error) {
 	pipelineID = c.String(rfPipelineID)
 	logsTopic = c.String(rfLogsTopic)
 	statusTopic = c.String(rfStatusTopic)
@@ -297,13 +297,13 @@ func resolveSecret(ctx context.Context, value string, lookupFn secrets.LookupFn)
 // parseCloudAuthFlags parses the OAuth2/cloud authentication CLI flags,
 // resolves any secret references, and initializes the global service account configuration.
 // Returns the authz resource name, policy file, and policy endpoint (if specified).
-func parseCloudAuthFlags(ctx context.Context, c *cli.Context, secretLookupFn secrets.LookupFn) (authzResourceName, authzPolicyFile, authzPolicyEndpoint string, err error) {
+func parseCloudAuthFlags(ctx context.Context, c *cli.Command, secretLookupFn secrets.LookupFn) (authzResourceName, authzPolicyFile, authzPolicyEndpoint string, err error) {
 	tokenURL := resolveSecret(ctx, c.String(rfCloudTokenURL), secretLookupFn)
 	clientID := resolveSecret(ctx, c.String(rfCloudClientID), secretLookupFn)
 	clientSecret := resolveSecret(ctx, c.String(rfCloudClientSecret), secretLookupFn)
 	audience := resolveSecret(ctx, c.String(rfCloudAudience), secretLookupFn)
 	authzResourceName = resolveSecret(ctx, c.String(rfCloudAuthzResourceName), secretLookupFn)
-	authzPolicyFile = resolveSecret(ctx, c.Path(rfCloudAuthzPolicyFile), secretLookupFn)
+	authzPolicyFile = resolveSecret(ctx, c.String(rfCloudAuthzPolicyFile), secretLookupFn)
 	authzPolicyEndpoint = resolveSecret(ctx, c.String(rfCloudAuthzPolicyEndpoint), secretLookupFn)
 
 	// Initialize global service account config if credentials are provided

--- a/internal/cli/generate_plugin.go
+++ b/internal/cli/generate_plugin.go
@@ -9,9 +9,10 @@
 package cli
 
 import (
+	"context"
 	"errors"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/connect/v4/internal/rpcplugin"
 )
@@ -42,7 +43,7 @@ Generates a project on the local filesystem that can be used as a starting point
 building a custom component for Redpanda Connect. It will overwrite all files in the specified
 directory (or the current directory if none is specified).
   `[1:],
-		Action: func(c *cli.Context) error {
+		Action: func(_ context.Context, c *cli.Command) error {
 			dir := "."
 			if c.Args().Len() > 0 {
 				if c.Args().Len() > 1 {
@@ -56,8 +57,8 @@ directory (or the current directory if none is specified).
 		},
 	}
 	return &cli.Command{
-		Name:        "plugin",
-		Usage:       "Plugin management commands",
-		Subcommands: []*cli.Command{cmd},
+		Name:     "plugin",
+		Usage:    "Plugin management commands",
+		Commands: []*cli.Command{cmd},
 	}
 }

--- a/internal/cli/mcp_server.go
+++ b/internal/cli/mcp_server.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/common-go/authz"
@@ -50,7 +50,7 @@ func mcpServerCli(rpMgr *enterprise.GlobalRedpandaManager) *cli.Command {
 		Name:  "mcp-server",
 		Usage: "Execute an MCP server against a suite of Redpanda Connect resources.",
 		Flags: flags,
-		Subcommands: []*cli.Command{
+		Commands: []*cli.Command{
 			mcpServerInitCli(),
 			customLintCli(),
 		},
@@ -60,7 +60,7 @@ Each resource will be exposed as a tool that AI can interact with:
   {{.BinaryName}} mcp-server ./repo
 
   `[1:],
-		Action: func(c *cli.Context) error {
+		Action: func(ctx context.Context, c *cli.Command) error {
 			if err := applyEnvFileFlag(c); err != nil {
 				return err
 			}
@@ -105,13 +105,13 @@ Each resource will be exposed as a tool that AI can interact with:
 
 			logger := slog.New(newTeeLogger(fallbackLogger.Handler(), rpMgr.SlogHandler()))
 
-			secretLookupFn, err := parseSecretsFlag(logger, c)
+			secretLookupFn, err := parseSecretsFlag(ctx, logger, c)
 			if err != nil {
 				return err
 			}
 
 			// Parse and resolve cloud auth flags
-			authzResourceName, authzPolicyFile, authzPolicyEndpoint, err := parseCloudAuthFlags(c.Context, c, secretLookupFn)
+			authzResourceName, authzPolicyFile, authzPolicyEndpoint, err := parseCloudAuthFlags(ctx, c, secretLookupFn)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/mcp_server_init.go
+++ b/internal/cli/mcp_server_init.go
@@ -9,12 +9,13 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 func mcpServerInitCli() *cli.Command {
@@ -29,7 +30,7 @@ func mcpServerInitCli() *cli.Command {
 
 Files that already exist will not be overwritten.
   `[1:],
-		Action: func(c *cli.Context) error {
+		Action: func(_ context.Context, c *cli.Command) error {
 			repositoryDir := "."
 			if c.Args().Len() > 0 {
 				if c.Args().Len() > 1 {


### PR DESCRIPTION
## Summary

Migrate connect's CLI from urfave/cli v2 (discontinued; has a known bug with global-flag parsing order) to urfave/cli v3.8.0.

Tracks **CON-373** / closes **#3502**.

## Status: WIP / blocked

This PR is marked draft because it depends on the corresponding benthos PR landing and a benthos release being cut. The current commit includes a **temporary `replace` directive** in `go.mod`:

```
replace github.com/redpanda-data/benthos/v4 => ../benthos-2
```

It must be **dropped before merge**, after benthos v3 is released and this PR's `benthos/v4` require is bumped to that release. Until then, CI cannot build this branch.

**Upstream dependency:** redpanda-data/benthos#428

## Mechanical changes

Across `internal/cli/*.go` (9 files):
- `Action` / `Before` / `After` / `OnUsageError` signatures gain a `context.Context` first parameter and operate on `*cli.Command` instead of `*cli.Context`.
- `Subcommands` field renamed to `Commands`.
- `cli.NewStringSlice(...)` replaced with `[]string{...}` literals.
- `cli.PathFlag` (removed in v3) replaced with `cli.StringFlag`.
- The connect-side callback for `service.CLIOptCustomRunFlags` adopts the new benthos signature.
- Helper functions previously taking `*cli.Context` now take `*cli.Command` (and a separate `ctx context.Context` where the underlying context was being used).

## Test plan

- [x] `go build ./...` clean
- [x] `task fmt` clean
- [x] `task lint` clean (0 issues)
- [ ] `task test:unit` — to be run by Travis
- [ ] `--help` smoke test on root + 3 subcommands — to be run by Travis
- [ ] After benthos v3 release: drop the replace directive, bump benthos/v4 require, re-run CI

## Out of scope (follow-up)

- `public/bundle/{free,enterprise}/go.mod` sub-modules pin an old connect version; they'll naturally update via `task bundles` after a connect release containing this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)