### PR TITLE
feat(telemetry): add deployment-type and tenant-id to call-home payload

### DIFF
--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -54,13 +54,15 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 	}
 
 	var (
-		licenseConfig       = defaultLicenseConfig()
-		chrootPath          string
-		chrootPassthrough   []string
-		disableTelemetry    bool
-		authzResourceName   string
-		authzPolicyFile     string
-		authzPolicyEndpoint string
+		licenseConfig           = defaultLicenseConfig()
+		chrootPath              string
+		chrootPassthrough       []string
+		disableTelemetry        bool
+		telemetryDeploymentType string
+		telemetryTenantID       string
+		authzResourceName       string
+		authzPolicyFile         string
+		authzPolicyEndpoint     string
 	)
 
 	flags := []cli.Flag{
@@ -156,7 +158,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 
 			// Kick off telemetry exporter
 			if !disableTelemetry {
-				telemetry.ActivateExporter(instanceID, version, fbLogger, schema, pConf)
+				telemetry.ActivateExporter(instanceID, version, telemetryDeploymentType, telemetryTenantID, fbLogger, schema, pConf)
 			}
 			return rpMgr.InitFromParsedConfig(pConf.Namespace("redpanda"))
 		}),
@@ -174,6 +176,14 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 						Name:  "disable-telemetry",
 						Usage: "Disable anonymous telemetry from being emitted by this Connect instance.",
 					},
+					&cli.StringFlag{
+						Name:  "telemetry-deployment-type",
+						Usage: "Tags telemetry payloads with the deployment type. Expected values: self-hosted, byoc, serverless. When unset the field is omitted from the payload.",
+					},
+					&cli.StringFlag{
+						Name:  "telemetry-tenant-id",
+						Usage: "Tags telemetry payloads with an opaque tenant identifier (typically the Redpanda Cloud organization ID for cloud-managed deployments). When unset the field is omitted from the payload.",
+					},
 					&cli.StringSliceFlag{
 						Name:  "rpc-plugins",
 						Usage: "Plugins to load over the RPC interface. This flag should point to manifest files containing the plugin definitions. Globs are also supported.",
@@ -187,6 +197,8 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				chrootPath = c.String("chroot")
 				chrootPassthrough = c.StringSlice("chroot-passthrough")
 				disableTelemetry = c.Bool("disable-telemetry")
+				telemetryDeploymentType = c.String("telemetry-deployment-type")
+				telemetryTenantID = c.String("telemetry-tenant-id")
 
 				if secretLookupFn, err = parseSecretsFlag(slog.New(rpLogger), c); err != nil {
 					return err

--- a/internal/telemetry/payload.go
+++ b/internal/telemetry/payload.go
@@ -60,14 +60,24 @@ type payload struct {
 
 	// Information about the host and process
 	HostInfo hostInfo `json:"hostInfo"`
+
+	// DeploymentType identifies how this Connect instance is deployed. Expected
+	// values: "self-hosted", "byoc", "serverless". Empty when not set.
+	DeploymentType string `json:"deploymentType,omitempty"`
+
+	// TenantID identifies the owning tenant for cloud-managed deployments
+	// (typically the Redpanda Cloud organization ID). Empty for self-hosted.
+	TenantID string `json:"tenantId,omitempty"`
 }
 
 // All information sent during a telemetry export is extracted within this
 // function and stored within the payload.
-func extractPayload(identifier string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) (*payload, error) {
+func extractPayload(identifier, deploymentType, tenantID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) (*payload, error) {
 	p := payload{
-		ID:     identifier,
-		Uptime: 0,
+		ID:             identifier,
+		Uptime:         0,
+		DeploymentType: deploymentType,
+		TenantID:       tenantID,
 		HostInfo: hostInfo{
 			NumCPU:     runtime.NumCPU(),
 			GoMaxProcs: runtime.GOMAXPROCS(0), // using 0 means to just read the value

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -85,7 +85,7 @@ func ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error) {
 
 // ActivateExporter runs the telemetry exporter asynchronously, provided all
 // conditions for telemetry are satisfied.
-func ActivateExporter(identifier, version string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) {
+func ActivateExporter(identifier, version, deploymentType, tenantID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) {
 	// If TLS information isn't present in the build then we do not send
 	// telemetry data.
 	if privateKey == "" {
@@ -139,7 +139,7 @@ func ActivateExporter(identifier, version string, logger *service.Logger, schema
 		JWTBuilder: josejwt.Signed(signer),
 	}
 
-	payload, err := extractPayload(identifier, logger, schema, conf)
+	payload, err := extractPayload(identifier, deploymentType, tenantID, logger, schema, conf)
 	if err != nil {
 		logger.With("error", err).Debug("Failed to create telemetry payload")
 		return


### PR DESCRIPTION
Adds two new fields to the anonymous telemetry payload posted to m.rp.vectorized.io:

  - deploymentType: "self-hosted", "byoc", or "serverless" (omitted when unset, treated as self-hosted at the analytics layer)
  - tenantId: opaque tenant identifier, typically the Redpanda Cloud organization ID for cloud-managed deployments

Both are configurable via new CLI flags --telemetry-deployment-type and --telemetry-tenant-id. Self-hosted users leave them unset; cloud control planes (cloudv2) inject them per pipeline at launch. This unblocks the analytics layer from segmenting Connect usage by deployment model and attributing cloud-managed pipelines to their owning org without relying on Scarf IP reveal (which does not work for cloud-egress IPs).