### PR TITLE
Preserve Avro logical types across common-schema round-trip

### DIFF
--- a/internal/impl/confluent/common_to_avro.go
+++ b/internal/impl/confluent/common_to_avro.go
@@ -72,9 +72,51 @@ func commonToAvroInner(c schema.Common, recordName, namespace string, isRoot boo
 	case schema.Any:
 		return "bytes", nil
 	case schema.Timestamp:
+		params := c.EffectiveTimestamp()
+		var logicalType string
+		switch {
+		case params.AdjustToUTC && params.Unit == schema.TimeUnitMillis:
+			logicalType = "timestamp-millis"
+		case params.AdjustToUTC && params.Unit == schema.TimeUnitMicros:
+			logicalType = "timestamp-micros"
+		case !params.AdjustToUTC && params.Unit == schema.TimeUnitMillis:
+			logicalType = "local-timestamp-millis"
+		case !params.AdjustToUTC && params.Unit == schema.TimeUnitMicros:
+			logicalType = "local-timestamp-micros"
+		default:
+			return nil, fmt.Errorf("timestamp field %q has unsupported unit %v (only millis and micros are representable in Avro)", c.Name, params.Unit)
+		}
 		return map[string]any{
 			"type":        "long",
-			"logicalType": "timestamp-millis",
+			"logicalType": logicalType,
+		}, nil
+	case schema.Date:
+		return map[string]any{
+			"type":        "int",
+			"logicalType": "date",
+		}, nil
+	case schema.TimeOfDay:
+		if c.Logical == nil || c.Logical.TimeOfDay == nil {
+			return nil, fmt.Errorf("time-of-day field %q missing LogicalParams.TimeOfDay", c.Name)
+		}
+		switch c.Logical.TimeOfDay.Unit {
+		case schema.TimeUnitMillis:
+			return map[string]any{
+				"type":        "int",
+				"logicalType": "time-millis",
+			}, nil
+		case schema.TimeUnitMicros:
+			return map[string]any{
+				"type":        "long",
+				"logicalType": "time-micros",
+			}, nil
+		default:
+			return nil, fmt.Errorf("time-of-day field %q has unsupported unit %v (only millis and micros are representable in Avro)", c.Name, c.Logical.TimeOfDay.Unit)
+		}
+	case schema.UUID:
+		return map[string]any{
+			"type":        "string",
+			"logicalType": "uuid",
 		}, nil
 	case schema.Decimal:
 		if c.Logical == nil || c.Logical.Decimal == nil {

--- a/internal/impl/confluent/common_to_avro_logical_type_test.go
+++ b/internal/impl/confluent/common_to_avro_logical_type_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+// TestCommonToAvroLogicalTypes is the encode-side counterpart to
+// TestEcsAvroFromBytesLogicalTypes. It pins that every common-schema
+// logical type round-trips into the matching Avro logical-type
+// annotation, including the precision/timezone parameters carried by
+// the LogicalParams payload — so a Timestamp with Unit=Micros is not
+// silently flattened to timestamp-millis, and a local-time field is
+// not silently promoted to UTC.
+//
+// `BigDecimal` is intentionally omitted: it has no fixed precision and
+// is rejected at encode time by design (see TestCommonToAvroBigDecimalRejected).
+// `duration` (Avro fixed-12) is omitted on both encode and decode
+// because benthos has no corresponding common-schema type.
+func TestCommonToAvroLogicalTypes(t *testing.T) {
+	cases := []struct {
+		name            string
+		in              schema.Common
+		wantType        string
+		wantLogicalType string
+	}{
+		{
+			name: "timestamp-millis",
+			in: schema.Common{
+				Type: schema.Timestamp,
+				Logical: &schema.LogicalParams{
+					Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true},
+				},
+			},
+			wantType:        "long",
+			wantLogicalType: "timestamp-millis",
+		},
+		{
+			name: "timestamp-micros",
+			in: schema.Common{
+				Type: schema.Timestamp,
+				Logical: &schema.LogicalParams{
+					Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true},
+				},
+			},
+			wantType:        "long",
+			wantLogicalType: "timestamp-micros",
+		},
+		{
+			name: "local-timestamp-millis",
+			in: schema.Common{
+				Type: schema.Timestamp,
+				Logical: &schema.LogicalParams{
+					Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+				},
+			},
+			wantType:        "long",
+			wantLogicalType: "local-timestamp-millis",
+		},
+		{
+			name: "local-timestamp-micros",
+			in: schema.Common{
+				Type: schema.Timestamp,
+				Logical: &schema.LogicalParams{
+					Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+				},
+			},
+			wantType:        "long",
+			wantLogicalType: "local-timestamp-micros",
+		},
+		{
+			name:            "date",
+			in:              schema.Common{Type: schema.Date},
+			wantType:        "int",
+			wantLogicalType: "date",
+		},
+		{
+			name: "time-millis",
+			in: schema.Common{
+				Type: schema.TimeOfDay,
+				Logical: &schema.LogicalParams{
+					TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+				},
+			},
+			wantType:        "int",
+			wantLogicalType: "time-millis",
+		},
+		{
+			name: "time-micros",
+			in: schema.Common{
+				Type: schema.TimeOfDay,
+				Logical: &schema.LogicalParams{
+					TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+				},
+			},
+			wantType:        "long",
+			wantLogicalType: "time-micros",
+		},
+		{
+			name:            "uuid",
+			in:              schema.Common{Type: schema.UUID},
+			wantType:        "string",
+			wantLogicalType: "uuid",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := avroUnmarshal(t, tc.in, "", "")
+			m, ok := got.(map[string]any)
+			if !ok {
+				t.Fatalf("expected map representing a logical-type annotation, got %T: %v", got, got)
+			}
+			assert.Equal(t, tc.wantType, m["type"], "underlying Avro type")
+			assert.Equal(t, tc.wantLogicalType, m["logicalType"], "Avro logicalType annotation")
+		})
+	}
+}

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -270,28 +270,76 @@ func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, err
 		return schema.Common{}, fmt.Errorf("expected `type` field of type string or array, got %T", t)
 	}
 
-	if logical, ok := as["logicalType"].(string); ok && logical == "decimal" {
-		p, err := avroSpecInt32(as["precision"])
-		if err != nil {
-			return schema.Common{}, fmt.Errorf("decimal precision: %w", err)
-		}
-		// Per the Avro spec scale is optional and defaults to 0 when absent;
-		// only an unparseable scale value (wrong type, non-integer) is an error.
-		var s int32
-		if _, present := as["scale"]; present {
-			s, err = avroSpecInt32(as["scale"])
+	if logical, ok := as["logicalType"].(string); ok {
+		switch logical {
+		case "decimal":
+			p, err := avroSpecInt32(as["precision"])
 			if err != nil {
-				return schema.Common{}, fmt.Errorf("decimal scale: %w", err)
+				return schema.Common{}, fmt.Errorf("decimal precision: %w", err)
 			}
+			// Per the Avro spec scale is optional and defaults to 0 when absent;
+			// only an unparseable scale value (wrong type, non-integer) is an error.
+			var s int32
+			if _, present := as["scale"]; present {
+				s, err = avroSpecInt32(as["scale"])
+				if err != nil {
+					return schema.Common{}, fmt.Errorf("decimal scale: %w", err)
+				}
+			}
+			c.Type = schema.Decimal
+			c.Logical = &schema.LogicalParams{
+				Decimal: &schema.DecimalParams{Precision: p, Scale: s},
+			}
+			if err := c.Validate(); err != nil {
+				return schema.Common{}, fmt.Errorf("decimal field: %w", err)
+			}
+			return c, nil
+		case "timestamp-millis":
+			c.Type = schema.Timestamp
+			c.Logical = &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true},
+			}
+			return c, nil
+		case "timestamp-micros":
+			c.Type = schema.Timestamp
+			c.Logical = &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true},
+			}
+			return c, nil
+		case "local-timestamp-millis":
+			c.Type = schema.Timestamp
+			c.Logical = &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+			}
+			return c, nil
+		case "local-timestamp-micros":
+			c.Type = schema.Timestamp
+			c.Logical = &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+			}
+			return c, nil
+		case "date":
+			c.Type = schema.Date
+			return c, nil
+		case "time-millis":
+			c.Type = schema.TimeOfDay
+			c.Logical = &schema.LogicalParams{
+				TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+			}
+			return c, nil
+		case "time-micros":
+			c.Type = schema.TimeOfDay
+			c.Logical = &schema.LogicalParams{
+				TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+			}
+			return c, nil
+		case "uuid":
+			c.Type = schema.UUID
+			return c, nil
 		}
-		c.Type = schema.Decimal
-		c.Logical = &schema.LogicalParams{
-			Decimal: &schema.DecimalParams{Precision: p, Scale: s},
-		}
-		if err := c.Validate(); err != nil {
-			return schema.Common{}, fmt.Errorf("decimal field: %w", err)
-		}
-		return c, nil
+		// Unknown logicalType: per the Avro spec, ignore unrecognised
+		// logical-type annotations and fall back to the underlying
+		// primitive type already set above.
 	}
 
 	switch c.Type {

--- a/internal/impl/confluent/ecs_avro_logical_type_test.go
+++ b/internal/impl/confluent/ecs_avro_logical_type_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+// TestEcsAvroFromBytesLogicalTypes covers every Avro logical type the
+// Avro 1.11 spec defines that has a corresponding type in benthos's
+// common schema. Each case parses a single-field Avro record and
+// asserts both the resulting CommonType and the LogicalParams payload
+// (where applicable) — so a fix that maps every logical type to the
+// same Common.Type without preserving precision/UTC semantics still
+// fails.
+//
+// `duration` is intentionally omitted because benthos has no
+// corresponding common-schema type for Avro's 12-byte month/day/ms
+// triple.
+func TestEcsAvroFromBytesLogicalTypes(t *testing.T) {
+	cases := []struct {
+		name        string
+		avroType    string
+		wantType    schema.CommonType
+		wantLogical *schema.LogicalParams
+	}{
+		{
+			name:     "timestamp-millis",
+			avroType: `{"type": "long", "logicalType": "timestamp-millis"}`,
+			wantType: schema.Timestamp,
+			wantLogical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true},
+			},
+		},
+		{
+			name:     "timestamp-micros",
+			avroType: `{"type": "long", "logicalType": "timestamp-micros"}`,
+			wantType: schema.Timestamp,
+			wantLogical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: true},
+			},
+		},
+		{
+			name:     "local-timestamp-millis",
+			avroType: `{"type": "long", "logicalType": "local-timestamp-millis"}`,
+			wantType: schema.Timestamp,
+			wantLogical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+			},
+		},
+		{
+			name:     "local-timestamp-micros",
+			avroType: `{"type": "long", "logicalType": "local-timestamp-micros"}`,
+			wantType: schema.Timestamp,
+			wantLogical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+			},
+		},
+		{
+			name:     "date",
+			avroType: `{"type": "int", "logicalType": "date"}`,
+			wantType: schema.Date,
+		},
+		{
+			name:     "time-millis",
+			avroType: `{"type": "int", "logicalType": "time-millis"}`,
+			wantType: schema.TimeOfDay,
+			wantLogical: &schema.LogicalParams{
+				TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+			},
+		},
+		{
+			name:     "time-micros",
+			avroType: `{"type": "long", "logicalType": "time-micros"}`,
+			wantType: schema.TimeOfDay,
+			wantLogical: &schema.LogicalParams{
+				TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+			},
+		},
+		{
+			name:     "uuid",
+			avroType: `{"type": "string", "logicalType": "uuid"}`,
+			wantType: schema.UUID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := fmt.Appendf(nil, `{
+				"type": "record",
+				"name": "Event",
+				"fields": [
+					{"name": "f", "type": %s}
+				]
+			}`, tc.avroType)
+
+			c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+			require.NoError(t, err)
+			require.Equal(t, schema.Object, c.Type)
+			require.Len(t, c.Children, 1)
+
+			field := c.Children[0]
+			assert.Equal(t, "f", field.Name)
+			assert.Equal(t, tc.wantType, field.Type)
+			if tc.wantLogical == nil {
+				assert.Nil(t, field.Logical)
+			} else {
+				assert.Equal(t, tc.wantLogical, field.Logical)
+			}
+		})
+	}
+}

--- a/internal/impl/iceberg/type_resolver.go
+++ b/internal/impl/iceberg/type_resolver.go
@@ -238,7 +238,20 @@ func commonTypeToIcebergTypeRec(c *schema.Common, ti *typeInferrer) (iceberg.Typ
 	case schema.ByteArray:
 		return iceberg.BinaryType{}, nil
 	case schema.Timestamp:
-		return iceberg.TimestampTzType{}, nil
+		// Iceberg's timestamptz models a UTC instant; timestamp models a
+		// local civil datetime without a timezone. Map AdjustToUTC
+		// accordingly. EffectiveTimestamp supplies the {Millis, UTC=true}
+		// default for legacy schemas that carry no LogicalParams.
+		if c.EffectiveTimestamp().AdjustToUTC {
+			return iceberg.TimestampTzType{}, nil
+		}
+		return iceberg.TimestampType{}, nil
+	case schema.Date:
+		return iceberg.DateType{}, nil
+	case schema.TimeOfDay:
+		return iceberg.TimeType{}, nil
+	case schema.UUID:
+		return iceberg.UUIDType{}, nil
 	case schema.Decimal:
 		if c.Logical == nil || c.Logical.Decimal == nil {
 			return nil, fmt.Errorf("decimal field %q is missing precision/scale", c.Name)

--- a/internal/impl/iceberg/type_resolver_test.go
+++ b/internal/impl/iceberg/type_resolver_test.go
@@ -90,6 +90,26 @@ func TestCommonTypeToIcebergType(t *testing.T) {
 		{"String", schema.Common{Type: schema.String}, "string", false},
 		{"ByteArray", schema.Common{Type: schema.ByteArray}, "binary", false},
 		{"Timestamp", schema.Common{Type: schema.Timestamp}, "timestamptz", false},
+		{"Timestamp UTC", schema.Common{
+			Type: schema.Timestamp,
+			Logical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: true},
+			},
+		}, "timestamptz", false},
+		{"Timestamp local", schema.Common{
+			Type: schema.Timestamp,
+			Logical: &schema.LogicalParams{
+				Timestamp: &schema.TimestampParams{Unit: schema.TimeUnitMillis, AdjustToUTC: false},
+			},
+		}, "timestamp", false},
+		{"Date", schema.Common{Type: schema.Date}, "date", false},
+		{"TimeOfDay", schema.Common{
+			Type: schema.TimeOfDay,
+			Logical: &schema.LogicalParams{
+				TimeOfDay: &schema.TimeOfDayParams{Unit: schema.TimeUnitMicros, AdjustToUTC: false},
+			},
+		}, "time", false},
+		{"UUID", schema.Common{Type: schema.UUID}, "uuid", false},
 		{"Any fallback", schema.Common{Type: schema.Any}, "string", false},
 		{"Null fallback", schema.Common{Type: schema.Null}, "string", false},
 		{"Object", schema.Common{


### PR DESCRIPTION
## Summary

Extends Avro logical-type handling on both the encode (`commonToAvroInner`) and decode (`ecsAvroFromAnyMap`) sides of the Schema Registry processors, and broadens the Iceberg type resolver to consume the now-richer common-schema types it receives. Prior to this change only `decimal` round-tripped correctly; every other Avro 1.11 logical type was either silently flattened to its underlying primitive on decode (`timestamp-millis`, `timestamp-micros`, `local-timestamp-millis`, `local-timestamp-micros`, `date`, `time-millis`, `time-micros`, `uuid`) or, on encode, either silently flattened (the `timestamp-*` family) or rejected outright with `unsupported schema type` (`date`, `TimeOfDay`, `UUID`).

Builds on the foundation laid by #4401, which began addressing this class of fidelity loss.

## Breaking changes

The following behaviours change in ways that may affect existing pipelines that flow data through `schema_registry_encode` / `schema_registry_decode` with `store_schema_metadata` set, or any downstream consumer that reads `meta(\"schema\")`:

1. **Avro `timestamp-millis` / `timestamp-micros` no longer decode as `Int64` in the common schema.** They now decode as `schema.Timestamp` with `AdjustToUTC=true` and the matching unit. Downstream consumers (notably the Iceberg output) that previously inferred `BIGINT` will now see a `TIMESTAMP`-shaped column.
2. **`local-timestamp-millis` / `local-timestamp-micros` are now distinguished from their UTC siblings.** They decode as `schema.Timestamp` with `AdjustToUTC=false` and encode as the matching `local-timestamp-*` annotation rather than being silently promoted to `timestamp-millis`.
3. **`schema.Timestamp` with `AdjustToUTC=false` now maps to Iceberg `timestamp` (no timezone)** instead of `timestamptz`. The historical default (no `LogicalParams.Timestamp` set) is preserved as `timestamptz` via `Common.EffectiveTimestamp()`.
4. **`schema.Timestamp` with `Unit=Micros` is now encoded as Avro `timestamp-micros`** rather than being silently downgraded to `timestamp-millis`. Pipelines that relied on the precision loss to compress timestamps into millisecond grids will see microsecond values flow through end-to-end.
5. **Avro `date`, `time-millis`, `time-micros`, and `uuid` now decode as their dedicated common-schema types** (`schema.Date`, `schema.TimeOfDay`, `schema.UUID`) instead of falling back to `Int32` / `Int64` / `String`.
6. **The same four types now encode correctly from common schema** instead of returning `unsupported schema type: ...`. Pipelines that previously errored at `commonToAvroInner` on encountering a `schema.Date` will now succeed.
7. **Iceberg `commonTypeToIcebergType` now produces `DateType`, `TimeType`, `UUIDType`, and `TimestampType` (in addition to the previously-supported `TimestampTzType`).** The iceberg-side parquet writer, shredder, and stats paths already handle all five, so this is purely an entry-point unlock.

## Customer-visible behaviour changes

- An Oracle `DATE` or Postgres `TIMESTAMP` column flowing through `oracle_cdc` (or any other CDC source that emits `schema.Timestamp`) → `schema_registry_encode` (avro) → `schema_registry_decode` → `iceberg` will now land as an Iceberg `TIMESTAMP` / `TIMESTAMPTZ` rather than a `BIGINT`.
- A `Timestamp{AdjustToUTC=false}` (a wall-clock datetime with no timezone) is no longer silently reinterpreted as a UTC instant when encoded to Avro — values that were previously off by the configured timezone offset will now flow through unchanged.
- Pipelines that pushed `schema.Date`, `schema.TimeOfDay`, or `schema.UUID` into `schema_registry_encode` will start succeeding where they previously errored out at encode time.
- Pipelines that received Avro `uuid` / `date` / `time-*` columns will now see them surfaced as the dedicated common-schema types downstream rather than as opaque strings/ints; downstream sinks that are sensitive to the common type (e.g. iceberg) will write the matching column type instead of an ambiguous primitive.

## Why this is an improvement

- **Avro fidelity.** A column declared as Oracle `DATE` or Postgres `TIMESTAMP` no longer collapses to an opaque `BIGINT` after a `schema_registry_encode` → `schema_registry_decode` round-trip. The semantic intent of the source schema survives the trip across the wire.
- **No more silent data shifts.** Encoding a `Timestamp{AdjustToUTC=false}` no longer reinterprets a wall-clock datetime as a UTC instant — a class of bug that produced timezone-shifted values without any error signal.
- **No more silent precision loss.** Encoding a `Timestamp{Unit=Micros}` no longer downgrades the value to milliseconds; consumers that rely on microsecond fidelity (Postgres `timestamptz`, Iceberg `timestamp(6)`) now receive what was sent.
- **Symmetric coverage.** Every Avro 1.11 logical type that has a matching `schema.Common` representation is now handled in both directions through a single switch in each direction, which is the single source of truth.

## Test plan

- [x] New `TestEcsAvroFromBytesLogicalTypes` table-driven test covers the eight logical types on the decode side, asserting both `CommonType` and the `LogicalParams` payload so a fix that flattens millis/micros/UTC/local variants still fails.
- [x] New `TestCommonToAvroLogicalTypes` table-driven test covers the same eight on the encode side, asserting the emitted `type` + `logicalType` shape.
- [x] `TestCommonTypeToIcebergType` extended with `Date`, `TimeOfDay`, `UUID`, `Timestamp UTC`, and `Timestamp local` cases.
- [x] `task fmt` clean.
- [x] `task lint` clean (0 issues).
- [x] `task test` clean (136 packages, 0 failures).

## Out of scope

`internal/impl/confluent/common_to_json_schema.go` and `internal/impl/parquet/processor_encode.go` exhibit the same shape of gap (Timestamp handled, Date/TimeOfDay/UUID absent). Those are intentionally left for a follow-up to keep this change focused on the Schema Registry → Iceberg path.