### PR TITLE
iceberg: skip duplicate-path check on AddDataFiles

### DIFF
--- a/internal/impl/iceberg/committer.go
+++ b/internal/impl/iceberg/committer.go
@@ -121,7 +121,13 @@ func (c *committer) doCommit(ctx context.Context, inputs []CommitInput) ([]struc
 		if c.cfg.MaxSnapshotAge > 0 {
 			props[table.MaxSnapshotAgeMsKey] = strconv.FormatInt(c.cfg.MaxSnapshotAge.Milliseconds(), 10)
 		}
-		if err := txn.AddDataFiles(ctx, allFiles, props, table.WithoutAutoNameMapping()); err != nil {
+		// WithoutDuplicateCheck: writer.Write stamps each path with a fresh uuid,
+		// so the default O(snapshot) manifest scan iceberg-go runs to detect path
+		// collisions is wasted work on the commit hot path (T6692).
+		if err := txn.AddDataFiles(ctx, allFiles, props,
+			table.WithoutAutoNameMapping(),
+			table.WithoutDuplicateCheck(),
+		); err != nil {
 			return nil, fmt.Errorf("adding files: %w", err)
 		}
 		tbl, err := txn.Commit(ctx)

--- a/internal/impl/iceberg/committer_test.go
+++ b/internal/impl/iceberg/committer_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// memCatalog is a minimal in-memory table.CatalogIO used to drive transaction
+// commits without standing up a real catalog. It mirrors the pattern used in
+// iceberg-go's own table_test.go.
+type memCatalog struct {
+	meta             table.Metadata
+	metadataLocation string
+	ident            table.Identifier
+	location         string
+}
+
+func (m *memCatalog) LoadTable(context.Context, table.Identifier) (*table.Table, error) {
+	return m.snapshot(), nil
+}
+
+func (m *memCatalog) CommitTable(_ context.Context, _ table.Identifier, _ []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	meta, err := table.UpdateTableMetadata(m.meta, updates, "")
+	if err != nil {
+		return nil, "", err
+	}
+	m.meta = meta
+	return meta, m.metadataLocation, nil
+}
+
+func (m *memCatalog) snapshot() *table.Table {
+	return table.New(
+		m.ident,
+		m.meta,
+		m.metadataLocation,
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		m,
+	)
+}
+
+// newTestTable creates an iceberg table backed by an in-memory catalog and the
+// local filesystem under tb.TempDir().
+func newTestTable(tb testing.TB) (*table.Table, *memCatalog) {
+	tb.Helper()
+	location := filepath.ToSlash(tb.TempDir())
+
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+
+	meta, err := table.NewMetadata(sc, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		location, iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(tb, err)
+
+	cat := &memCatalog{
+		meta:             meta,
+		metadataLocation: fmt.Sprintf("%s/metadata/00001-%s.metadata.json", location, uuid.New()),
+		ident:            table.Identifier{"default", "t"},
+		location:         location,
+	}
+	return cat.snapshot(), cat
+}
+
+// synthDataFile builds a DataFile referencing path. The path need not exist on
+// disk — AddDataFiles validates metadata only.
+func synthDataFile(tb testing.TB, spec iceberg.PartitionSpec, path string) iceberg.DataFile {
+	tb.Helper()
+	b, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		path,
+		iceberg.ParquetFile,
+		nil, nil, nil,
+		1, 256,
+	)
+	require.NoError(tb, err)
+	return b.Build()
+}
+
+// seedTable commits `count` separate single-file snapshots, approximating a
+// table that has accumulated many manifests from many small writes. The
+// committed paths each carry a fresh uuid, so they do not collide with any
+// later "real" commit by the unit under test. Returns the latest table handle.
+func seedTable(tb testing.TB, ctx context.Context, tbl *table.Table, count int) *table.Table {
+	tb.Helper()
+	for range count {
+		df := synthDataFile(tb, tbl.Spec(),
+			fmt.Sprintf("%s/data/seed-%s.parquet", tbl.Location(), uuid.New()))
+		tx := tbl.NewTransaction()
+		require.NoError(tb, tx.AddDataFiles(ctx, []iceberg.DataFile{df}, nil,
+			table.WithoutAutoNameMapping(), table.WithoutDuplicateCheck()))
+		next, err := tx.Commit(ctx)
+		require.NoError(tb, err)
+		tbl = next
+	}
+	return tbl
+}
+
+// TestCommitterSkipsDuplicateCheck pins the T6692 fix: the committer must
+// bypass iceberg-go's default duplicate-path check on AddDataFiles. That check
+// is an O(snapshot) scan of every manifest entry and dominated the commit hot
+// path for Comcast. The writer already guarantees per-file path uniqueness via
+// uuid stamping (writer.go), so the check is redundant.
+//
+// Behavioural assertion: committing a path that already exists in the table
+// succeeds. Without the fix, AddDataFiles returns
+// "cannot add files that are already referenced by table" and Commit fails.
+func TestCommitterSkipsDuplicateCheck(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTable(t)
+
+	tbl = seedTable(t, ctx, tbl, 1)
+
+	logger := service.MockResources().Logger()
+	c, err := NewCommitter(tbl, CommitConfig{
+		ManifestMergeEnabled: false,
+		MaxRetries:           1,
+	}, func(context.Context) (*table.Table, error) { return cat.snapshot(), nil }, logger)
+	require.NoError(t, err)
+	defer c.Close()
+
+	dupPath := fmt.Sprintf("%s/data/collision.parquet", tbl.Location())
+	df1 := synthDataFile(t, tbl.Spec(), dupPath)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df1}, SchemaID: c.currentSchemaID()}))
+
+	// Second commit at the same path: only succeeds if the dup check is off.
+	df2 := synthDataFile(t, tbl.Spec(), dupPath)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df2}, SchemaID: c.currentSchemaID()}))
+}
+
+// BenchmarkAddDataFilesDupCheck measures the cost of Transaction.AddDataFiles
+// against a snapshot pre-seeded with N existing data files, with iceberg-go's
+// duplicate-path check on vs off. It is the local reproduction harness for
+// T6692.
+//
+// Run locally with e.g.:
+//
+//	go test -bench BenchmarkAddDataFilesDupCheck -benchmem -benchtime=20x \
+//	    ./internal/impl/iceberg
+//
+// The `dup_check=true` variants scale roughly linearly with seed; the
+// `dup_check=false` variants are flat. The committer in this package ships
+// with dup_check off (see committer.go doCommit) — the `dup_check=true`
+// numbers are what production looked like before T6692.
+func BenchmarkAddDataFilesDupCheck(b *testing.B) {
+	ctx := b.Context()
+
+	for _, seed := range []int{10, 100, 1000} {
+		// Build the seeded table once per `seed` size and reuse it across the
+		// inner sub-benchmarks. Seeding 1000 commits is the dominant cost, and
+		// the AddDataFiles call we measure operates on the parent snapshot
+		// without mutating it — so sharing is safe.
+		tbl, _ := newTestTable(b)
+		tbl = seedTable(b, ctx, tbl, seed)
+
+		for _, dupCheck := range []bool{true, false} {
+			opts := []table.WriteOption{table.WithoutAutoNameMapping()}
+			if !dupCheck {
+				opts = append(opts, table.WithoutDuplicateCheck())
+			}
+
+			b.Run(fmt.Sprintf("seed=%d/dup_check=%v", seed, dupCheck), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; b.Loop(); i++ {
+					df := synthDataFile(b, tbl.Spec(),
+						fmt.Sprintf("%s/data/bench-%d.parquet", tbl.Location(), i))
+					tx := tbl.NewTransaction()
+					if err := tx.AddDataFiles(ctx, []iceberg.DataFile{df}, nil, opts...); err != nil {
+						b.Fatal(err)
+					}
+					// Discard the transaction — we are timing AddDataFiles, not Commit.
+				}
+			})
+		}
+	}
+}

--- a/internal/impl/kafka/franz_writer.go
+++ b/internal/impl/kafka/franz_writer.go
@@ -210,7 +210,7 @@ func FranzProducerLimitsOptsFromConfig(conf *service.ParsedConfig) ([]kgo.Opt, e
 	var maxBufferedBytes uint64
 	maxBufferedBytes, err = humanize.ParseBytes(maxBufferedBytesStr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse max_buffered_bytes: %w", err)
+		return nil, fmt.Errorf("parsing max_buffered_bytes: %w", err)
 	}
 	if maxBufferedBytes > uint64(math.MaxInt) {
 		return nil, fmt.Errorf("invalid max_buffered_bytes, must not exceed %v", math.MaxInt)


### PR DESCRIPTION
## Summary

`doCommit` now passes `table.WithoutDuplicateCheck()` alongside the existing `table.WithoutAutoNameMapping()` when calling `Transaction.AddDataFiles`. By default `iceberg-go` performs an O(snapshot) scan of every manifest entry in the current snapshot on every `AddDataFiles` call to detect path collisions with files being added. The writer in this package already stamps every parquet path with a fresh UUID, so the guarantee is held by the caller and the scan is wasted work.

This addresses ticket T6692, where the customer's Iceberg writer collapsed to approximately 40 messages/sec on a busy table — roughly 150× slower than the same workload on Kafka Connect (around 6,000 messages/sec). Profiling provided by the customer showed 88.6 GB of allocations (46% of total) inside `iceberg-go.(*ManifestReader).ReadEntry`, with the committer goroutine continuously blocked in `doCommit`. The dup-check scan is the exclusive driver of that hot path.

The check still runs in `iceberg-go` for any other caller that does not opt out, so this change is scoped strictly to this writer's commit path.

## Measurements

Benchmark added in `internal/impl/iceberg/committer_test.go` (`BenchmarkAddDataFilesDupCheck`). Apple M3 Pro, `-benchtime=20x`, single `Transaction.AddDataFiles` call against a table pre-seeded with `seed` separate single-file commits:

| seed  | dup_check on              | dup_check off          | speedup |
|------:|---------------------------|------------------------|---------|
|    10 | 7.55 ms / 6.6 MB / 55K allocs    | 1.84 ms / 2.8 MB / 14K allocs | ~4×     |
|   100 | 58.9 ms / 39 MB / 407K allocs    | 1.98 ms / 3.0 MB / 14K allocs | ~30×    |
| 1,000 | 530 ms / 364 MB / 3.9M allocs    | 3.56 ms / 5.9 MB / 17K allocs | ~150×   |

The `dup_check=on` cost scales linearly with the number of manifest entries in the current snapshot; the `dup_check=off` cost is effectively flat. The 150× figure at seed=1,000 lines up with the customer's observed RPCN-vs-Kafka-Connect throughput gap, supporting the diagnosis that this single check accounted for the dominant share of the regression.

Run locally with:

```
go test -bench BenchmarkAddDataFilesDupCheck -benchmem -run='^' -benchtime=20x ./internal/impl/iceberg
```

## Why this has not surfaced for other customers

The cost is `O(manifest_entries_in_current_snapshot) × commits_per_second × concurrent_pods`. For most workloads at least one of those terms is small enough to mask the dup-check overhead entirely. The reporting customer happened to maximise all three at once:

1. **Manifest entry count was unbounded.** The table was created on April 30 from scratch and accumulated approximately a week of small commits with no compaction in the pipeline. Customers running RPCN's iceberg compaction processor, or who have an external Spark/Trino maintenance job, keep the manifest entry count bounded and the per-commit scan remains small.
2. **Commit cadence was very high.** The initial deployment used `batch.count=10000, period=1s`, producing roughly one commit/sec/pod. The dup-check runs per commit, so the cost-per-second scales linearly with commit rate. Customers who batch more aggressively amortise the scan across many more messages.
3. **Multi-pod fan-in on a single hot table.** All eight Kafka partitions wrote to the same table with 1-8 pods auto-scaling. As single-pod commits slowed, the inter-pod commit window widened, catalog collisions grew, retries replayed the scan, and the autoscaler added more pods — a compounding death spiral. A workload with one pod per table or with writers sharded across tables would not see this amplification.
4. **The cost is invisible on day one.** Empty or freshly-compacted snapshots scan zero entries and complete instantly. Demos, smoke tests, and our standard integration tests do not run a single table long enough for the manifest list to grow to a problematic size, so the regression does not surface during pre-production evaluation.

## Test plan

- [x] `TestCommitterSkipsDuplicateCheck` added in `internal/impl/iceberg/committer_test.go`. It commits the same path twice through the committer and asserts both calls succeed. Verified locally that the test fails with the expected `cannot add files that are already referenced by table` error when the option is removed.
- [x] `go test -count=1 ./internal/impl/iceberg/...` — all packages pass.
- [x] `bin/golangci-lint run ./internal/impl/iceberg/...` — clean.