### PR TITLE
WIP: hdfs: add Kerberos authentication support

### DIFF
--- a/docs/modules/components/pages/inputs/hdfs.adoc
+++ b/docs/modules/components/pages/inputs/hdfs.adoc
@@ -25,8 +25,15 @@ component_type_dropdown::[]
 
 Reads files from a HDFS directory, where each discrete file will be consumed as a single message payload.
 
+
+[tabs]
+======
+Common::
++
+--
+
 ```yml
-# Config fields, showing default values
+# Common config fields, showing default values
 input:
   label: ""
   hdfs:
@@ -34,6 +41,32 @@ input:
     user: ""
     directory: "" # No default (required)
 ```
+
+--
+Advanced::
++
+--
+
+```yml
+# All config fields, showing default values
+input:
+  label: ""
+  hdfs:
+    hosts: [] # No default (required)
+    user: ""
+    auth:
+      kerberos:
+        enabled: false
+        krb5_conf: /etc/krb5.conf
+        keytab: ""
+        principal: ""
+        service_principal: nn/_HOST
+        data_transfer_protection: ""
+    directory: "" # No default (required)
+```
+
+--
+======
 
 == Metadata
 
@@ -64,6 +97,76 @@ hosts: localhost:9000
 === `user`
 
 A user ID to connect as.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth`
+
+Optional HDFS authentication settings.
+
+
+*Type*: `object`
+
+
+=== `auth.kerberos`
+
+Kerberos authentication settings.
+
+
+*Type*: `object`
+
+
+=== `auth.kerberos.enabled`
+
+Whether to use Kerberos authentication.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `auth.kerberos.krb5_conf`
+
+The path to a krb5.conf file.
+
+
+*Type*: `string`
+
+*Default*: `"/etc/krb5.conf"`
+
+=== `auth.kerberos.keytab`
+
+The path to a Kerberos keytab file. The Connect process must be able to read this file.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth.kerberos.principal`
+
+The Kerberos principal to authenticate as, in the form username@REALM. Service principals may include a slash in the username, such as connect/worker@EXAMPLE.COM.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth.kerberos.service_principal`
+
+The Kerberos service principal name for HDFS namenodes. The special string _HOST can be used for hostname substitution.
+
+
+*Type*: `string`
+
+*Default*: `"nn/_HOST"`
+
+=== `auth.kerberos.data_transfer_protection`
+
+The HDFS data transfer protection level. HDFS input reads currently support "authentication" or empty. The "integrity" and "privacy" modes are not supported for input reads.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/hdfs.adoc
+++ b/docs/modules/components/pages/outputs/hdfs.adoc
@@ -61,6 +61,14 @@ output:
   hdfs:
     hosts: [] # No default (required)
     user: ""
+    auth:
+      kerberos:
+        enabled: false
+        krb5_conf: /etc/krb5.conf
+        keytab: ""
+        principal: ""
+        service_principal: nn/_HOST
+        data_transfer_protection: ""
     directory: "" # No default (required)
     path: ${!counter()}-${!timestamp_unix_nano()}.txt
     max_in_flight: 64
@@ -100,6 +108,76 @@ hosts: localhost:9000
 === `user`
 
 A user ID to connect as.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth`
+
+Optional HDFS authentication settings.
+
+
+*Type*: `object`
+
+
+=== `auth.kerberos`
+
+Kerberos authentication settings.
+
+
+*Type*: `object`
+
+
+=== `auth.kerberos.enabled`
+
+Whether to use Kerberos authentication.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `auth.kerberos.krb5_conf`
+
+The path to a krb5.conf file.
+
+
+*Type*: `string`
+
+*Default*: `"/etc/krb5.conf"`
+
+=== `auth.kerberos.keytab`
+
+The path to a Kerberos keytab file. The Connect process must be able to read this file.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth.kerberos.principal`
+
+The Kerberos principal to authenticate as, in the form username@REALM. Service principals may include a slash in the username, such as connect/worker@EXAMPLE.COM.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auth.kerberos.service_principal`
+
+The Kerberos service principal name for HDFS namenodes. The special string _HOST can be used for hostname substitution.
+
+
+*Type*: `string`
+
+*Default*: `"nn/_HOST"`
+
+=== `auth.kerberos.data_transfer_protection`
+
+The HDFS data transfer protection level. Must match the target HDFS cluster configuration when set. Valid values are "authentication", "integrity", "privacy", or empty.
 
 
 *Type*: `string`

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/clbanning/mxj/v2 v2.7.0
-	github.com/colinmarc/hdfs v1.1.3
+	github.com/colinmarc/hdfs/v2 v2.4.0
 	github.com/couchbase/gocb/v2 v2.12.1
 	github.com/cyborginc/cyborgdb-go v0.15.0
 	github.com/databricks/databricks-sql-go v1.10.0
@@ -477,7 +477,7 @@ require (
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.7.6 // indirect
-	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.18.5

--- a/go.sum
+++ b/go.sum
@@ -587,9 +587,9 @@ github.com/cockroachdb/apd/v3 v3.2.2 h1:R1VaDQkMR321HBM6+6b2eYZfxi0ybPJgUh0Ztr7t
 github.com/cockroachdb/apd/v3 v3.2.2/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/cohere-ai/cohere-go/v2 v2.16.2 h1:r4jiShwcbiaddvhylzeai+9S1NNzZUGVkSGTq2ormnQ=
 github.com/cohere-ai/cohere-go/v2 v2.16.2/go.mod h1:MuiJkCxlR18BDV2qQPbz2Yb/OCVphT1y6nD2zYaKeR0=
-github.com/colinmarc/hdfs v1.1.3 h1:662salalXLFmp+ctD+x0aG+xOg62lnVnOJHksXYpFBw=
-github.com/colinmarc/hdfs v1.1.3/go.mod h1:0DumPviB681UcSuJErAbDIOx6SIaJWj463TymfZG02I=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
+github.com/colinmarc/hdfs/v2 v2.4.0 h1:v6R8oBx/Wu9fHpdPoJJjpGSUxo8NhHIwrwsfhFvU9W0=
+github.com/colinmarc/hdfs/v2 v2.4.0/go.mod h1:0NAO+/3knbMx6+5pCv+Hcbaz4xn/Zzbn9+WIib2rKVI=
 github.com/compose-spec/compose-go/v2 v2.10.2 h1:USa1NUbDcl/cjb8T9iwnuFsnO79H+2ho2L5SjFKz3uI=
 github.com/compose-spec/compose-go/v2 v2.10.2/go.mod h1:ZU6zlcweCZKyiB7BVfCizQT9XmkEIMFE+PRZydVcsZg=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=

--- a/internal/impl/hdfs/config.go
+++ b/internal/impl/hdfs/config.go
@@ -1,0 +1,240 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hdfs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/colinmarc/hdfs/v2"
+	krbclient "github.com/jcmturner/gokrb5/v8/client"
+	krbconfig "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+const (
+	fieldHosts = "hosts"
+	fieldUser  = "user"
+
+	fieldAuth                            = "auth"
+	fieldKerberos                        = "kerberos"
+	fieldKerberosEnabled                 = "enabled"
+	fieldKerberosKrb5Conf                = "krb5_conf"
+	fieldKerberosKeytab                  = "keytab"
+	fieldKerberosPrincipal               = "principal"
+	fieldKerberosServicePrincipal        = "service_principal"
+	fieldKerberosDataTransferProtection  = "data_transfer_protection"
+	defaultKerberosServicePrincipal      = "nn/_HOST"
+	defaultKerberosKrb5Conf              = "/etc/krb5.conf"
+	dataTransferProtectionAuthentication = hdfs.DataTransferProtectionAuthentication
+	dataTransferProtectionIntegrity      = hdfs.DataTransferProtectionIntegrity
+	dataTransferProtectionPrivacy        = hdfs.DataTransferProtectionPrivacy
+)
+
+type hdfsConfig struct {
+	hosts    []string
+	user     string
+	kerberos hdfsKerberosConfig
+}
+
+type hdfsKerberosConfig struct {
+	enabled                bool
+	krb5Conf               string
+	keytab                 string
+	principal              string
+	servicePrincipal       string
+	dataTransferProtection string
+}
+
+func hdfsCommonFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewStringListField(fieldHosts).
+			Description("A list of target host addresses to connect to.").
+			Example("localhost:9000"),
+		service.NewStringField(fieldUser).
+			Description("A user ID to connect as.").
+			Default(""),
+	}
+}
+
+func hdfsAuthField() *service.ConfigField {
+	return hdfsAuthFieldWithDataTransferProtectionDescription(`The HDFS data transfer protection level. Must match the target HDFS cluster configuration when set. Valid values are "authentication", "integrity", "privacy", or empty.`)
+}
+
+func hdfsInputAuthField() *service.ConfigField {
+	return hdfsAuthFieldWithDataTransferProtectionDescription(`The HDFS data transfer protection level. HDFS input reads currently support "authentication" or empty. The "integrity" and "privacy" modes are not supported for input reads.`)
+}
+
+func hdfsAuthFieldWithDataTransferProtectionDescription(dataTransferProtectionDescription string) *service.ConfigField {
+	return service.NewObjectField(fieldAuth,
+		service.NewObjectField(fieldKerberos,
+			service.NewBoolField(fieldKerberosEnabled).
+				Description("Whether to use Kerberos authentication.").
+				Default(false),
+			service.NewStringField(fieldKerberosKrb5Conf).
+				Description("The path to a krb5.conf file.").
+				Default(defaultKerberosKrb5Conf),
+			service.NewStringField(fieldKerberosKeytab).
+				Description("The path to a Kerberos keytab file. The Connect process must be able to read this file.").
+				Default(""),
+			service.NewStringField(fieldKerberosPrincipal).
+				Description("The Kerberos principal to authenticate as, in the form username@REALM. Service principals may include a slash in the username, such as connect/worker@EXAMPLE.COM.").
+				Default(""),
+			service.NewStringField(fieldKerberosServicePrincipal).
+				Description("The Kerberos service principal name for HDFS namenodes. The special string _HOST can be used for hostname substitution.").
+				Default(defaultKerberosServicePrincipal),
+			service.NewStringField(fieldKerberosDataTransferProtection).
+				Description(dataTransferProtectionDescription).
+				Default(""),
+		).Description("Kerberos authentication settings.").Optional(),
+	).Description("Optional HDFS authentication settings.").Advanced().Optional()
+}
+
+func hdfsConfigFromParsed(conf *service.ParsedConfig) (c hdfsConfig, err error) {
+	if c.hosts, err = conf.FieldStringList(fieldHosts); err != nil {
+		return
+	}
+	if c.user, err = conf.FieldString(fieldUser); err != nil {
+		return
+	}
+	if c.kerberos, err = hdfsKerberosConfigFromParsed(conf); err != nil {
+		return
+	}
+	err = c.kerberos.validate()
+	return
+}
+
+func hdfsInputConfigFromParsed(conf *service.ParsedConfig) (c hdfsConfig, err error) {
+	if c, err = hdfsConfigFromParsed(conf); err != nil {
+		return
+	}
+	err = c.validateInput()
+	return
+}
+
+func hdfsKerberosConfigFromParsed(conf *service.ParsedConfig) (c hdfsKerberosConfig, err error) {
+	if !conf.Contains(fieldAuth) {
+		return
+	}
+	authConf := conf.Namespace(fieldAuth)
+	if !authConf.Contains(fieldKerberos) {
+		return
+	}
+	kerberosConf := authConf.Namespace(fieldKerberos)
+	if c.enabled, err = kerberosConf.FieldBool(fieldKerberosEnabled); err != nil {
+		return
+	}
+	if c.krb5Conf, err = kerberosConf.FieldString(fieldKerberosKrb5Conf); err != nil {
+		return
+	}
+	if c.keytab, err = kerberosConf.FieldString(fieldKerberosKeytab); err != nil {
+		return
+	}
+	if c.principal, err = kerberosConf.FieldString(fieldKerberosPrincipal); err != nil {
+		return
+	}
+	if c.servicePrincipal, err = kerberosConf.FieldString(fieldKerberosServicePrincipal); err != nil {
+		return
+	}
+	if c.dataTransferProtection, err = kerberosConf.FieldString(fieldKerberosDataTransferProtection); err != nil {
+		return
+	}
+	return
+}
+
+func (c hdfsKerberosConfig) validate() error {
+	if !c.enabled {
+		return nil
+	}
+	if c.keytab == "" {
+		return errors.New("auth.kerberos.keytab is required when Kerberos is enabled")
+	}
+	if c.principal == "" {
+		return errors.New("auth.kerberos.principal is required when Kerberos is enabled")
+	}
+	if _, _, err := splitKerberosPrincipal(c.principal); err != nil {
+		return fmt.Errorf("auth.kerberos.principal is invalid: %w", err)
+	}
+	switch c.dataTransferProtection {
+	case "", dataTransferProtectionAuthentication, dataTransferProtectionIntegrity, dataTransferProtectionPrivacy:
+		return nil
+	default:
+		return fmt.Errorf("auth.kerberos.data_transfer_protection must be one of %q, %q, %q, or empty", dataTransferProtectionAuthentication, dataTransferProtectionIntegrity, dataTransferProtectionPrivacy)
+	}
+}
+
+func (c hdfsConfig) validateInput() error {
+	if !c.kerberos.enabled {
+		return nil
+	}
+	switch c.kerberos.dataTransferProtection {
+	case "", dataTransferProtectionAuthentication:
+		return nil
+	case dataTransferProtectionIntegrity, dataTransferProtectionPrivacy:
+		return fmt.Errorf("auth.kerberos.data_transfer_protection %q is not supported for the hdfs input; use %q or leave it empty", c.kerberos.dataTransferProtection, dataTransferProtectionAuthentication)
+	default:
+		return c.kerberos.validate()
+	}
+}
+
+func (c hdfsConfig) clientOptions() (hdfs.ClientOptions, error) {
+	opts := hdfs.ClientOptions{
+		Addresses: c.hosts,
+		User:      c.user,
+	}
+	if !c.kerberos.enabled {
+		return opts, nil
+	}
+
+	krbClient, err := c.kerberos.client()
+	if err != nil {
+		return opts, err
+	}
+	opts.KerberosClient = krbClient
+	opts.KerberosServicePrincipleName = c.kerberos.servicePrincipal
+	opts.DataTransferProtection = c.kerberos.dataTransferProtection
+	return opts, nil
+}
+
+func (c hdfsKerberosConfig) client() (*krbclient.Client, error) {
+	krbConf, err := krbconfig.Load(c.krb5Conf)
+	if err != nil {
+		return nil, fmt.Errorf("loading krb5.conf: %w", err)
+	}
+	kt, err := keytab.Load(c.keytab)
+	if err != nil {
+		return nil, fmt.Errorf("loading keytab: %w", err)
+	}
+	username, realm, err := splitKerberosPrincipal(c.principal)
+	if err != nil {
+		return nil, err
+	}
+	client := krbclient.NewWithKeytab(username, realm, kt, krbConf)
+	if err := client.Login(); err != nil {
+		return nil, fmt.Errorf("kerberos login: %w", err)
+	}
+	return client, nil
+}
+
+func splitKerberosPrincipal(principal string) (string, string, error) {
+	username, realm, ok := strings.Cut(principal, "@")
+	if !ok || username == "" || realm == "" {
+		return "", "", errors.New("expected format username@REALM")
+	}
+	return username, realm, nil
+}

--- a/internal/impl/hdfs/config_test.go
+++ b/internal/impl/hdfs/config_test.go
@@ -1,0 +1,274 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hdfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestHDFSOutputConfigParsing(t *testing.T) {
+	env := service.NewEnvironment()
+
+	tests := []struct {
+		name        string
+		config      string
+		errContains string
+	}{
+		{
+			name: "old config without auth",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+path: ${!counter()}.txt
+`,
+		},
+		{
+			name: "kerberos disabled does not require credentials",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+auth:
+  kerberos:
+    enabled: false
+`,
+		},
+		{
+			name: "kerberos enabled",
+			config: `
+hosts: [namenode.example.com:8020]
+user: connect
+directory: /events
+auth:
+  kerberos:
+    enabled: true
+    krb5_conf: /etc/krb5.conf
+    keytab: /etc/security/keytabs/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    service_principal: nn/_HOST
+    data_transfer_protection: privacy
+`,
+		},
+		{
+			name: "kerberos missing keytab",
+			config: `
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    principal: connect/worker@EXAMPLE.COM
+`,
+			errContains: "auth.kerberos.keytab is required",
+		},
+		{
+			name: "kerberos missing principal",
+			config: `
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+`,
+			errContains: "auth.kerberos.principal is required",
+		},
+		{
+			name: "kerberos invalid principal",
+			config: `
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect
+`,
+			errContains: "auth.kerberos.principal is invalid",
+		},
+		{
+			name: "invalid data transfer protection",
+			config: `
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    data_transfer_protection: invalid
+`,
+			errContains: "auth.kerberos.data_transfer_protection",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := outputSpec().ParseYAML(test.config, env)
+			require.NoError(t, err)
+			_, err = hdfsConfigFromParsed(parsed)
+			if test.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.errContains)
+		})
+	}
+}
+
+func TestHDFSInputConfigParsing(t *testing.T) {
+	env := service.NewEnvironment()
+
+	tests := []struct {
+		name        string
+		config      string
+		errContains string
+	}{
+		{
+			name: "old config without auth",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+`,
+		},
+		{
+			name: "kerberos enabled with empty data transfer protection",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+`,
+		},
+		{
+			name: "kerberos enabled with authentication",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    data_transfer_protection: authentication
+`,
+		},
+		{
+			name: "kerberos enabled with integrity",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    data_transfer_protection: integrity
+`,
+			errContains: `auth.kerberos.data_transfer_protection "integrity" is not supported for the hdfs input`,
+		},
+		{
+			name: "kerberos enabled with privacy",
+			config: `
+hosts: [localhost:9000]
+user: root
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    data_transfer_protection: privacy
+`,
+			errContains: `auth.kerberos.data_transfer_protection "privacy" is not supported for the hdfs input`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := inputSpec().ParseYAML(test.config, env)
+			require.NoError(t, err)
+			conf, err := hdfsInputConfigFromParsed(parsed)
+			if test.errContains == "" {
+				require.NoError(t, err)
+				require.Equal(t, []string{"localhost:9000"}, conf.hosts)
+				require.Equal(t, "root", conf.user)
+				return
+			}
+			require.ErrorContains(t, err, test.errContains)
+		})
+	}
+}
+
+func TestHDFSKerberosConfigDefaults(t *testing.T) {
+	env := service.NewEnvironment()
+
+	parsed, err := outputSpec().ParseYAML(`
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+`, env)
+	require.NoError(t, err)
+
+	conf, err := hdfsConfigFromParsed(parsed)
+	require.NoError(t, err)
+	require.Equal(t, defaultKerberosKrb5Conf, conf.kerberos.krb5Conf)
+	require.Equal(t, defaultKerberosServicePrincipal, conf.kerberos.servicePrincipal)
+	require.Empty(t, conf.kerberos.dataTransferProtection)
+}
+
+func TestHDFSOutputConfigAcceptsAllDataTransferProtectionModes(t *testing.T) {
+	env := service.NewEnvironment()
+
+	for _, mode := range []string{
+		dataTransferProtectionAuthentication,
+		dataTransferProtectionIntegrity,
+		dataTransferProtectionPrivacy,
+	} {
+		t.Run(mode, func(t *testing.T) {
+			parsed, err := outputSpec().ParseYAML(`
+hosts: [localhost:9000]
+directory: /tmp
+auth:
+  kerberos:
+    enabled: true
+    keytab: /tmp/connect.keytab
+    principal: connect/worker@EXAMPLE.COM
+    data_transfer_protection: `+mode+`
+`, env)
+			require.NoError(t, err)
+
+			conf, err := hdfsConfigFromParsed(parsed)
+			require.NoError(t, err)
+			require.Equal(t, mode, conf.kerberos.dataTransferProtection)
+		})
+	}
+}

--- a/internal/impl/hdfs/input.go
+++ b/internal/impl/hdfs/input.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/colinmarc/hdfs"
+	"github.com/colinmarc/hdfs/v2"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 const (
-	iFieldHosts     = "hosts"
-	iFieldUser      = "user"
 	iFieldDirectory = "directory"
 )
 
@@ -45,12 +43,10 @@ This input adds the following metadata fields to each message:
 You can access these metadata fields using
 xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].`).
 		Fields(
-			service.NewStringListField(iFieldHosts).
-				Description("A list of target host addresses to connect to.").
-				Example("localhost:9000"),
-			service.NewStringField(iFieldUser).
-				Description("A user ID to connect as.").
-				Default(""),
+			hdfsCommonFields()...,
+		).
+		Fields(hdfsInputAuthField()).
+		Fields(
 			service.NewStringField(iFieldDirectory).
 				Description("The directory to consume from."),
 		)
@@ -64,10 +60,7 @@ func init() {
 				log: mgr.Logger(),
 			}
 			out = rdr
-			if rdr.hosts, err = conf.FieldStringList(iFieldHosts); err != nil {
-				return
-			}
-			if rdr.user, err = conf.FieldString(iFieldUser); err != nil {
+			if rdr.hdfsConf, err = hdfsInputConfigFromParsed(conf); err != nil {
 				return
 			}
 			if rdr.directory, err = conf.FieldString(iFieldDirectory); err != nil {
@@ -78,8 +71,7 @@ func init() {
 }
 
 type hdfsReader struct {
-	hosts     []string
-	user      string
+	hdfsConf  hdfsConfig
 	directory string
 
 	targets []string
@@ -94,10 +86,11 @@ func (h *hdfsReader) Connect(context.Context) error {
 		return nil
 	}
 
-	client, err := hdfs.NewClient(hdfs.ClientOptions{
-		Addresses: h.hosts,
-		User:      h.user,
-	})
+	opts, err := h.hdfsConf.clientOptions()
+	if err != nil {
+		return err
+	}
+	client, err := hdfs.NewClient(opts)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/hdfs/integration_test.go
+++ b/internal/impl/hdfs/integration_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/colinmarc/hdfs"
+	"github.com/colinmarc/hdfs/v2"
 	"github.com/moby/moby/api/types/container"
 	mobynet "github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"

--- a/internal/impl/hdfs/output.go
+++ b/internal/impl/hdfs/output.go
@@ -20,14 +20,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/colinmarc/hdfs"
+	"github.com/colinmarc/hdfs/v2"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 const (
-	oFieldHosts     = "hosts"
-	oFieldUser      = "user"
 	oFieldDirectory = "directory"
 	oFieldPath      = "path"
 	oFieldBatching  = "batching"
@@ -40,12 +38,10 @@ func outputSpec() *service.ConfigSpec {
 		Summary(`Sends message parts as files to a HDFS directory.`).
 		Description(`Each file is written with the path specified with the 'path' field, in order to have a different path for each object you should use function interpolations described xref:configuration:interpolation.adoc#bloblang-queries[here].`+service.OutputPerformanceDocs(true, false)).
 		Fields(
-			service.NewStringListField(oFieldHosts).
-				Description("A list of target host addresses to connect to.").
-				Example("localhost:9000"),
-			service.NewStringField(oFieldUser).
-				Description("A user ID to connect as.").
-				Default(""),
+			hdfsCommonFields()...,
+		).
+		Fields(hdfsAuthField()).
+		Fields(
 			service.NewInterpolatedStringField(oFieldDirectory).
 				Description("A directory to store message files within. If the directory does not exist it will be created."),
 			service.NewInterpolatedStringField(oFieldPath).
@@ -64,10 +60,7 @@ func init() {
 				log: mgr.Logger(),
 			}
 			out = w
-			if w.hosts, err = conf.FieldStringList(oFieldHosts); err != nil {
-				return
-			}
-			if w.user, err = conf.FieldString(oFieldUser); err != nil {
+			if w.hdfsConf, err = hdfsConfigFromParsed(conf); err != nil {
 				return
 			}
 			if w.directory, err = conf.FieldInterpolatedString(oFieldDirectory); err != nil {
@@ -87,8 +80,7 @@ func init() {
 }
 
 type hdfsWriter struct {
-	hosts     []string
-	user      string
+	hdfsConf  hdfsConfig
 	directory *service.InterpolatedString
 	path      *service.InterpolatedString
 
@@ -101,10 +93,11 @@ func (h *hdfsWriter) Connect(context.Context) error {
 		return nil
 	}
 
-	client, err := hdfs.NewClient(hdfs.ClientOptions{
-		Addresses: h.hosts,
-		User:      h.user,
-	})
+	opts, err := h.hdfsConf.clientOptions()
+	if err != nil {
+		return err
+	}
+	client, err := hdfs.NewClient(opts)
 	if err != nil {
 		return err
 	}

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -120,7 +120,7 @@
 | github.com/cncf/xds/go | Apache-2.0 |
 | github.com/cockroachdb/apd/v3 | Apache-2.0 |
 | github.com/cohere-ai/cohere-go/v2 | MIT |
-| github.com/colinmarc/hdfs | MIT |
+| github.com/colinmarc/hdfs/v2 | MIT |
 | github.com/couchbase/gocb/v2 | Apache-2.0 |
 | github.com/couchbase/gocbcore/v10 | Apache-2.0 |
 | github.com/couchbase/gocbcoreps | Apache-2.0 |

--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
-	github.com/colinmarc/hdfs v1.1.3 // indirect
+	github.com/colinmarc/hdfs/v2 v2.4.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/couchbase/gocb/v2 v2.12.1 // indirect
 	github.com/cyborginc/cyborgdb-go v0.15.0 // indirect

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
-	github.com/colinmarc/hdfs v1.1.3 // indirect
+	github.com/colinmarc/hdfs/v2 v2.4.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/couchbase/gocb/v2 v2.12.1 // indirect
 	github.com/cyborginc/cyborgdb-go v0.15.0 // indirect


### PR DESCRIPTION

Adds Kerberos authentication support for the HDFS connector by upgrading to github.com/colinmarc/hdfs/v2 and introducing shared HDFS auth configuration for input and output.

  **Changes**

  - Adds auth.kerberos config for HDFS output.
  - Adds limited Kerberos support for HDFS input.
  - Supports keytab-based Kerberos auth with:
      - krb5_conf
      - keytab
      - principal
      - service_principal
      - data_transfer_protection

**Related Issues**
#1347