### PR TITLE
mysqlcdc: checkpoint at transaction boundary

### DIFF
--- a/internal/impl/mysql/event.go
+++ b/internal/impl/mysql/event.go
@@ -35,6 +35,11 @@ const (
 	// snapshot rows have been sent so the checkpoint can advance once all snapshot batches
 	// are acknowledged
 	messageOperationSnapshotComplete MessageOperation = "snapshot_complete"
+
+	// messageOperationXID is an internal sentinel emitted when a transaction commits
+	// so readMessages can advance the checkpoint to a transaction boundary, ensuring
+	// we never resume mid-transaction (which would miss the TABLE_MAP_EVENT).
+	messageOperationXID MessageOperation = "xid"
 )
 
 // MessageEvent represents a message from mysql cdc plugin

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -777,6 +777,11 @@ func prepSnapshotScannerAndMappers(cols []*sql.ColumnType) (values []any, mapper
 
 func (i *mysqlStreamInput) readMessages(ctx context.Context) error {
 	var nextTimedBatchChan <-chan time.Time
+	// latestXIDPos tracks the most recently committed transaction boundary.
+	// Checkpoints only advance to XID positions so that on restart canal.RunFrom
+	// always resumes at the start of a new transaction, ensuring TABLE_MAP_EVENTs
+	// are received before any row events.
+	var latestXIDPos *position
 	for {
 		select {
 		case <-ctx.Done():
@@ -788,17 +793,22 @@ func (i *mysqlStreamInput) readMessages(ctx context.Context) error {
 				return fmt.Errorf("timed flush batch error: %w", err)
 			}
 
-			if err := i.flushBatch(ctx, i.cp, flushedBatch); err != nil {
+			if err := i.flushBatch(ctx, i.cp, flushedBatch, latestXIDPos); err != nil {
 				return fmt.Errorf("flushing periodic batch: %w", err)
 			}
 		case me := <-i.rawMessageEvents:
+			if me.Operation == messageOperationXID {
+				latestXIDPos = me.Position
+				continue
+			}
+
 			if me.Operation == messageOperationSnapshotComplete {
 				// Flush any remaining messages before post snapshot checkpoint
 				flushedBatch, err := i.batchPolicy.Flush(ctx)
 				if err != nil {
 					return fmt.Errorf("flushing snapshot completion batch: %w", err)
 				}
-				if err := i.flushBatch(ctx, i.cp, flushedBatch); err != nil {
+				if err := i.flushBatch(ctx, i.cp, flushedBatch, latestXIDPos); err != nil {
 					return fmt.Errorf("flushing snapshot completion batch: %w", err)
 				}
 
@@ -841,7 +851,7 @@ func (i *mysqlStreamInput) readMessages(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("flush batch error: %w", err)
 				}
-				if err := i.flushBatch(ctx, i.cp, flushedBatch); err != nil {
+				if err := i.flushBatch(ctx, i.cp, flushedBatch, latestXIDPos); err != nil {
 					return fmt.Errorf("flushing batch: %w", err)
 				}
 			} else {
@@ -858,23 +868,13 @@ func (i *mysqlStreamInput) flushBatch(
 	ctx context.Context,
 	checkpointer *checkpoint.Capped[*position],
 	batch service.MessageBatch,
+	checkpointPos *position,
 ) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
-	lastMsg := batch[len(batch)-1]
-	strPosition, ok := lastMsg.MetaGet("binlog_position")
-	var binLogPos *position
-	if ok {
-		pos, err := parseBinlogPosition(strPosition)
-		if err != nil {
-			return err
-		}
-		binLogPos = &pos
-	}
-
-	resolveFn, err := checkpointer.Track(ctx, binLogPos, int64(len(batch)))
+	resolveFn, err := checkpointer.Track(ctx, checkpointPos, int64(len(batch)))
 	if err != nil {
 		return fmt.Errorf("tracking checkpoint for batch: %w", err)
 	}
@@ -984,6 +984,15 @@ func (i *mysqlStreamInput) setCachedBinlogPosition(ctx context.Context, binLogPo
 
 func (i *mysqlStreamInput) OnRotate(_ *replication.EventHeader, re *replication.RotateEvent) error {
 	i.currentBinlogName = string(re.NextLogName)
+	return nil
+}
+
+func (i *mysqlStreamInput) OnXID(_ *replication.EventHeader, nextPos gomysql.Position) error {
+	select {
+	case i.rawMessageEvents <- MessageEvent{Operation: messageOperationXID, Position: &nextPos}:
+	case <-i.shutSig.SoftStopChan():
+		return context.Canceled
+	}
 	return nil
 }
 

--- a/internal/impl/mysql/integration_test.go
+++ b/internal/impl/mysql/integration_test.go
@@ -207,7 +207,7 @@ file:
 			assert.Eventually(t, func() bool {
 				outBatchMut.Lock()
 				defer outBatchMut.Unlock()
-				return len(outBatches) == 1000
+				return len(outBatches) >= 1000
 			}, time.Minute*5, time.Millisecond*100)
 
 			require.NoError(t, streamOut.StopWithin(time.Second*10))


### PR DESCRIPTION
**The problem:**

> Err: table id 1302: invalid table id, no corresponding table map event"

Currently we checkpoint at a row level. A MySQL binlog looks like the following, with `go-mysql` keeping an internal buffer of events keyed by the table ID that's set in the `TABLE_MAP_EVENT` :

```
  TABLE_MAP_EVENT  pos=100 → LogPos=150                                                                                                                             
  ROWS_EVENT #1    pos=150 → LogPos=250   ← batch flushed here, checkpoint saved as 250                                                                             
  ROWS_EVENT #2    pos=250 → LogPos=350                                                                                                                             
  XID_EVENT        pos=350 → LogPos=380  
```

If the connector restarts mid transaction then it's unable to recover as it no longer has the table id and we see the above error.

**This change:**

This changes listens to a sentient event (`XID_EVENT`) that exists after every transaction is flushed. Ensuring we checkpoint at this position ensures we capture at clean transaction boundaries and only recover at the beginning of the transaction.

**Attn:** This does mean that in the event of a connector crash, it's possible that we redeliver already processed messages as we start from the beginning of the transaction (satisfying at-least-once delivery). 

<img width="1300" height="662" alt="image" src="https://github.com/user-attachments/assets/82c78062-a092-4ad2-814f-9b7bb5ec7bbc" />