### PR TITLE
confluent,iceberg: preserve avro logical types end-to-end (#4399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
   - **Pipelines whose own code reads the `schema_metadata` bytes via `meta()`** and pattern-matches the historical INT64 shape: schemas now contain `TIMESTAMP` / `DATE` / `TIME_OF_DAY` / `UUID` along with new `unit` and `adjust_to_utc` fields. Update the pattern.
   - **iceberg shredder** is now schema-aware for numeric inputs: a numeric millisecond value declared by the schema as `timestamp-millis` is correctly interpreted as milliseconds rather than as Unix seconds. This closes a previously-silent corruption case where an int64 millis input into a TIMESTAMPTZ column would land ~50,000 years in the future.
 
+### Added
+
+- iceberg: `schema_evolution.require_schema_metadata` (default `false`). When enabled along with `schema_evolution.schema_metadata`, numeric values shredded into a `timestamp`, `timestamptz`, `date`, or `time` column without registered schema metadata are rejected loudly instead of falling through to the bloblang Unix-seconds default. Use this when you cannot guarantee the upstream attaches schema metadata and prefer a hard error to silently corrupting dates by ~50,000 years. No effect on time-typed columns receiving native `time.Time` / `time.Duration` Go values.
+
 ### Changed
 
 - iceberg: `NewWriter` now takes a `*typeResolver` argument so the writer can use schema metadata to interpret numeric inputs into time-typed columns at shredding time. Internal API change only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **BREAKING:** schema_registry_decode (avro): Avro logical types — `timestamp-{millis,micros,nanos}`, `local-timestamp-{millis,micros,nanos}`, `date`, `time-{millis,micros}`, and `uuid` — are now preserved end-to-end in the schema metadata produced by the schema-registry decoder. Previously only `decimal` was honoured; every other logical type silently degraded to its base primitive (`long`, `int`, or `string`). Downstream sinks that consume `schema_metadata` (notably `iceberg`) now create the correct column type. ([#4399](https://github.com/redpanda-data/connect/issues/4399))
+
+  Pipeline values flow through unchanged in both `preserve_logical_types=false` (default — values stay numeric) and `preserve_logical_types=true` (values stay rich Go time types). Bloblang behaviour and JSON-output bytes are unaffected.
+
+  **What this changes for existing pipelines:**
+  - **iceberg with existing tables that have BIGINT / INT / STRING columns from this bug**: the connector now wants to create or evolve those columns to TIMESTAMP / TIMESTAMPTZ / DATE / TIME / UUID. Iceberg disallows BIGINT → TIMESTAMP schema evolution, so the first write after upgrade will fail loudly. Drop and re-create the table, or use Iceberg-native column-rename + add-new-column tooling to migrate before upgrading.
+  - **Pipelines whose own code reads the `schema_metadata` bytes via `meta()`** and pattern-matches the historical INT64 shape: schemas now contain `TIMESTAMP` / `DATE` / `TIME_OF_DAY` / `UUID` along with new `unit` and `adjust_to_utc` fields. Update the pattern.
+  - **iceberg shredder** is now schema-aware for numeric inputs: a numeric millisecond value declared by the schema as `timestamp-millis` is correctly interpreted as milliseconds rather than as Unix seconds. This closes a previously-silent corruption case where an int64 millis input into a TIMESTAMPTZ column would land ~50,000 years in the future.
+
+### Changed
+
+- iceberg: `NewWriter` now takes a `*typeResolver` argument so the writer can use schema metadata to interpret numeric inputs into time-typed columns at shredding time. Internal API change only.
+
 ## 4.90.0 - 2026-04-30
 
 ### Added

--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -149,6 +149,7 @@ output:
       table_location: s3://my-iceberg-bucket/ # No default (optional)
       schema_metadata: ""
       new_column_type_mapping: "" # No default (optional)
+      require_schema_metadata: false
     commit:
       manifest_merge_enabled: true
       max_snapshot_age: 24h
@@ -891,6 +892,15 @@ An optional Bloblang mapping to customize column types during schema evolution. 
 
 *Type*: `string`
 
+
+=== `schema_evolution.require_schema_metadata`
+
+When `true`, writing a numeric value into a `timestamp`, `timestamptz`, `date`, or `time` column without `schema_metadata` registered for that column is a hard error. The default `false` permits a fallback path that interprets bare numeric timestamps as Unix seconds and bare numeric times as already-microseconds — convenient, but silently wrong if upstream produced milliseconds. Enable this when you cannot guarantee the upstream attaches schema metadata and want to fail loudly rather than corrupt dates by ~50,000 years. No effect on time-typed columns receiving `time.Time`/`time.Duration` Go values, which carry their own unit unambiguously, and no effect on non-time columns. Requires `schema_metadata` to be set.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `commit`
 

--- a/internal/impl/confluent/common_to_avro.go
+++ b/internal/impl/confluent/common_to_avro.go
@@ -72,9 +72,48 @@ func commonToAvroInner(c schema.Common, recordName, namespace string, isRoot boo
 	case schema.Any:
 		return "bytes", nil
 	case schema.Timestamp:
+		// Honour Logical.Timestamp params if present; legacy nil-Logical
+		// schemas fall through EffectiveTimestamp() to {Millis, UTC},
+		// preserving the pre-PR encoder output exactly.
+		p := c.EffectiveTimestamp()
+		base := "long"
+		logicalName, err := avroTimestampLogicalName(p)
+		if err != nil {
+			return nil, fmt.Errorf("timestamp field %q: %w", c.Name, err)
+		}
 		return map[string]any{
-			"type":        "long",
-			"logicalType": "timestamp-millis",
+			"type":        base,
+			"logicalType": logicalName,
+		}, nil
+	case schema.Date:
+		return map[string]any{
+			"type":        "int",
+			"logicalType": "date",
+		}, nil
+	case schema.TimeOfDay:
+		if c.Logical == nil || c.Logical.TimeOfDay == nil {
+			return nil, fmt.Errorf("time-of-day field %q missing Logical.TimeOfDay parameters", c.Name)
+		}
+		// Avro time-{millis,micros} carry no zone semantics, so a
+		// TimeOfDay{AdjustToUTC=true} cannot be expressed faithfully.
+		// Reject loudly rather than silently dropping that bit.
+		if c.Logical.TimeOfDay.AdjustToUTC {
+			return nil, fmt.Errorf("time-of-day field %q has AdjustToUTC=true; Avro time-millis/time-micros have no UTC-adjust variant — coerce upstream before encoding", c.Name)
+		}
+		// Avro defines only time-millis (int) and time-micros (long); reject
+		// anything else loudly rather than silently downcasting.
+		switch c.Logical.TimeOfDay.Unit {
+		case schema.TimeUnitMillis:
+			return map[string]any{"type": "int", "logicalType": "time-millis"}, nil
+		case schema.TimeUnitMicros:
+			return map[string]any{"type": "long", "logicalType": "time-micros"}, nil
+		default:
+			return nil, fmt.Errorf("time-of-day field %q has unit %v which Avro cannot express; only MILLIS and MICROS are supported", c.Name, c.Logical.TimeOfDay.Unit)
+		}
+	case schema.UUID:
+		return map[string]any{
+			"type":        "string",
+			"logicalType": "uuid",
 		}, nil
 	case schema.Decimal:
 		if c.Logical == nil || c.Logical.Decimal == nil {
@@ -170,6 +209,28 @@ func commonToAvroUnion(c schema.Common) (any, error) {
 		variants = append(variants, v)
 	}
 	return variants, nil
+}
+
+// avroTimestampLogicalName picks the Avro logical-type name for a
+// TimestampParams value. The mapping mirrors the reverse path in
+// applyAvroLogicalType: AdjustToUTC=true picks `timestamp-*`, false picks
+// `local-timestamp-*`. Avro 1.10+ supports nanos; older brokers may reject it.
+func avroTimestampLogicalName(p schema.TimestampParams) (string, error) {
+	var unit string
+	switch p.Unit {
+	case schema.TimeUnitMillis:
+		unit = "millis"
+	case schema.TimeUnitMicros:
+		unit = "micros"
+	case schema.TimeUnitNanos:
+		unit = "nanos"
+	default:
+		return "", fmt.Errorf("unsupported timestamp unit %v (Avro supports only MILLIS, MICROS, NANOS)", p.Unit)
+	}
+	if p.AdjustToUTC {
+		return "timestamp-" + unit, nil
+	}
+	return "local-timestamp-" + unit, nil
 }
 
 // sanitizeAvroName derives a valid Avro name from an arbitrary subject string.

--- a/internal/impl/confluent/common_to_avro_test.go
+++ b/internal/impl/confluent/common_to_avro_test.go
@@ -219,3 +219,186 @@ func TestSanitizeAvroName(t *testing.T) {
 		})
 	}
 }
+
+// TestCommonToAvroLogicalTypeRoundTrip drives both halves of the Avro
+// adapter to confirm encode/decode are symmetric for every logical type
+// the connector now preserves. A schema.Common produced by a synthetic
+// decoder run, re-encoded to Avro JSON, must yield byte-equivalent output
+// to the original Avro spec for the same field.
+func TestCommonToAvroLogicalTypeRoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     schema.Common
+		wantOuter map[string]any
+	}{
+		{
+			name:      "Timestamp default (millis, UTC)",
+			input:     schema.Common{Type: schema.Timestamp},
+			wantOuter: map[string]any{"type": "long", "logicalType": "timestamp-millis"},
+		},
+		{
+			name: "Timestamp millis explicit",
+			input: schema.Common{
+				Type:    schema.Timestamp,
+				Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true}},
+			},
+			wantOuter: map[string]any{"type": "long", "logicalType": "timestamp-millis"},
+		},
+		{
+			name: "Timestamp micros UTC",
+			input: schema.Common{
+				Type:    schema.Timestamp,
+				Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+			},
+			wantOuter: map[string]any{"type": "long", "logicalType": "timestamp-micros"},
+		},
+		{
+			name: "Timestamp nanos UTC",
+			input: schema.Common{
+				Type:    schema.Timestamp,
+				Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitNanos, AdjustToUTC: true}},
+			},
+			wantOuter: map[string]any{"type": "long", "logicalType": "timestamp-nanos"},
+		},
+		{
+			name: "Timestamp local micros",
+			input: schema.Common{
+				Type:    schema.Timestamp,
+				Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false}},
+			},
+			wantOuter: map[string]any{"type": "long", "logicalType": "local-timestamp-micros"},
+		},
+		{
+			name:      "Date",
+			input:     schema.Common{Type: schema.Date},
+			wantOuter: map[string]any{"type": "int", "logicalType": "date"},
+		},
+		{
+			name: "TimeOfDay millis",
+			input: schema.Common{
+				Type:    schema.TimeOfDay,
+				Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis}},
+			},
+			wantOuter: map[string]any{"type": "int", "logicalType": "time-millis"},
+		},
+		{
+			name: "TimeOfDay micros",
+			input: schema.Common{
+				Type:    schema.TimeOfDay,
+				Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros}},
+			},
+			wantOuter: map[string]any{"type": "long", "logicalType": "time-micros"},
+		},
+		{
+			name:      "UUID",
+			input:     schema.Common{Type: schema.UUID},
+			wantOuter: map[string]any{"type": "string", "logicalType": "uuid"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := avroUnmarshal(t, tc.input, "", "")
+			m, ok := got.(map[string]any)
+			require.True(t, ok, "expected object output, got %T", got)
+			assert.Equal(t, tc.wantOuter["type"], m["type"])
+			assert.Equal(t, tc.wantOuter["logicalType"], m["logicalType"])
+		})
+	}
+}
+
+// TestCommonToAvroTimeOfDayRejectsAdjustToUTC verifies that the Avro
+// encoder refuses to emit a TimeOfDay schema with AdjustToUTC=true.
+// Avro's time-millis / time-micros logical types carry no UTC-adjust bit,
+// so silently dropping it would lose the metadata. Fail loud instead.
+func TestCommonToAvroTimeOfDayRejectsAdjustToUTC(t *testing.T) {
+	c := schema.Common{
+		Name:    "shift_start",
+		Type:    schema.TimeOfDay,
+		Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+	}
+	_, err := commonToAvroSchema(c, "Row", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AdjustToUTC=true")
+	assert.Contains(t, err.Error(), "shift_start")
+}
+
+// TestCommonToAvroTimeOfDayRejectsUnsupportedUnit verifies that the
+// encoder refuses TimeOfDay schemas with units Avro doesn't define
+// (Seconds, Nanos), with a field-naming error mentioning the supported
+// units. Without this guard, an encoder downcast would silently change
+// resolution.
+func TestCommonToAvroTimeOfDayRejectsUnsupportedUnit(t *testing.T) {
+	for _, u := range []schema.TimeUnit{schema.TimeUnitSeconds, schema.TimeUnitNanos} {
+		t.Run(u.String(), func(t *testing.T) {
+			c := schema.Common{
+				Name:    "open_at",
+				Type:    schema.TimeOfDay,
+				Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: u}},
+			}
+			_, err := commonToAvroSchema(c, "Row", "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "MILLIS and MICROS")
+			assert.Contains(t, err.Error(), "open_at")
+		})
+	}
+}
+
+// TestCommonToAvroTimestampRejectsUnsupportedUnit verifies that the
+// avroTimestampLogicalName helper rejects timestamp units Avro doesn't
+// define (Seconds, and any other invalid TimeUnit). Avro 1.10+ supports
+// millis/micros/nanos.
+func TestCommonToAvroTimestampRejectsUnsupportedUnit(t *testing.T) {
+	c := schema.Common{
+		Name:    "event_time",
+		Type:    schema.Timestamp,
+		Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitSeconds, AdjustToUTC: true}},
+	}
+	_, err := commonToAvroSchema(c, "Row", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "event_time")
+	assert.Contains(t, err.Error(), "MILLIS, MICROS, NANOS")
+}
+
+// TestCommonToAvroDecodeEncodeRoundTrip ensures that decoding an Avro spec
+// via ecsAvroParseFromBytes and re-encoding via commonToAvroSchema yields a
+// schema with the same logicalType annotation. This is the symmetry contract
+// future format adapters should maintain.
+func TestCommonToAvroDecodeEncodeRoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		fieldType string
+	}{
+		{"timestamp-millis", `{"type":"long","logicalType":"timestamp-millis"}`},
+		{"timestamp-micros", `{"type":"long","logicalType":"timestamp-micros"}`},
+		{"local-timestamp-millis", `{"type":"long","logicalType":"local-timestamp-millis"}`},
+		{"date", `{"type":"int","logicalType":"date"}`},
+		{"time-millis", `{"type":"int","logicalType":"time-millis"}`},
+		{"time-micros", `{"type":"long","logicalType":"time-micros"}`},
+		{"uuid", `{"type":"string","logicalType":"uuid"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := []byte(`{
+				"type":"record","name":"Row",
+				"fields":[{"name":"f","type":` + tc.fieldType + `}]
+			}`)
+			c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+			require.NoError(t, err)
+			require.Len(t, c.Children, 1)
+
+			// Re-encode the decoded child and verify the logicalType is
+			// the same as what we started with.
+			f := c.Children[0]
+			out, err := commonToAvroSchema(f, "Inner", "")
+			require.NoError(t, err)
+			var rt map[string]any
+			require.NoError(t, json.Unmarshal([]byte(out), &rt))
+
+			var want map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tc.fieldType), &want))
+			assert.Equal(t, want["logicalType"], rt["logicalType"])
+		})
+	}
+}

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/redpanda-data/benthos/v4/public/schema"
 )
@@ -124,6 +125,133 @@ func ecsAvroIsUnionJustOptionalObject(cfg ecsAvroConfig, types []any) (schema.Co
 		return schema.Common{}, false
 	}
 	return c, true
+}
+
+// applyAvroLogicalType reads the optional "logicalType" annotation from an
+// Avro schema node and refines c (whose Type was already set from the base
+// primitive) with the matching schema.Common type and Logical parameters.
+//
+// Returns (true, nil) when a logical type was recognised and fully populated
+// c; the caller should treat c as final and skip the container-handling
+// switch in [ecsAvroFromAnyMap]. Returns (false, nil) when no logicalType is
+// present or it isn't recognised — per the Avro 1.10 spec, readers must
+// silently fall back to the base type for unknown logical types. Returns an
+// error only for malformed annotations on a known logical type (e.g. a
+// decimal missing precision, a primitive mismatch we want to flag).
+func applyAvroLogicalType(c *schema.Common, as map[string]any) (bool, error) {
+	logical, ok := as["logicalType"].(string)
+	if !ok {
+		return false, nil
+	}
+
+	switch logical {
+	case "decimal":
+		// Per the Avro spec, decimal sits on top of bytes or fixed only.
+		// Other base primitives are malformed — fall back to the base
+		// type and ignore the annotation, matching how we treat every
+		// other primitive/logical-type mismatch below. Note that
+		// ecsAvroTypeToCommon maps `fixed` to schema.Any (it's not in
+		// the named primitive set), so we allow Any through too.
+		if c.Type != schema.ByteArray && c.Type != schema.Any {
+			return false, nil
+		}
+		p, err := avroSpecInt32(as["precision"])
+		if err != nil {
+			return false, fmt.Errorf("decimal precision: %w", err)
+		}
+		// Per the Avro spec scale is optional and defaults to 0 when absent;
+		// only an unparseable scale value (wrong type, non-integer) is an error.
+		var s int32
+		if _, present := as["scale"]; present {
+			s, err = avroSpecInt32(as["scale"])
+			if err != nil {
+				return false, fmt.Errorf("decimal scale: %w", err)
+			}
+		}
+		c.Type = schema.Decimal
+		c.Logical = &schema.LogicalParams{
+			Decimal: &schema.DecimalParams{Precision: p, Scale: s},
+		}
+		if err := c.Validate(); err != nil {
+			return false, fmt.Errorf("decimal field: %w", err)
+		}
+		return true, nil
+
+	case "uuid":
+		// Avro UUID logical type sits on top of `string`. If the base
+		// primitive doesn't match, treat as unknown and fall back per spec.
+		if c.Type != schema.String {
+			return false, nil
+		}
+		c.Type = schema.UUID
+		return true, nil
+
+	case "date":
+		if c.Type != schema.Int32 {
+			return false, nil
+		}
+		c.Type = schema.Date
+		return true, nil
+
+	case "time-millis":
+		if c.Type != schema.Int32 {
+			return false, nil
+		}
+		c.Type = schema.TimeOfDay
+		c.Logical = &schema.LogicalParams{
+			TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis},
+		}
+		return true, nil
+
+	case "time-micros":
+		if c.Type != schema.Int64 {
+			return false, nil
+		}
+		c.Type = schema.TimeOfDay
+		c.Logical = &schema.LogicalParams{
+			TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros},
+		}
+		return true, nil
+
+	case "timestamp-millis", "timestamp-micros", "timestamp-nanos",
+		"local-timestamp-millis", "local-timestamp-micros", "local-timestamp-nanos":
+		// All six timestamp logical types use long as their base primitive.
+		if c.Type != schema.Int64 {
+			return false, nil
+		}
+		unit := avroLogicalTimestampUnit(logical)
+		adjust := !strings.HasPrefix(logical, "local-")
+		c.Type = schema.Timestamp
+		c.Logical = &schema.LogicalParams{
+			Timestamp: &schema.TimestampParams{Unit: unit, AdjustToUTC: adjust},
+		}
+		return true, nil
+
+	default:
+		// Unknown logicalType. Per Avro 1.10 spec readers must ignore.
+		return false, nil
+	}
+}
+
+// avroLogicalTimestampUnit maps the suffix of an Avro timestamp logical-type
+// name to the corresponding [schema.TimeUnit]. Both `timestamp-*` and
+// `local-timestamp-*` variants share the suffix → unit mapping.
+//
+// The caller in [applyAvroLogicalType] has already filtered to one of the
+// six supported timestamp logical-type names, so the default branch is
+// unreachable. We panic rather than return an invalid TimeUnit(0)
+// sentinel that would propagate a malformed Logical past Validate().
+func avroLogicalTimestampUnit(logical string) schema.TimeUnit {
+	switch {
+	case strings.HasSuffix(logical, "-millis"):
+		return schema.TimeUnitMillis
+	case strings.HasSuffix(logical, "-micros"):
+		return schema.TimeUnitMicros
+	case strings.HasSuffix(logical, "-nanos"):
+		return schema.TimeUnitNanos
+	default:
+		panic(fmt.Sprintf("unreachable: avroLogicalTimestampUnit called with non-timestamp logical type %q", logical))
+	}
 }
 
 func ecsAvroTypeToCommon(t string) schema.CommonType {
@@ -270,27 +398,9 @@ func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, err
 		return schema.Common{}, fmt.Errorf("expected `type` field of type string or array, got %T", t)
 	}
 
-	if logical, ok := as["logicalType"].(string); ok && logical == "decimal" {
-		p, err := avroSpecInt32(as["precision"])
-		if err != nil {
-			return schema.Common{}, fmt.Errorf("decimal precision: %w", err)
-		}
-		// Per the Avro spec scale is optional and defaults to 0 when absent;
-		// only an unparseable scale value (wrong type, non-integer) is an error.
-		var s int32
-		if _, present := as["scale"]; present {
-			s, err = avroSpecInt32(as["scale"])
-			if err != nil {
-				return schema.Common{}, fmt.Errorf("decimal scale: %w", err)
-			}
-		}
-		c.Type = schema.Decimal
-		c.Logical = &schema.LogicalParams{
-			Decimal: &schema.DecimalParams{Precision: p, Scale: s},
-		}
-		if err := c.Validate(); err != nil {
-			return schema.Common{}, fmt.Errorf("decimal field: %w", err)
-		}
+	if applied, err := applyAvroLogicalType(&c, as); err != nil {
+		return schema.Common{}, err
+	} else if applied {
 		return c, nil
 	}
 

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -293,3 +293,153 @@ func TestEcsAvroRecordWithNilFields(t *testing.T) {
 	assert.Equal(t, schema.Object, party.Type)
 	assert.Empty(t, party.Children)
 }
+
+// TestEcsAvroLogicalTypeDispatcher exercises the full dispatcher in
+// applyAvroLogicalType for every Avro logical type the connector now
+// preserves. Each case drives the original-issue-#4399 path: the schema's
+// logicalType annotation is honoured rather than dropped.
+func TestEcsAvroLogicalTypeDispatcher(t *testing.T) {
+	type expect struct {
+		ctype       schema.CommonType
+		hasLogical  bool
+		unit        schema.TimeUnit
+		adjustToUTC bool
+	}
+	cases := []struct {
+		name   string
+		field  string // raw JSON for the field's "type" entry
+		expect expect
+	}{
+		{
+			name:   "timestamp-millis",
+			field:  `{"type":"long","logicalType":"timestamp-millis"}`,
+			expect: expect{ctype: schema.Timestamp, hasLogical: true, unit: schema.TimeUnitMillis, adjustToUTC: true},
+		},
+		{
+			name:   "timestamp-micros",
+			field:  `{"type":"long","logicalType":"timestamp-micros"}`,
+			expect: expect{ctype: schema.Timestamp, hasLogical: true, unit: schema.TimeUnitMicros, adjustToUTC: true},
+		},
+		{
+			name:   "timestamp-nanos",
+			field:  `{"type":"long","logicalType":"timestamp-nanos"}`,
+			expect: expect{ctype: schema.Timestamp, hasLogical: true, unit: schema.TimeUnitNanos, adjustToUTC: true},
+		},
+		{
+			name:   "local-timestamp-millis",
+			field:  `{"type":"long","logicalType":"local-timestamp-millis"}`,
+			expect: expect{ctype: schema.Timestamp, hasLogical: true, unit: schema.TimeUnitMillis, adjustToUTC: false},
+		},
+		{
+			name:   "local-timestamp-micros",
+			field:  `{"type":"long","logicalType":"local-timestamp-micros"}`,
+			expect: expect{ctype: schema.Timestamp, hasLogical: true, unit: schema.TimeUnitMicros, adjustToUTC: false},
+		},
+		{
+			name:   "date",
+			field:  `{"type":"int","logicalType":"date"}`,
+			expect: expect{ctype: schema.Date},
+		},
+		{
+			name:   "time-millis",
+			field:  `{"type":"int","logicalType":"time-millis"}`,
+			expect: expect{ctype: schema.TimeOfDay, hasLogical: true, unit: schema.TimeUnitMillis},
+		},
+		{
+			name:   "time-micros",
+			field:  `{"type":"long","logicalType":"time-micros"}`,
+			expect: expect{ctype: schema.TimeOfDay, hasLogical: true, unit: schema.TimeUnitMicros},
+		},
+		{
+			name:   "uuid",
+			field:  `{"type":"string","logicalType":"uuid"}`,
+			expect: expect{ctype: schema.UUID},
+		},
+		{
+			name: "unknown logicalType falls back to base primitive",
+			// Per Avro 1.10 spec readers must ignore unknown logicalType
+			// values. The base primitive (long) survives.
+			field:  `{"type":"long","logicalType":"frobnicate-millis"}`,
+			expect: expect{ctype: schema.Int64},
+		},
+		{
+			name: "logicalType on mismatched primitive falls back",
+			// timestamp-millis declared on `string` is malformed; reader
+			// silently uses the base primitive instead of failing the schema.
+			field:  `{"type":"string","logicalType":"timestamp-millis"}`,
+			expect: expect{ctype: schema.String},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := []byte(`{
+				"type": "record",
+				"name": "Row",
+				"fields": [
+					{"name": "field", "type": ` + tc.field + `}
+				]
+			}`)
+			c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+			require.NoError(t, err)
+			require.Len(t, c.Children, 1)
+			f := c.Children[0]
+			assert.Equal(t, tc.expect.ctype, f.Type, "type mapping")
+			if tc.expect.hasLogical {
+				require.NotNil(t, f.Logical, "Logical should be populated")
+				switch tc.expect.ctype {
+				case schema.Timestamp:
+					require.NotNil(t, f.Logical.Timestamp)
+					assert.Equal(t, tc.expect.unit, f.Logical.Timestamp.Unit)
+					assert.Equal(t, tc.expect.adjustToUTC, f.Logical.Timestamp.AdjustToUTC)
+				case schema.TimeOfDay:
+					require.NotNil(t, f.Logical.TimeOfDay)
+					assert.Equal(t, tc.expect.unit, f.Logical.TimeOfDay.Unit)
+				}
+			}
+		})
+	}
+}
+
+// TestEcsAvroDecimalOnWrongPrimitiveFallsBack verifies that a `decimal`
+// logical-type annotation on something other than `bytes` or `fixed` is
+// silently dropped per the spec, rather than producing a malformed
+// schema.Decimal whose precision/scale claims to govern an int64 value.
+func TestEcsAvroDecimalOnWrongPrimitiveFallsBack(t *testing.T) {
+	spec := []byte(`{
+		"type":"record","name":"Row",
+		"fields":[
+			{"name":"amount","type":{"type":"long","logicalType":"decimal","precision":18,"scale":4}}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 1)
+	amount := c.Children[0]
+	assert.Equal(t, schema.Int64, amount.Type, "decimal on long should fall back to base type")
+	assert.Nil(t, amount.Logical, "no Logical params should be set when annotation falls back")
+}
+
+// TestEcsAvroLogicalTypeOptionalUnion verifies that the [null, {logical}]
+// idiom under rawUnion=true unwraps to an Optional node with the logical
+// type fully preserved. This is the shape the original issue #4399 reported.
+func TestEcsAvroLogicalTypeOptionalUnion(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Row",
+		"fields": [
+			{"name": "event_time", "type": ["null", {"type": "long", "logicalType": "timestamp-millis"}]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 1)
+	f := c.Children[0]
+	assert.Equal(t, "event_time", f.Name)
+	assert.Equal(t, schema.Timestamp, f.Type)
+	assert.True(t, f.Optional, "[null, timestamp-millis] should produce Optional Timestamp")
+	require.NotNil(t, f.Logical)
+	require.NotNil(t, f.Logical.Timestamp)
+	assert.Equal(t, schema.TimeUnitMillis, f.Logical.Timestamp.Unit)
+	assert.True(t, f.Logical.Timestamp.AdjustToUTC)
+}

--- a/internal/impl/iceberg/config.go
+++ b/internal/impl/iceberg/config.go
@@ -69,12 +69,13 @@ const (
 	ioFieldAzureAccessKey        = "storage_access_key"
 
 	// Schema evolution fields
-	ioFieldSchemaEvolution                     = "schema_evolution"
-	ioFieldSchemaEvolutionEnabled              = "enabled"
-	ioFieldSchemaEvolutionPartitionSpec        = "partition_spec"
-	ioFieldSchemaEvolutionTableLoc             = "table_location"
-	ioFieldSchemaEvolutionSchemaMetadata       = "schema_metadata"
-	ioFieldSchemaEvolutionNewColumnTypeMapping = "new_column_type_mapping"
+	ioFieldSchemaEvolution                      = "schema_evolution"
+	ioFieldSchemaEvolutionEnabled               = "enabled"
+	ioFieldSchemaEvolutionPartitionSpec         = "partition_spec"
+	ioFieldSchemaEvolutionTableLoc              = "table_location"
+	ioFieldSchemaEvolutionSchemaMetadata        = "schema_metadata"
+	ioFieldSchemaEvolutionNewColumnTypeMapping  = "new_column_type_mapping"
+	ioFieldSchemaEvolutionRequireSchemaMetadata = "require_schema_metadata"
 
 	// Commit fields
 	ioFieldCommit               = "commit"
@@ -331,6 +332,10 @@ array:list
 				service.NewBloblangField(ioFieldSchemaEvolutionNewColumnTypeMapping).
 					Description("An optional Bloblang mapping to customize column types during schema evolution. This mapping is executed for each new column and can override the inferred or schema-metadata-derived type. The mapping receives an object with fields `name` (column name), `path` (dot-separated path), `value` (sample value), `inferred_type` (the type that would be used without this mapping), `message` (the full message body), `namespace`, and `table`. It must return a string with a valid Iceberg type name: `boolean`, `int`, `long`, `float`, `double`, `string`, `binary`, `date`, `time`, `timestamp`, `timestamptz`, `uuid`, `decimal(p,s)`, or `fixed[n]`.").
 					Optional().
+					Advanced(),
+				service.NewBoolField(ioFieldSchemaEvolutionRequireSchemaMetadata).
+					Description("When `true`, writing a numeric value into a `timestamp`, `timestamptz`, `date`, or `time` column without `schema_metadata` registered for that column is a hard error. The default `false` permits a fallback path that interprets bare numeric timestamps as Unix seconds and bare numeric times as already-microseconds — convenient, but silently wrong if upstream produced milliseconds. Enable this when you cannot guarantee the upstream attaches schema metadata and want to fail loudly rather than corrupt dates by ~50,000 years. No effect on time-typed columns receiving `time.Time`/`time.Duration` Go values, which carry their own unit unambiguously, and no effect on non-time columns. Requires `schema_metadata` to be set.").
+					Default(false).
 					Advanced(),
 			).Description("Schema evolution configuration.").
 				Optional().

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -484,6 +484,17 @@ func parseSchemaEvolutionConfig(conf *service.ParsedConfig) (SchemaEvolutionConf
 		}
 	}
 
+	// Parse require_schema_metadata
+	if conf.Contains(ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata) {
+		cfg.RequireSchemaMetadata, err = conf.FieldBool(ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata)
+		if err != nil {
+			return cfg, err
+		}
+		if cfg.RequireSchemaMetadata && cfg.SchemaMetadata == "" {
+			return cfg, fmt.Errorf("%s.%s requires %s.%s to be set", ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata, ioFieldSchemaEvolution, ioFieldSchemaEvolutionSchemaMetadata)
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -663,8 +663,10 @@ func (r *Router) createWriter(ctx context.Context, key tableKey) (*writer, error
 		return nil, fmt.Errorf("creating committer: %w", err)
 	}
 
-	// Create writer with its own table reference and the committer
-	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.logger)
+	// Create writer with its own table reference and the committer.
+	// The resolver is passed so the writer can use schema metadata to
+	// interpret numeric inputs into time-typed columns at shredding time.
+	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.resolver, r.logger)
 	r.logger.Debugf("Created writer for table %s.%s", key.namespace, key.table)
 
 	return w, nil

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -52,6 +52,11 @@ type SchemaEvolutionConfig struct {
 	// NewColumnTypeMapping is an optional Bloblang mapping that can override inferred
 	// or schema-metadata-derived column types during schema evolution.
 	NewColumnTypeMapping *bloblang.Executor
+	// RequireSchemaMetadata enables strict mode: when true, writing a numeric
+	// value into a time-typed column without registered schema metadata is a
+	// hard error rather than a silent fallback to bloblang's seconds-default.
+	// Only meaningful when SchemaMetadata is also set.
+	RequireSchemaMetadata bool
 }
 
 const maxSchemaEvolutionRetries = 10
@@ -666,7 +671,7 @@ func (r *Router) createWriter(ctx context.Context, key tableKey) (*writer, error
 	// Create writer with its own table reference and the committer.
 	// The resolver is passed so the writer can use schema metadata to
 	// interpret numeric inputs into time-typed columns at shredding time.
-	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.resolver, r.logger)
+	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.resolver, r.schemaEvoCfg.RequireSchemaMetadata, r.logger)
 	r.logger.Debugf("Created writer for table %s.%s", key.namespace, key.table)
 
 	return w, nil

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -80,6 +80,13 @@ type RecordShredder struct {
 	// iceberg's recommended convention and with engines like Spark and Trino
 	// in their default configurations.
 	caseSensitive bool
+	// fieldCommons optionally maps an iceberg field ID to the upstream
+	// schema.Common describing the same field. When present, the leaf
+	// value-conversion step uses Logical params (timestamp unit,
+	// AdjustToUTC, time-of-day unit) to interpret numeric inputs into
+	// typed columns instead of guessing. nil entries fall back to the
+	// pre-schema-metadata behavior — see [convertLeafValue].
+	fieldCommons map[int]*schema.Common
 }
 
 // NewRecordShredder creates a new shredder for the given schema.
@@ -91,6 +98,21 @@ func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredd
 		schema:        schema,
 		caseSensitive: caseSensitive,
 	}
+}
+
+// SetFieldSchemaMetadata supplies a field-ID → schema.Common map that the
+// leaf value converter consults when it sees a numeric input destined for a
+// time-typed Iceberg column (TIMESTAMP, TIMESTAMPTZ, TIMESTAMP_NS,
+// TIMESTAMP_TZ_NS, DATE, TIME). Without this map, the converter accepts
+// time.Time / time.Duration / int64 directly but cannot disambiguate the
+// unit of a bare numeric millis vs. micros vs. seconds — and historically
+// defaulted to interpreting numbers as Unix seconds. Supplying this map
+// lets the connector tell the shredder "this column was sourced from an
+// Avro timestamp-millis", which the converter then honours.
+//
+// Passing nil clears any previously-set metadata.
+func (rs *RecordShredder) SetFieldSchemaMetadata(byID map[int]*schema.Common) {
+	rs.fieldCommons = byID
 }
 
 // Shred converts a nested record into a sequence of shredded values.
@@ -219,7 +241,7 @@ func (rs *RecordShredder) shredValue(
 
 	default:
 		// Leaf/primitive type.
-		pqVal, err := convertLeafValue(value, typ)
+		pqVal, err := convertLeafValue(value, typ, rs.commonForField(fieldID))
 		if err != nil {
 			return err
 		}
@@ -331,8 +353,9 @@ func (rs *RecordShredder) shredMap(
 		}
 		first = false
 
-		// Shred the key.
-		keyVal, err := convertLeafValue(k, mapType.KeyType)
+		// Shred the key. Map keys are always leaf primitives, never time
+		// types, so the schema-metadata lookup never fires for them.
+		keyVal, err := convertLeafValue(k, mapType.KeyType, nil)
 		if err != nil {
 			return fmt.Errorf("map key: %w", err)
 		}
@@ -399,9 +422,15 @@ func (rs *RecordShredder) shredNull(
 	}
 }
 
-// convertLeafValue converts a Go value to a parquet.Value based on the Iceberg type.
-// This is a stub - full implementation would handle all type conversions.
-func convertLeafValue(value any, typ iceberg.Type) (parquet.Value, error) {
+// convertLeafValue converts a Go value to a parquet.Value based on the
+// Iceberg type. common is the upstream schema.Common describing the same
+// column (or nil); when present it carries logical params consulted by the
+// time/date arms to interpret numeric inputs using the declared unit
+// instead of guessing. Without metadata, the converter accepts time.Time /
+// time.Duration directly and treats bare numerics as already-in-the-target
+// unit (microseconds for time, seconds for timestamp via bloblang
+// ValueAsTimestamp's default — preserves the pre-PR behavior).
+func convertLeafValue(value any, typ iceberg.Type, common *schema.Common) (parquet.Value, error) {
 	if value == nil {
 		return parquet.NullValue(), nil
 	}
@@ -443,36 +472,25 @@ func convertLeafValue(value any, typ iceberg.Type) (parquet.Value, error) {
 		return parquet.ByteArrayValue(v), err
 
 	case iceberg.DateType:
-		// Date is days since epoch as int32.
-		// TODO: Handle time.Time conversion.
-		switch v := value.(type) {
-		case int32:
-			return parquet.Int32Value(v), nil
-		case int:
-			return parquet.Int32Value(int32(v)), nil
-		case float64:
-			return parquet.Int32Value(int32(v)), nil
-		default:
-			return parquet.NullValue(), fmt.Errorf("cannot convert %T to date", value)
-		}
+		return convertDate(value)
 
 	case iceberg.TimeType:
-		// Time is microseconds since midnight as int64.
-		switch v := value.(type) {
-		case int64:
-			return parquet.Int64Value(v), nil
-		case int:
-			return parquet.Int64Value(int64(v)), nil
-		case float64:
-			return parquet.Int64Value(int64(v)), nil
-		default:
-			return parquet.NullValue(), fmt.Errorf("cannot convert %T to time", value)
-		}
+		// Iceberg TIME is microseconds since midnight. Accept time.Duration
+		// directly (the twmb/avro decode of time-millis/time-micros), and
+		// fall back to numeric input interpreted via the schema-declared
+		// unit when available.
+		return convertTime(value, common)
 
 	case iceberg.TimestampType, iceberg.TimestampTzType:
-		// Timestamp is microseconds since epoch as int64.
-		v, err := bloblang.ValueAsTimestamp(value)
-		return parquet.Int64Value(v.UnixMicro()), err
+		// Iceberg TIMESTAMP / TIMESTAMPTZ are microseconds since epoch.
+		// time.Time inputs are unambiguous and used directly. For numeric
+		// inputs, prefer the schema's declared unit so that millis stays
+		// millis (instead of being interpreted as seconds and landing in
+		// year 56755).
+		return convertTimestamp(value, common, false)
+
+	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
+		return convertTimestamp(value, common, true)
 
 	case iceberg.UUIDType:
 		switch v := value.(type) {

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -87,6 +87,13 @@ type RecordShredder struct {
 	// typed columns instead of guessing. nil entries fall back to the
 	// pre-schema-metadata behavior — see [convertLeafValue].
 	fieldCommons map[int]*schema.Common
+	// strictTemporal causes [convertLeafValue] to refuse numeric inputs
+	// into time-typed columns when no schema metadata has been
+	// registered for that column. When false (the default), the value
+	// converter falls back to [bloblang.ValueAsTimestamp]'s seconds
+	// default — convenient but silently wrong if the upstream produced
+	// a different unit. When true, the writer fails the batch loudly.
+	strictTemporal bool
 }
 
 // NewRecordShredder creates a new shredder for the given schema.
@@ -98,6 +105,22 @@ func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredd
 		schema:        schema,
 		caseSensitive: caseSensitive,
 	}
+}
+
+// SetStrictTemporalMode toggles whether numeric inputs into time-typed
+// columns require registered schema metadata. With strict mode on, a bare
+// int64 / float64 value reaching a TIMESTAMP / TIMESTAMPTZ / DATE / TIME
+// column with no [schema.Common] in the field map is rejected with a
+// per-field error rather than guessed-as-Unix-seconds.
+//
+// Strict mode has no effect on time.Time / time.Duration values, which
+// carry their own unit unambiguously, and no effect on non-time columns.
+//
+// Defaults to off (back-compat). Operators that cannot guarantee schema
+// metadata flows end-to-end can flip this on to fail loudly instead of
+// silently corrupting dates by ~50,000 years.
+func (rs *RecordShredder) SetStrictTemporalMode(on bool) {
+	rs.strictTemporal = on
 }
 
 // SetFieldSchemaMetadata supplies a field-ID → schema.Common map that the
@@ -241,7 +264,7 @@ func (rs *RecordShredder) shredValue(
 
 	default:
 		// Leaf/primitive type.
-		pqVal, err := convertLeafValue(value, typ, rs.commonForField(fieldID))
+		pqVal, err := convertLeafValue(value, typ, rs.commonForField(fieldID), rs.strictTemporal)
 		if err != nil {
 			return err
 		}
@@ -355,7 +378,7 @@ func (rs *RecordShredder) shredMap(
 
 		// Shred the key. Map keys are always leaf primitives, never time
 		// types, so the schema-metadata lookup never fires for them.
-		keyVal, err := convertLeafValue(k, mapType.KeyType, nil)
+		keyVal, err := convertLeafValue(k, mapType.KeyType, nil, false)
 		if err != nil {
 			return fmt.Errorf("map key: %w", err)
 		}
@@ -430,7 +453,7 @@ func (rs *RecordShredder) shredNull(
 // time.Duration directly and treats bare numerics as already-in-the-target
 // unit (microseconds for time, seconds for timestamp via bloblang
 // ValueAsTimestamp's default — preserves the pre-PR behavior).
-func convertLeafValue(value any, typ iceberg.Type, common *schema.Common) (parquet.Value, error) {
+func convertLeafValue(value any, typ iceberg.Type, common *schema.Common, strictTemporal bool) (parquet.Value, error) {
 	if value == nil {
 		return parquet.NullValue(), nil
 	}
@@ -472,14 +495,14 @@ func convertLeafValue(value any, typ iceberg.Type, common *schema.Common) (parqu
 		return parquet.ByteArrayValue(v), err
 
 	case iceberg.DateType:
-		return convertDate(value)
+		return convertDate(value, common, strictTemporal)
 
 	case iceberg.TimeType:
 		// Iceberg TIME is microseconds since midnight. Accept time.Duration
 		// directly (the twmb/avro decode of time-millis/time-micros), and
 		// fall back to numeric input interpreted via the schema-declared
 		// unit when available.
-		return convertTime(value, common)
+		return convertTime(value, common, strictTemporal)
 
 	case iceberg.TimestampType, iceberg.TimestampTzType:
 		// Iceberg TIMESTAMP / TIMESTAMPTZ are microseconds since epoch.
@@ -487,10 +510,10 @@ func convertLeafValue(value any, typ iceberg.Type, common *schema.Common) (parqu
 		// inputs, prefer the schema's declared unit so that millis stays
 		// millis (instead of being interpreted as seconds and landing in
 		// year 56755).
-		return convertTimestamp(value, common, false)
+		return convertTimestamp(value, common, false, strictTemporal)
 
 	case iceberg.TimestampNsType, iceberg.TimestampTzNsType:
-		return convertTimestamp(value, common, true)
+		return convertTimestamp(value, common, true, strictTemporal)
 
 	case iceberg.UUIDType:
 		switch v := value.(type) {

--- a/internal/impl/iceberg/shredder/shredder_test.go
+++ b/internal/impl/iceberg/shredder/shredder_test.go
@@ -1055,7 +1055,7 @@ func TestConvertLeafValueDecimal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := convertLeafValue(tt.value, dt)
+			result, err := convertLeafValue(tt.value, dt, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -1069,7 +1069,7 @@ func TestConvertLeafValueDecimal(t *testing.T) {
 func TestConvertLeafValueDecimalPrecision(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	result, err := convertLeafValue(float64(123.45), dt)
+	result, err := convertLeafValue(float64(123.45), dt, nil)
 	require.NoError(t, err)
 
 	b := result.ByteArray()
@@ -1085,7 +1085,7 @@ func TestConvertLeafValueDecimalPrecision(t *testing.T) {
 func TestConvertLeafValueDecimalNegative(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	result, err := convertLeafValue(float64(-123.45), dt)
+	result, err := convertLeafValue(float64(-123.45), dt, nil)
 	require.NoError(t, err)
 
 	b := result.ByteArray()
@@ -1131,7 +1131,7 @@ func TestConvertLeafValueDecimalExactValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := convertLeafValue(tt.value, dt)
+			result, err := convertLeafValue(tt.value, dt, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantUnscaled, decodeUnscaled(t, result))
 		})
@@ -1143,16 +1143,16 @@ func TestConvertLeafValueDecimalOverflow(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(5, 2)
 
 	// 999.99 should succeed
-	_, err := convertLeafValue(float64(999.99), dt)
+	_, err := convertLeafValue(float64(999.99), dt, nil)
 	require.NoError(t, err)
 
 	// 1000.00 exceeds precision — unscaled 100000 >= 10^5
-	_, err = convertLeafValue(float64(1000.00), dt)
+	_, err = convertLeafValue(float64(1000.00), dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds decimal(5, 2) precision")
 
 	// Large negative should also fail
-	_, err = convertLeafValue(float64(-1000.00), dt)
+	_, err = convertLeafValue(float64(-1000.00), dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds decimal(5, 2) precision")
 }
@@ -1160,7 +1160,7 @@ func TestConvertLeafValueDecimalOverflow(t *testing.T) {
 func TestConvertLeafValueDecimalStringError(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	_, err := convertLeafValue("not_a_number", dt)
+	_, err := convertLeafValue("not_a_number", dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse")
 }
@@ -1168,32 +1168,32 @@ func TestConvertLeafValueDecimalStringError(t *testing.T) {
 func TestConvertLeafValueDecimalNaNInf(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	_, err := convertLeafValue(math.NaN(), dt)
+	_, err := convertLeafValue(math.NaN(), dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(math.Inf(1), dt)
+	_, err = convertLeafValue(math.Inf(1), dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(math.Inf(-1), dt)
+	_, err = convertLeafValue(math.Inf(-1), dt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(float32(math.NaN()), dt)
+	_, err = convertLeafValue(float32(math.NaN()), dt, nil)
 	require.Error(t, err)
 
-	_, err = convertLeafValue(float32(math.Inf(1)), dt)
+	_, err = convertLeafValue(float32(math.Inf(1)), dt, nil)
 	require.Error(t, err)
 }
 
 func TestConvertLeafValueUint64Overflow(t *testing.T) {
-	_, err := convertLeafValue(uint64(math.MaxInt64+1), iceberg.Int64Type{})
+	_, err := convertLeafValue(uint64(math.MaxInt64+1), iceberg.Int64Type{}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds int64 range")
 
 	// Value within range should succeed
-	_, err = convertLeafValue(uint64(math.MaxInt64), iceberg.Int64Type{})
+	_, err = convertLeafValue(uint64(math.MaxInt64), iceberg.Int64Type{}, nil)
 	require.NoError(t, err)
 }
 

--- a/internal/impl/iceberg/shredder/shredder_test.go
+++ b/internal/impl/iceberg/shredder/shredder_test.go
@@ -1055,7 +1055,7 @@ func TestConvertLeafValueDecimal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := convertLeafValue(tt.value, dt, nil)
+			result, err := convertLeafValue(tt.value, dt, nil, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -1069,7 +1069,7 @@ func TestConvertLeafValueDecimal(t *testing.T) {
 func TestConvertLeafValueDecimalPrecision(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	result, err := convertLeafValue(float64(123.45), dt, nil)
+	result, err := convertLeafValue(float64(123.45), dt, nil, false)
 	require.NoError(t, err)
 
 	b := result.ByteArray()
@@ -1085,7 +1085,7 @@ func TestConvertLeafValueDecimalPrecision(t *testing.T) {
 func TestConvertLeafValueDecimalNegative(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	result, err := convertLeafValue(float64(-123.45), dt, nil)
+	result, err := convertLeafValue(float64(-123.45), dt, nil, false)
 	require.NoError(t, err)
 
 	b := result.ByteArray()
@@ -1131,7 +1131,7 @@ func TestConvertLeafValueDecimalExactValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := convertLeafValue(tt.value, dt, nil)
+			result, err := convertLeafValue(tt.value, dt, nil, false)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantUnscaled, decodeUnscaled(t, result))
 		})
@@ -1143,16 +1143,16 @@ func TestConvertLeafValueDecimalOverflow(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(5, 2)
 
 	// 999.99 should succeed
-	_, err := convertLeafValue(float64(999.99), dt, nil)
+	_, err := convertLeafValue(float64(999.99), dt, nil, false)
 	require.NoError(t, err)
 
 	// 1000.00 exceeds precision — unscaled 100000 >= 10^5
-	_, err = convertLeafValue(float64(1000.00), dt, nil)
+	_, err = convertLeafValue(float64(1000.00), dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds decimal(5, 2) precision")
 
 	// Large negative should also fail
-	_, err = convertLeafValue(float64(-1000.00), dt, nil)
+	_, err = convertLeafValue(float64(-1000.00), dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds decimal(5, 2) precision")
 }
@@ -1160,7 +1160,7 @@ func TestConvertLeafValueDecimalOverflow(t *testing.T) {
 func TestConvertLeafValueDecimalStringError(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	_, err := convertLeafValue("not_a_number", dt, nil)
+	_, err := convertLeafValue("not_a_number", dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse")
 }
@@ -1168,32 +1168,32 @@ func TestConvertLeafValueDecimalStringError(t *testing.T) {
 func TestConvertLeafValueDecimalNaNInf(t *testing.T) {
 	dt := iceberg.DecimalTypeOf(10, 2)
 
-	_, err := convertLeafValue(math.NaN(), dt, nil)
+	_, err := convertLeafValue(math.NaN(), dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(math.Inf(1), dt, nil)
+	_, err = convertLeafValue(math.Inf(1), dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(math.Inf(-1), dt, nil)
+	_, err = convertLeafValue(math.Inf(-1), dt, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot convert")
 
-	_, err = convertLeafValue(float32(math.NaN()), dt, nil)
+	_, err = convertLeafValue(float32(math.NaN()), dt, nil, false)
 	require.Error(t, err)
 
-	_, err = convertLeafValue(float32(math.Inf(1)), dt, nil)
+	_, err = convertLeafValue(float32(math.Inf(1)), dt, nil, false)
 	require.Error(t, err)
 }
 
 func TestConvertLeafValueUint64Overflow(t *testing.T) {
-	_, err := convertLeafValue(uint64(math.MaxInt64+1), iceberg.Int64Type{}, nil)
+	_, err := convertLeafValue(uint64(math.MaxInt64+1), iceberg.Int64Type{}, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds int64 range")
 
 	// Value within range should succeed
-	_, err = convertLeafValue(uint64(math.MaxInt64), iceberg.Int64Type{}, nil)
+	_, err = convertLeafValue(uint64(math.MaxInt64), iceberg.Int64Type{}, nil, false)
 	require.NoError(t, err)
 }
 

--- a/internal/impl/iceberg/shredder/temporal.go
+++ b/internal/impl/iceberg/shredder/temporal.go
@@ -9,6 +9,7 @@
 package shredder
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -33,7 +34,12 @@ func (rs *RecordShredder) commonForField(fieldID int) *schema.Common {
 // Iceberg DATE column (int32 days since the unix epoch). Accepts time.Time
 // (UTC midnight idiom from twmb/avro `date` decode), or a numeric value
 // already expressing days since epoch.
-func convertDate(value any) (parquet.Value, error) {
+//
+// strictTemporal causes numeric inputs without registered schema metadata
+// to be rejected — the column is DATE (days since epoch) but a bare
+// numeric could be days, milliseconds, or seconds depending on upstream;
+// strict mode forces the operator to attach metadata or convert upstream.
+func convertDate(value any, common *schema.Common, strictTemporal bool) (parquet.Value, error) {
 	switch v := value.(type) {
 	case time.Time:
 		// Iceberg / Avro DATE is days since 1970-01-01, including negative
@@ -46,19 +52,30 @@ func convertDate(value any) (parquet.Value, error) {
 			days--
 		}
 		return parquet.Int32Value(int32(days)), nil
-	case int32:
-		return parquet.Int32Value(v), nil
-	case int:
-		return parquet.Int32Value(int32(v)), nil
-	case int64:
-		return parquet.Int32Value(int32(v)), nil
-	case float64:
-		// NaN and ±Inf cast to int32 as implementation-defined garbage;
-		// silent corruption (year 1970) is worse than a hard error.
-		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return parquet.NullValue(), fmt.Errorf("cannot convert %v to date", v)
+	case int32, int, int64, float64:
+		// In strict mode, a numeric value into a DATE column must come
+		// with metadata whose Type is also Date — anything else either
+		// has no shape information at all or has the wrong shape, both
+		// of which the operator asked us to fail on.
+		if strictTemporal && (common == nil || common.Type != schema.Date) {
+			return parquet.NullValue(), errors.New("date column received numeric value without matching schema.Common (Type=Date); require_schema_metadata=true demands a Date metadata entry to disambiguate the unit")
 		}
-		return parquet.Int32Value(int32(v)), nil
+		switch v := v.(type) {
+		case int32:
+			return parquet.Int32Value(v), nil
+		case int:
+			return parquet.Int32Value(int32(v)), nil
+		case int64:
+			return parquet.Int32Value(int32(v)), nil
+		case float64:
+			// NaN and ±Inf cast to int32 as implementation-defined garbage;
+			// silent corruption (year 1970) is worse than a hard error.
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return parquet.NullValue(), fmt.Errorf("cannot convert %v to date", v)
+			}
+			return parquet.Int32Value(int32(v)), nil
+		}
+		return parquet.NullValue(), fmt.Errorf("cannot convert %T to date", value)
 	default:
 		return parquet.NullValue(), fmt.Errorf("cannot convert %T to date", value)
 	}
@@ -77,7 +94,7 @@ func convertDate(value any) (parquet.Value, error) {
 // (matching Java's LocalTime, Postgres TIME, and Iceberg TIME): a
 // time.Time of 14:30 EST yields 14:30 in the column, not 19:30 UTC.
 // If the upstream wants UTC-shifted, it should v.UTC() before passing in.
-func convertTime(value any, common *schema.Common) (parquet.Value, error) {
+func convertTime(value any, common *schema.Common, strictTemporal bool) (parquet.Value, error) {
 	switch v := value.(type) {
 	case time.Duration:
 		return parquet.Int64Value(v.Microseconds()), nil
@@ -87,19 +104,31 @@ func convertTime(value any, common *schema.Common) (parquet.Value, error) {
 			time.Duration(v.Second())*time.Second +
 			time.Duration(v.Nanosecond())*time.Nanosecond
 		return parquet.Int64Value(dur.Microseconds()), nil
-	case int64:
-		return parquet.Int64Value(numericToTimeMicros(v, common)), nil
-	case int32:
-		// Avro time-millis is int32; accept it directly as well.
-		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
-	case int:
-		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
-	case float64:
-		// NaN/±Inf cast is implementation-defined; reject explicitly.
-		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return parquet.NullValue(), fmt.Errorf("cannot convert %v to time", v)
+	case int64, int32, int, float64:
+		// In strict mode, a numeric value into a TIME column must come
+		// with TimeOfDay-typed metadata that names the unit. Anything
+		// else (no metadata, wrong-typed metadata, or a TimeOfDay common
+		// missing its Logical params) means the unit is undeclared and
+		// the operator asked us to fail rather than guess.
+		if strictTemporal && (common == nil || common.Type != schema.TimeOfDay || common.Logical == nil || common.Logical.TimeOfDay == nil) {
+			return parquet.NullValue(), errors.New("time column received numeric value without matching schema.Common (Type=TimeOfDay with Logical.TimeOfDay); require_schema_metadata=true demands a TimeOfDay metadata entry with declared unit")
 		}
-		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+		switch v := v.(type) {
+		case int64:
+			return parquet.Int64Value(numericToTimeMicros(v, common)), nil
+		case int32:
+			// Avro time-millis is int32; accept it directly as well.
+			return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+		case int:
+			return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+		case float64:
+			// NaN/±Inf cast is implementation-defined; reject explicitly.
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return parquet.NullValue(), fmt.Errorf("cannot convert %v to time", v)
+			}
+			return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+		}
+		return parquet.NullValue(), fmt.Errorf("cannot convert %T to time", value)
 	default:
 		return parquet.NullValue(), fmt.Errorf("cannot convert %T to time", value)
 	}
@@ -147,7 +176,7 @@ func numericToTimeMicros(n int64, common *schema.Common) int64 {
 // bloblang.ValueAsTimestamp — which preserves the pre-PR behavior for
 // callers that genuinely store unix-seconds in a numeric column without
 // any schema annotation.
-func convertTimestamp(value any, common *schema.Common, nanos bool) (parquet.Value, error) {
+func convertTimestamp(value any, common *schema.Common, nanos, strictTemporal bool) (parquet.Value, error) {
 	if v, ok := value.(time.Time); ok {
 		if nanos {
 			return parquet.Int64Value(v.UnixNano()), nil
@@ -180,6 +209,14 @@ func convertTimestamp(value any, common *schema.Common, nanos bool) (parquet.Val
 		p := common.EffectiveTimestamp()
 		out := scaleTimestampNumeric(n, p.Unit, nanos)
 		return parquet.Int64Value(out), nil
+	}
+
+	// Strict mode: refuse the bloblang fallback for numeric values when
+	// the operator has asked us to fail loudly on missing metadata.
+	if strictTemporal {
+		if _, ok := numericInt64(value); ok {
+			return parquet.NullValue(), errors.New("timestamp column received numeric value with no Timestamp schema metadata; require_schema_metadata=true demands a schema.Common with Type=Timestamp to disambiguate the unit")
+		}
 	}
 
 	// No applicable schema metadata: keep the historical bloblang path.

--- a/internal/impl/iceberg/shredder/temporal.go
+++ b/internal/impl/iceberg/shredder/temporal.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package shredder
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+// commonForField returns the upstream schema.Common registered for the given
+// iceberg field ID, or nil when no metadata has been registered for that
+// field. Returns nil when the shredder itself has no metadata at all.
+func (rs *RecordShredder) commonForField(fieldID int) *schema.Common {
+	if rs.fieldCommons == nil {
+		return nil
+	}
+	return rs.fieldCommons[fieldID]
+}
+
+// convertDate converts a Go value into the Parquet representation of an
+// Iceberg DATE column (int32 days since the unix epoch). Accepts time.Time
+// (UTC midnight idiom from twmb/avro `date` decode), or a numeric value
+// already expressing days since epoch.
+func convertDate(value any) (parquet.Value, error) {
+	switch v := value.(type) {
+	case time.Time:
+		// Iceberg / Avro DATE is days since 1970-01-01, including negative
+		// values for pre-epoch dates. Go integer division truncates toward
+		// zero, so we floor explicitly: 1969-12-31 23:59:59 UTC has
+		// Unix() == -1, and floor(-1/86400) == -1, not 0.
+		secs := v.UTC().Unix()
+		days := secs / 86400
+		if secs < 0 && secs%86400 != 0 {
+			days--
+		}
+		return parquet.Int32Value(int32(days)), nil
+	case int32:
+		return parquet.Int32Value(v), nil
+	case int:
+		return parquet.Int32Value(int32(v)), nil
+	case int64:
+		return parquet.Int32Value(int32(v)), nil
+	case float64:
+		// NaN and ±Inf cast to int32 as implementation-defined garbage;
+		// silent corruption (year 1970) is worse than a hard error.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return parquet.NullValue(), fmt.Errorf("cannot convert %v to date", v)
+		}
+		return parquet.Int32Value(int32(v)), nil
+	default:
+		return parquet.NullValue(), fmt.Errorf("cannot convert %T to date", value)
+	}
+}
+
+// convertTime converts a Go value into the Parquet representation of an
+// Iceberg TIME column (int64 microseconds since midnight). Accepts
+// time.Duration directly (the twmb/avro decode of time-millis/time-micros),
+// or a numeric value whose unit is consulted via common.Logical.TimeOfDay
+// when present. Without schema metadata, numeric inputs are treated as
+// already in microseconds — matching the historical behavior for numeric
+// values landing in this column.
+//
+// time.Time inputs are extracted in the value's own [time.Location], not
+// converted to UTC first. This treats time-of-day as zoneless wall-clock
+// (matching Java's LocalTime, Postgres TIME, and Iceberg TIME): a
+// time.Time of 14:30 EST yields 14:30 in the column, not 19:30 UTC.
+// If the upstream wants UTC-shifted, it should v.UTC() before passing in.
+func convertTime(value any, common *schema.Common) (parquet.Value, error) {
+	switch v := value.(type) {
+	case time.Duration:
+		return parquet.Int64Value(v.Microseconds()), nil
+	case time.Time:
+		dur := time.Duration(v.Hour())*time.Hour +
+			time.Duration(v.Minute())*time.Minute +
+			time.Duration(v.Second())*time.Second +
+			time.Duration(v.Nanosecond())*time.Nanosecond
+		return parquet.Int64Value(dur.Microseconds()), nil
+	case int64:
+		return parquet.Int64Value(numericToTimeMicros(v, common)), nil
+	case int32:
+		// Avro time-millis is int32; accept it directly as well.
+		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+	case int:
+		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+	case float64:
+		// NaN/±Inf cast is implementation-defined; reject explicitly.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return parquet.NullValue(), fmt.Errorf("cannot convert %v to time", v)
+		}
+		return parquet.Int64Value(numericToTimeMicros(int64(v), common)), nil
+	default:
+		return parquet.NullValue(), fmt.Errorf("cannot convert %T to time", value)
+	}
+}
+
+// numericToTimeMicros scales a numeric time-of-day value to microseconds
+// using the schema's declared unit. Without schema metadata, the input is
+// assumed to already be microseconds (Iceberg's internal representation),
+// which preserves the pre-PR behavior for numeric inputs.
+//
+// An unrecognised TimeUnit reaching this function indicates a benthos
+// schema-package contract violation — Validate() guards against it
+// upstream — and we panic rather than silently misinterpret. Returning n
+// unchanged would conflate a malformed schema with the no-metadata case.
+func numericToTimeMicros(n int64, common *schema.Common) int64 {
+	if common == nil || common.Logical == nil || common.Logical.TimeOfDay == nil {
+		return n
+	}
+	switch common.Logical.TimeOfDay.Unit {
+	case schema.TimeUnitSeconds:
+		return n * 1_000_000
+	case schema.TimeUnitMillis:
+		return n * 1_000
+	case schema.TimeUnitMicros:
+		return n
+	case schema.TimeUnitNanos:
+		return n / 1_000
+	default:
+		panic(fmt.Sprintf("unreachable: invalid TimeUnit %v escaped Validate()", common.Logical.TimeOfDay.Unit))
+	}
+}
+
+// convertTimestamp converts a Go value into the Parquet representation of an
+// Iceberg TIMESTAMP / TIMESTAMPTZ column (int64 microseconds since epoch by
+// default; nanoseconds when nanos is true, for the V3 *NsType variants).
+// Accepts time.Time directly. For numeric inputs, prefers
+// common.Logical.Timestamp.Unit to interpret the unit. When common is a
+// Timestamp schema with no Logical (legacy / hand-constructed), falls back
+// to EffectiveTimestamp's millis/UTC default rather than to
+// bloblang.ValueAsTimestamp's seconds default — so a numeric millis value
+// declared by the schema as Timestamp lands at the correct microsecond
+// offset, not 1000× too far in the future.
+//
+// Only when no schema metadata is available at all do we fall through to
+// bloblang.ValueAsTimestamp — which preserves the pre-PR behavior for
+// callers that genuinely store unix-seconds in a numeric column without
+// any schema annotation.
+func convertTimestamp(value any, common *schema.Common, nanos bool) (parquet.Value, error) {
+	if v, ok := value.(time.Time); ok {
+		if nanos {
+			return parquet.Int64Value(v.UnixNano()), nil
+		}
+		return parquet.Int64Value(v.UnixMicro()), nil
+	}
+
+	// Reject NaN/±Inf up front. int64(NaN) is implementation-defined
+	// garbage; left to fall through, this would silently produce year 1970
+	// (or worse) timestamps via either the metadata path or the bloblang
+	// fallback. Mirrors the guard the decimal converter already enforces.
+	switch v := value.(type) {
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return parquet.NullValue(), fmt.Errorf("cannot convert %v to timestamp", v)
+		}
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return parquet.NullValue(), fmt.Errorf("cannot convert %v to timestamp", v)
+		}
+	}
+
+	// Numeric path. Honour the schema's declared unit when we have one.
+	// A Timestamp schema with nil Logical falls through EffectiveTimestamp
+	// to the legacy millis/UTC default, which is also the right
+	// interpretation for the population that produced this PR: an
+	// upstream Avro timestamp-millis value flowing through the schema
+	// metadata path.
+	if n, ok := numericInt64(value); ok && common != nil && common.Type == schema.Timestamp {
+		p := common.EffectiveTimestamp()
+		out := scaleTimestampNumeric(n, p.Unit, nanos)
+		return parquet.Int64Value(out), nil
+	}
+
+	// No applicable schema metadata: keep the historical bloblang path.
+	// This preserves behavior for callers that pass unix-seconds directly
+	// into a numeric column without schema annotation.
+	t, err := bloblang.ValueAsTimestamp(value)
+	if err != nil {
+		return parquet.NullValue(), err
+	}
+	if nanos {
+		return parquet.Int64Value(t.UnixNano()), nil
+	}
+	return parquet.Int64Value(t.UnixMicro()), nil
+}
+
+// scaleTimestampNumeric scales a numeric timestamp from its declared unit
+// into either microseconds (the standard Iceberg TIMESTAMP/TIMESTAMPTZ
+// internal representation) or nanoseconds (the V3 *NsType internal
+// representation).
+//
+// An unrecognised TimeUnit reaching this function indicates a benthos
+// schema-package contract violation — Validate() guards against it
+// upstream — and we panic rather than silently misinterpret. Returning n
+// unchanged would conflate "unit=micros (no scaling needed)" with
+// "malformed schema (no scaling possible)".
+func scaleTimestampNumeric(n int64, unit schema.TimeUnit, nanos bool) int64 {
+	if nanos {
+		switch unit {
+		case schema.TimeUnitSeconds:
+			return n * 1_000_000_000
+		case schema.TimeUnitMillis:
+			return n * 1_000_000
+		case schema.TimeUnitMicros:
+			return n * 1_000
+		case schema.TimeUnitNanos:
+			return n
+		default:
+			panic(fmt.Sprintf("unreachable: invalid TimeUnit %v escaped Validate()", unit))
+		}
+	}
+	switch unit {
+	case schema.TimeUnitSeconds:
+		return n * 1_000_000
+	case schema.TimeUnitMillis:
+		return n * 1_000
+	case schema.TimeUnitMicros:
+		return n
+	case schema.TimeUnitNanos:
+		return n / 1_000
+	default:
+		panic(fmt.Sprintf("unreachable: invalid TimeUnit %v escaped Validate()", unit))
+	}
+}
+
+// numericInt64 extracts an int64 from an arbitrary numeric Go value. Returns
+// (0, false) for non-numeric inputs and for NaN/±Inf floats — so callers
+// can either error explicitly on those cases or fall through to a more
+// permissive parsing path.
+//
+// Float inputs are truncated toward zero — sub-unit precision is lost
+// silently. Floats outside the int64 representable range overflow to
+// undefined int64 values per Go conversion semantics; in practice this
+// is unreachable for any sane timestamp/date/time-of-day value, but
+// callers passing arbitrary numeric values should prefer integer types
+// to avoid the precision loss. NaN and ±Inf are filtered to (0, false)
+// because their int64 conversion is implementation-defined garbage; the
+// callers add explicit error paths so these can't silently corrupt.
+//
+// uint64 values above MaxInt64 overflow to negative int64 values; this
+// matches what the existing iceberg.Int64Type arm rejects via an
+// explicit range check, but here we accept the wrap because timestamp
+// values that high are nonsensical regardless.
+func numericInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case uint64:
+		return int64(v), true
+	case uint32:
+		return int64(v), true
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return 0, false
+		}
+		return int64(v), true
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return 0, false
+		}
+		return int64(v), true
+	}
+	return 0, false
+}

--- a/internal/impl/iceberg/shredder/temporal_test.go
+++ b/internal/impl/iceberg/shredder/temporal_test.go
@@ -9,6 +9,7 @@
 package shredder
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -96,7 +97,7 @@ func TestConvertTimestampSchemaAware(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pq, err := convertLeafValue(tc.value, tc.typ, tc.common)
+			pq, err := convertLeafValue(tc.value, tc.typ, tc.common, false)
 			if !tc.wantOK {
 				require.Error(t, err)
 				return
@@ -139,7 +140,7 @@ func TestConvertDateSchemaAware(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pq, err := convertLeafValue(tc.value, iceberg.DateType{}, nil)
+			pq, err := convertLeafValue(tc.value, iceberg.DateType{}, nil, false)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -191,7 +192,7 @@ func TestConvertTimeOfDaySchemaAware(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pq, err := convertLeafValue(tc.value, iceberg.TimeType{}, tc.common)
+			pq, err := convertLeafValue(tc.value, iceberg.TimeType{}, tc.common, false)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, pq.Int64())
 		})
@@ -218,7 +219,7 @@ func TestConvertDatePreEpoch(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pq, err := convertLeafValue(tc.t, iceberg.DateType{}, nil)
+			pq, err := convertLeafValue(tc.t, iceberg.DateType{}, nil, false)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, pq.Int32())
 		})
@@ -233,7 +234,7 @@ func TestConvertTimeUsesValueLocation(t *testing.T) {
 	est, err := time.LoadLocation("America/New_York")
 	require.NoError(t, err)
 	v := time.Date(2024, 1, 15, 14, 30, 0, 0, est)
-	pq, err := convertLeafValue(v, iceberg.TimeType{}, nil)
+	pq, err := convertLeafValue(v, iceberg.TimeType{}, nil, false)
 	require.NoError(t, err)
 	want := int64(14*3600+30*60) * 1_000_000
 	assert.Equal(t, want, pq.Int64())
@@ -249,7 +250,7 @@ func TestConvertTimestampLegacyNilLogical(t *testing.T) {
 	const wantMicros = epochMillis * 1000
 
 	common := &schema.Common{Type: schema.Timestamp} // nil Logical
-	pq, err := convertLeafValue(epochMillis, iceberg.TimestampTzType{}, common)
+	pq, err := convertLeafValue(epochMillis, iceberg.TimestampTzType{}, common, false)
 	require.NoError(t, err)
 	assert.Equal(t, wantMicros, pq.Int64())
 }
@@ -264,6 +265,153 @@ func TestScaleTimestampNumericPanicsOnInvalid(t *testing.T) {
 		}
 	}()
 	scaleTimestampNumeric(123, schema.TimeUnit(99), false)
+}
+
+// TestTemporalRejectsNaNInf locks in a defense-in-depth guard against
+// silent corruption: a NaN or ±Inf float reaching a time-typed column
+// must fail loudly rather than be cast to implementation-defined
+// int32/int64 garbage (typically 0, i.e. year 1970).
+func TestTemporalRejectsNaNInf(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  iceberg.Type
+		val  any
+	}{
+		{"date NaN", iceberg.DateType{}, math.NaN()},
+		{"date +Inf", iceberg.DateType{}, math.Inf(1)},
+		{"date -Inf", iceberg.DateType{}, math.Inf(-1)},
+		{"time NaN", iceberg.TimeType{}, math.NaN()},
+		{"time +Inf", iceberg.TimeType{}, math.Inf(1)},
+		{"timestamp NaN", iceberg.TimestampTzType{}, math.NaN()},
+		{"timestamp +Inf", iceberg.TimestampTzType{}, math.Inf(1)},
+		{"timestamp -Inf", iceberg.TimestampTzType{}, math.Inf(-1)},
+		{"timestamp_ns NaN", iceberg.TimestampNsType{}, math.NaN()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertLeafValue(tc.val, tc.typ, nil, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot convert")
+		})
+	}
+}
+
+// TestNumericInt64FiltersNaNInf verifies the helper returns (0, false)
+// for non-finite floats so callers can route them to explicit error paths
+// instead of letting the int64 cast produce garbage.
+func TestNumericInt64FiltersNaNInf(t *testing.T) {
+	for _, v := range []any{math.NaN(), math.Inf(1), math.Inf(-1), float32(math.NaN()), float32(math.Inf(1))} {
+		_, ok := numericInt64(v)
+		assert.False(t, ok, "%v should not extract as int64", v)
+	}
+}
+
+// TestStrictTemporalModeRejectsNumericWithoutMetadata exercises the
+// require_schema_metadata=true path: numeric inputs into time-typed
+// columns must fail loudly when no schema.Common has been registered for
+// the field.
+func TestStrictTemporalModeRejectsNumericWithoutMetadata(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  iceberg.Type
+		val  any
+	}{
+		{"date numeric strict", iceberg.DateType{}, int64(19737)},
+		{"time numeric strict", iceberg.TimeType{}, int64(123456)},
+		{"timestamp numeric strict", iceberg.TimestampTzType{}, int64(1_730_000_000_000)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertLeafValue(tc.val, tc.typ, nil, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "require_schema_metadata=true")
+		})
+	}
+}
+
+// TestStrictTemporalModeRejectsWrongTypeMetadata verifies that strict
+// mode is not satisfied by *any* schema.Common — the registered Type
+// must match the iceberg-side column type. Otherwise a hand-crafted
+// metadata mismatch (e.g. claiming a column is `string` while iceberg
+// actually has it as DATE) would silently pass the strict check and
+// the value-converter would interpret the numeric using the wrong
+// shape.
+func TestStrictTemporalModeRejectsWrongTypeMetadata(t *testing.T) {
+	cases := []struct {
+		name   string
+		typ    iceberg.Type
+		val    any
+		common *schema.Common
+	}{
+		{
+			name:   "DATE column with String-typed metadata",
+			typ:    iceberg.DateType{},
+			val:    int64(19737),
+			common: &schema.Common{Type: schema.String},
+		},
+		{
+			name:   "DATE column with Int64-typed metadata",
+			typ:    iceberg.DateType{},
+			val:    int64(19737),
+			common: &schema.Common{Type: schema.Int64},
+		},
+		{
+			name: "TIME column with Timestamp-typed metadata",
+			typ:  iceberg.TimeType{},
+			val:  int64(8 * 3600 * 1_000_000),
+			common: &schema.Common{
+				Type:    schema.Timestamp,
+				Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true}},
+			},
+		},
+		{
+			name:   "TIMESTAMPTZ column with Date-typed metadata",
+			typ:    iceberg.TimestampTzType{},
+			val:    int64(1_730_000_000_000),
+			common: &schema.Common{Type: schema.Date},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := convertLeafValue(tc.val, tc.typ, tc.common, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "require_schema_metadata=true")
+		})
+	}
+}
+
+// TestStrictTemporalModeAcceptsTimeTypeNatives confirms that strict mode
+// has no effect when the input is already an unambiguous Go time type.
+func TestStrictTemporalModeAcceptsTimeTypeNatives(t *testing.T) {
+	const epochMillis = int64(1_730_000_000_000)
+	t.Run("time.Time into TIMESTAMPTZ without metadata", func(t *testing.T) {
+		v := time.UnixMilli(epochMillis).UTC()
+		pq, err := convertLeafValue(v, iceberg.TimestampTzType{}, nil, true)
+		require.NoError(t, err)
+		assert.Equal(t, epochMillis*1000, pq.Int64())
+	})
+	t.Run("time.Duration into TIME without metadata", func(t *testing.T) {
+		d := 8*time.Hour + 30*time.Minute
+		pq, err := convertLeafValue(d, iceberg.TimeType{}, nil, true)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8*3600+30*60)*1_000_000, pq.Int64())
+	})
+	t.Run("time.Time into DATE without metadata", func(t *testing.T) {
+		v := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+		pq, err := convertLeafValue(v, iceberg.DateType{}, nil, true)
+		require.NoError(t, err)
+		assert.Equal(t, int32(19737), pq.Int32())
+	})
+}
+
+// TestStrictTemporalModeAcceptsNumericWithMetadata confirms that strict
+// mode is inert once schema metadata is registered for the field.
+func TestStrictTemporalModeAcceptsNumericWithMetadata(t *testing.T) {
+	const epochMillis = int64(1_730_000_000_000)
+	common := tsCommon(schema.TimeUnitMillis, true)
+	pq, err := convertLeafValue(epochMillis, iceberg.TimestampTzType{}, common, true)
+	require.NoError(t, err)
+	assert.Equal(t, epochMillis*1000, pq.Int64())
 }
 
 func tsCommon(u schema.TimeUnit, utc bool) *schema.Common {

--- a/internal/impl/iceberg/shredder/temporal_test.go
+++ b/internal/impl/iceberg/shredder/temporal_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package shredder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+// TestConvertTimestampSchemaAware exercises the unit-aware numeric path that
+// closes the silent-corruption case from issue #4399. Without schema
+// metadata, bloblang.ValueAsTimestamp interprets a numeric input as Unix
+// seconds — a millisecond input therefore lands ~50,000 years in the
+// future. With schema metadata declaring `timestamp-millis`, the same
+// numeric input lands at the correct microsecond offset.
+func TestConvertTimestampSchemaAware(t *testing.T) {
+	const epochMillis = int64(1_730_000_000_000) // 2024-10-27 03:33:20 UTC
+	const wantMicros = epochMillis * 1000
+
+	cases := []struct {
+		name    string
+		value   any
+		common  *schema.Common
+		typ     iceberg.Type
+		wantOK  bool
+		wantVal int64
+		exactly bool // assert exact equality on wantVal
+	}{
+		{
+			name:    "millis with schema metadata → correct micros",
+			value:   epochMillis,
+			common:  tsCommon(schema.TimeUnitMillis, true),
+			typ:     iceberg.TimestampTzType{},
+			wantOK:  true,
+			wantVal: wantMicros,
+			exactly: true,
+		},
+		{
+			name:    "micros with schema metadata → identity micros",
+			value:   wantMicros,
+			common:  tsCommon(schema.TimeUnitMicros, true),
+			typ:     iceberg.TimestampTzType{},
+			wantOK:  true,
+			wantVal: wantMicros,
+			exactly: true,
+		},
+		{
+			name:    "nanos with schema metadata → micros (truncated)",
+			value:   wantMicros * 1000,
+			common:  tsCommon(schema.TimeUnitNanos, true),
+			typ:     iceberg.TimestampTzType{},
+			wantOK:  true,
+			wantVal: wantMicros,
+			exactly: true,
+		},
+		{
+			name:    "time.Time always wins over numeric path",
+			value:   time.UnixMilli(epochMillis).UTC(),
+			common:  nil, // even without schema metadata, time.Time is unambiguous
+			typ:     iceberg.TimestampTzType{},
+			wantOK:  true,
+			wantVal: wantMicros,
+			exactly: true,
+		},
+		{
+			name:    "numeric without schema falls back to bloblang seconds default",
+			value:   epochMillis,               // user intended millis
+			common:  nil,                       // but no schema to disambiguate
+			typ:     iceberg.TimestampTzType{}, // → bloblang treats as seconds
+			wantOK:  true,
+			wantVal: epochMillis * 1_000_000, // year 56755, but loud at least via comparison
+			exactly: false,                   // we don't assert exact correctness here, just existence
+		},
+		{
+			name:    "TIMESTAMP_NS with millis metadata scales to nanos",
+			value:   epochMillis,
+			common:  tsCommon(schema.TimeUnitMillis, true),
+			typ:     iceberg.TimestampTzNsType{},
+			wantOK:  true,
+			wantVal: epochMillis * 1_000_000,
+			exactly: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq, err := convertLeafValue(tc.value, tc.typ, tc.common)
+			if !tc.wantOK {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.exactly {
+				assert.Equal(t, tc.wantVal, pq.Int64())
+			}
+		})
+	}
+}
+
+func TestConvertDateSchemaAware(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   any
+		want    int32
+		wantErr bool
+	}{
+		{
+			name:  "time.Time at UTC midnight",
+			value: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			want:  19737, // days since epoch
+		},
+		{
+			name:  "int32 days passes through",
+			value: int32(19737),
+			want:  19737,
+		},
+		{
+			name:  "int days passes through",
+			value: 19737,
+			want:  19737,
+		},
+		{
+			name:    "string rejected",
+			value:   "2024-01-15",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq, err := convertLeafValue(tc.value, iceberg.DateType{}, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, pq.Int32())
+		})
+	}
+}
+
+func TestConvertTimeOfDaySchemaAware(t *testing.T) {
+	const eightThirtyMicros = int64(8*3600+30*60) * 1_000_000
+	cases := []struct {
+		name   string
+		value  any
+		common *schema.Common
+		want   int64
+	}{
+		{
+			name:   "time.Duration passes through directly",
+			value:  8*time.Hour + 30*time.Minute,
+			common: nil,
+			want:   eightThirtyMicros,
+		},
+		{
+			name:   "millis numeric with schema metadata scales correctly",
+			value:  int64(8*3600+30*60) * 1_000,
+			common: todCommon(schema.TimeUnitMillis),
+			want:   eightThirtyMicros,
+		},
+		{
+			name:   "micros numeric with schema metadata is identity",
+			value:  eightThirtyMicros,
+			common: todCommon(schema.TimeUnitMicros),
+			want:   eightThirtyMicros,
+		},
+		{
+			name:   "nanos numeric with schema metadata divides correctly",
+			value:  eightThirtyMicros * 1_000,
+			common: todCommon(schema.TimeUnitNanos),
+			want:   eightThirtyMicros,
+		},
+		{
+			name:   "numeric without schema treated as already-micros (legacy)",
+			value:  eightThirtyMicros,
+			common: nil,
+			want:   eightThirtyMicros,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq, err := convertLeafValue(tc.value, iceberg.TimeType{}, tc.common)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, pq.Int64())
+		})
+	}
+}
+
+// TestConvertDatePreEpoch covers the floor-vs-truncate bug for negative
+// Unix timestamps. 1969-12-31 23:59:59 UTC has Unix() == -1; truncating
+// integer division gives 0 (Jan 1 1970) instead of the correct -1
+// (Dec 31 1969). Iceberg DATE supports negative day indices.
+func TestConvertDatePreEpoch(t *testing.T) {
+	cases := []struct {
+		name string
+		t    time.Time
+		want int32
+	}{
+		{"1969-12-31 23:59:59 UTC", time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC), -1},
+		{"1969-12-31 00:00:00 UTC", time.Date(1969, 12, 31, 0, 0, 0, 0, time.UTC), -1},
+		{"1969-01-01 UTC", time.Date(1969, 1, 1, 0, 0, 0, 0, time.UTC), -365},
+		{"1900-01-01 UTC", time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC), -25567},
+		{"1970-01-01 00:00:00 UTC (boundary)", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), 0},
+		{"1970-01-01 23:59:59 UTC", time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC), 0},
+		{"1970-01-02 UTC", time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pq, err := convertLeafValue(tc.t, iceberg.DateType{}, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, pq.Int32())
+		})
+	}
+}
+
+// TestConvertTimeUsesValueLocation verifies that time.Time inputs are
+// extracted in the value's own location (zoneless wall-clock semantics)
+// rather than UTC-shifted. A 14:30 EST time.Time should produce the
+// 14:30 microsecond offset, not 19:30 UTC.
+func TestConvertTimeUsesValueLocation(t *testing.T) {
+	est, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	v := time.Date(2024, 1, 15, 14, 30, 0, 0, est)
+	pq, err := convertLeafValue(v, iceberg.TimeType{}, nil)
+	require.NoError(t, err)
+	want := int64(14*3600+30*60) * 1_000_000
+	assert.Equal(t, want, pq.Int64())
+}
+
+// TestConvertTimestampLegacyNilLogical verifies that a Timestamp schema
+// with no Logical params (legacy / hand-constructed) treats numeric inputs
+// as millis (the EffectiveTimestamp default) rather than seconds (the
+// bloblang fallback). Without this guard, a numeric millis value declared
+// by the schema as Timestamp would land 1000× too far in the future.
+func TestConvertTimestampLegacyNilLogical(t *testing.T) {
+	const epochMillis = int64(1_730_000_000_000) // 2024-10-27 03:33:20 UTC
+	const wantMicros = epochMillis * 1000
+
+	common := &schema.Common{Type: schema.Timestamp} // nil Logical
+	pq, err := convertLeafValue(epochMillis, iceberg.TimestampTzType{}, common)
+	require.NoError(t, err)
+	assert.Equal(t, wantMicros, pq.Int64())
+}
+
+// TestScaleTimestampNumericPanicsOnInvalid asserts the defense-in-depth
+// behavior: an invalid TimeUnit slipping past Validate() must not silently
+// degrade to a wrong unit interpretation.
+func TestScaleTimestampNumericPanicsOnInvalid(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on invalid TimeUnit")
+		}
+	}()
+	scaleTimestampNumeric(123, schema.TimeUnit(99), false)
+}
+
+func tsCommon(u schema.TimeUnit, utc bool) *schema.Common {
+	return &schema.Common{
+		Type:    schema.Timestamp,
+		Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: u, AdjustToUTC: utc}},
+	}
+}
+
+func todCommon(u schema.TimeUnit) *schema.Common {
+	return &schema.Common{
+		Type:    schema.TimeOfDay,
+		Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: u}},
+	}
+}

--- a/internal/impl/iceberg/type_inference.go
+++ b/internal/impl/iceberg/type_inference.go
@@ -120,6 +120,12 @@ func (ti *typeInferrer) inferType(value any) (iceberg.Type, error) {
 	case time.Time:
 		return iceberg.TimestampTzType{}, nil
 
+	case time.Duration:
+		// time.Duration is the natural Go representation for time-of-day
+		// values produced by twmb/avro decoding `time-millis`/`time-micros`.
+		// Iceberg TIME stores microseconds since midnight, no timezone.
+		return iceberg.TimeType{}, nil
+
 	case []byte:
 		return iceberg.BinaryType{}, nil
 

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -238,7 +238,45 @@ func commonTypeToIcebergTypeRec(c *schema.Common, ti *typeInferrer) (iceberg.Typ
 	case schema.ByteArray:
 		return iceberg.BinaryType{}, nil
 	case schema.Timestamp:
-		return iceberg.TimestampTzType{}, nil
+		// Pick an Iceberg variant per the schema's declared unit/UTC-adjust.
+		// Legacy Timestamps (nil Logical) fall through to the millis/UTC
+		// default via EffectiveTimestamp(), preserving today's behavior of
+		// "always TimestampTzType". Schemas that explicitly say nanos use
+		// the V3 *NsType variants (catalog must support spec V3 to read
+		// these — that's surfaced as a write-time error from iceberg-go,
+		// not silently downcast here).
+		p := c.EffectiveTimestamp()
+		switch {
+		case p.Unit == schema.TimeUnitNanos && p.AdjustToUTC:
+			return iceberg.TimestampTzNsType{}, nil
+		case p.Unit == schema.TimeUnitNanos:
+			return iceberg.TimestampNsType{}, nil
+		case p.AdjustToUTC:
+			return iceberg.TimestampTzType{}, nil
+		default:
+			return iceberg.TimestampType{}, nil
+		}
+	case schema.Date:
+		return iceberg.DateType{}, nil
+	case schema.TimeOfDay:
+		// Iceberg's TIME is microseconds since midnight, no timezone. Reject
+		// shapes Iceberg can't faithfully represent rather than silently
+		// downcast — see sink-design-guidance.md.
+		if c.Logical == nil || c.Logical.TimeOfDay == nil {
+			return nil, fmt.Errorf("time-of-day field %q missing Logical.TimeOfDay parameters", c.Name)
+		}
+		p := c.Logical.TimeOfDay
+		if p.AdjustToUTC {
+			return nil, fmt.Errorf("time-of-day field %q has AdjustToUTC=true; Iceberg has no time-with-tz column type, downcast or restructure upstream", c.Name)
+		}
+		switch p.Unit {
+		case schema.TimeUnitMillis, schema.TimeUnitMicros:
+			return iceberg.TimeType{}, nil
+		default:
+			return nil, fmt.Errorf("time-of-day field %q has unit %v; Iceberg supports only MILLIS and MICROS for TIME columns", c.Name, p.Unit)
+		}
+	case schema.UUID:
+		return iceberg.UUIDType{}, nil
 	case schema.Decimal:
 		if c.Logical == nil || c.Logical.Decimal == nil {
 			return nil, fmt.Errorf("decimal field %q is missing precision/scale", c.Name)

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -116,6 +116,44 @@ func TestCommonTypeToIcebergType(t *testing.T) {
 			Name: "amount",
 			Type: schema.BigDecimal,
 		}, "", true},
+		// Logical-type cases the original issue #4399 stopped at INT/BIGINT —
+		// these now produce the right Iceberg column types.
+		{"Timestamp millis UTC default (legacy nil Logical)", schema.Common{Type: schema.Timestamp}, "timestamptz", false},
+		{"Timestamp micros UTC", schema.Common{
+			Type:    schema.Timestamp,
+			Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+		}, "timestamptz", false},
+		{"Timestamp local micros (no tz)", schema.Common{
+			Type:    schema.Timestamp,
+			Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false}},
+		}, "timestamp", false},
+		{"Timestamp nanos UTC (V3)", schema.Common{
+			Type:    schema.Timestamp,
+			Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitNanos, AdjustToUTC: true}},
+		}, "timestamptz_ns", false},
+		{"Timestamp local nanos (V3)", schema.Common{
+			Type:    schema.Timestamp,
+			Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitNanos, AdjustToUTC: false}},
+		}, "timestamp_ns", false},
+		{"Date", schema.Common{Type: schema.Date}, "date", false},
+		{"TimeOfDay millis (no tz)", schema.Common{
+			Type:    schema.TimeOfDay,
+			Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis}},
+		}, "time", false},
+		{"TimeOfDay micros (no tz)", schema.Common{
+			Type:    schema.TimeOfDay,
+			Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros}},
+		}, "time", false},
+		{"TimeOfDay AdjustToUTC rejected (Iceberg has no time-with-tz)", schema.Common{
+			Type:    schema.TimeOfDay,
+			Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+		}, "", true},
+		{"TimeOfDay missing Logical rejected", schema.Common{Type: schema.TimeOfDay}, "", true},
+		{"TimeOfDay nanos rejected (Iceberg TIME is micros)", schema.Common{
+			Type:    schema.TimeOfDay,
+			Logical: &schema.LogicalParams{TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitNanos}},
+		}, "", true},
+		{"UUID", schema.Common{Type: schema.UUID}, "uuid", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -31,12 +31,13 @@ import (
 
 // writer handles writing batches of messages to a single Iceberg table.
 type writer struct {
-	table         *table.Table
-	committer     *committer
-	caseSensitive bool
-	writerOpts    []parquet.WriterOption
-	resolver      *typeResolver
-	logger        *service.Logger
+	table                 *table.Table
+	committer             *committer
+	caseSensitive         bool
+	writerOpts            []parquet.WriterOption
+	resolver              *typeResolver
+	requireSchemaMetadata bool
+	logger                *service.Logger
 }
 
 // NewWriter creates a new writer for a specific table.
@@ -45,14 +46,17 @@ type writer struct {
 // caseSensitive controls how message keys are matched against the schema.
 // resolver supplies optional per-message schema metadata used by the shredder
 // to interpret numeric inputs into time-typed columns; pass nil to disable.
-func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, logger *service.Logger) *writer {
+// requireSchemaMetadata enables shredder strict mode — see
+// [shredder.RecordShredder.SetStrictTemporalMode].
+func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, requireSchemaMetadata bool, logger *service.Logger) *writer {
 	return &writer{
-		table:         tbl,
-		committer:     comm,
-		caseSensitive: caseSensitive,
-		writerOpts:    writerOpts,
-		resolver:      resolver,
-		logger:        logger,
+		table:                 tbl,
+		committer:             comm,
+		caseSensitive:         caseSensitive,
+		writerOpts:            writerOpts,
+		resolver:              resolver,
+		requireSchemaMetadata: requireSchemaMetadata,
+		logger:                logger,
 	}
 }
 
@@ -209,6 +213,9 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 	// silently for messages 1..N; in that case the writer must be
 	// extended to per-message metadata lookup with a small cache.
 	rs := shredder.NewRecordShredder(schema, w.caseSensitive)
+	if w.requireSchemaMetadata {
+		rs.SetStrictTemporalMode(true)
+	}
 	if w.resolver != nil && len(batch) > 0 {
 		if common, err := w.resolver.parseSchemaMetadata(batch[0]); err != nil {
 			w.logger.Warnf("parsing schema metadata for shredder: %v (falling back to schema-agnostic conversion)", err)

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/format"
 
+	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/icebergx"
 	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/shredder"
@@ -34,6 +35,7 @@ type writer struct {
 	committer     *committer
 	caseSensitive bool
 	writerOpts    []parquet.WriterOption
+	resolver      *typeResolver
 	logger        *service.Logger
 }
 
@@ -41,12 +43,15 @@ type writer struct {
 // The table and committer should use separate table references since they
 // operate in different goroutines and the table object is mutable.
 // caseSensitive controls how message keys are matched against the schema.
-func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, logger *service.Logger) *writer {
+// resolver supplies optional per-message schema metadata used by the shredder
+// to interpret numeric inputs into time-typed columns; pass nil to disable.
+func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, logger *service.Logger) *writer {
 	return &writer{
 		table:         tbl,
 		committer:     comm,
 		caseSensitive: caseSensitive,
 		writerOpts:    writerOpts,
+		resolver:      resolver,
 		logger:        logger,
 	}
 }
@@ -186,8 +191,31 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 	}
 	numPartitionFields := spec.NumFields()
 
-	// Create shredder for the schema
+	// Create shredder for the schema. When schema metadata is configured
+	// and the first message in the batch carries it, use it to inform the
+	// shredder's numeric-to-temporal conversion. Schema metadata is the
+	// authoritative source for "this BIGINT-shaped value is actually
+	// timestamp-millis" and prevents the year-50000 silent corruption
+	// that bloblang.ValueAsTimestamp's seconds-default would otherwise
+	// produce.
+	//
+	// We sample the schema metadata from batch[0] only and apply it to
+	// every message in the batch. Connect's iceberg router groups by
+	// (namespace, table) before reaching this method, so messages in a
+	// batch share a destination table and — in every supported upstream
+	// (schema-registry decode, parquet decode, single-source streams) —
+	// a single schema. If a future upstream genuinely interleaves
+	// different schema metadata into one batch, this assumption breaks
+	// silently for messages 1..N; in that case the writer must be
+	// extended to per-message metadata lookup with a small cache.
 	rs := shredder.NewRecordShredder(schema, w.caseSensitive)
+	if w.resolver != nil && len(batch) > 0 {
+		if common, err := w.resolver.parseSchemaMetadata(batch[0]); err != nil {
+			w.logger.Warnf("parsing schema metadata for shredder: %v (falling back to schema-agnostic conversion)", err)
+		} else if common != nil {
+			rs.SetFieldSchemaMetadata(buildShredderFieldCommons(schema, common, w.caseSensitive))
+		}
+	}
 
 	// For unpartitioned tables, use a single writer
 	if spec.IsUnpartitioned() {
@@ -303,6 +331,95 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 // Close closes the writer and its committer.
 func (w *writer) Close() {
 	w.committer.Close()
+}
+
+// buildShredderFieldCommons walks an iceberg schema and the parallel
+// schema.Common metadata that produced it, returning a fieldID → *schema.Common
+// map keyed by the iceberg field IDs of every leaf column. The shredder
+// consults this to interpret numeric inputs into time-typed columns using
+// the unit/AdjustToUTC semantics declared by the upstream schema.
+//
+// Only leaf-level entries are emitted; struct/list/map containers are
+// recursed into. Field matching uses the same case-sensitivity rule as
+// shredding so the lookup behaves consistently with how values are routed.
+// Fields present in the iceberg schema but absent from the metadata are
+// skipped — those columns either pre-date the metadata or were added by
+// schema evolution from a different source.
+func buildShredderFieldCommons(s *iceberg.Schema, root *schema.Common, caseSensitive bool) map[int]*schema.Common {
+	if root == nil {
+		return nil
+	}
+	out := make(map[int]*schema.Common)
+	visitIcebergSchemaFields(s.AsStruct().FieldList, root, caseSensitive, out)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func visitIcebergSchemaFields(fields []iceberg.NestedField, parent *schema.Common, caseSensitive bool, out map[int]*schema.Common) {
+	if parent == nil || parent.Type != schema.Object {
+		return
+	}
+	for _, f := range fields {
+		child := lookupCommonChild(parent, f.Name, caseSensitive)
+		if child == nil {
+			continue
+		}
+		recordOrRecurseIcebergField(f.ID, f.Type, child, caseSensitive, out)
+	}
+}
+
+// recordOrRecurseIcebergField is the leaf-vs-recurse decision for a single
+// iceberg type/common pair. Leaves are registered in out; container types
+// (struct, list, map) are recursed into so their leaf descendants pick up
+// metadata too.
+//
+// When the iceberg-side container shape and the common-side type don't
+// agree (e.g. iceberg has ListType but the common says Object), we skip
+// rather than blindly consume children of the wrong shape. The shredder
+// then falls back to the historical schema-agnostic conversion for those
+// fields, which is the safe loss-of-precision rather than misinterpreting.
+func recordOrRecurseIcebergField(fieldID int, typ iceberg.Type, common *schema.Common, caseSensitive bool, out map[int]*schema.Common) {
+	switch t := typ.(type) {
+	case *iceberg.StructType:
+		if common.Type != schema.Object {
+			return
+		}
+		visitIcebergSchemaFields(t.FieldList, common, caseSensitive, out)
+	case *iceberg.ListType:
+		// A schema.Common array carries the element schema as its single
+		// child; skip if the shape doesn't match.
+		if common.Type != schema.Array || len(common.Children) != 1 {
+			return
+		}
+		recordOrRecurseIcebergField(t.ElementID, t.Element, &common.Children[0], caseSensitive, out)
+	case *iceberg.MapType:
+		// schema.Common maps are encoded as type Map with a single child
+		// representing the value schema. Keys are always primitives in
+		// our model, so they don't need metadata. Recurse into the value.
+		if common.Type != schema.Map || len(common.Children) != 1 {
+			return
+		}
+		recordOrRecurseIcebergField(t.ValueID, t.ValueType, &common.Children[0], caseSensitive, out)
+	default:
+		// Leaf — register the metadata so the shredder can consult it.
+		out[fieldID] = common
+	}
+}
+
+func lookupCommonChild(parent *schema.Common, name string, caseSensitive bool) *schema.Common {
+	for i := range parent.Children {
+		ch := &parent.Children[i]
+		if caseSensitive {
+			if ch.Name == name {
+				return ch
+			}
+		} else if strings.EqualFold(ch.Name, name) {
+			return ch
+		}
+	}
+	return nil
 }
 
 // parquetColumn holds state for writing to a single parquet column.

--- a/internal/impl/iceberg/writer_test.go
+++ b/internal/impl/iceberg/writer_test.go
@@ -11,9 +11,11 @@ package iceberg
 import (
 	"testing"
 
+	"github.com/apache/iceberg-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/icebergx"
 )
 
@@ -108,5 +110,139 @@ func TestParquetSinkNewFieldDedup(t *testing.T) {
 		sink.OnNewField(icebergx.Path{}, "foo", "y")
 
 		assert.Len(t, sink.newFieldErrors(), 2)
+	})
+}
+
+// TestBuildShredderFieldCommons verifies that the field-id → schema.Common
+// map produced for the shredder correctly traverses iceberg containers
+// (struct, list, map) so descendant leaf columns pick up unit metadata
+// instead of being treated as the container's leaf.
+func TestBuildShredderFieldCommons(t *testing.T) {
+	tsCommon := schema.Common{
+		Name:    "ts",
+		Type:    schema.Timestamp,
+		Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true}},
+	}
+
+	t.Run("nil root returns nil", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "x", Type: iceberg.PrimitiveTypes.Int64},
+		)
+		assert.Nil(t, buildShredderFieldCommons(s, nil, false))
+	})
+
+	t.Run("flat schema registers leaf metadata", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+			iceberg.NestedField{ID: 2, Name: "ts", Type: iceberg.TimestampTzType{}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "id", Type: schema.Int64},
+				tsCommon,
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		require.NotNil(t, got)
+		require.Contains(t, got, 2)
+		assert.Equal(t, schema.Timestamp, got[2].Type)
+		require.NotNil(t, got[2].Logical)
+		require.NotNil(t, got[2].Logical.Timestamp)
+		assert.Equal(t, schema.TimeUnitMillis, got[2].Logical.Timestamp.Unit)
+	})
+
+	t.Run("nested struct registers descendant leaf", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "outer", Type: &iceberg.StructType{
+				FieldList: []iceberg.NestedField{
+					{ID: 2, Name: "inner_ts", Type: iceberg.TimestampTzType{}},
+				},
+			}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "outer", Type: schema.Object, Children: []schema.Common{
+					{
+						Name: "inner_ts", Type: schema.Timestamp,
+						Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+					},
+				}},
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		require.Contains(t, got, 2, "inner_ts should be registered by element ID")
+		assert.Equal(t, schema.TimeUnitMicros, got[2].Logical.Timestamp.Unit)
+	})
+
+	t.Run("list of timestamps registers element metadata", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "events", Type: &iceberg.ListType{
+				ElementID: 100, Element: iceberg.TimestampTzType{}, ElementRequired: false,
+			}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "events", Type: schema.Array, Children: []schema.Common{tsCommon}},
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		require.Contains(t, got, 100)
+		assert.Equal(t, schema.TimeUnitMillis, got[100].Logical.Timestamp.Unit)
+	})
+
+	t.Run("map of string to timestamp registers value metadata", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "by_event", Type: &iceberg.MapType{
+				KeyID: 100, KeyType: iceberg.PrimitiveTypes.String,
+				ValueID: 101, ValueType: iceberg.TimestampTzType{}, ValueRequired: false,
+			}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "by_event", Type: schema.Map, Children: []schema.Common{tsCommon}},
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		require.Contains(t, got, 101, "map value should be registered by ValueID")
+		assert.NotContains(t, got, 100, "map key should not be registered")
+		assert.Equal(t, schema.TimeUnitMillis, got[101].Logical.Timestamp.Unit)
+	})
+
+	t.Run("shape mismatch skips silently", func(t *testing.T) {
+		// iceberg has a list, but metadata has scalar Int64 — skip the field.
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "events", Type: &iceberg.ListType{
+				ElementID: 100, Element: iceberg.TimestampTzType{},
+			}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{Name: "events", Type: schema.Int64},
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		assert.Empty(t, got, "wrong-shape metadata should not register anything")
+	})
+
+	t.Run("case-insensitive matching", func(t *testing.T) {
+		s := iceberg.NewSchema(1,
+			iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.TimestampTzType{}},
+		)
+		root := schema.Common{
+			Type: schema.Object,
+			Children: []schema.Common{
+				{
+					Name: "TS", Type: schema.Timestamp,
+					Logical: &schema.LogicalParams{Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true}},
+				},
+			},
+		}
+		got := buildShredderFieldCommons(s, &root, false)
+		require.Contains(t, got, 1, "case-insensitive match should still register the metadata")
 	})
 }


### PR DESCRIPTION
## Summary

Issue [#4399](https://github.com/redpanda-data/connect/issues/4399): the Confluent Schema Registry Avro decoder was dropping every logical-type annotation other than `decimal`. Downstream sinks that consume `schema_metadata` (notably `iceberg`) inferred BIGINT / INT / STRING columns where the source schema declared timestamp / date / time / uuid. This PR makes every Avro logical type round-trip through `schema.Common` and lands at the right Iceberg column type.

The new `schema.Common` types and parameter blocks land in benthos v4.73.0 ([redpanda-data/benthos#429](https://github.com/redpanda-data/benthos/pull/429)), which is the version this PR consumes.

## Changes

- **Decoder** (`internal/impl/confluent/ecs_avro.go`): replace the decimal-only logical block with a full dispatcher covering `timestamp-{millis,micros,nanos}`, `local-timestamp-{millis,micros,nanos}`, `date`, `time-{millis,micros}`, `uuid`. Per Avro 1.10 spec, unrecognised annotations and primitive/logical-type mismatches fall back silently to the base primitive.
- **Encoder** (`internal/impl/confluent/common_to_avro.go`): symmetric encode. Legacy `Timestamp` schemas (nil `Logical`) keep emitting `timestamp-millis` via `EffectiveTimestamp()` for backwards compatibility. Avro-inexpressible shapes (e.g. `time-of-day` with `AdjustToUTC=true`, `time-of-day` with nanos) are rejected with field-naming errors rather than silently downcast.
- **Iceberg type-resolver** (`internal/impl/iceberg/type_resolver.go`): adds `Date`, `TimeOfDay`, `UUID` arms and uses `EffectiveTimestamp()` to pick `TimestampType` / `TimestampTzType` / `TimestampNsType` / `TimestampTzNsType` based on the schema's declared unit and `AdjustToUTC`. Iceberg has no time-with-tz, so `TimeOfDay` with `AdjustToUTC=true` is rejected loudly.
- **Iceberg shredder** (`internal/impl/iceberg/shredder/{shredder,temporal}.go`): plumbs a fieldID → `*schema.Common` map onto `RecordShredder` via `SetFieldSchemaMetadata`. The leaf-value converter consults it for time-typed columns and uses the declared unit to scale numeric inputs into the column's internal representation. **Closes the silent-corruption case**: a numeric millisecond value declared by the schema as `timestamp-millis` would previously land ~50,000 years in the future when the column type flipped from BIGINT to TIMESTAMPTZ. Now the schema's declared unit is the source of truth for unit interpretation.
- **Iceberg writer** (`internal/impl/iceberg/{writer,router}.go`): `NewWriter` accepts the `*typeResolver`. The writer parses `schema_metadata` from the first message of a batch and builds the field-ID lookup the shredder consults. Internal API change only.
- **`schema_evolution.require_schema_metadata`** (default `false`): opt-in strict mode. When `true` along with `schema_evolution.schema_metadata`, numeric values shredded into `timestamp` / `timestamptz` / `date` / `time` columns without registered schema metadata are rejected loudly instead of falling through to the bloblang Unix-seconds default. Use this when you cannot guarantee the upstream attaches schema metadata and prefer a hard error to silently corrupting dates by ~50,000 years. No effect on time-typed columns receiving native `time.Time` / `time.Duration` Go values.

## Breaking changes

Pipeline values flow through unchanged in both `preserve_logical_types=false` (default — values stay numeric) and `preserve_logical_types=true` (values stay rich Go time types). Bloblang behaviour and JSON-output bytes are unaffected.

The breakage is concentrated in:

1. **Existing Iceberg tables** with BIGINT / INT / STRING columns that were created from this bug. Iceberg disallows BIGINT → TIMESTAMP schema evolution, so the first write after upgrade will fail loudly. Drop and re-create, or use Iceberg-native column-rename + add-new-column tooling.
2. **Custom code reading `schema_metadata` bytes via `meta()`** and pattern-matching the historical INT64 shape: schemas now contain `TIMESTAMP` / `DATE` / `TIME_OF_DAY` / `UUID` along with new `unit` and `adjust_to_utc` fields.

## Test plan

- [x] `task lint` — 0 issues.
- [x] `go test ./internal/impl/confluent/...` — pass. Tests cover every Avro logical type, optional-union shape, decode/encode round-trip, decimal-on-wrong-primitive fallback.
- [x] `go test ./internal/impl/iceberg/...` (top-level + shredder + icebergx + catalogx + integration + e2e/{glue,polaris-aws,polaris-azure}) — pass. Tests cover Common→Iceberg mapping for each variant, schema-aware numeric conversion (including the year-50000 case), pre-epoch dates, time-of-day location semantics, container-recursion through nested struct/list/map metadata, strict-mode rejection of wrong-shape metadata, and panic-on-invalid TimeUnit defense.
- [ ] Manual smoke: schema-registry-decode → iceberg integration with a `timestamp-millis` Avro field, default mode. Verify TIMESTAMPTZ column with correct epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)