### PR TITLE
oracledb_cdc: fix failing test

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -593,7 +593,7 @@ oracledb_cdc:
 		require.NoError(t, json.Unmarshal(content, &row))
 		assert.Len(t, row, 2)
 		assert.Contains(t, row, "ID")
-		assert.EqualValues(t, 1, row["VAL"])
+		assert.EqualValues(t, "1", row["VAL"])
 	})
 
 	t.Run("Streaming update changes...", func(t *testing.T) {
@@ -610,7 +610,7 @@ oracledb_cdc:
 		require.NoError(t, json.Unmarshal(content, &row))
 		assert.Len(t, row, 2)
 		assert.Contains(t, row, "ID")
-		assert.EqualValues(t, 2, row["VAL"])
+		assert.EqualValues(t, "2", row["VAL"])
 	})
 
 	t.Run("Streaming delete changes...", func(t *testing.T) {
@@ -627,7 +627,7 @@ oracledb_cdc:
 		require.NoError(t, json.Unmarshal(content, &row))
 		assert.Len(t, row, 2)
 		assert.Contains(t, row, "ID")
-		assert.EqualValues(t, 2, row["VAL"])
+		assert.EqualValues(t, "2", row["VAL"])
 	})
 
 	require.NoError(t, stream.StopWithin(time.Second*10))


### PR DESCRIPTION
This [PR](https://github.com/redpanda-data/connect/pull/4307) (specifically commit https://github.com/redpanda-data/connect/pull/4307/changes/5cc54834e2342ad1c73da6bb983073865e782215) reverted an assertion change set by [this larger change](https://github.com/redpanda-data/connect/pull/4358) around handling of big decimals.

Integration tests now passing:

<img width="935" height="665" alt="image" src="https://github.com/user-attachments/assets/63fa61ef-1a80-4743-aa9b-673a35e9c509" />

