### PR TITLE
oracledb_cdc: extend checkpoint cache to support multiple callers

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -324,7 +324,7 @@ A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache r
 
 === `checkpoint_cache_table_name`
 
-The identifier for the checkpoint cache table name. If no `checkpoint_cache` field is specified, this input will automatically create a table and stored procedure under the `rpcn` schema to act as a checkpoint cache. This table stores the latest processed System Change Number (SCN) that has been successfully delivered, allowing Redpanda Connect to resume from that point upon restart rather than reconsume the entire redo log.
+The identifier for the checkpoint cache table name. If no `checkpoint_cache` field is specified, this input will automatically create a table and stored procedure under the `rpcn` schema to act as a checkpoint cache. This table stores the latest processed System Change Number (SCN) that has been successfully delivered, allowing Redpanda Connect to resume from that point upon restart rather than reconsume the entire redo log. When `pdb_name` is set and this field is left at its default value, the table name is automatically derived per PDB (e.g. `RPCN.CDC_CHECKPOINT_MYPDB`) to avoid SCN collisions between pipelines monitoring different PDBs. Set this field explicitly to opt out of that auto-derivation.
 
 
 *Type*: `string`

--- a/internal/impl/oracledb/checkpoint_cache.go
+++ b/internal/impl/oracledb/checkpoint_cache.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	// cache updates a single row so we use a fixed key
-	defaultCacheKey = "max_scn"
 	// defaultCheckpointCache can be configured by the user
 	defaultCheckpointCache = "RPCN.CDC_CHECKPOINT_CACHE"
 	// defaultStoredProcName schema is inferred from the provided checkpoint cache config
@@ -63,6 +61,7 @@ func newCheckpointCache(
 	ctx context.Context,
 	connStr string,
 	cacheTableName string,
+	cacheKey string,
 	log *service.Logger,
 ) (*checkpointCache, error) {
 	var (
@@ -83,7 +82,7 @@ func newCheckpointCache(
 		return nil, fmt.Errorf("connecting to oracle database for caching checkpoints: %w", err)
 	}
 
-	if created, err := createCacheTable(ctx, db, cacheTable); err != nil {
+	if created, err := createCacheTable(ctx, db, cacheTable, cacheKey, log); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("creating checkpoint cache table '%s': %w", cacheTable.String(), err)
 	} else if created {
@@ -121,15 +120,15 @@ func newCheckpointCache(
 	return c, nil
 }
 
-// Get a cache item, we only do this at start up, key can be ignored as we only ever store one entry
-func (c *checkpointCache) Get(ctx context.Context, _ string) ([]byte, error) {
+// Get a cache item, we only do this at start up
+func (c *checkpointCache) Get(ctx context.Context, key string) ([]byte, error) {
 	if c.db == nil {
 		return nil, fmt.Errorf("checkpoint cache not initialised for get operation: %w", service.ErrNotConnected)
 	}
 
 	var val []byte
 	q := "SELECT cache_val FROM %s WHERE cache_key = :1"
-	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, c.cacheTableName.String()), defaultCacheKey).Scan(&val); err != nil {
+	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, c.cacheTableName.String()), key).Scan(&val); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, service.ErrKeyNotFound
 		}
@@ -145,13 +144,13 @@ func (c *checkpointCache) Get(ctx context.Context, _ string) ([]byte, error) {
 }
 
 // Set a cache item, specifying an optional TTL. It is okay for caches to
-// ignore the ttl parameter if it isn't possible to implement. Key can be ignored as we only ever store one entry
-func (c *checkpointCache) Set(ctx context.Context, _ string, value []byte, _ *time.Duration) error {
+// ignore the ttl parameter if it isn't possible to implement.
+func (c *checkpointCache) Set(ctx context.Context, key string, value []byte, _ *time.Duration) error {
 	if c.cacheSetStmt == nil {
 		return errors.New("prepared statement for cache set not initialised")
 	}
 	// go-ora driver handles []byte parameters as RAW type
-	if _, err := c.cacheSetStmt.ExecContext(ctx, defaultCacheKey, value); err != nil {
+	if _, err := c.cacheSetStmt.ExecContext(ctx, key, value); err != nil {
 		return fmt.Errorf("writing to checkpoint cache: %w", err)
 	}
 	return nil
@@ -168,7 +167,40 @@ func (c *checkpointCache) Close(ctx context.Context) error {
 	return nil
 }
 
-func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, error) {
+// migrateCacheTable is a temporary migration function to migrate existing customers' cache. After a while this, along with the test can
+// be deleted once we're happy customers are on later versions.
+func migrateCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable, cacheKey string, log *service.Logger) error {
+	var charLen int
+	colQuery := `SELECT CHAR_LENGTH FROM all_tab_columns WHERE owner = :1 AND table_name = :2 AND column_name = 'CACHE_KEY'`
+	if err := db.QueryRowContext(ctx, colQuery, strings.ToUpper(tbl.schema), strings.ToUpper(tbl.name)).Scan(&charLen); err != nil {
+		return fmt.Errorf("checking cache_key column size: %w", err)
+	}
+
+	if charLen < 128 {
+		// Step 1 - Migrate existing tables that were created with the old VARCHAR2(10) column size.
+		log.Infof("Checkpoint Migration: Found checkpoint cache table '%s', updating cache_key schema to VARCHAR2(128)", tbl.String())
+		alterQuery := fmt.Sprintf(`ALTER TABLE %s MODIFY (cache_key VARCHAR2(128))`, tbl.String())
+		if _, err := db.ExecContext(ctx, alterQuery); err != nil {
+			return fmt.Errorf("migrating cache_key column to VARCHAR2(128): %w", err)
+		}
+
+		// Step 2 - Migrate cache key to configured value.
+		updateQuery := fmt.Sprintf(`UPDATE %s SET cache_key = :1 WHERE cache_key = 'max_scn'`, tbl.String())
+		result, err := db.ExecContext(ctx, updateQuery, cacheKey)
+		if err != nil {
+			return fmt.Errorf("migrating cache key from 'max_scn' to '%s': %w", cacheKey, err)
+		}
+		if rows, _ := result.RowsAffected(); rows > 0 {
+			log.Infof("Checkpoint Migration: Updated cache key from 'max_scn' to '%s' in '%s'", cacheKey, tbl.String())
+		}
+
+		log.Info("Checkpoint Migration: Checkpoint cache table migration applied")
+	}
+
+	return nil
+}
+
+func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable, cacheKey string, log *service.Logger) (bool, error) {
 	// Check if table exists
 	var count int
 	checkQuery := `SELECT COUNT(*) FROM all_tables WHERE owner = :1 AND table_name = :2`
@@ -177,15 +209,18 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	}
 
 	if count > 0 {
-		return false, nil // Table already exists
+		if err := migrateCacheTable(ctx, db, tbl, cacheKey, log); err != nil {
+			return false, fmt.Errorf("applying migration to cache table: %w", err)
+		}
+		// migration applied
+		return false, nil
 	}
 
 	// Create table if it doesn't exist
-	// cache_key length is based on default (fixed) cache key
 	// cache_val stores binary data as RAW (8 bytes for SCN uint64)
 	createQuery := fmt.Sprintf(`
 		CREATE TABLE %s (
-			cache_key VARCHAR2(10) NOT NULL PRIMARY KEY,
+			cache_key VARCHAR2(128) NOT NULL PRIMARY KEY,
 			cache_val RAW(8)
 		)`, tbl.String())
 

--- a/internal/impl/oracledb/checkpoint_cache.go
+++ b/internal/impl/oracledb/checkpoint_cache.go
@@ -29,6 +29,8 @@ const (
 	// defaultStoredProcName schema is inferred from the provided checkpoint cache config
 	// the stored procedure name cannot be configured by the user
 	defaultStoredProcName = "CDC_CHECKPOINT_CACHE_UPDATE"
+	// checkpointCacheKeyLimit specifies the maximum length of the checkpoint cache key
+	checkpointCacheKeyLimit = 128
 )
 
 // allowedTableIdentifiers is used for validating cache table names
@@ -72,6 +74,10 @@ func newCheckpointCache(
 	)
 	if connStr == "" {
 		return nil, errors.New("no connection string provided")
+	}
+
+	if err = validateCacheKey(cacheKey); err != nil {
+		return nil, fmt.Errorf("invalid checkpoint cache key: %w", err)
 	}
 
 	if cacheTable, err = validateCacheTableName(cacheTableName); err != nil {
@@ -177,7 +183,7 @@ func migrateCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable, cacheKey
 	}
 
 	// Step 1: Widen the cache_key column.
-	if charLen < 128 {
+	if charLen < checkpointCacheKeyLimit {
 		log.Infof("Checkpoint Migration: Found checkpoint cache table '%s', updating cache_key schema to VARCHAR2(128)", tbl.String())
 		alterQuery := fmt.Sprintf(`ALTER TABLE %s MODIFY (cache_key VARCHAR2(128))`, tbl.String())
 		if _, err := db.ExecContext(ctx, alterQuery); err != nil {
@@ -314,4 +320,15 @@ func validateCacheTableName(input string) (cacheTable, error) {
 		return cacheTable{}, errInvalidIdentifiedInTableName
 	}
 	return ct, nil
+}
+
+func validateCacheKey(key string) error {
+	if key == "" {
+		return errors.New("checkpoint cache key must not be empty")
+	}
+	// len() gives byte count, which matches Oracle's default byte-semantic VARCHAR2(128) column.
+	if len(key) > checkpointCacheKeyLimit {
+		return fmt.Errorf("checkpoint cache key must not exceed %d characters", checkpointCacheKeyLimit)
+	}
+	return nil
 }

--- a/internal/impl/oracledb/checkpoint_cache.go
+++ b/internal/impl/oracledb/checkpoint_cache.go
@@ -176,25 +176,24 @@ func migrateCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable, cacheKey
 		return fmt.Errorf("checking cache_key column size: %w", err)
 	}
 
+	// Step 1: Widen the cache_key column.
 	if charLen < 128 {
-		// Step 1 - Migrate existing tables that were created with the old VARCHAR2(10) column size.
 		log.Infof("Checkpoint Migration: Found checkpoint cache table '%s', updating cache_key schema to VARCHAR2(128)", tbl.String())
 		alterQuery := fmt.Sprintf(`ALTER TABLE %s MODIFY (cache_key VARCHAR2(128))`, tbl.String())
 		if _, err := db.ExecContext(ctx, alterQuery); err != nil {
 			return fmt.Errorf("migrating cache_key column to VARCHAR2(128): %w", err)
 		}
+	}
 
-		// Step 2 - Migrate cache key to configured value.
-		updateQuery := fmt.Sprintf(`UPDATE %s SET cache_key = :1 WHERE cache_key = 'max_scn'`, tbl.String())
-		result, err := db.ExecContext(ctx, updateQuery, cacheKey)
-		if err != nil {
-			return fmt.Errorf("migrating cache key from 'max_scn' to '%s': %w", cacheKey, err)
-		}
-		if rows, _ := result.RowsAffected(); rows > 0 {
-			log.Infof("Checkpoint Migration: Updated cache key from 'max_scn' to '%s' in '%s'", cacheKey, tbl.String())
-		}
-
-		log.Info("Checkpoint Migration: Checkpoint cache table migration applied")
+	// Step 2: Rename any legacy 'max_scn' row to the configured cache key.
+	updateQuery := fmt.Sprintf(`UPDATE %s SET cache_key = :1 WHERE cache_key = 'max_scn'`, tbl.String())
+	result, err := db.ExecContext(ctx, updateQuery, cacheKey)
+	if err != nil {
+		return fmt.Errorf("migrating cache key from 'max_scn' to '%s': %w", cacheKey, err)
+	}
+	if rows, _ := result.RowsAffected(); rows > 0 {
+		log.Infof("Checkpoint Migration: Updated cache key from 'max_scn' to '%s' in '%s'", cacheKey, tbl.String())
+		log.Info("Checkpoint Migration: Checkpoint cache table migration complete")
 	}
 
 	return nil

--- a/internal/impl/oracledb/checkpoint_cache_integration_test.go
+++ b/internal/impl/oracledb/checkpoint_cache_integration_test.go
@@ -48,7 +48,7 @@ func TestIntegrationMigrateCheckpointCache(t *testing.T) {
 		defaultCacheKeyOld = "max_scn"
 		defaultCacheKeyNew = "oracledb_cdc"
 	)
-	t.Log("Pre-creating checkpoint cache table in to simulate an existing deployment...")
+	t.Log("Pre-creating checkpoint cache table to simulate an existing deployment...")
 	{
 		cacheTableName = fmt.Sprintf("C##RPCN.CDC_CHECKPOINT_%s", strings.ToUpper(pdbName))
 		_, err = cdbDB.ExecContext(t.Context(), fmt.Sprintf(`

--- a/internal/impl/oracledb/checkpoint_cache_integration_test.go
+++ b/internal/impl/oracledb/checkpoint_cache_integration_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package oracledb_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/sijms/go-ora/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+	oracledbtest "github.com/redpanda-data/connect/v4/internal/impl/oracledb/oracledbtest"
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+// TestIntegrationMigrateCheckpointCache can be deleted once we're happy customers have migrated.
+func TestIntegrationMigrateCheckpointCache(t *testing.T) {
+	integration.CheckSkip(t)
+
+	cdbConnStr, pdbDB, pdbName := oracledbtest.SetupCDBTestWithPDB(t)
+	require.NoError(t, pdbDB.CreatePDBTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.mtfoo", "CREATE TABLE testdb.mtfoo (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+
+	cdbDB, err := sql.Open("oracle", cdbConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, cdbDB.Close()) })
+	require.NoError(t, cdbDB.PingContext(t.Context()))
+
+	var (
+		cacheTableName     string
+		expectedSCN        []byte
+		defaultCacheKeyOld = "max_scn"
+		defaultCacheKeyNew = "oracledb_cdc"
+	)
+	t.Log("Pre-creating checkpoint cache table in to simulate an existing deployment...")
+	{
+		cacheTableName = fmt.Sprintf("C##RPCN.CDC_CHECKPOINT_%s", strings.ToUpper(pdbName))
+		_, err = cdbDB.ExecContext(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			cache_key VARCHAR2(10) NOT NULL PRIMARY KEY,
+			cache_val RAW(8)
+		)`, cacheTableName))
+		require.NoError(t, err)
+
+		// testSCNBytes simulates a valid checkpoint from a prior deployment
+		var scn uint64
+		require.NoError(t, cdbDB.QueryRowContext(t.Context(), `SELECT CURRENT_SCN FROM V$DATABASE`).Scan(&scn))
+		expectedSCN = make([]byte, 8)
+		binary.LittleEndian.PutUint64(expectedSCN, scn)
+		_, err = cdbDB.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s (cache_key, cache_val) VALUES (:1, :2)`, cacheTableName), defaultCacheKeyOld, expectedSCN)
+		require.NoError(t, err)
+	}
+
+	var batch oracledbtest.Batch
+
+	t.Log("Launching component...")
+	cfg := `
+oracledb_cdc:
+  connection_string: %s
+  pdb_name: %s
+  stream_snapshot: false
+  max_parallel_snapshot_tables: 1
+  snapshot_max_batch_size: 10
+  logminer:
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.MTFOO"]
+  batching:
+    count: 500`
+
+	streamBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, cdbConnStr, pdbName)))
+	require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		batch.Lock()
+		defer batch.Unlock()
+		for _, msg := range mb {
+			msgBytes, err := msg.AsBytes()
+			assert.NoError(t, err)
+			batch.Msgs = append(batch.Msgs, string(msgBytes))
+		}
+		return nil
+	}))
+
+	stream, err := streamBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(stream.Resources())
+
+	go func() {
+		if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// Poll until the migration renames default 'max_scn' to config checkpoint_cache_key value, then immediately
+	// assert the SCN value is unchanged — the migration must only rename the key.
+	var actualSCN []byte
+	q := fmt.Sprintf(`SELECT cache_val FROM %s WHERE cache_key = :1`, cacheTableName)
+	assert.Eventually(t, func() bool {
+		return cdbDB.QueryRowContext(t.Context(), q, "oracledb_cdc").Scan(&actualSCN) == nil
+	}, time.Minute, time.Second, "expected migration to rename 'max_scn' to 'oracledb_cdc'")
+	assert.Equal(t, expectedSCN, actualSCN, "expected migration to leave SCN value unchanged")
+
+	t.Log("Verifying streaming changes...")
+	{
+		want := 1000
+		_, err = pdbDB.Exec(`
+BEGIN
+	FOR i IN 1..1000 LOOP
+		INSERT INTO testdb.mtfoo (id) VALUES (DEFAULT);
+	END LOOP;
+	COMMIT;
+END;`)
+		require.NoError(t, err)
+
+		var got int
+		assert.Eventually(t, func() bool {
+			got = batch.Count()
+			return got >= want
+		}, time.Minute*1, time.Second*1)
+		assert.Equalf(t, want, got, "Wanted %d streaming messages but got %d", want, got)
+	}
+
+	require.NoError(t, stream.StopWithin(time.Second*10))
+
+	// assert cache state via connection after the stream has fully stopped.
+	var (
+		charLen   int
+		colQuery  = `SELECT CHAR_LENGTH FROM all_tab_columns WHERE owner = 'C##RPCN' AND table_name = :1 AND column_name = 'CACHE_KEY'`
+		tableName = fmt.Sprintf("CDC_CHECKPOINT_%s", strings.ToUpper(pdbName))
+	)
+	require.NoError(t, cdbDB.QueryRowContext(t.Context(), colQuery, tableName).Scan(&charLen))
+	assert.Equal(t, 128, charLen, "expected cache_key VARCHAR2 limit to be 128")
+
+	// assert checkpoint cache key is migrated
+	var (
+		cacheKeyCount int
+		keyQuery      = fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE cache_key = :1`, cacheTableName)
+	)
+	require.NoError(t, cdbDB.QueryRowContext(t.Context(), keyQuery, defaultCacheKeyNew).Scan(&cacheKeyCount))
+	assert.Equalf(t, 1, cacheKeyCount, "expected cache key '%s' to exist in checkpoint cache", defaultCacheKeyNew)
+
+	// assert scn stored in cache as progressed
+	var (
+		finalSCNBytes []byte
+		query         = fmt.Sprintf(`SELECT cache_val FROM %s WHERE cache_key = :1`, cacheTableName)
+	)
+	require.NoError(t, cdbDB.QueryRowContext(t.Context(), query, defaultCacheKeyNew).Scan(&finalSCNBytes))
+	finalSCN := binary.LittleEndian.Uint64(finalSCNBytes)
+	initialSCN := binary.LittleEndian.Uint64(expectedSCN)
+	assert.Greaterf(t, finalSCN, initialSCN, "expected final SCN (%d) to have advanced beyond initial SCN (%d)", finalSCN, initialSCN)
+}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -254,14 +254,12 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 
 	// cache
 	// if no cache component is specified then we fall back to default SQL based version
+	if scnCacheKey, err = conf.FieldString(ociFieldCheckpointCacheKey); err != nil {
+		return nil, err
+	}
 	if conf.Contains(ociFieldCheckpointCache) {
 		if scnCache, err = conf.FieldString(ociFieldCheckpointCache); err != nil {
 			return nil, err
-		}
-		if conf.Resources().HasCache(scnCache) {
-			if scnCacheKey, err = conf.FieldString(ociFieldCheckpointCacheKey); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -392,7 +390,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 	// no cache specified so use default, internal oracle based cache
 	if o.cfg.SCNCache == "" && o.cpCache == nil {
-		c, err := newCheckpointCache(ctx, o.cfg.ConnectionString, cpCacheTable, o.log)
+		c, err := newCheckpointCache(ctx, o.cfg.ConnectionString, cpCacheTable, o.cfg.SCNCacheKey, o.log)
 		if err != nil {
 			return fmt.Errorf("initialising oracle based checkpoint cache: %w", err)
 		}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -150,7 +151,7 @@ When using the default Oracle based cache, the Connect user requires permission 
 		Optional(),
 	).
 	Field(service.NewStringField(ociFieldCheckpointCacheTableName).
-		Description("The identifier for the checkpoint cache table name. If no `" + ociFieldCheckpointCache + "` field is specified, this input will automatically create a table and stored procedure under the `rpcn` schema to act as a checkpoint cache. This table stores the latest processed System Change Number (SCN) that has been successfully delivered, allowing Redpanda Connect to resume from that point upon restart rather than reconsume the entire redo log.").
+		Description("The identifier for the checkpoint cache table name. If no `" + ociFieldCheckpointCache + "` field is specified, this input will automatically create a table and stored procedure under the `rpcn` schema to act as a checkpoint cache. This table stores the latest processed System Change Number (SCN) that has been successfully delivered, allowing Redpanda Connect to resume from that point upon restart rather than reconsume the entire redo log. When `" + ociFieldPDBName + "` is set and this field is left at its default value, the table name is automatically derived per PDB (e.g. `RPCN.CDC_CHECKPOINT_MYPDB`) to avoid SCN collisions between pipelines monitoring different PDBs. Set this field explicitly to opt out of that auto-derivation.").
 		Default(defaultCheckpointCache).
 		Example("RPCN.CHECKPOINT_CACHE").
 		Optional(),
@@ -158,6 +159,7 @@ When using the default Oracle based cache, the Connect user requires permission 
 	Field(service.NewStringField(ociFieldCheckpointCacheKey).
 		Description("The key to use to store the snapshot position in `" + ociFieldCheckpointCache + "`. An alternative key can be provided if multiple CDC inputs share the same cache.").
 		Default("oracledb_cdc").
+		LintRule(`root = if this == "" { [ "must not be empty" ] } else if this.length() > ` + strconv.Itoa(checkpointCacheKeyLimit) + ` { [ "must not exceed ` + strconv.Itoa(checkpointCacheKeyLimit) + ` characters" ] }`).
 		Optional(),
 	).
 	Field(service.NewIntField(ociFieldCheckpointLimit).


### PR DESCRIPTION
This change updates the internal OracleDB checkpoint cache to support multiple connect instances.

Upon launch if it detects the original checkpoint schema then it'll migrate it to the new schema, including:
- Updating the default cache key to the configured default, whilst leaving the SCN untouched
- Updating `CACHE_KEY` length to 128

First run that detects migration:

<img width="1918" height="497" alt="image" src="https://github.com/user-attachments/assets/345c8ffd-ea53-4b2b-b4c4-2cc83365cb0d" />

Subsequent runs shows no log output as table has been migrated:

<img width="1753" height="481" alt="image" src="https://github.com/user-attachments/assets/bcdd7013-c80f-4faa-9b62-eb6437f34df5" />

Change in table schema to allow custom cache keys and renames the key value from the original default `max_scn` to the value of `checkpoint_cache_key` between before and after runs:

Before:
<img width="645" height="311" alt="image" src="https://github.com/user-attachments/assets/c2a2cb48-02f4-4e9f-9d12-0e3e7c47b163" />

After:

<img width="489" height="296" alt="image" src="https://github.com/user-attachments/assets/3d31906a-5c03-477c-b364-a166e754c542" />

Sharing table with multiple instances, arriving at the same SCN:

<img width="474" height="164" alt="image" src="https://github.com/user-attachments/assets/963cfb1c-42b7-4320-b9a5-f01395862702" />
