### PR TITLE
avro: resolve named-type references in nullable unions

### DIFF
--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -534,19 +534,14 @@ func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) er
 func ecsAvroHydrateLameUnion(cfg ecsAvroConfig, c *schema.Common, types []any) error {
 	c.Type = schema.Union
 	for i, uObj := range types {
-		var childT schema.Common
-
-		switch ut := uObj.(type) {
-		case string:
-			childT = schema.Common{
-				Name: ut,
-				Type: ecsAvroTypeToCommon(ut),
-			}
-		case map[string]any:
-			var err error
-			if childT, err = ecsAvroFromAnyMap(cfg, ut); err != nil {
-				return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
-			}
+		childT, ok := ecsAvroResolveTypeRef(cfg, uObj)
+		if !ok {
+			return fmt.Errorf("union `%v` child '%v': could not resolve type %T", c.Name, i, uObj)
+		}
+		if s, isStr := uObj.(string); isStr {
+			// Lame-union children keep the type-name as the Common.Name so
+			// the tagged-JSON envelope key matches the Avro wire form.
+			childT.Name = s
 		}
 
 		if childT.Type == schema.Null {

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -75,15 +75,19 @@ type ecsAvroConfig struct {
 	// for sibling-form Avro by [applyAvroLogicalType].
 	translateKafkaConnectTypes bool
 
-	// names accumulates resolved record/enum/fixed definitions during a
-	// single parse so that string-form references (e.g. "Fee" in
-	// ["null", "Fee"]) can be expanded to their full Common shape. The
-	// map is lazily allocated by ecsAvroParseFromBytes and shared by
-	// reference through recursive ecsAvroFromAnyMap calls; mutations from
-	// sub-trees propagate to later siblings as the Avro spec requires
-	// (named types are lexically scoped from the schema root, and a name
-	// must be defined before it is referenced).
+	// names is the lexical-scope registry of resolved record/enum/fixed
+	// definitions, keyed by Avro fullname (and short name for
+	// convenience). Stored values must be treated as immutable — every
+	// retrieval clones via cloneCommon so callers can mutate freely
+	// without corrupting later look-ups.
 	names map[string]schema.Common
+
+	// namespace is the enclosing Avro namespace, threaded through the
+	// recursion by value. It is updated when entering a named-type
+	// declaration that introduces a new namespace, per the Avro spec's
+	// inheritance rule (a name with no dots and no `namespace` field
+	// inherits the most tightly enclosing namespace).
+	namespace string
 }
 
 // ecsAvroParseFromBytes parses an Avro JSON spec into a schema.Common. The
@@ -134,12 +138,14 @@ func ecsAvroParseFromBytes(cfg ecsAvroConfig, specBytes []byte) (schema.Common, 
 //     resolved via cfg.names per the Avro lexical-scope rule,
 //   - an inline type definition object (e.g. {"type":"record",...}).
 //
-// Returns (Common{}, false) when the union doesn't fit this shape (length
-// != 2, no "null" branch, two non-null branches, or an inline object that
-// fails to parse).
-func ecsAvroResolveOptionalUnion(cfg ecsAvroConfig, types []any) (schema.Common, bool) {
+// The matched bool reports whether the union has the [null, X] / [X, null]
+// shape; the error is non-nil only when the shape matched but resolving the
+// non-null branch failed (e.g. a malformed inline decimal). Callers must
+// surface the error rather than falling through to the general-union path —
+// the fall-through would also fail, with a less informative message.
+func ecsAvroResolveOptionalUnion(cfg ecsAvroConfig, types []any) (resolved schema.Common, matched bool, err error) {
 	if len(types) != 2 {
-		return schema.Common{}, false
+		return schema.Common{}, false, nil
 	}
 	var other any
 	for _, t := range types {
@@ -148,19 +154,19 @@ func ecsAvroResolveOptionalUnion(cfg ecsAvroConfig, types []any) (schema.Common,
 		}
 		if other != nil {
 			// Two non-null branches — not a nullable wrapper.
-			return schema.Common{}, false
+			return schema.Common{}, false, nil
 		}
 		other = t
 	}
 	if other == nil {
-		return schema.Common{}, false
+		return schema.Common{}, false, nil
 	}
-	inner, ok := ecsAvroResolveTypeRef(cfg, other)
-	if !ok {
-		return schema.Common{}, false
+	inner, err := ecsAvroResolveTypeRef(cfg, other)
+	if err != nil {
+		return schema.Common{}, true, err
 	}
 	inner.Optional = true
-	return inner, true
+	return inner, true, nil
 }
 
 // ecsAvroResolveTypeRef resolves a single Avro type reference — the value
@@ -169,28 +175,26 @@ func ecsAvroResolveOptionalUnion(cfg ecsAvroConfig, types []any) (schema.Common,
 // reference string (resolved via cfg.names), or an inline type definition
 // object.
 //
-// Returns (Common{}, false) only when an inline object fails to parse.
-// Unknown string names fall back to schema.Any so that downstream sinks
-// see a sensible (if structureless) column rather than a parse error.
-func ecsAvroResolveTypeRef(cfg ecsAvroConfig, ref any) (schema.Common, bool) {
+// Unknown string names fall back to schema.Any so downstream sinks see a
+// sensible (if structureless) column. An error is returned only when an
+// inline object fails to parse (the wrapped cause flows back to the caller)
+// or when ref is neither a string nor a map (a malformed Avro JSON shape
+// the upstream parser couldn't reject).
+func ecsAvroResolveTypeRef(cfg ecsAvroConfig, ref any) (schema.Common, error) {
 	switch b := ref.(type) {
 	case string:
 		// Try the names map first so a name reference takes priority over
 		// the schema.Any fallback in ecsAvroTypeToCommon. Primitive names
 		// are never registered in the map, so primitives reach the
 		// fallback unchanged.
-		if resolved, ok := cfg.names[b]; ok {
-			return resolved, true
+		if resolved, ok := ecsAvroLookupName(cfg, b); ok {
+			return resolved, nil
 		}
-		return schema.Common{Type: ecsAvroTypeToCommon(b)}, true
+		return schema.Common{Type: ecsAvroTypeToCommon(b)}, nil
 	case map[string]any:
-		inner, err := ecsAvroFromAnyMap(cfg, b)
-		if err != nil {
-			return schema.Common{}, false
-		}
-		return inner, true
+		return ecsAvroFromAnyMap(cfg, b)
 	}
-	return schema.Common{}, false
+	return schema.Common{}, fmt.Errorf("expected type reference to be a string or object, got %T", ref)
 }
 
 // applyAvroLogicalType reads the optional "logicalType" annotation from an
@@ -477,6 +481,56 @@ func applyKafkaConnectType(cfg ecsAvroConfig, c *schema.Common, as map[string]an
 	}
 }
 
+// ecsAvroLookupName resolves a string reference to a previously-registered
+// named type, applying Avro's name-resolution rules: a reference that
+// contains a dot is treated as a fullname; an unqualified reference is
+// looked up first against the enclosing namespace, then against the bare
+// name as a fallback for root-scope references.
+//
+// The returned Common is cloned so callers can mutate it freely without
+// corrupting the registered entry.
+func ecsAvroLookupName(cfg ecsAvroConfig, ref string) (schema.Common, bool) {
+	if !strings.ContainsRune(ref, '.') && cfg.namespace != "" {
+		if resolved, ok := cfg.names[cfg.namespace+"."+ref]; ok {
+			return cloneCommon(resolved), true
+		}
+	}
+	if resolved, ok := cfg.names[ref]; ok {
+		return cloneCommon(resolved), true
+	}
+	return schema.Common{}, false
+}
+
+// cloneCommon deep-copies a schema.Common, allocating fresh slice and
+// pointer storage for Children and Logical so the result aliases nothing
+// with the source.
+func cloneCommon(c schema.Common) schema.Common {
+	if c.Children != nil {
+		children := make([]schema.Common, len(c.Children))
+		for i := range c.Children {
+			children[i] = cloneCommon(c.Children[i])
+		}
+		c.Children = children
+	}
+	if c.Logical != nil {
+		l := *c.Logical
+		if l.Decimal != nil {
+			d := *l.Decimal
+			l.Decimal = &d
+		}
+		if l.Timestamp != nil {
+			ts := *l.Timestamp
+			l.Timestamp = &ts
+		}
+		if l.TimeOfDay != nil {
+			tod := *l.TimeOfDay
+			l.TimeOfDay = &tod
+		}
+		c.Logical = &l
+	}
+	return c
+}
+
 func ecsAvroTypeToCommon(t string) schema.CommonType {
 	switch t {
 	case "record":
@@ -511,7 +565,10 @@ func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) er
 	// [null, X] or [X, null] → Optional X. ecsAvroResolveOptionalUnion
 	// handles primitive names, named-type references, and inline objects
 	// in either ordering.
-	if inner, ok := ecsAvroResolveOptionalUnion(cfg, types); ok {
+	if inner, matched, err := ecsAvroResolveOptionalUnion(cfg, types); matched {
+		if err != nil {
+			return fmt.Errorf("union `%v`: %w", c.Name, err)
+		}
 		name := c.Name
 		*c = inner
 		if name != "" {
@@ -522,9 +579,9 @@ func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) er
 
 	c.Type = schema.Union
 	for i, uObj := range types {
-		child, ok := ecsAvroResolveTypeRef(cfg, uObj)
-		if !ok {
-			return fmt.Errorf("union `%v` child '%v': could not resolve type %T", c.Name, i, uObj)
+		child, err := ecsAvroResolveTypeRef(cfg, uObj)
+		if err != nil {
+			return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
 		}
 		c.Children = append(c.Children, child)
 	}
@@ -534,9 +591,9 @@ func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) er
 func ecsAvroHydrateLameUnion(cfg ecsAvroConfig, c *schema.Common, types []any) error {
 	c.Type = schema.Union
 	for i, uObj := range types {
-		childT, ok := ecsAvroResolveTypeRef(cfg, uObj)
-		if !ok {
-			return fmt.Errorf("union `%v` child '%v': could not resolve type %T", c.Name, i, uObj)
+		childT, err := ecsAvroResolveTypeRef(cfg, uObj)
+		if err != nil {
+			return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
 		}
 		if s, isStr := uObj.(string); isStr {
 			// Lame-union children keep the type-name as the Common.Name so
@@ -563,39 +620,84 @@ func ecsAvroHydrateLameUnion(cfg ecsAvroConfig, c *schema.Common, types []any) e
 }
 
 func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, error) {
+	// Pre-register a structural placeholder before walking children so a
+	// self-reference (e.g. a linked-list record with a `next` field of its
+	// own type) resolves to a one-level stub rather than collapsing to
+	// schema.Any. The placeholder is overwritten with the fully-resolved
+	// Common once the walk completes. Mutual recursion across distinct
+	// records is still not supported — the second record's placeholder
+	// does not exist while the first is being walked.
+	typeName, _ := as["type"].(string)
+	fullname, shortName, childNamespace := ecsAvroAssignFullname(cfg.namespace, typeName, as)
+	if fullname != "" {
+		placeholder := ecsAvroPlaceholder(typeName, shortName)
+		cfg.names[fullname] = placeholder
+		if shortName != "" && shortName != fullname {
+			cfg.names[shortName] = placeholder
+		}
+		// Inheritable namespace propagates into the child walk; sibling
+		// scopes are unaffected because cfg is passed by value.
+		cfg.namespace = childNamespace
+	}
+
 	c, err := ecsAvroFromAnyMapImpl(cfg, as)
-	if err == nil {
-		ecsAvroRegisterNamedType(cfg, as, c)
+	if err == nil && fullname != "" {
+		cfg.names[fullname] = c
+		if shortName != "" && shortName != fullname {
+			cfg.names[shortName] = c
+		}
 	}
 	return c, err
 }
 
-// ecsAvroRegisterNamedType records a resolved record/enum/fixed Common in
-// cfg.names so that later string-form references (e.g. "Fee" instead of an
-// inline record definition) can be expanded. Avro's lexical-scope rule
-// requires the name to appear before any reference, so a single forward-only
-// pass through the schema is sufficient. Recursive types — where a record's
-// own children reference it by name before its definition completes — are
-// not supported by this approach; the registered entry must not be mutated
-// after registration to avoid surprising aliasing with later look-ups.
-func ecsAvroRegisterNamedType(cfg ecsAvroConfig, as map[string]any, c schema.Common) {
-	if cfg.names == nil {
-		return
-	}
-	typeName, _ := as["type"].(string)
+// ecsAvroAssignFullname computes the Avro fullname of a named-type
+// declaration ([record, enum, fixed]) from its declaration map and the
+// enclosing namespace, alongside the short name and the namespace that
+// should be threaded into the child walk. Returns empty fullname when the
+// node is not a named-type declaration or lacks a `name` field.
+//
+// Per the Avro spec (`Names` section):
+//  1. If `name` contains a dot, it IS the fullname and any `namespace`
+//     field is ignored.
+//  2. Else if `namespace` is set, the fullname is `namespace.name`.
+//  3. Else the fullname inherits the enclosing namespace.
+func ecsAvroAssignFullname(enclosing, typeName string, as map[string]any) (fullname, shortName, childNamespace string) {
 	switch typeName {
 	case "record", "enum", "fixed":
 	default:
-		return
+		return "", "", enclosing
 	}
 	name, _ := as["name"].(string)
 	if name == "" {
-		return
+		return "", "", enclosing
 	}
-	cfg.names[name] = c
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		return name, name[idx+1:], name[:idx]
+	}
 	if ns, _ := as["namespace"].(string); ns != "" {
-		cfg.names[ns+"."+name] = c
+		return ns + "." + name, name, ns
 	}
+	if enclosing != "" {
+		return enclosing + "." + name, name, enclosing
+	}
+	return name, name, ""
+}
+
+// ecsAvroPlaceholder returns the structural stub that stands in for a
+// self-referencing named type while its definition is being walked. The
+// placeholder uses the short name (matching what ecsAvroFromAnyMapImpl
+// would set) and the closest leaf type so downstream sinks see a coherent
+// shape rather than schema.Any.
+func ecsAvroPlaceholder(typeName, shortName string) schema.Common {
+	switch typeName {
+	case "record":
+		return schema.Common{Name: shortName, Type: schema.Object}
+	case "enum":
+		return schema.Common{Name: shortName, Type: schema.String}
+	case "fixed":
+		return schema.Common{Name: shortName, Type: schema.ByteArray}
+	}
+	return schema.Common{Name: shortName}
 }
 
 func ecsAvroFromAnyMapImpl(cfg ecsAvroConfig, as map[string]any) (schema.Common, error) {
@@ -637,7 +739,7 @@ func ecsAvroFromAnyMapImpl(cfg ecsAvroConfig, as map[string]any) (schema.Common,
 	case string:
 		// String form may be a primitive type name OR a name reference to
 		// a previously-defined record/enum/fixed in lexical scope.
-		if resolved, ok := cfg.names[t]; ok {
+		if resolved, ok := ecsAvroLookupName(cfg, t); ok {
 			fieldName := c.Name
 			c = resolved
 			if fieldName != "" {

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -74,6 +74,16 @@ type ecsAvroConfig struct {
 	// but the metadata still claims Int64 — the exact mismatch fixed
 	// for sibling-form Avro by [applyAvroLogicalType].
 	translateKafkaConnectTypes bool
+
+	// names accumulates resolved record/enum/fixed definitions during a
+	// single parse so that string-form references (e.g. "Fee" in
+	// ["null", "Fee"]) can be expanded to their full Common shape. The
+	// map is lazily allocated by ecsAvroParseFromBytes and shared by
+	// reference through recursive ecsAvroFromAnyMap calls; mutations from
+	// sub-trees propagate to later siblings as the Avro spec requires
+	// (named types are lexically scoped from the schema root, and a name
+	// must be defined before it is referenced).
+	names map[string]schema.Common
 }
 
 // ecsAvroParseFromBytes parses an Avro JSON spec into a schema.Common. The
@@ -81,6 +91,9 @@ type ecsAvroConfig struct {
 // decimal field paths during value normalisation; callers that just want
 // the metadata copy can call ToAny() on the result.
 func ecsAvroParseFromBytes(cfg ecsAvroConfig, specBytes []byte) (schema.Common, error) {
+	if cfg.names == nil {
+		cfg.names = map[string]schema.Common{}
+	}
 	var as any
 	if err := json.Unmarshal(specBytes, &as); err != nil {
 		return schema.Common{}, err
@@ -109,51 +122,75 @@ func ecsAvroParseFromBytes(cfg ecsAvroConfig, specBytes []byte) (schema.Common, 
 	return schema.Common{}, fmt.Errorf("expected either an array or object at root of schema, got %T", as)
 }
 
-// If the union is actually just a verbose way of defining an optional field
-// then we return the real type and true. E.g. if we see:
+// ecsAvroResolveOptionalUnion checks whether a 2-element union is just a
+// nullable wrapper (one branch is "null") and returns the resolved non-null
+// branch as a Common with Optional=true.
 //
-// `"type": [ "null", "string" ]`
+// Handles both orderings ([null, X] and [X, null]) and resolves the non-null
+// branch in three forms:
 //
-// Then we return string and true.
-func ecsAvroIsUnionJustOptional(types []any) (schema.CommonType, bool) {
+//   - a primitive type name string (e.g. "string"),
+//   - a previously-defined named-type reference string (e.g. "Fee"),
+//     resolved via cfg.names per the Avro lexical-scope rule,
+//   - an inline type definition object (e.g. {"type":"record",...}).
+//
+// Returns (Common{}, false) when the union doesn't fit this shape (length
+// != 2, no "null" branch, two non-null branches, or an inline object that
+// fails to parse).
+func ecsAvroResolveOptionalUnion(cfg ecsAvroConfig, types []any) (schema.Common, bool) {
 	if len(types) != 2 {
-		return schema.CommonType(-1), false
+		return schema.Common{}, false
 	}
-
-	firstTypeStr, ok := types[0].(string)
-	if !ok || firstTypeStr != "null" {
-		return schema.CommonType(-1), false
+	var other any
+	for _, t := range types {
+		if s, ok := t.(string); ok && s == "null" {
+			continue
+		}
+		if other != nil {
+			// Two non-null branches — not a nullable wrapper.
+			return schema.Common{}, false
+		}
+		other = t
 	}
-
-	secondTypeStr, ok := types[1].(string)
+	if other == nil {
+		return schema.Common{}, false
+	}
+	inner, ok := ecsAvroResolveTypeRef(cfg, other)
 	if !ok {
-		return schema.CommonType(-1), false
+		return schema.Common{}, false
 	}
-
-	return ecsAvroTypeToCommon(secondTypeStr), true
+	inner.Optional = true
+	return inner, true
 }
 
-// ecsAvroIsUnionJustOptionalObject mirrors ecsAvroIsUnionJustOptional but
-// for the [null, {object}] shape — Avro's idiom for a nullable named or
-// logically-typed field. Returns the resolved Common (with any
-// LogicalParams populated) and true on match.
-func ecsAvroIsUnionJustOptionalObject(cfg ecsAvroConfig, types []any) (schema.Common, bool) {
-	if len(types) != 2 {
-		return schema.Common{}, false
+// ecsAvroResolveTypeRef resolves a single Avro type reference — the value
+// of a "type" field, or one branch of a union — to a Common. The reference
+// may be a primitive type name string, a previously-defined named-type
+// reference string (resolved via cfg.names), or an inline type definition
+// object.
+//
+// Returns (Common{}, false) only when an inline object fails to parse.
+// Unknown string names fall back to schema.Any so that downstream sinks
+// see a sensible (if structureless) column rather than a parse error.
+func ecsAvroResolveTypeRef(cfg ecsAvroConfig, ref any) (schema.Common, bool) {
+	switch b := ref.(type) {
+	case string:
+		// Try the names map first so a name reference takes priority over
+		// the schema.Any fallback in ecsAvroTypeToCommon. Primitive names
+		// are never registered in the map, so primitives reach the
+		// fallback unchanged.
+		if resolved, ok := cfg.names[b]; ok {
+			return resolved, true
+		}
+		return schema.Common{Type: ecsAvroTypeToCommon(b)}, true
+	case map[string]any:
+		inner, err := ecsAvroFromAnyMap(cfg, b)
+		if err != nil {
+			return schema.Common{}, false
+		}
+		return inner, true
 	}
-	firstStr, ok := types[0].(string)
-	if !ok || firstStr != "null" {
-		return schema.Common{}, false
-	}
-	secondMap, ok := types[1].(map[string]any)
-	if !ok {
-		return schema.Common{}, false
-	}
-	c, err := ecsAvroFromAnyMap(cfg, secondMap)
-	if err != nil {
-		return schema.Common{}, false
-	}
-	return c, true
+	return schema.Common{}, false
 }
 
 // applyAvroLogicalType reads the optional "logicalType" annotation from an
@@ -471,38 +508,25 @@ func ecsAvroTypeToCommon(t string) schema.CommonType {
 }
 
 func ecsAvroHydrateRawUnion(cfg ecsAvroConfig, c *schema.Common, types []any) error {
-	// [null, primitive-name] → Optional <primitive>.
-	if t, optional := ecsAvroIsUnionJustOptional(types); optional {
-		c.Type, c.Optional = t, true
-		return nil
-	}
-	// [null, {object}] → Optional <object>, propagating logical params and
-	// nested children. This catches the common Avro idiom for nullable
-	// decimal/timestamp/etc. logical types.
-	if inner, ok := ecsAvroIsUnionJustOptionalObject(cfg, types); ok {
+	// [null, X] or [X, null] → Optional X. ecsAvroResolveOptionalUnion
+	// handles primitive names, named-type references, and inline objects
+	// in either ordering.
+	if inner, ok := ecsAvroResolveOptionalUnion(cfg, types); ok {
 		name := c.Name
 		*c = inner
 		if name != "" {
 			c.Name = name
 		}
-		c.Optional = true
 		return nil
 	}
 
 	c.Type = schema.Union
 	for i, uObj := range types {
-		switch ut := uObj.(type) {
-		case string:
-			c.Children = append(c.Children, schema.Common{
-				Type: ecsAvroTypeToCommon(ut),
-			})
-		case map[string]any:
-			tmpC, err := ecsAvroFromAnyMap(cfg, ut)
-			if err != nil {
-				return fmt.Errorf("union `%v` child '%v': %w", c.Name, i, err)
-			}
-			c.Children = append(c.Children, tmpC)
+		child, ok := ecsAvroResolveTypeRef(cfg, uObj)
+		if !ok {
+			return fmt.Errorf("union `%v` child '%v': could not resolve type %T", c.Name, i, uObj)
 		}
+		c.Children = append(c.Children, child)
 	}
 	return nil
 }
@@ -544,6 +568,42 @@ func ecsAvroHydrateLameUnion(cfg ecsAvroConfig, c *schema.Common, types []any) e
 }
 
 func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, error) {
+	c, err := ecsAvroFromAnyMapImpl(cfg, as)
+	if err == nil {
+		ecsAvroRegisterNamedType(cfg, as, c)
+	}
+	return c, err
+}
+
+// ecsAvroRegisterNamedType records a resolved record/enum/fixed Common in
+// cfg.names so that later string-form references (e.g. "Fee" instead of an
+// inline record definition) can be expanded. Avro's lexical-scope rule
+// requires the name to appear before any reference, so a single forward-only
+// pass through the schema is sufficient. Recursive types — where a record's
+// own children reference it by name before its definition completes — are
+// not supported by this approach; the registered entry must not be mutated
+// after registration to avoid surprising aliasing with later look-ups.
+func ecsAvroRegisterNamedType(cfg ecsAvroConfig, as map[string]any, c schema.Common) {
+	if cfg.names == nil {
+		return
+	}
+	typeName, _ := as["type"].(string)
+	switch typeName {
+	case "record", "enum", "fixed":
+	default:
+		return
+	}
+	name, _ := as["name"].(string)
+	if name == "" {
+		return
+	}
+	cfg.names[name] = c
+	if ns, _ := as["namespace"].(string); ns != "" {
+		cfg.names[ns+"."+name] = c
+	}
+}
+
+func ecsAvroFromAnyMapImpl(cfg ecsAvroConfig, as map[string]any) (schema.Common, error) {
 	var c schema.Common
 	c.Name, _ = as["name"].(string)
 
@@ -580,6 +640,16 @@ func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, err
 		}
 		return c, nil
 	case string:
+		// String form may be a primitive type name OR a name reference to
+		// a previously-defined record/enum/fixed in lexical scope.
+		if resolved, ok := cfg.names[t]; ok {
+			fieldName := c.Name
+			c = resolved
+			if fieldName != "" {
+				c.Name = fieldName
+			}
+			return c, nil
+		}
 		c.Type = ecsAvroTypeToCommon(t)
 	case map[string]any:
 		// The type field is an object (e.g. {"type":"map","values":"long"}).

--- a/internal/impl/confluent/ecs_avro.go
+++ b/internal/impl/confluent/ecs_avro.go
@@ -76,11 +76,23 @@ type ecsAvroConfig struct {
 	translateKafkaConnectTypes bool
 
 	// names is the lexical-scope registry of resolved record/enum/fixed
-	// definitions, keyed by Avro fullname (and short name for
-	// convenience). Stored values must be treated as immutable — every
-	// retrieval clones via cloneCommon so callers can mutate freely
-	// without corrupting later look-ups.
+	// definitions, keyed by Avro fullname plus an unambiguous short-name
+	// shortcut for each declaration. Stored values must be treated as
+	// immutable — every retrieval clones via cloneCommon so callers can
+	// mutate freely without corrupting later look-ups.
 	names map[string]schema.Common
+
+	// nameOwners tracks the fullname that owns each key in [names]. A
+	// fullname-key is its own owner ("Fee" → "Fee" for a root-scope Fee,
+	// "com.a.Fee" → "com.a.Fee" for a namespaced Fee). A short-name key
+	// inherits its owning declaration's fullname ("Fee" → "com.a.Fee").
+	// When a second declaration tries to claim a short-name key that a
+	// different fullname already owns the entry is marked ambiguous —
+	// owner becomes "" and the [names] entry is deleted — so unqualified
+	// references fall through to schema.Any instead of silently binding
+	// to whichever fullname registered last. A canonical fullname binding
+	// (key equals owner) always wins over a colliding short-name claim.
+	nameOwners map[string]string
 
 	// namespace is the enclosing Avro namespace, threaded through the
 	// recursion by value. It is updated when entering a named-type
@@ -97,6 +109,9 @@ type ecsAvroConfig struct {
 func ecsAvroParseFromBytes(cfg ecsAvroConfig, specBytes []byte) (schema.Common, error) {
 	if cfg.names == nil {
 		cfg.names = map[string]schema.Common{}
+	}
+	if cfg.nameOwners == nil {
+		cfg.nameOwners = map[string]string{}
 	}
 	var as any
 	if err := json.Unmarshal(specBytes, &as); err != nil {
@@ -631,9 +646,9 @@ func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, err
 	fullname, shortName, childNamespace := ecsAvroAssignFullname(cfg.namespace, typeName, as)
 	if fullname != "" {
 		placeholder := ecsAvroPlaceholder(typeName, shortName)
-		cfg.names[fullname] = placeholder
-		if shortName != "" && shortName != fullname {
-			cfg.names[shortName] = placeholder
+		putName(cfg, fullname, fullname, placeholder)
+		if shortName != fullname {
+			putName(cfg, shortName, fullname, placeholder)
 		}
 		// Inheritable namespace propagates into the child walk; sibling
 		// scopes are unaffected because cfg is passed by value.
@@ -642,12 +657,54 @@ func ecsAvroFromAnyMap(cfg ecsAvroConfig, as map[string]any) (schema.Common, err
 
 	c, err := ecsAvroFromAnyMapImpl(cfg, as)
 	if err == nil && fullname != "" {
-		cfg.names[fullname] = c
-		if shortName != "" && shortName != fullname {
-			cfg.names[shortName] = c
+		putName(cfg, fullname, fullname, c)
+		if shortName != fullname {
+			putName(cfg, shortName, fullname, c)
 		}
 	}
 	return c, err
+}
+
+// putName registers a resolved Common under one lookup key in cfg.names,
+// arbitrating short-name collisions across namespaces. A fullname-as-key
+// call (`key == owner`) is canonical and always wins. Two short-name
+// claims from different fullnames mark the key as ambiguous (`nameOwners`
+// becomes "" and the [names] entry is deleted), so unqualified references
+// fall through to schema.Any instead of silently binding to whichever
+// fullname registered last. A short-name claim that collides with an
+// existing canonical fullname binding for the same key is dropped — the
+// fullname keeps the slot.
+func putName(cfg ecsAvroConfig, key, owner string, c schema.Common) {
+	if key == "" {
+		return
+	}
+	existing, seen := cfg.nameOwners[key]
+	if !seen {
+		cfg.nameOwners[key] = owner
+		cfg.names[key] = c
+		return
+	}
+	if existing == "" {
+		return // already ambiguous
+	}
+	if existing == owner {
+		cfg.names[key] = c // same owner; placeholder→final replacement
+		return
+	}
+	if key == owner {
+		// This call is the canonical fullname registration — take the slot
+		// over from whoever was using it as a short-name shortcut.
+		cfg.nameOwners[key] = owner
+		cfg.names[key] = c
+		return
+	}
+	if key == existing {
+		// Existing owner's fullname matches the key — canonical, leave it.
+		return
+	}
+	// Both claims are short-name shortcuts from different fullnames.
+	cfg.nameOwners[key] = ""
+	delete(cfg.names, key)
 }
 
 // ecsAvroAssignFullname computes the Avro fullname of a named-type

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -516,6 +516,212 @@ func TestEcsAvroLameUnionNameResolution(t *testing.T) {
 	assert.Equal(t, schema.Int64, feeInner.Children[0].Type)
 }
 
+// TestEcsAvroUnionInlineErrorPropagation pins down the %w-wrapping
+// contract through the union resolvers. A malformed inline decimal sitting
+// inside a nullable union must surface its root-cause error (the precision
+// parse failure), not collapse to a generic "could not resolve type
+// map[string]interface{}". Covers both the optional-union fast path and the
+// general union fall-through, and both raw- and lame-union flavours.
+func TestEcsAvroUnionInlineErrorPropagation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ecsAvroConfig
+		spec    string
+		wantMsg string
+	}{
+		{
+			name: "raw union, nullable shape, malformed decimal precision",
+			cfg:  ecsAvroConfig{rawUnion: true},
+			spec: `{
+				"type": "record",
+				"name": "Tx",
+				"fields": [{
+					"name": "amount",
+					"type": ["null", {"type": "bytes", "logicalType": "decimal", "precision": "not-a-number", "scale": 2}]
+				}]
+			}`,
+			wantMsg: "decimal precision",
+		},
+		{
+			name: "raw union, three-branch shape, malformed decimal scale",
+			cfg:  ecsAvroConfig{rawUnion: true},
+			spec: `{
+				"type": "record",
+				"name": "Tx",
+				"fields": [{
+					"name": "amount",
+					"type": ["null", "string", {"type": "bytes", "logicalType": "decimal", "precision": 9, "scale": "nope"}]
+				}]
+			}`,
+			wantMsg: "decimal scale",
+		},
+		{
+			name: "lame union, nullable shape, malformed decimal precision",
+			cfg:  ecsAvroConfig{},
+			spec: `{
+				"type": "record",
+				"name": "Tx",
+				"fields": [{
+					"name": "amount",
+					"type": ["null", {"type": "bytes", "logicalType": "decimal", "precision": "not-a-number", "scale": 2}]
+				}]
+			}`,
+			wantMsg: "decimal precision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ecsAvroParseFromBytes(tt.cfg, []byte(tt.spec))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg, "inner error context must propagate via %%w wrapping, got %q", err.Error())
+			assert.NotContains(t, err.Error(), "could not resolve type", "must not collapse to the type-stringifier fallback when an inner error exists")
+		})
+	}
+}
+
+// TestEcsAvroNamespaceInheritance verifies that named types defined inside
+// a namespaced record inherit the enclosing namespace when they omit their
+// own `namespace` field, per the Avro spec's name-resolution rules. Both
+// short-name and fully-qualified references to the inherited fullname must
+// resolve, including across deeply nested scopes.
+func TestEcsAvroNamespaceInheritance(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"namespace": "com.example",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "Fee",
+					"fields": [{"name": "amount", "type": "long"}]
+				}
+			},
+			{"name": "by_short_name", "type": ["null", "Fee"]},
+			{"name": "by_inherited_full_name", "type": ["null", "com.example.Fee"]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 3)
+
+	short := c.Children[1]
+	assert.Equal(t, "by_short_name", short.Name)
+	assert.Equal(t, schema.Object, short.Type, "unqualified Fee should resolve via inherited com.example namespace")
+	require.Len(t, short.Children, 1)
+	assert.Equal(t, "amount", short.Children[0].Name)
+
+	full := c.Children[2]
+	assert.Equal(t, "by_inherited_full_name", full.Name)
+	assert.Equal(t, schema.Object, full.Type, "Fee implicitly belongs to com.example and must be reachable by FQN")
+	require.Len(t, full.Children, 1)
+}
+
+// TestEcsAvroNameWithEmbeddedDot exercises the third form of Avro's named-
+// type spelling: the `name` field itself contains a dot, in which case the
+// dot-bearing value IS the fullname and any sibling `namespace` field is
+// ignored. References must resolve under the embedded fullname.
+func TestEcsAvroNameWithEmbeddedDot(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"namespace": "ignored.outer",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "com.example.Fee",
+					"namespace": "this.is.ignored",
+					"fields": [{"name": "amount", "type": "long"}]
+				}
+			},
+			{"name": "by_fqn", "type": ["null", "com.example.Fee"]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 2)
+
+	fqn := c.Children[1]
+	assert.Equal(t, "by_fqn", fqn.Name)
+	assert.Equal(t, schema.Object, fqn.Type)
+	require.Len(t, fqn.Children, 1)
+}
+
+// TestEcsAvroSelfReferentialRecord verifies that a record whose own field
+// references it by name (e.g. a linked-list `next` pointer) resolves to a
+// structural stub — a one-level Object carrying the record's short name —
+// rather than collapsing to schema.Any (VARCHAR downstream).
+//
+// True recursive resolution is out of scope: schema.Common is a value type
+// with no back-reference machinery, so the self-reference is necessarily a
+// stub. The fix exists so downstream sinks see "this is some kind of
+// record" rather than an opaque blob.
+func TestEcsAvroSelfReferentialRecord(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Node",
+		"fields": [
+			{"name": "value", "type": "long"},
+			{"name": "next", "type": ["null", "Node"]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Equal(t, schema.Object, c.Type)
+	require.Len(t, c.Children, 2)
+	assert.Equal(t, "value", c.Children[0].Name)
+	assert.Equal(t, schema.Int64, c.Children[0].Type)
+
+	next := c.Children[1]
+	assert.Equal(t, "next", next.Name)
+	assert.Equal(t, schema.Object, next.Type, "self-reference should resolve to Object stub, not schema.Any")
+	assert.True(t, next.Optional)
+	assert.Empty(t, next.Children, "self-reference is a one-level stub — recursive resolution is out of scope")
+}
+
+// TestEcsAvroNamesMapIsolation verifies the clone-on-retrieval contract for
+// the names map: mutating a resolved Common (e.g. appending to its Children)
+// must not propagate to subsequent lookups of the same named type. Without
+// the clone, the second `secondary_fee` resolution would see the mutated
+// shape of the first.
+func TestEcsAvroNamesMapIsolation(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "Fee",
+					"fields": [{"name": "amount", "type": "long"}]
+				}
+			},
+			{"name": "first_ref", "type": "Fee"},
+			{"name": "second_ref", "type": "Fee"}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 3)
+
+	first := c.Children[1]
+	require.Equal(t, schema.Object, first.Type)
+	require.Len(t, first.Children, 1)
+	// Mutate the first resolved copy. If the names map were aliased, the
+	// next retrieval would see a record with two children.
+	first.Children = append(first.Children, schema.Common{Name: "poison", Type: schema.String})
+	assert.Len(t, first.Children, 2)
+
+	second := c.Children[2]
+	require.Equal(t, schema.Object, second.Type)
+	assert.Len(t, second.Children, 1, "later retrieval of Fee must not see mutations applied to earlier resolutions")
+}
+
 // TestEcsAvroRecordWithNilFields is a regression test for schemas where a
 // field's type is a record object without a "fields" key (e.g. back-reference
 // form {"type":"record","name":"Party"} or "fields":null from some generators).

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -269,6 +269,204 @@ func TestEcsAvroRawUnionNestedRecord(t *testing.T) {
 	assert.Equal(t, schema.String, party.Children[0].Type)
 }
 
+// TestEcsAvroRawUnionNullableRecordByName is the CON-468 regression for
+// nullable record unions where the non-null branch is a string name
+// reference to a previously-defined record (rather than an inline
+// definition). The Avro JSON spec requires named types to be defined once
+// then referenced by name, so any non-trivial customer schema with reused
+// records will exercise this path.
+func TestEcsAvroRawUnionNullableRecordByName(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "Fee",
+					"fields": [
+						{"name": "amount", "type": "long"},
+						{"name": "currency", "type": "string"}
+					]
+				}
+			},
+			{"name": "secondary_fee", "type": ["null", "Fee"], "default": null}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Equal(t, schema.Object, c.Type)
+	require.Len(t, c.Children, 2)
+
+	primary := c.Children[0]
+	assert.Equal(t, "primary_fee", primary.Name)
+	require.Equal(t, schema.Object, primary.Type)
+	require.Len(t, primary.Children, 2)
+
+	secondary := c.Children[1]
+	assert.Equal(t, "secondary_fee", secondary.Name)
+	require.Equal(t, schema.Object, secondary.Type, "name reference to Fee should resolve to the same record structure, not VARCHAR")
+	assert.True(t, secondary.Optional)
+	require.Len(t, secondary.Children, 2)
+	assert.Equal(t, "amount", secondary.Children[0].Name)
+	assert.Equal(t, schema.Int64, secondary.Children[0].Type)
+	assert.Equal(t, "currency", secondary.Children[1].Name)
+	assert.Equal(t, schema.String, secondary.Children[1].Type)
+}
+
+// TestEcsAvroRawUnionNullableOrderIndependence covers CON-468 acceptance
+// criterion 2: the [<type>, "null"] ordering (null second) must resolve
+// identically to ["null", <type>] (null first), across inline objects,
+// primitives, and name references.
+func TestEcsAvroRawUnionNullableOrderIndependence(t *testing.T) {
+	t.Run("inline record, null second", func(t *testing.T) {
+		spec := []byte(`{
+			"type": "record",
+			"name": "Transfer",
+			"fields": [{
+				"name": "fee",
+				"type": [{
+					"type": "record",
+					"name": "Fee",
+					"fields": [{"name": "amount", "type": "long"}]
+				}, "null"]
+			}]
+		}`)
+		c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+		require.NoError(t, err)
+		fee := c.Children[0]
+		assert.Equal(t, schema.Object, fee.Type)
+		assert.True(t, fee.Optional)
+		require.Len(t, fee.Children, 1)
+		assert.Equal(t, "amount", fee.Children[0].Name)
+	})
+
+	t.Run("primitive, null second", func(t *testing.T) {
+		spec := []byte(`{
+			"type": "record",
+			"name": "Transfer",
+			"fields": [{"name": "ref", "type": ["string", "null"]}]
+		}`)
+		c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+		require.NoError(t, err)
+		ref := c.Children[0]
+		assert.Equal(t, schema.String, ref.Type)
+		assert.True(t, ref.Optional)
+	})
+
+	t.Run("name reference, null second", func(t *testing.T) {
+		spec := []byte(`{
+			"type": "record",
+			"name": "Transfer",
+			"fields": [
+				{
+					"name": "primary_fee",
+					"type": {
+						"type": "record",
+						"name": "Fee",
+						"fields": [{"name": "amount", "type": "long"}]
+					}
+				},
+				{"name": "secondary_fee", "type": ["Fee", "null"]}
+			]
+		}`)
+		c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+		require.NoError(t, err)
+		secondary := c.Children[1]
+		assert.Equal(t, schema.Object, secondary.Type)
+		assert.True(t, secondary.Optional)
+		require.Len(t, secondary.Children, 1)
+		assert.Equal(t, "amount", secondary.Children[0].Name)
+	})
+}
+
+// TestEcsAvroRawUnionNullableRecordNamespaced verifies that namespaced
+// record names can be referenced either by short name (Fee) or by fully-
+// qualified name (com.example.Fee), matching the Avro spec's name
+// resolution rules.
+func TestEcsAvroRawUnionNullableRecordNamespaced(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"namespace": "com.example",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "Fee",
+					"namespace": "com.example",
+					"fields": [{"name": "amount", "type": "long"}]
+				}
+			},
+			{"name": "by_short_name", "type": ["null", "Fee"]},
+			{"name": "by_full_name", "type": ["null", "com.example.Fee"]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 3)
+
+	short := c.Children[1]
+	assert.Equal(t, "by_short_name", short.Name)
+	assert.Equal(t, schema.Object, short.Type)
+	require.Len(t, short.Children, 1)
+
+	full := c.Children[2]
+	assert.Equal(t, "by_full_name", full.Name)
+	assert.Equal(t, schema.Object, full.Type)
+	require.Len(t, full.Children, 1)
+}
+
+// TestEcsAvroRawUnionNullableRecordNested covers CON-468 acceptance
+// criterion 2's "record-with-nested-record" case: a nullable record union
+// whose record contains its own nullable record union, both as inline
+// definitions and as name references at the inner level.
+func TestEcsAvroRawUnionNullableRecordNested(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"fields": [
+			{
+				"name": "inner_template",
+				"type": {
+					"type": "record",
+					"name": "Inner",
+					"fields": [{"name": "code", "type": "string"}]
+				}
+			},
+			{
+				"name": "outer",
+				"type": ["null", {
+					"type": "record",
+					"name": "Outer",
+					"fields": [
+						{"name": "label", "type": "string"},
+						{"name": "inner", "type": ["null", "Inner"]}
+					]
+				}]
+			}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 2)
+
+	outer := c.Children[1]
+	assert.Equal(t, "outer", outer.Name)
+	assert.Equal(t, schema.Object, outer.Type)
+	assert.True(t, outer.Optional)
+	require.Len(t, outer.Children, 2)
+
+	inner := outer.Children[1]
+	assert.Equal(t, "inner", inner.Name)
+	assert.Equal(t, schema.Object, inner.Type, "nested name reference must resolve, not collapse to VARCHAR")
+	assert.True(t, inner.Optional)
+	require.Len(t, inner.Children, 1)
+	assert.Equal(t, "code", inner.Children[0].Name)
+}
+
 // TestEcsAvroRecordWithNilFields is a regression test for schemas where a
 // field's type is a record object without a "fields" key (e.g. back-reference
 // form {"type":"record","name":"Party"} or "fields":null from some generators).

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -467,6 +467,55 @@ func TestEcsAvroRawUnionNullableRecordNested(t *testing.T) {
 	assert.Equal(t, "code", inner.Children[0].Name)
 }
 
+// TestEcsAvroLameUnionNameResolution covers the same CON-468 bug class in
+// the lame-union (rawUnion=false) path that the schema_registry_decode
+// processor takes by default. The lame envelope wraps each branch in a
+// tagged Object so the wire shape stays the same, but the inner Common
+// must still expand previously-defined named-type references rather than
+// collapsing them to schema.Any.
+func TestEcsAvroLameUnionNameResolution(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Transfer",
+		"fields": [
+			{
+				"name": "primary_fee",
+				"type": {
+					"type": "record",
+					"name": "Fee",
+					"fields": [{"name": "amount", "type": "long"}]
+				}
+			},
+			{"name": "secondary_fee", "type": ["null", "Fee"]}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{}, spec)
+	require.NoError(t, err)
+
+	secondary := c.Children[1]
+	assert.Equal(t, "secondary_fee", secondary.Name)
+	assert.Equal(t, schema.Union, secondary.Type)
+	require.Len(t, secondary.Children, 2)
+
+	// One child is the null branch (Common.Type=Null, Name="").
+	// The other is the tagged-Object envelope wrapping the resolved Fee.
+	var feeEnvelope schema.Common
+	for _, ch := range secondary.Children {
+		if ch.Type == schema.Object {
+			feeEnvelope = ch
+			break
+		}
+	}
+	require.Equal(t, schema.Object, feeEnvelope.Type, "Fee branch should be tagged-Object envelope")
+	require.Len(t, feeEnvelope.Children, 1)
+	feeInner := feeEnvelope.Children[0]
+	assert.Equal(t, "Fee", feeInner.Name)
+	assert.Equal(t, schema.Object, feeInner.Type, "name reference to Fee should resolve to its record structure, not schema.Any")
+	require.Len(t, feeInner.Children, 1)
+	assert.Equal(t, "amount", feeInner.Children[0].Name)
+	assert.Equal(t, schema.Int64, feeInner.Children[0].Type)
+}
+
 // TestEcsAvroRecordWithNilFields is a regression test for schemas where a
 // field's type is a record object without a "fields" key (e.g. back-reference
 // form {"type":"record","name":"Party"} or "fields":null from some generators).

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -516,6 +516,68 @@ func TestEcsAvroLameUnionNameResolution(t *testing.T) {
 	assert.Equal(t, schema.Int64, feeInner.Children[0].Type)
 }
 
+// TestEcsAvroRawUnionAnnotatedInlinePrimitive verifies that the
+// optional-union collapse handles the [{primitive-with-annotations}, null]
+// shape — the form Kafka Connect / Debezium emit for nullable string fields,
+// where the non-null branch is an inline object carrying `connect.default`
+// (or similar extension properties) alongside `type: "string"`. The
+// resolver should ignore the unknown annotations (per Avro spec) and
+// collapse the union to Optional STRING the same way it collapses
+// `["null", "string"]`.
+//
+// Both branch orderings are covered: null-second is the shape the bug
+// report came in with, null-first is the canonical Avro spelling.
+func TestEcsAvroRawUnionAnnotatedInlinePrimitive(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{
+			name: "null second",
+			spec: `{
+				"type": "record",
+				"name": "Rec",
+				"fields": [{
+					"name": "category",
+					"type": [
+						{"type": "string", "connect.default": ""},
+						"null"
+					],
+					"default": ""
+				}]
+			}`,
+		},
+		{
+			name: "null first",
+			spec: `{
+				"type": "record",
+				"name": "Rec",
+				"fields": [{
+					"name": "category",
+					"type": [
+						"null",
+						{"type": "string", "connect.default": ""}
+					],
+					"default": null
+				}]
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, []byte(tt.spec))
+			require.NoError(t, err)
+			require.Equal(t, schema.Object, c.Type)
+			require.Len(t, c.Children, 1)
+			category := c.Children[0]
+			assert.Equal(t, "category", category.Name, "outer field name must be preserved across the union collapse")
+			assert.Equal(t, schema.String, category.Type, "annotated inline primitive should collapse to STRING, not stay a Union")
+			assert.True(t, category.Optional, "the null branch must drive Optional=true")
+			assert.Empty(t, category.Children, "collapsed primitive has no children")
+		})
+	}
+}
+
 // TestEcsAvroUnionInlineErrorPropagation pins down the %w-wrapping
 // contract through the union resolvers. A malformed inline decimal sitting
 // inside a nullable union must surface its root-cause error (the precision

--- a/internal/impl/confluent/ecs_avro_test.go
+++ b/internal/impl/confluent/ecs_avro_test.go
@@ -516,6 +516,141 @@ func TestEcsAvroLameUnionNameResolution(t *testing.T) {
 	assert.Equal(t, schema.Int64, feeInner.Children[0].Type)
 }
 
+// TestEcsAvroSharedShortNameAcrossNamespaces pins down the collision-
+// detection contract: when two records in different namespaces share the
+// same short name, the bare-name shortcut in cfg.names must drop out so
+// unqualified references fall through to schema.Any instead of silently
+// binding to whichever record registered last.
+//
+// Fully-qualified references continue to resolve through the fullname
+// keys, which are unique by construction. References from inside one of
+// the two colliding namespaces also resolve through the
+// enclosing-namespace prefix, never relying on the bare-name shortcut.
+func TestEcsAvroSharedShortNameAcrossNamespaces(t *testing.T) {
+	spec := []byte(`{
+		"type": "record",
+		"name": "Container",
+		"fields": [
+			{
+				"name": "from_a",
+				"type": {
+					"type": "record",
+					"name": "com.a.Fee",
+					"fields": [{"name": "amount_a", "type": "long"}]
+				}
+			},
+			{
+				"name": "from_b",
+				"type": {
+					"type": "record",
+					"name": "com.b.Fee",
+					"fields": [{"name": "amount_b", "type": "string"}]
+				}
+			},
+			{"name": "by_qualified_a", "type": "com.a.Fee"},
+			{"name": "by_qualified_b", "type": "com.b.Fee"},
+			{"name": "by_bare_name", "type": "Fee"}
+		]
+	}`)
+	c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+	require.NoError(t, err)
+	require.Len(t, c.Children, 5)
+
+	byQualA := c.Children[2]
+	require.Equal(t, schema.Object, byQualA.Type, "fully-qualified com.a.Fee must resolve")
+	require.Len(t, byQualA.Children, 1)
+	assert.Equal(t, "amount_a", byQualA.Children[0].Name)
+
+	byQualB := c.Children[3]
+	require.Equal(t, schema.Object, byQualB.Type, "fully-qualified com.b.Fee must resolve")
+	require.Len(t, byQualB.Children, 1)
+	assert.Equal(t, "amount_b", byQualB.Children[0].Name)
+
+	byBare := c.Children[4]
+	assert.Equal(t, schema.Any, byBare.Type, "ambiguous short name must not silently bind to whichever namespaced type registered last")
+	assert.Empty(t, byBare.Children)
+}
+
+// TestEcsAvroRootShortNameWinsOverNamespacedCollision verifies that a
+// canonical fullname binding (a record whose fullname equals the colliding
+// short name) preserves its slot when a namespaced record tries to claim
+// the same bare-name shortcut. The fullname binding is unique per type
+// and takes priority regardless of registration order.
+func TestEcsAvroRootShortNameWinsOverNamespacedCollision(t *testing.T) {
+	t.Run("root declared first", func(t *testing.T) {
+		spec := []byte(`{
+			"type": "record",
+			"name": "Container",
+			"fields": [
+				{
+					"name": "root_fee",
+					"type": {
+						"type": "record",
+						"name": "Fee",
+						"fields": [{"name": "root_amount", "type": "long"}]
+					}
+				},
+				{
+					"name": "ns_fee",
+					"type": {
+						"type": "record",
+						"name": "com.a.Fee",
+						"fields": [{"name": "ns_amount", "type": "string"}]
+					}
+				},
+				{"name": "by_bare", "type": "Fee"},
+				{"name": "by_qualified", "type": "com.a.Fee"}
+			]
+		}`)
+		c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+		require.NoError(t, err)
+		require.Len(t, c.Children, 4)
+		byBare := c.Children[2]
+		require.Equal(t, schema.Object, byBare.Type, "bare Fee must resolve to the canonical root-scope Fee, not the namespaced shortcut")
+		require.Len(t, byBare.Children, 1)
+		assert.Equal(t, "root_amount", byBare.Children[0].Name)
+		byQualified := c.Children[3]
+		require.Equal(t, schema.Object, byQualified.Type)
+		assert.Equal(t, "ns_amount", byQualified.Children[0].Name)
+	})
+
+	t.Run("namespaced declared first", func(t *testing.T) {
+		spec := []byte(`{
+			"type": "record",
+			"name": "Container",
+			"fields": [
+				{
+					"name": "ns_fee",
+					"type": {
+						"type": "record",
+						"name": "com.a.Fee",
+						"fields": [{"name": "ns_amount", "type": "string"}]
+					}
+				},
+				{
+					"name": "root_fee",
+					"type": {
+						"type": "record",
+						"name": "Fee",
+						"fields": [{"name": "root_amount", "type": "long"}]
+					}
+				},
+				{"name": "by_bare", "type": "Fee"},
+				{"name": "by_qualified", "type": "com.a.Fee"}
+			]
+		}`)
+		c, err := ecsAvroParseFromBytes(ecsAvroConfig{rawUnion: true}, spec)
+		require.NoError(t, err)
+		require.Len(t, c.Children, 4)
+		byBare := c.Children[2]
+		require.Equal(t, schema.Object, byBare.Type, "canonical fullname must win regardless of registration order")
+		require.Len(t, byBare.Children, 1)
+		assert.Equal(t, "root_amount", byBare.Children[0].Name)
+		byQualified := c.Children[3]
+		assert.Equal(t, "ns_amount", byQualified.Children[0].Name)
+	})
+}
+
 // TestEcsAvroRawUnionAnnotatedInlinePrimitive verifies that the
 // optional-union collapse handles the [{primitive-with-annotations}, null]
 // shape — the form Kafka Connect / Debezium emit for nullable string fields,

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -484,15 +484,14 @@ func parseSchemaEvolutionConfig(conf *service.ParsedConfig) (SchemaEvolutionConf
 		}
 	}
 
-	// Parse require_schema_metadata
-	if conf.Contains(ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata) {
-		cfg.RequireSchemaMetadata, err = conf.FieldBool(ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata)
-		if err != nil {
-			return cfg, err
-		}
-		if cfg.RequireSchemaMetadata && cfg.SchemaMetadata == "" {
-			return cfg, fmt.Errorf("%s.%s requires %s.%s to be set", ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata, ioFieldSchemaEvolution, ioFieldSchemaEvolutionSchemaMetadata)
-		}
+	// Parse require_schema_metadata. The field carries Default(false) in the
+	// spec so FieldBool returns false-without-error when absent, no Contains
+	// guard required.
+	if cfg.RequireSchemaMetadata, err = conf.FieldBool(ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata); err != nil {
+		return cfg, err
+	}
+	if cfg.RequireSchemaMetadata && cfg.SchemaMetadata == "" {
+		return cfg, fmt.Errorf("%s.%s requires %s.%s to be set", ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata, ioFieldSchemaEvolution, ioFieldSchemaEvolutionSchemaMetadata)
 	}
 
 	return cfg, nil

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -87,13 +87,20 @@ type RecordShredder struct {
 	// typed columns instead of guessing. nil entries fall back to the
 	// pre-schema-metadata behavior — see [convertLeafValue].
 	fieldCommons map[int]*schema.Common
-	// strictTemporal causes [convertLeafValue] to refuse numeric inputs
-	// into time-typed columns when no schema metadata has been
-	// registered for that column. When false (the default), the value
-	// converter falls back to [bloblang.ValueAsTimestamp]'s seconds
-	// default — convenient but silently wrong if the upstream produced
-	// a different unit. When true, the writer fails the batch loudly.
-	strictTemporal bool
+	// StrictTemporalMode causes [convertLeafValue] to refuse numeric
+	// inputs into time-typed columns (TIMESTAMP / TIMESTAMPTZ / DATE /
+	// TIME) when no schema metadata has been registered for that
+	// column. When false (the default), the value converter falls back
+	// to [bloblang.ValueAsTimestamp]'s seconds default — convenient but
+	// silently wrong if the upstream produced a different unit. When
+	// true, the writer fails the batch loudly.
+	//
+	// No effect on time.Time / time.Duration values, which carry their
+	// own unit unambiguously, and no effect on non-time columns. Set
+	// directly on the shredder after construction; operators that
+	// cannot guarantee schema metadata flows end-to-end flip this on to
+	// fail loudly instead of silently corrupting dates by ~50,000 years.
+	StrictTemporalMode bool
 }
 
 // NewRecordShredder creates a new shredder for the given schema.
@@ -105,22 +112,6 @@ func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredd
 		schema:        schema,
 		caseSensitive: caseSensitive,
 	}
-}
-
-// SetStrictTemporalMode toggles whether numeric inputs into time-typed
-// columns require registered schema metadata. With strict mode on, a bare
-// int64 / float64 value reaching a TIMESTAMP / TIMESTAMPTZ / DATE / TIME
-// column with no [schema.Common] in the field map is rejected with a
-// per-field error rather than guessed-as-Unix-seconds.
-//
-// Strict mode has no effect on time.Time / time.Duration values, which
-// carry their own unit unambiguously, and no effect on non-time columns.
-//
-// Defaults to off (back-compat). Operators that cannot guarantee schema
-// metadata flows end-to-end can flip this on to fail loudly instead of
-// silently corrupting dates by ~50,000 years.
-func (rs *RecordShredder) SetStrictTemporalMode(on bool) {
-	rs.strictTemporal = on
 }
 
 // SetFieldSchemaMetadata supplies a field-ID → schema.Common map that the
@@ -264,7 +255,7 @@ func (rs *RecordShredder) shredValue(
 
 	default:
 		// Leaf/primitive type.
-		pqVal, err := convertLeafValue(value, typ, rs.commonForField(fieldID), rs.strictTemporal)
+		pqVal, err := convertLeafValue(value, typ, rs.commonForField(fieldID), rs.StrictTemporalMode)
 		if err != nil {
 			return err
 		}
@@ -477,6 +468,14 @@ func convertLeafValue(value any, typ iceberg.Type, common *schema.Common, strict
 		if n, ok := coerceTemporalToNumeric(value, common); ok {
 			if strictTemporal {
 				return parquet.NullValue(), fmt.Errorf("int column received %T while schema metadata declares type %v; require_schema_metadata=true demands the existing column type match the schema metadata — recreate the table to migrate", value, common.Type)
+			}
+			// A Timestamp common's UnixMilli/Micros/Nanos far exceeds the
+			// int32 range, but the Int32Type arm is intended for Date /
+			// TimeOfDay coercions whose values do fit. Reject the
+			// schema/column mismatch loudly rather than silently
+			// truncating into a garbage year.
+			if n > math.MaxInt32 || n < math.MinInt32 {
+				return parquet.NullValue(), fmt.Errorf("int column received %T with schema metadata type %v; coerced value %d overflows int32 — the column should be BIGINT or the schema metadata is wrong", value, common.Type, n)
 			}
 			return parquet.Int32Value(int32(n)), nil
 		}

--- a/internal/impl/iceberg/shredder/temporal_test.go
+++ b/internal/impl/iceberg/shredder/temporal_test.go
@@ -498,6 +498,50 @@ func TestCoerceTemporalIntoNumericColumn(t *testing.T) {
 	})
 }
 
+// TestCoerceTemporalInt32OverflowGuard covers the schema/column mismatch
+// where a TIMESTAMP schema common reaches an Int32 column — coerceTemporal-
+// ToNumeric returns a UnixMilli value (~10^12) that vastly exceeds int32
+// range. The Int32 arm is intended for Date / TimeOfDay coercions whose
+// values fit in int32; a Timestamp value silently truncating into a garbage
+// year is the failure mode this guard exists to prevent.
+//
+// The complementary Int64 arm has no bounds problem (Timestamp values fit
+// comfortably in int64) and is verified separately by
+// TestCoerceTemporalIntoNumericColumn.
+func TestCoerceTemporalInt32OverflowGuard(t *testing.T) {
+	const tsMillis = int64(1_700_000_000_000) // 2023-11-14, ~10^12, well beyond int32
+
+	t.Run("Timestamp(Millis) into Int32 errors with overflow message", func(t *testing.T) {
+		v := time.UnixMilli(tsMillis).UTC()
+		_, err := convertLeafValue(v, iceberg.Int32Type{}, tsCommon(schema.TimeUnitMillis, true), false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "overflows int32", "must reject the schema/column mismatch loudly, not truncate to a garbage year")
+	})
+
+	t.Run("Timestamp(Micros) into Int32 errors with overflow message", func(t *testing.T) {
+		v := time.UnixMilli(tsMillis).UTC()
+		_, err := convertLeafValue(v, iceberg.Int32Type{}, tsCommon(schema.TimeUnitMicros, true), false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "overflows int32")
+	})
+
+	// Sanity check: the in-range coercions the Int32 arm was designed for
+	// still succeed.
+	t.Run("Date into Int32 still succeeds", func(t *testing.T) {
+		v := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+		pq, err := convertLeafValue(v, iceberg.Int32Type{}, &schema.Common{Type: schema.Date}, false)
+		require.NoError(t, err)
+		assert.Equal(t, int32(19737), pq.Int32())
+	})
+
+	t.Run("TimeOfDay into Int32 still succeeds", func(t *testing.T) {
+		d := 8*time.Hour + 30*time.Minute
+		pq, err := convertLeafValue(d, iceberg.Int32Type{}, todCommon(schema.TimeUnitMillis), false)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8*3600+30*60)*1000, pq.Int32())
+	})
+}
+
 // TestCoerceTemporalRejectedInStrictMode confirms that the temporal->numeric
 // coerce path is disabled when require_schema_metadata=true. In strict mode
 // a type disagreement between the existing column and the schema metadata

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -55,7 +55,7 @@ type writer struct {
 // resolver supplies optional per-message schema metadata used by the shredder
 // to interpret numeric inputs into time-typed columns; pass nil to disable.
 // requireSchemaMetadata enables shredder strict mode — see
-// [shredder.RecordShredder.SetStrictTemporalMode].
+// [shredder.RecordShredder.StrictTemporalMode].
 func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, requireSchemaMetadata bool, logger *service.Logger) *writer {
 	return &writer{
 		table:                 tbl,
@@ -222,9 +222,7 @@ func (w *writer) messagesToParquet(batch service.MessageBatch) ([]partitionFile,
 	// silently for messages 1..N; in that case the writer must be
 	// extended to per-message metadata lookup with a small cache.
 	rs := shredder.NewRecordShredder(schema, w.caseSensitive)
-	if w.requireSchemaMetadata {
-		rs.SetStrictTemporalMode(true)
-	}
+	rs.StrictTemporalMode = w.requireSchemaMetadata
 	if w.resolver != nil && len(batch) > 0 {
 		if common, err := w.resolver.parseSchemaMetadata(batch[0]); err != nil {
 			w.logger.Warnf("parsing schema metadata for shredder: %v (falling back to schema-agnostic conversion)", err)

--- a/internal/impl/parquet/schema_coercion.go
+++ b/internal/impl/parquet/schema_coercion.go
@@ -172,12 +172,7 @@ func coerceTimestampForEncode(value any, ts *format.TimestampType) (any, error) 
 func coerceDateForEncode(value any) (any, error) {
 	switch v := value.(type) {
 	case time.Time:
-		secs := v.UTC().Unix()
-		days := secs / 86400
-		if secs < 0 && secs%86400 != 0 {
-			days--
-		}
-		return int32(days), nil
+		return int32(unixDaysFloor(v)), nil
 	case string:
 		t, errRFC := time.Parse(time.RFC3339, v)
 		if errRFC != nil {
@@ -191,7 +186,7 @@ func coerceDateForEncode(value any) (any, error) {
 			}
 			t = t2
 		}
-		return int32(t.UTC().Unix() / 86400), nil
+		return int32(unixDaysFloor(t)), nil
 	case int32:
 		return v, nil
 	case int64:
@@ -208,6 +203,20 @@ func coerceDateForEncode(value any) (any, error) {
 	default:
 		return nil, fmt.Errorf("DATE values must be time.Time, date string, or numeric days-since-epoch; got %T", value)
 	}
+}
+
+// unixDaysFloor returns days-since-epoch for t with floor-toward-negative-
+// infinity rounding. Go's integer division truncates toward zero, which
+// would map a pre-epoch wall-clock like 1969-12-31T23:59:59Z (Unix = -1) to
+// day 0 (1970-01-01) instead of the correct day -1 (1969-12-31). Times at
+// or after the epoch are unaffected.
+func unixDaysFloor(t time.Time) int64 {
+	secs := t.UTC().Unix()
+	days := secs / 86400
+	if secs < 0 && secs%86400 != 0 {
+		days--
+	}
+	return days
 }
 
 // coerceTimeForEncode converts a value into the parquet physical

--- a/internal/impl/parquet/schema_coercion_coverage_test.go
+++ b/internal/impl/parquet/schema_coercion_coverage_test.go
@@ -202,3 +202,38 @@ func TestCoerceDateForEncode_StringErrorSurfacesBothAttempts(t *testing.T) {
 	assert.Contains(t, msg, "RFC3339", "error should mention the RFC3339 attempt")
 	assert.Contains(t, msg, "YYYY-MM-DD", "error should mention the bare-date attempt")
 }
+
+// TestCoerceDateForEncode_FloorsTowardNegativeInfinity pins down the
+// pre-epoch rounding contract: a time.Time and an RFC3339 string at the
+// same instant must produce the same days-since-epoch, and a pre-epoch
+// wall clock with a non-midnight component must round down (1969-12-31)
+// rather than truncate toward zero (1970-01-01).
+//
+// Go's integer division truncates, which silently mapped pre-epoch
+// RFC3339 strings to the wrong day before the floor adjustment landed.
+// The bare-date YYYY-MM-DD form happens to land on midnight UTC, so its
+// Unix() is a multiple of 86400 and truncate/floor agree — but it is
+// included here to confirm the shared helper hasn't perturbed it.
+func TestCoerceDateForEncode_FloorsTowardNegativeInfinity(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		wantDays int32
+	}{
+		{"time.Time pre-epoch non-midnight", time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC), -1},
+		{"RFC3339 pre-epoch non-midnight", "1969-12-31T23:59:59Z", -1},
+		{"RFC3339 pre-epoch midnight", "1969-12-31T00:00:00Z", -1},
+		{"bare date pre-epoch", "1969-12-31", -1},
+		{"time.Time epoch", time.Unix(0, 0).UTC(), 0},
+		{"RFC3339 epoch", "1970-01-01T00:00:00Z", 0},
+		{"RFC3339 post-epoch non-midnight", "1970-01-01T12:34:56Z", 0},
+		{"bare date post-epoch", "2024-03-14", 19796},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coerceDateForEncode(tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDays, got, "days-since-epoch must be floor-rounded, not truncated")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes [CON-468](https://redpandadata.atlassian.net/browse/CON-468). The Avro JSON schema parser at `internal/impl/confluent/ecs_avro.go` was dropping named-type references in nullable unions — i.e. the `["null", "Fee"]` idiom where `Fee` is a previously-defined record reused across more than one field — to `schema.Any`, so downstream sinks (notably `iceberg`) saw a VARCHAR column where the customer's Avro schema asked for a nested struct.

[#4380](https://github.com/redpanda-data/connect/pull/4380) closed the **inline-record** form of this shape (`["null", {"type":"record","name":"Fee",...}]`). It did not address the more common **name-reference** form, which any non-trivial Avro schema with a reused record will produce — the Avro spec requires named types to be defined once and referenced by name thereafter.

## What changed

`ecsAvroConfig` now carries a `names map[string]schema.Common` populated as the parser walks the schema. Every `record`, `enum`, and `fixed` definition is registered under both its simple name and its fully-qualified `namespace.name` form, matching Avro's lexical-scope resolution rules. String-form type references consult the map before falling back to the primitive-name lookup, so `"Fee"` resolves to the registered record's full structure instead of collapsing to `schema.Any`.

The two existing optional-union helpers (`ecsAvroIsUnionJustOptional` for primitives, `ecsAvroIsUnionJustOptionalObject` for inline objects) are replaced by a unified `ecsAvroResolveOptionalUnion` that handles all three branch forms (primitive, named reference, inline object) and accepts either ordering — `["null", X]` and `[X, null]` are now equivalent, per CON-468 acceptance criterion 2.

Both the raw-union and lame-union (default `raw_unions: false`) hydrators route through the same `ecsAvroResolveTypeRef` helper, so the fix covers every customer regardless of their `raw_unions` setting.

## Commit narrative

| Commit | Scope |
|---|---|
| `4531c5171` | Names map, unified resolver, named-type registration, raw-union path. Five tests covering CON-468 criterion 2 verbatim. |
| `10000e8a4` | Same fix routed through the lame-union path (default config). One additional test. |

## Scope notes

- **Self-referential records** (a record whose own children reference it by name before its definition completes) remain unsupported. Closing that would require pre-registering a placeholder before walking children. Avro recursive types are rare; we can address as a follow-up if a customer hits it.
- **JSON Schema and Protobuf** decode paths in the Schema Registry processor never produced `schema.Common` metadata to begin with — `store_schema_metadata` is wired only for the Avro arm. That is a pre-existing limitation, not a regression, and a feature request worth its own ticket if a customer asks for it.

## Test plan

- [x] `go test ./internal/impl/confluent/...` — all green, including the six new tests below.
- [x] `task lint` — `0 issues`.
- [x] Verified the existing `TestEcsAvroRawUnionNestedRecord` (the [#4380](https://github.com/redpanda-data/connect/pull/4380) regression) still passes — the inline-record path is unchanged.

New tests:

- `TestEcsAvroRawUnionNullableRecordByName` — `["null", "Fee"]` name reference.
- `TestEcsAvroRawUnionNullableOrderIndependence` (3 sub-tests) — `[X, "null"]` across inline records, primitives, and name references.
- `TestEcsAvroRawUnionNullableRecordNamespaced` — short and fully-qualified namespace references.
- `TestEcsAvroRawUnionNullableRecordNested` — record-containing-record where the inner is a name-reference union.
- `TestEcsAvroLameUnionNameResolution` — same fix verified in the default-config (lame-union) path.


[CON-468]: https://redpandadata.atlassian.net/browse/CON-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ