### PR TITLE
gh(release-notes): base diff on last minor tag to capture patch-release

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -21,17 +21,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          CURRENT=$(gh release view --json tagName -q '.tagName' | sed 's/^v//')
+          LAST_MINOR=$(gh release list --limit 100 --exclude-pre-releases --exclude-drafts \
+            --json tagName -q '.[].tagName' | grep -E '^v[0-9]+\.[0-9]+\.0$' | head -1)
+          CURRENT=$(echo "$LAST_MINOR" | sed 's/^v//')
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
           NEXT="4.$((MINOR + 1)).0"
+          echo "last_minor=$LAST_MINOR" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "**Last minor:** $LAST_MINOR" >> "$GITHUB_STEP_SUMMARY"
           echo "**Next version:** $NEXT" >> "$GITHUB_STEP_SUMMARY"
 
       - name: List merged PRs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "repos/${{ github.repository }}/compare/$(gh release view --json tagName -q '.tagName')...${{ github.ref_name }}" --jq '.commits[].sha' |
+          gh api "repos/${{ github.repository }}/compare/${{ steps.version.outputs.last_minor }}...${{ github.ref_name }}" --jq '.commits[].sha' |
           xargs -P8 -I{} gh api "repos/${{ github.repository }}/commits/{}/pulls" --jq '.[].number' |
           sort -u |
           xargs -I{} gh pr view {} --json number,author,commits,comments |


### PR DESCRIPTION
The workflow used `gh release view` (returns whichever release GitHub marks "latest", typically the most recent patch) for both the version bump and the PR diff range. When patches like v4.90.1/.2/.3 are cut between minor releases, the diff `v4.90.3..main` skips every commit that went into those patches, so the v4.91.0 changelog ends up missing them.

Switch to the last `vX.Y.0` release as the diff base so all commits since the previous minor are included regardless of any patches in between.