### PR TITLE
gcp: migrate Pub/Sub input and output to the pubsub/v2 SDK

### DIFF
--- a/docs/modules/components/pages/inputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/inputs/gcp_pubsub.adoc
@@ -41,7 +41,6 @@ input:
     credentials_json: ""
     subscription: "" # No default (required)
     endpoint: ""
-    sync: false
     max_outstanding_messages: 1000
     max_outstanding_bytes: 1e+09
 ```
@@ -60,7 +59,6 @@ input:
     credentials_json: ""
     subscription: "" # No default (required)
     endpoint: ""
-    sync: false
     max_outstanding_messages: 1000
     max_outstanding_bytes: 1e+09
     create_subscription:
@@ -134,15 +132,6 @@ endpoint: us-central1-pubsub.googleapis.com:443
 
 endpoint: us-west3-pubsub.googleapis.com:443
 ```
-
-=== `sync`
-
-Enable synchronous pull mode.
-
-
-*Type*: `bool`
-
-*Default*: `false`
 
 === `max_outstanding_messages`
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	buf.build/go/hyperpb v0.1.3
 	cloud.google.com/go/aiplatform v1.121.0
 	cloud.google.com/go/bigquery v1.75.0
-	cloud.google.com/go/pubsub v1.50.1
+	cloud.google.com/go/pubsub/v2 v2.4.0
 	cloud.google.com/go/spanner v1.88.0
 	cloud.google.com/go/storage v1.62.1
 	connectrpc.com/connect v1.19.1
@@ -218,7 +218,6 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	cloud.google.com/go/pubsub/v2 v2.4.0 // indirect
 	cloud.google.com/go/secretmanager v1.16.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
@@ -358,7 +357,7 @@ require (
 	cloud.google.com/go/auth v0.20.0
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/iam v1.7.0
 	cloud.google.com/go/trace v1.11.7 // indirect
 	cuelang.org/go v0.16.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/iam v1.7.0/go.mod h1:tetWZW1PD/m6vcuY2Zj/aU0eCHNPuxedbnbRTyKXvdY=
 cloud.google.com/go/kms v1.1.0/go.mod h1:WdbppnCDMDpOvoYBMn1+gNmOeEoZYqAv+HeuKARGCXI=
 cloud.google.com/go/kms v1.4.0/go.mod h1:fajBHndQ+6ubNw6Ss2sSd+SWvjL26RNo/dr7uxsnnOA=
-cloud.google.com/go/kms v1.26.0 h1:cK9mN2cf+9V63D3H1f6koxTatWy39aTI/hCjz1I+adU=
-cloud.google.com/go/kms v1.26.0/go.mod h1:pHKOdFJm63hxBsiPkYtowZPltu9dW0MWvBa6IA4HM58=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/logging v1.13.2/go.mod h1:zaybliM3yun1J8mU2dVQ1/qDzjbOqEijZCn6hSBtKak=
 cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8grmqY=
@@ -107,8 +105,6 @@ cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/pubsub v1.19.0/go.mod h1:/O9kmSe9bb9KRnIAWkzmqhPjHo6LtzGOBYd/kr06XSs=
-cloud.google.com/go/pubsub v1.50.1 h1:fzbXpPyJnSGvWXF1jabhQeXyxdbCIkXTpjXHy7xviBM=
-cloud.google.com/go/pubsub v1.50.1/go.mod h1:6YVJv3MzWJUVdvQXG081sFvS0dWQOdnV+oTo++q/xFk=
 cloud.google.com/go/pubsub/v2 v2.4.0 h1:oMKNiBQpXImRWnHYla9uSU66ZzByZwBSCJOEs/pTKVg=
 cloud.google.com/go/pubsub/v2 v2.4.0/go.mod h1:2lS/XQKq5qtOMs6kHBK+WX1ytUC36kLl2ig3zqsGUx8=
 cloud.google.com/go/secretmanager v1.3.0/go.mod h1:+oLTkouyiYiabAQNugCeTS3PAArGiMJuBqvJnJsyH+U=

--- a/internal/impl/aws/s3/bench/read/redpanda-connect/main.go
+++ b/internal/impl/aws/s3/bench/read/redpanda-connect/main.go
@@ -137,9 +137,7 @@ func seedBucket(ctx context.Context, client *s3.Client, total, objSize, numWorke
 	errCh := make(chan error, 1)
 
 	for range numWorkers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for n := range jobs {
 				if err := uploadObject(ctx, client, n, objSize); err != nil {
 					select {
@@ -154,7 +152,7 @@ func seedBucket(ctx context.Context, client *s3.Client, total, objSize, numWorke
 					fmt.Printf("Progress: %d/%d objects (%.0f obj/sec)\n", done, total, float64(done)/elapsed)
 				}
 			}
-		}()
+		})
 	}
 
 	for i := range total {
@@ -196,10 +194,7 @@ func uploadObject(ctx context.Context, client *s3.Client, n, size int) error {
 func makeObjectBody(n, size int) []byte {
 	prefix := fmt.Sprintf(`{"id":"obj-%d","created_at":"%s","data":"`, n, time.Now().UTC().Format(time.RFC3339))
 	suffix := `"}`
-	pad := size - len(prefix) - len(suffix)
-	if pad < 0 {
-		pad = 0
-	}
+	pad := max(size-len(prefix)-len(suffix), 0)
 	return []byte(prefix + strings.Repeat("x", pad) + suffix)
 }
 

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -21,7 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -124,8 +126,9 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 				Example("us-west3-pubsub.googleapis.com:443").
 				Default(""),
 			service.NewBoolField(pbiFieldSync).
-				Description("Enable synchronous pull mode.").
-				Default(false),
+				Description("Enable synchronous pull mode. This field is deprecated and no longer has any effect: the underlying GCP Pub/Sub client only supports streaming pull.").
+				Default(false).
+				Deprecated(),
 			service.NewIntField(pbiFieldMaxOutstandingMessages).
 				Description("The maximum number of outstanding pending messages to be consumed at a given time.").
 				Default(1000), // pubsub.DefaultReceiveSettings.MaxOutstandingMessages)
@@ -156,13 +159,17 @@ func init() {
 }
 
 func createSubscription(conf pbiConfig, client *pubsub.Client, log *service.Logger) {
-	subsExists, err := client.Subscription(conf.SubscriptionID).Exists(context.Background())
-	if err != nil {
+	subName := client.Subscriber(conf.SubscriptionID).String()
+
+	_, err := client.SubscriptionAdminClient.GetSubscription(context.Background(), &pubsubpb.GetSubscriptionRequest{
+		Subscription: subName,
+	})
+	if err != nil && status.Code(err) != codes.NotFound {
 		log.Errorf("Error checking if subscription exists: %v", err)
 		return
 	}
 
-	if subsExists {
+	if err == nil {
 		log.Infof("Subscription '%v' already exists", conf.SubscriptionID)
 		return
 	}
@@ -173,7 +180,10 @@ func createSubscription(conf pbiConfig, client *pubsub.Client, log *service.Logg
 	}
 
 	log.Infof("Creating subscription '%v' on topic '%v'\n", conf.SubscriptionID, conf.CreateTopicID)
-	_, err = client.CreateSubscription(context.Background(), conf.SubscriptionID, pubsub.SubscriptionConfig{Topic: client.Topic(conf.CreateTopicID)})
+	_, err = client.SubscriptionAdminClient.CreateSubscription(context.Background(), &pubsubpb.Subscription{
+		Name:  subName,
+		Topic: client.Publisher(conf.CreateTopicID).String(),
+	})
 	if err != nil {
 		log.Errorf("Error creating subscription %v", err)
 	}
@@ -182,7 +192,7 @@ func createSubscription(conf pbiConfig, client *pubsub.Client, log *service.Logg
 type gcpPubSubReader struct {
 	conf pbiConfig
 
-	subscription *pubsub.Subscription
+	subscription *pubsub.Subscriber
 	msgsChan     chan *pubsub.Message
 	closeFunc    context.CancelFunc
 	subMut       sync.Mutex
@@ -210,6 +220,10 @@ func newGCPPubSubReader(conf pbiConfig, res *service.Resources) (*gcpPubSubReade
 		return nil, err
 	}
 
+	if conf.Sync {
+		res.Logger().Warn("The 'sync' field is deprecated and no longer has any effect: the GCP Pub/Sub client only supports streaming pull.")
+	}
+
 	if conf.CreateEnabled {
 		if conf.CreateTopicID == "" {
 			return nil, errors.New("must specify a topic_id when create_subscription is enabled")
@@ -232,18 +246,20 @@ func (c *gcpPubSubReader) Connect(context.Context) error {
 		return nil
 	}
 
-	sub := c.client.Subscription(c.conf.SubscriptionID)
+	sub := c.client.Subscriber(c.conf.SubscriptionID)
 	sub.ReceiveSettings.MaxOutstandingMessages = c.conf.MaxOutstandingMessages
 	sub.ReceiveSettings.MaxOutstandingBytes = c.conf.MaxOutstandingBytes
-	sub.ReceiveSettings.Synchronous = c.conf.Sync
 
-	p, err := sub.IAM().TestPermissions(context.Background(), []string{"pubsub.subscriptions.consume"})
+	p, err := c.client.SubscriptionAdminClient.TestIamPermissions(context.Background(), &iampb.TestIamPermissionsRequest{
+		Resource:    sub.String(),
+		Permissions: []string{"pubsub.subscriptions.consume"},
+	})
 	// Ignore these checks when running against the emulator
 	if status.Code(err) != codes.Unimplemented {
 		if err != nil {
 			return service.NewErrBackOff(err, 5*time.Second)
 		}
-		if len(p) == 0 {
+		if len(p.GetPermissions()) == 0 {
 			return service.NewErrBackOff(errors.New("missing subscription permissions"), 5*time.Second)
 		}
 	}

--- a/internal/impl/gcp/input_pubsub_test.go
+++ b/internal/impl/gcp/input_pubsub_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/internal/impl/gcp/integration_pubsub_test.go
+++ b/internal/impl/gcp/integration_pubsub_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -65,8 +66,10 @@ func TestIntegrationGCPPubSub(t *testing.T) {
 		}
 		defer client.Close()
 
-		ok, err := client.Topic(dummyTopic).Exists(ctx)
-		return err == nil && ok
+		_, err = client.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{
+			Topic: client.Publisher(dummyTopic).String(),
+		})
+		return err == nil
 	}, time.Minute, time.Second)
 
 	template := `
@@ -94,7 +97,9 @@ input:
 			client, err := pubsub.NewClient(ctx, dummyProject)
 			require.NoError(t, err)
 
-			_, err = client.CreateTopic(ctx, fmt.Sprintf("topic-%v", vars.ID))
+			_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{
+				Name: client.Publisher(fmt.Sprintf("topic-%v", vars.ID)).String(),
+			})
 			require.NoError(t, err)
 
 			client.Close()

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/sourcegraph/conc/pool"
 	"google.golang.org/api/option"
 

--- a/internal/impl/gcp/output_pubsub_test.go
+++ b/internal/impl/gcp/output_pubsub_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 

--- a/internal/impl/gcp/pubsub.go
+++ b/internal/impl/gcp/pubsub.go
@@ -17,7 +17,10 @@ package gcp
 import (
 	"context"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var _ pubsubClient = (*airGappedPubsubClient)(nil)
@@ -47,28 +50,36 @@ func (ac *airGappedPubsubClient) Close() error {
 }
 
 func (ac *airGappedPubsubClient) Topic(id string, settings *pubsub.PublishSettings) pubsubTopic {
-	t := ac.c.Topic(id)
-	t.PublishSettings = *settings
+	p := ac.c.Publisher(id)
+	p.PublishSettings = *settings
 
-	return &airGappedTopic{t: t}
+	return &airGappedTopic{publisher: p, client: ac.c}
 }
 
 type airGappedTopic struct {
-	t *pubsub.Topic
+	publisher *pubsub.Publisher
+	client    *pubsub.Client
 }
 
 func (at *airGappedTopic) Exists(ctx context.Context) (bool, error) {
-	return at.t.Exists(ctx)
+	_, err := at.client.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{Topic: at.publisher.String()})
+	if status.Code(err) == codes.NotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (at *airGappedTopic) Publish(ctx context.Context, msg *pubsub.Message) publishResult {
-	return at.t.Publish(ctx, msg)
+	return at.publisher.Publish(ctx, msg)
 }
 
 func (at *airGappedTopic) EnableOrdering() {
-	at.t.EnableMessageOrdering = true
+	at.publisher.EnableMessageOrdering = true
 }
 
 func (at *airGappedTopic) Stop() {
-	at.t.Stop()
+	at.publisher.Stop()
 }

--- a/internal/impl/gcp/pubsub_mock_test.go
+++ b/internal/impl/gcp/pubsub_mock_test.go
@@ -17,7 +17,7 @@ package gcp
 import (
 	"context"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/stretchr/testify/mock"
 )
 


### PR DESCRIPTION
Google's Cloud Go SDK moved Pub/Sub to a v2 package, so this migrates the `gcp_pubsub` input and output over to it.

The main issue is that v2 splits the data clients from admin operations. Topic and subscription existence checks, IAM, and CreateSubscription aren't on `Publisher`/`Subscriber` anymore, so those now go through `TopicAdminClient`/`SubscriptionAdminClient` with a `codes.NotFound` check.

One behaviour change worth calling out: v2 dropped synchronous pull, so the input's `sync` field doesn't map to anything now. I left it in and marked it deprecated rather than removing it since this is a Stable connector, and the reader logs a warning if someone sets it. Can rip it out instead if you'd prefer.

Ran the unit tests and the full `gcp_pubsub` integration suite against the emulator, all green.

Happy to take feedback and iterate on any of this.

Fixes #4041