### PR TITLE
oracledb_cdc: handle LOB_TRIM redo SQL separately from SELECT_LOB_LOCATOR

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -1893,4 +1893,159 @@ oracledb_cdc:
 		}
 		require.NoError(t, stream.StopWithin(time.Second*10))
 	})
+
+	t.Run("LOB_TRIM handling for BASICFILE LOB updates", func(t *testing.T) {
+		// BASICFILE storage emits LOB_TRIM(0) → LOB_WRITE(s) on UPDATE (clear-then-write),
+		// whereas SecureFile emits LOB_WRITE(s) → LOB_TRIM(N). The LOB_TRIM(0) must not
+		// discard the fragments written after it, and the assembled value should appear in
+		// the UPDATE CDC event merged via MergeLOBsIntoDMLEvents.
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.lobtrimbasic",
+			`CREATE TABLE testdb.lobtrimbasic (
+			id      NUMBER GENERATED ALWAYS AS IDENTITY (NOCACHE) PRIMARY KEY,
+			clobcol CLOB
+		) LOB(clobcol) STORE AS BASICFILE`))
+
+		var batch oracledbtest.Batch
+
+		cfg := fmt.Sprintf(`
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  logminer:
+    lob_enabled: true
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.LOBTRIMBASIC"]`, connStr)
+
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(cfg))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			batch.Lock()
+			defer batch.Unlock()
+			for _, msg := range mb {
+				msgBytes, err := msg.AsBytes()
+				assert.NoError(t, err)
+				batch.Msgs = append(batch.Msgs, string(msgBytes))
+			}
+			return nil
+		}))
+
+		stream, err := streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		t.Log("Inserting initial LOB row and waiting CDC event")
+		{
+			initialClob := strings.Repeat("A", 5000)
+			db.MustExec("INSERT INTO testdb.lobtrimbasic (clobcol) VALUES (:1)", initialClob)
+
+			assert.Eventually(t, func() bool {
+				return batch.Count() >= 1
+			}, time.Minute*2, time.Millisecond*500, "timed out waiting for INSERT CDC event")
+		}
+
+		t.Log("Updating LOB row and waiting for CDC event")
+		{
+			updatedClob := strings.Repeat("B", 5000)
+			db.MustExec("UPDATE testdb.lobtrimbasic SET clobcol = :1 WHERE id = 1", updatedClob)
+
+			assert.Eventually(t, func() bool {
+				for _, msg := range batch.Clone() {
+					var row map[string]any
+					if err := json.Unmarshal([]byte(msg), &row); err != nil {
+						continue
+					}
+					if v, ok := row["CLOBCOL"].(string); ok && v == updatedClob {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Millisecond*500, "expected a CDC event carrying the updated CLOB value after BASICFILE LOB_TRIM handling")
+		}
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
+
+	t.Run("LOB_TRIM handling for BASICFILE out-of-row LOB updates", func(t *testing.T) {
+		// BASICFILE with DISABLE STORAGE IN ROW stores the LOB out-of-row and does not
+		// emit SELECT_LOB_LOCATOR. The inferLOBLocator path must create the accumulator
+		// from an existing DML event, and the assembled value must appear in the UPDATE.
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.lobtrimbasicoor",
+			`CREATE TABLE testdb.lobtrimbasicoor (
+			id      NUMBER GENERATED ALWAYS AS IDENTITY (NOCACHE) PRIMARY KEY,
+			clobcol CLOB
+		) LOB(clobcol) STORE AS BASICFILE (DISABLE STORAGE IN ROW NOCACHE)`))
+
+		var batch oracledbtest.Batch
+
+		cfg := fmt.Sprintf(`
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  logminer:
+    lob_enabled: true
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.LOBTRIMBASICOOR"]`, connStr)
+
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(cfg))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			batch.Lock()
+			defer batch.Unlock()
+			for _, msg := range mb {
+				msgBytes, err := msg.AsBytes()
+				assert.NoError(t, err)
+				batch.Msgs = append(batch.Msgs, string(msgBytes))
+			}
+			return nil
+		}))
+
+		stream, err := streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		t.Log("Inserting initial LOB row and waiting CDC event")
+		{
+			initialClob := strings.Repeat("A", 5000)
+			db.MustExec("INSERT INTO testdb.lobtrimbasicoor (clobcol) VALUES (:1)", initialClob)
+
+			assert.Eventually(t, func() bool {
+				return batch.Count() >= 1
+			}, time.Minute*2, time.Millisecond*500, "timed out waiting for INSERT CDC event")
+		}
+
+		t.Log("Updating LOB row and waiting for CDC event")
+		{
+			updatedClob := strings.Repeat("B", 5000)
+			db.MustExec("UPDATE testdb.lobtrimbasicoor SET clobcol = :1 WHERE id = 1", updatedClob)
+
+			assert.Eventually(t, func() bool {
+				for _, msg := range batch.Clone() {
+					var row map[string]any
+					if err := json.Unmarshal([]byte(msg), &row); err != nil {
+						continue
+					}
+					if v, ok := row["CLOBCOL"].(string); ok && v == updatedClob {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Millisecond*500, "expected a CDC event carrying the updated CLOB value after BASICFILE out-of-row LOB_TRIM handling")
+		}
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
 }

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -1809,3 +1809,88 @@ oracledb_cdc:
 
 	require.NoError(t, stream.StopWithin(10*time.Second))
 }
+
+func TestIntegrationOracleDBCDCLOB(t *testing.T) {
+	integration.CheckSkip(t)
+
+	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+
+	t.Run("LOB_TRIM handling for SecureFile LOB updates", func(t *testing.T) {
+		// Use default storage (SecureFile on Oracle Free 23c) so that Oracle emits
+		// the SELECT_LOB_LOCATOR → LOB_WRITE(s) → LOB_TRIM(N) sequence on UPDATE.
+		// The LOB_TRIM finalisation step must not discard already-accumulated fragments.
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.lobtrim",
+			`CREATE TABLE testdb.lobtrim (
+			id      NUMBER GENERATED ALWAYS AS IDENTITY (NOCACHE) PRIMARY KEY,
+			clobcol CLOB
+		)`))
+
+		var batch oracledbtest.Batch
+
+		cfg := fmt.Sprintf(`
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  logminer:
+    lob_enabled: true
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.LOBTRIM"]`, connStr)
+
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(cfg))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			batch.Lock()
+			defer batch.Unlock()
+			for _, msg := range mb {
+				msgBytes, err := msg.AsBytes()
+				assert.NoError(t, err)
+				batch.Msgs = append(batch.Msgs, string(msgBytes))
+			}
+			return nil
+		}))
+
+		stream, err := streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		t.Log("Inserting initial LOB row and waiting CDC event")
+		{
+			initialClob := strings.Repeat("A", 5000)
+			db.MustExec("INSERT INTO testdb.lobtrim (clobcol) VALUES (:1)", initialClob)
+
+			assert.Eventually(t, func() bool {
+				return batch.Count() >= 1
+			}, time.Minute*2, time.Millisecond*500, "timed out waiting for INSERT CDC event")
+		}
+
+		t.Log("Updating LOB row and waiting for CDC event")
+		{
+			// UPDATE the row — Oracle emits SELECT_LOB_LOCATOR → LOB_WRITE(s) → LOB_TRIM.
+			// The assembled CLOB value should equal the new content, not the old value.
+			updatedClob := strings.Repeat("B", 5000)
+			db.MustExec("UPDATE testdb.lobtrim SET clobcol = :1 WHERE id = 1", updatedClob)
+
+			assert.Eventually(t, func() bool {
+				for _, msg := range batch.Clone() {
+					var row map[string]any
+					if err := json.Unmarshal([]byte(msg), &row); err != nil {
+						continue
+					}
+					if v, ok := row["CLOBCOL"].(string); ok && v == updatedClob {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Millisecond*500, "expected a CDC event carrying the updated CLOB value after LOB_TRIM handling")
+		}
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
+}

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -318,13 +318,13 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 		//
 		// Form B — dbms_lob.trim(loc_b, N)
 		//   Emitted when a SELECT_LOB_LOCATOR has already established the active key.
-		//   No schema/table/column info is present; we just clear accumulated fragments so
-		//   subsequent LOB_WRITE calls start with a clean slate.
+		//   No schema/table/column info is present. The accumulator is left untouched
+		//   regardless of N — see the inline comment below for the rationale.
 		//
-		//   When N=0 this is the standard "clear before full rewrite" pattern and clearing
-		//   fragments is correct. When N>0, Oracle means "keep the first N bytes/chars" of
-		//   the pre-existing LOB — data we do not hold in the accumulator. The assembled
-		//   value will be incomplete in that case (missing the preserved prefix).
+		//   When N>0 and no fragments have been accumulated, a warning is emitted because
+		//   Oracle intends to keep the first N bytes/chars of the pre-existing LOB, which
+		//   we do not hold. In the common SecureFile full-rewrite path LOB_WRITE(s) precede
+		//   LOB_TRIM and the assembled length equals N, so no data is lost in practice.
 		if redoEvent.SQLRedo.Valid && redoEvent.SQLRedo.String != "" {
 			if info, err := sqlredo.ParseSelectLobLocator(redoEvent.SQLRedo.String); err == nil {
 				// Form A: establish (or reset) the accumulator for this LOB column.
@@ -361,9 +361,14 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 		}
 		if redoEvent.SQLRedo.Valid && redoEvent.SQLRedo.String != "" {
 			if trimLen, err := sqlredo.ParseLobTrim(redoEvent.SQLRedo.String); err == nil && trimLen > 0 {
-				// N>0 with no prior LOB_WRITEs would indicate a genuine partial truncation
-				// where the existing prefix is preserved. We cannot reconstruct that prefix
-				// from redo alone, so warn but still emit what was written.
+				// Warn only for the blatant case: N>0 with no fragments at all, meaning
+				// the existing LOB prefix is preserved but we have nothing to emit.
+				// Two adjacent cases (N < total written bytes, or N > total written bytes
+				// with M>0) also produce an assembled value that does not exactly match N,
+				// but Assemble() is not truncated to N here. This is an intentional
+				// tradeoff: SecureFile full-rewrite UPDATEs (the common path) always write
+				// all bytes then trim to the exact final length, so assembled==N in
+				// practice. Partial-update patterns are not supported by this path.
 				if acc := state.Accumulators[*state.ActiveKey]; acc != nil && len(acc.Fragments) == 0 {
 					lm.log.Warnf("LOB_TRIM to non-zero length %d with no prior LOB_WRITE (scn=%d, txn=%s): assembled value may be incomplete", trimLen, redoEvent.SCN, redoEvent.TransactionID)
 				}
@@ -425,6 +430,17 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 					// event. This handles Oracle SecureFile out-of-row LOBs where Oracle does
 					// not emit a DML UPDATE in LogMiner — only SELECT_LOB_LOCATOR + LOB_WRITE
 					// + LOB_TRIM operations are recorded.
+					//
+					// The synthesized event is intentionally sparse: Data contains only the
+					// LOB column(s) and OldValues contains only the PK columns extracted from
+					// the SELECT_LOB_LOCATOR WHERE clause. Other row columns are not available
+					// from redo alone. Carrying over values from a prior event in the same
+					// transaction is not possible here: MergeLOBsIntoDMLEvents merges into any
+					// matching INSERT (Pass 1) or PK-bearing UPDATE (Pass 2) before returning
+					// an accumulator as unmerged, so by definition no full-row DML event for
+					// this row exists in the transaction. Downstream consumers should treat a
+					// sparse UPDATE (OldValues containing only PK columns) as a LOB-column-only
+					// change with no information about other columns.
 					for _, acc := range unmerged {
 						assembled := acc.Assemble()
 						if assembled == nil {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -271,19 +271,17 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 
 		lm.txnCache.AddEvent(redoEvent.TransactionID, redoEvent.SCN, &event)
 
-	case sqlredo.OpSelectLobLocator, sqlredo.OpLobTrim:
+	case sqlredo.OpSelectLobLocator:
 		if !lm.cfg.LOBEnabled {
 			return nil
 		}
 		if !redoEvent.SQLRedo.Valid || redoEvent.SQLRedo.String == "" {
-			lm.log.Warnf("Skipping %s with no SQL_REDO (scn=%d, txn=%s)", redoEvent.Operation, redoEvent.SCN, redoEvent.TransactionID)
+			lm.log.Warnf("Skipping SELECT_LOB_LOCATOR with no SQL_REDO (scn=%d, txn=%s)", redoEvent.SCN, redoEvent.TransactionID)
 			return nil
 		}
-		// LOB_TRIM SQL has the same SELECT "COL" INTO ... FROM "SCHEMA"."TABLE" WHERE ...
-		// structure as SELECT_LOB_LOCATOR, so the same parser works for both.
 		info, err := sqlredo.ParseSelectLobLocator(redoEvent.SQLRedo.String)
 		if err != nil {
-			lm.log.Warnf("Failed to parse %s SQL (scn=%d, txn=%s): %v\nSQL: %.500s", redoEvent.Operation, redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
+			lm.log.Warnf("Failed to parse SELECT_LOB_LOCATOR SQL (scn=%d, txn=%s): %v\nSQL: %.500s", redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
 			return nil
 		}
 		// Resolve LOB type from the schema cache populated at startup.
@@ -307,6 +305,70 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 			}
 		}
 		state.ActiveKey = &key
+
+	case sqlredo.OpLobTrim:
+		if !lm.cfg.LOBEnabled {
+			return nil
+		}
+		// LOB_TRIM (op 11) comes in two forms depending on Oracle LOB type:
+		//
+		// Form A — SELECT "COL" INTO ... FROM "SCHEMA"."TABLE" WHERE ...
+		//   Emitted for certain LOB types (e.g. out-of-line SecureFile) without a preceding
+		//   SELECT_LOB_LOCATOR. In this case LOB_TRIM itself must establish the accumulator.
+		//
+		// Form B — dbms_lob.trim(loc_b, N)
+		//   Emitted when a SELECT_LOB_LOCATOR has already established the active key.
+		//   No schema/table/column info is present; we just clear accumulated fragments so
+		//   subsequent LOB_WRITE calls start with a clean slate.
+		//
+		//   When N=0 this is the standard "clear before full rewrite" pattern and clearing
+		//   fragments is correct. When N>0, Oracle means "keep the first N bytes/chars" of
+		//   the pre-existing LOB — data we do not hold in the accumulator. The assembled
+		//   value will be incomplete in that case (missing the preserved prefix).
+		if redoEvent.SQLRedo.Valid && redoEvent.SQLRedo.String != "" {
+			if info, err := sqlredo.ParseSelectLobLocator(redoEvent.SQLRedo.String); err == nil {
+				// Form A: establish (or reset) the accumulator for this LOB column.
+				colKey := fmt.Sprintf("%s.%s.%s", info.Schema, info.Table, info.Column)
+				lobType := lm.lobColTypes[strings.ToUpper(colKey)]
+				state := lm.getOrCreateLOBState(redoEvent.TransactionID)
+				key := sqlredo.LobKey{
+					Schema:   info.Schema,
+					Table:    info.Table,
+					Column:   info.Column,
+					PKString: sqlredo.FormatPKString(info.PKValues),
+				}
+				state.Accumulators[key] = &sqlredo.LobAccumulator{
+					Schema:   info.Schema,
+					Table:    info.Table,
+					Column:   info.Column,
+					PKValues: info.PKValues,
+					IsBinary: lobType == "BLOB",
+				}
+				state.ActiveKey = &key
+				return nil
+			}
+		}
+		// Form B: LOB_TRIM carries no schema/table/column info — the active key was
+		// already established by SELECT_LOB_LOCATOR. Oracle may emit LOB_TRIM before
+		// LOB_WRITE (BASICFILE "clear then write") or after (SecureFile "write then
+		// finalize"). In both cases the accumulator should be left untouched:
+		//   - Before LOB_WRITE: accumulator is empty anyway, so there is nothing to clear.
+		//   - After LOB_WRITE:  fragments are already accumulated; clearing them would
+		//     destroy the data before commit.
+		state, exists := lm.lobStates[redoEvent.TransactionID]
+		if !exists || state.ActiveKey == nil {
+			return nil
+		}
+		if redoEvent.SQLRedo.Valid && redoEvent.SQLRedo.String != "" {
+			if trimLen, err := sqlredo.ParseLobTrim(redoEvent.SQLRedo.String); err == nil && trimLen > 0 {
+				// N>0 with no prior LOB_WRITEs would indicate a genuine partial truncation
+				// where the existing prefix is preserved. We cannot reconstruct that prefix
+				// from redo alone, so warn but still emit what was written.
+				if acc := state.Accumulators[*state.ActiveKey]; acc != nil && len(acc.Fragments) == 0 {
+					lm.log.Warnf("LOB_TRIM to non-zero length %d with no prior LOB_WRITE (scn=%d, txn=%s): assembled value may be incomplete", trimLen, redoEvent.SCN, redoEvent.TransactionID)
+				}
+			}
+		}
 
 	case sqlredo.OpLobWrite:
 		if !lm.cfg.LOBEnabled {
@@ -358,7 +420,28 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 			if lm.cfg.LOBEnabled {
 				// Merge any accumulated LOB data into DML events before publishing.
 				if state, ok := lm.lobStates[redoEvent.TransactionID]; ok {
-					sqlredo.MergeLOBsIntoDMLEvents(state, txn.Events, lm.log)
+					unmerged := sqlredo.MergeLOBsIntoDMLEvents(state, txn.Events, lm.log)
+					// Synthesize UPDATE events for LOB accumulators that had no matching DML
+					// event. This handles Oracle SecureFile out-of-row LOBs where Oracle does
+					// not emit a DML UPDATE in LogMiner — only SELECT_LOB_LOCATOR + LOB_WRITE
+					// + LOB_TRIM operations are recorded.
+					for _, acc := range unmerged {
+						assembled := acc.Assemble()
+						if assembled == nil {
+							continue
+						}
+						synthetic := &sqlredo.DMLEvent{
+							Operation:     sqlredo.OpUpdate,
+							Schema:        acc.Schema,
+							Table:         acc.Table,
+							Data:          map[string]any{acc.Column: assembled},
+							OldValues:     acc.PKValues,
+							TransactionID: redoEvent.TransactionID,
+							Timestamp:     redoEvent.Timestamp,
+						}
+						txn.Events = append(txn.Events, synthetic)
+						lm.log.Debugf("LOB merge: synthesized UPDATE for %s.%s.%s (pks=%v, fragments=%d)", acc.Schema, acc.Table, acc.Column, acc.PKValues, len(acc.Fragments))
+					}
 				}
 			}
 

--- a/internal/impl/oracledb/logminer/sqlredo/lob.go
+++ b/internal/impl/oracledb/logminer/sqlredo/lob.go
@@ -114,19 +114,26 @@ func NewTxnLOBState() *TxnLOBState {
 
 // MergeLOBsIntoDMLEvents matches each LOB accumulator to its corresponding DML
 // event (by schema, table, and PK values) and overwrites the LOB column value
-// with the assembled data.
+// with the assembled data. It returns any accumulators whose data could not be
+// merged — the caller should synthesize DML events for these (see logminer.go).
 //
 // For small LOBs stored inline, Oracle emits both the original INSERT (with empty
 // LOB placeholders) and a subsequent LOB-initialisation UPDATE (with only LOB columns).
 // To ensure the LOB values land on the INSERT rather than the UPDATE, this function
 // first searches forward for an INSERT event with a matching PK, then falls back to
 // the most-recent matching DML event of any type.
-func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service.Logger) {
+//
+// Oracle SecureFile out-of-row LOBs may emit only SELECT_LOB_LOCATOR + LOB_WRITE +
+// LOB_TRIM with no DML UPDATE. In that case all three passes find nothing and the
+// accumulator is returned as unmerged so the caller can synthesize a synthetic UPDATE.
+func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service.Logger) []*LobAccumulator {
 	logDebugf := func(msg string, args ...any) {
 		if log != nil {
 			log.Debugf(msg, args...)
 		}
 	}
+
+	var unmerged []*LobAccumulator
 
 	for _, acc := range state.Accumulators {
 		assembled := acc.Assemble()
@@ -137,8 +144,8 @@ func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service
 
 		merged := false
 
-		// Prefer merging into an INSERT so that Oracle's internal LOB-initialisation
-		// UPDATE (which only carries LOB columns) does not shadow the original INSERT.
+		// Pass 1: prefer an INSERT event with matching PK so that Oracle's
+		// LOB-initialisation UPDATE does not shadow the original INSERT.
 		for i := range events {
 			ev := events[i]
 			if ev.Operation != OpInsert {
@@ -159,13 +166,15 @@ func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service
 			continue
 		}
 
-		// Fall back to the most-recent matching DML event of any operation type.
+		// Pass 2: fall back to the most-recent DML event of any type with a matching PK.
+		// For LOB-only UPDATE events the SET clause contains only LOB columns, so
+		// PK columns are not in ev.Data — they are in ev.OldValues (WHERE clause).
 		for i := len(events) - 1; i >= 0; i-- {
 			ev := events[i]
 			if ev.Schema != acc.Schema || ev.Table != acc.Table {
 				continue
 			}
-			if pkMatches(ev.Data, acc.PKValues) {
+			if pkMatches(ev.Data, acc.PKValues) || pkMatches(ev.OldValues, acc.PKValues) {
 				ev.Data[acc.Column] = assembled
 				merged = true
 				logDebugf("LOB merge: set %s.%s.%s (pks=%v, fragments=%d)", acc.Schema, acc.Table, acc.Column, acc.PKValues, len(acc.Fragments))
@@ -173,10 +182,31 @@ func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service
 			}
 		}
 
+		if merged {
+			continue
+		}
+
+		// Pass 3: schema/table-only fallback. Oracle SecureFile LOB-init UPDATEs
+		// sometimes carry only ROWID in their WHERE clause (no PK columns), making
+		// PK matching impossible. If there is exactly one candidate event for this
+		// table, merge unconditionally; otherwise take the most recent one.
+		for i := len(events) - 1; i >= 0; i-- {
+			ev := events[i]
+			if ev.Schema == acc.Schema && ev.Table == acc.Table {
+				ev.Data[acc.Column] = assembled
+				merged = true
+				logDebugf("LOB merge: set %s.%s.%s via schema/table fallback (fragments=%d)", acc.Schema, acc.Table, acc.Column, len(acc.Fragments))
+				break
+			}
+		}
+
 		if !merged {
-			logDebugf("LOB merge: no matching DML event found for %s.%s.%s (pks=%v)", acc.Schema, acc.Table, acc.Column, acc.PKValues)
+			logDebugf("LOB merge: no matching DML event for %s.%s.%s (pks=%v) — will synthesize UPDATE", acc.Schema, acc.Table, acc.Column, acc.PKValues)
+			unmerged = append(unmerged, acc)
 		}
 	}
+
+	return unmerged
 }
 
 // MergeInlineLOBValues merges LOB column values from an inline-LOB-only UPDATE into the

--- a/internal/impl/oracledb/logminer/sqlredo/lob.go
+++ b/internal/impl/oracledb/logminer/sqlredo/lob.go
@@ -132,6 +132,11 @@ func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service
 			log.Debugf(msg, args...)
 		}
 	}
+	logWarnf := func(msg string, args ...any) {
+		if log != nil {
+			log.Warnf(msg, args...)
+		}
+	}
 
 	var unmerged []*LobAccumulator
 
@@ -188,16 +193,25 @@ func MergeLOBsIntoDMLEvents(state *TxnLOBState, events []*DMLEvent, log *service
 
 		// Pass 3: schema/table-only fallback. Oracle SecureFile LOB-init UPDATEs
 		// sometimes carry only ROWID in their WHERE clause (no PK columns), making
-		// PK matching impossible. If there is exactly one candidate event for this
-		// table, merge unconditionally; otherwise take the most recent one.
-		for i := len(events) - 1; i >= 0; i-- {
+		// PK matching impossible. Only merge when exactly one candidate event exists
+		// for this table; if multiple exist, rows cannot be distinguished and the
+		// accumulator is left unmerged so the caller synthesizes a separate UPDATE.
+		var candidates []*DMLEvent
+		for i := range events {
 			ev := events[i]
 			if ev.Schema == acc.Schema && ev.Table == acc.Table {
-				ev.Data[acc.Column] = assembled
-				merged = true
-				logDebugf("LOB merge: set %s.%s.%s via schema/table fallback (fragments=%d)", acc.Schema, acc.Table, acc.Column, len(acc.Fragments))
-				break
+				candidates = append(candidates, ev)
 			}
+		}
+		switch len(candidates) {
+		case 1:
+			candidates[0].Data[acc.Column] = assembled
+			merged = true
+			logDebugf("LOB merge: set %s.%s.%s via schema/table fallback (fragments=%d)", acc.Schema, acc.Table, acc.Column, len(acc.Fragments))
+		case 0:
+			// no candidates — fall through to unmerged
+		default:
+			logWarnf("LOB merge: %s.%s.%s has %d candidate events with no PK in WHERE clause — cannot distinguish rows; will synthesize UPDATE", acc.Schema, acc.Table, acc.Column, len(candidates))
 		}
 
 		if !merged {

--- a/internal/impl/oracledb/logminer/sqlredo/lob_parser.go
+++ b/internal/impl/oracledb/logminer/sqlredo/lob_parser.go
@@ -80,6 +80,22 @@ type LobWriteInfo struct {
 	Length int64
 }
 
+var reLobTrimLength = regexp.MustCompile(`(?i)dbms_lob\.trim\s*\([^,]+,\s*(\d+)\s*\)`)
+
+// ParseLobTrim extracts the new length N from a dbms_lob.trim(locator, N) call
+// emitted by Oracle LogMiner for LOB_TRIM (op 11) entries.
+func ParseLobTrim(sql string) (int64, error) {
+	m := reLobTrimLength.FindStringSubmatch(sql)
+	if m == nil {
+		return 0, errors.New("could not find dbms_lob.trim() call in LOB_TRIM SQL")
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing LOB_TRIM length: %w", err)
+	}
+	return n, nil
+}
+
 var (
 	// Extracts length (1) and offset (2) from dbms_lob.write.
 	reLobWriteParams = regexp.MustCompile(`(?i)dbms_lob\.write\s*\([^,]+,\s*(\d+)\s*,\s*(\d+)\s*,`)


### PR DESCRIPTION
When updating an existing LOB field via a SQL `UPDATE` command, OracleDB will handle that update in a number of ways.

1. SecureFile (Oracle Free 23c default): emits LOB_WRITE(s) → LOB_TRIM(N). The trim finalises the value after fragments are written, so clearing fragments on LOB_TRIM was the bug. May emit no DML UPDATE — in that case a synthetic UPDATE is synthesized from the assembled accumulator.

2. BASICFILE: emits LOB_TRIM(0) → LOB_WRITE(s) (clear-then-write). The DML UPDATE is always present; fragments arrive after the trim, so LOB_TRIM(0) must be a no-op against the fragment list.

3. BASICFILE out-of-row (DISABLE STORAGE IN ROW): no SELECT_LOB_LOCATOR is emitted. The inferLOBLocator path creates the accumulator from an existing DML event rather than from the locator SQL, and the DML UPDATE is always present for PK matching.

This change ensures we support these three variants and includes a test to verify each. 

<img width="1489" height="810" alt="image" src="https://github.com/user-attachments/assets/688618d1-5b70-48b4-a908-143766fb060f" />
