### PR TITLE
mysql_cdc: smooth IAM auth setup for RDS

### DIFF
--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -422,7 +422,6 @@ The MySQL endpoint as `host:port` (for example `mydb.abc123.us-east-1.rds.amazon
 
 *Default*: `""`
 
-
 === `aws.id`
 
 The ID of credentials to use.

--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -86,7 +86,7 @@ input:
     aws:
       enabled: false
       region: "" # No default (optional)
-      endpoint: "" # No default (required)
+      endpoint: ""
       id: "" # No default (optional)
       secret: "" # No default (optional)
       token: "" # No default (optional)
@@ -137,7 +137,7 @@ The type of MySQL database to connect to.
 
 === `dsn`
 
-The DSN of the MySQL database to connect to.
+The DSN of the MySQL database to connect to. When `aws.enabled` is `true`, the Go MySQL driver's `allowCleartextPasswords=1` flag is set automatically so the IAM auth token can be transmitted; pair it with TLS (`tls=true` plus the RDS CA bundle, or `tls=skip-verify` for non-production) to protect the token on the wire.
 
 
 *Type*: `string`
@@ -147,6 +147,8 @@ The DSN of the MySQL database to connect to.
 # Examples
 
 dsn: user:password@tcp(localhost:3306)/database
+
+dsn: user@tcp(mydb.abc123.us-east-1.rds.amazonaws.com:3306)/database?tls=true
 ```
 
 === `tables`
@@ -413,10 +415,12 @@ The AWS region where the MySQL instance is located. If no region is specified th
 
 === `aws.endpoint`
 
-The MySQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com).
+The MySQL endpoint as `host:port` (for example `mydb.abc123.us-east-1.rds.amazonaws.com:3306`). The AWS IAM token signer requires the port; if it is omitted the port from the DSN is used, falling back to `3306`. When this field is empty the address from the DSN is used.
 
 
 *Type*: `string`
+
+*Default*: `""`
 
 
 === `aws.id`

--- a/internal/impl/mysql/aws/aws.go
+++ b/internal/impl/mysql/aws/aws.go
@@ -16,7 +16,10 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -30,6 +33,8 @@ import (
 
 	mysqlimpl "github.com/redpanda-data/connect/v4/internal/impl/mysql"
 )
+
+const defaultMySQLPort = "3306"
 
 type roleConfig struct {
 	arn        string
@@ -58,6 +63,9 @@ func awsIAMAuth(ctx context.Context, awsConf *service.ParsedConfig, dbConf *mysq
 		return nil, fmt.Errorf("unable to load AWS config: %w", err)
 	}
 	if endpoint, err = awsConf.FieldString("endpoint"); err != nil {
+		return nil, err
+	}
+	if endpoint, err = normalizeIAMEndpoint(endpoint, dbConf.Addr); err != nil {
 		return nil, err
 	}
 	if region, _ = awsConf.FieldString("region"); region != "" {
@@ -151,6 +159,28 @@ func assumeRoleChain(ctx context.Context, awsCfg aws.Config, roles []roleConfig,
 	}
 
 	return currentConfig, nil
+}
+
+// normalizeIAMEndpoint returns a `host:port` value suitable for
+// auth.BuildAuthToken. The AWS SDK rejects an endpoint without a port, so this
+// helper fills one in: if `endpoint` is empty the DSN address is used; if
+// `endpoint` is a bare hostname the port is taken from the DSN address, with
+// the well-known MySQL port as a final fallback.
+func normalizeIAMEndpoint(endpoint, dsnAddr string) (string, error) {
+	if endpoint == "" {
+		endpoint = dsnAddr
+	}
+	if endpoint == "" {
+		return "", errors.New("aws IAM authentication requires an endpoint and the DSN does not contain an address")
+	}
+	if strings.Contains(endpoint, ":") {
+		return endpoint, nil
+	}
+	port := defaultMySQLPort
+	if _, p, splitErr := net.SplitHostPort(dsnAddr); splitErr == nil && p != "" {
+		port = p
+	}
+	return net.JoinHostPort(endpoint, port), nil
 }
 
 func parseRoleConfig(awsConf *service.ParsedConfig) ([]roleConfig, error) {

--- a/internal/impl/mysql/aws/aws_test.go
+++ b/internal/impl/mysql/aws/aws_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeIAMEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		dsnAddr  string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "endpoint already has port",
+			endpoint: "mydb.rds.amazonaws.com:3306",
+			dsnAddr:  "mydb.rds.amazonaws.com:3306",
+			want:     "mydb.rds.amazonaws.com:3306",
+		},
+		{
+			name:     "endpoint missing port, derive from DSN",
+			endpoint: "mydb.rds.amazonaws.com",
+			dsnAddr:  "mydb.rds.amazonaws.com:3307",
+			want:     "mydb.rds.amazonaws.com:3307",
+		},
+		{
+			name:     "endpoint missing port, DSN missing port, fall back to 3306",
+			endpoint: "mydb.rds.amazonaws.com",
+			dsnAddr:  "mydb.rds.amazonaws.com",
+			want:     "mydb.rds.amazonaws.com:3306",
+		},
+		{
+			name:     "endpoint empty, fall back to DSN",
+			endpoint: "",
+			dsnAddr:  "mydb.rds.amazonaws.com:3306",
+			want:     "mydb.rds.amazonaws.com:3306",
+		},
+		{
+			name:     "endpoint empty, DSN missing port, append default port",
+			endpoint: "",
+			dsnAddr:  "mydb.rds.amazonaws.com",
+			want:     "mydb.rds.amazonaws.com:3306",
+		},
+		{
+			name:     "endpoint empty and DSN empty errors",
+			endpoint: "",
+			dsnAddr:  "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeIAMEndpoint(tc.endpoint, tc.dsnAddr)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -68,6 +68,30 @@ var AWSOptFn = notImportedAWSOptFn
 // TokenBuilder can be used for fetching passwords at runtime during connection (ie. IAM auth tokens)
 type TokenBuilder func(context.Context) error
 
+// parseMySQLConfig parses a MySQL DSN and applies the driver-level options
+// this connector always requires.
+func parseMySQLConfig(dsn string) (*mysql.Config, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing mysql DSN: %v", err)
+	}
+	// We require this configuration option is enabled.
+	cfg.ParseTime = true
+	return cfg, nil
+}
+
+// applyIAMDriverDefaults adjusts the parsed mysql.Config to match what AWS
+// RDS IAM authentication needs from the Go MySQL driver. The IAM token is
+// presented to MySQL as the user's password; the driver refuses to transmit
+// it unless `AllowCleartextPasswords` is set. TLS on the DSN is what protects
+// the token in transit.
+func applyIAMDriverDefaults(cfg *mysql.Config, iamEnabled bool) {
+	if !iamEnabled {
+		return
+	}
+	cfg.AllowCleartextPasswords = true
+}
+
 var mysqlStreamConfigSpec = service.NewConfigSpec().
 	Stable().
 	Categories("Services").
@@ -91,8 +115,9 @@ This input adds the following metadata fields to each message:
 			Description("The type of MySQL database to connect to.").
 			Default(gomysql.MySQLFlavor),
 		service.NewStringField(fieldMySQLDSN).
-			Description("The DSN of the MySQL database to connect to.").
-			Example("user:password@tcp(localhost:3306)/database"),
+			Description("The DSN of the MySQL database to connect to. When `"+fieldAWSIAMAuth+".enabled` is `true`, the Go MySQL driver's `allowCleartextPasswords=1` flag is set automatically so the IAM auth token can be transmitted; pair it with TLS (`tls=true` plus the RDS CA bundle, or `tls=skip-verify` for non-production) to protect the token on the wire.").
+			Example("user:password@tcp(localhost:3306)/database").
+			Example("user@tcp(mydb.abc123.us-east-1.rds.amazonaws.com:3306)/database?tls=true"),
 		service.NewStringListField(fieldMySQLTables).
 			Description("A list of tables to stream from the database.").
 			Example([]string{"table1", "table2"}).
@@ -130,7 +155,8 @@ This input adds the following metadata fields to each message:
 				Description("The AWS region where the MySQL instance is located. If no region is specified then the environment default will be used.").
 				Optional(),
 			service.NewStringField("endpoint").
-				Description("The MySQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com)."),
+				Description("The MySQL endpoint as `host:port` (for example `mydb.abc123.us-east-1.rds.amazonaws.com:3306`). The AWS IAM token signer requires the port; if it is omitted the port from the DSN is used, falling back to `3306`. When this field is empty the address from the DSN is used.").
+				Default(""),
 			service.NewStringField("id").
 				Description("The ID of credentials to use.").
 				Optional().Advanced(),
@@ -240,12 +266,10 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	if err := gomysql.ValidateFlavor(i.flavor); err != nil {
 		return nil, err
 	}
-	i.mysqlConfig, err = mysql.ParseDSN(i.dsn)
+	i.mysqlConfig, err = parseMySQLConfig(i.dsn)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing mysql DSN: %v", err)
+		return nil, err
 	}
-	// We require this configuration option is enabled.
-	i.mysqlConfig.ParseTime = true
 
 	// Configure TLS if specified
 	if i.customTLSConfig, err = conf.FieldTLS("tls"); err != nil {
@@ -269,6 +293,8 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 	// Configure AWS IAM authentication if enabled
 	awsConf := conf.Namespace(fieldAWSIAMAuth)
 	i.iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
+
+	applyIAMDriverDefaults(i.mysqlConfig, i.iamAuthEnabled)
 
 	if i.iamAuthTokenBuilder, err = AWSOptFn(context.Background(), awsConf, i.mysqlConfig, res.Logger()); err != nil {
 		return nil, err

--- a/internal/impl/mysql/input_mysql_stream_test.go
+++ b/internal/impl/mysql/input_mysql_stream_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMySQLConfigSetsParseTime(t *testing.T) {
+	cfg, err := parseMySQLConfig("user:password@tcp(localhost:3306)/db")
+	require.NoError(t, err)
+	require.True(t, cfg.ParseTime, "ParseTime must be enabled to deserialise binlog timestamps")
+}
+
+func TestApplyIAMDriverDefaults(t *testing.T) {
+	cfg, err := parseMySQLConfig("user@tcp(mydb.rds.amazonaws.com:3306)/db")
+	require.NoError(t, err)
+
+	applyIAMDriverDefaults(cfg, false)
+	require.False(t, cfg.AllowCleartextPasswords, "must not enable cleartext passwords when IAM auth is off")
+
+	applyIAMDriverDefaults(cfg, true)
+	require.True(t, cfg.AllowCleartextPasswords, "must enable cleartext passwords so the IAM auth token can be sent to MySQL")
+}


### PR DESCRIPTION
## Summary

Two small papercuts surfaced while validating the [redpanda-operator Pipeline CRD against RDS with native IAM database authentication](https://github.com/redpanda-data/redpanda-operator/pull/1337#issuecomment-4464604928). Both can be fixed inside `mysql_cdc` itself.

- **`AllowCleartextPasswords` is now set automatically when `aws.enabled` is true.** The IAM token is sent to MySQL as the user's password, which the Go MySQL driver refuses unless this flag is set. Users no longer need to remember `&allowCleartextPasswords=1` in the DSN. TLS on the DSN is what protects the token in transit — the field docstring calls this out.
- **`aws.endpoint` is more forgiving.** The AWS SDK's RDS token signer requires `host:port`, but the field was documented as a bare hostname. Connect now derives the port from the DSN when the user omits it (falling back to `3306`), and falls back to the DSN address entirely when `aws.endpoint` is empty. Field is now optional with a `""` default.

Refactored DSN parsing and IAM driver-flag toggling into small testable helpers (`parseMySQLConfig` / `applyIAMDriverDefaults`) and added unit tests for `normalizeIAMEndpoint`.

The N9 friction point from the operator PR comment ("`REQUIRE SSL;` as a standalone statement") is purely user-side SQL — no Connect change applies.

## UX before / after

### 1. `allowCleartextPasswords=1` in the DSN

**Before** — without the flag, the driver refuses to send the IAM token and the pipeline crashes:

```yaml
input:
  mysql_cdc:
    dsn: "${MYSQL_USER}@tcp(${MYSQL_HOST}:3306)/shop?tls=skip-verify"
    aws:
      enabled: true
      region: us-east-2
      endpoint: "${MYSQL_HOST}:3306"
    tables: [orders]
```
```
ERROR  mysql.Connect: this user requires clear text authentication.
       If you still want to use it, please add 'allowCleartextPasswords=1' to your DSN
```

**Workaround users had to apply:**
```diff
- dsn: "${MYSQL_USER}@tcp(${MYSQL_HOST}:3306)/shop?tls=skip-verify"
+ dsn: "${MYSQL_USER}@tcp(${MYSQL_HOST}:3306)/shop?tls=skip-verify&allowCleartextPasswords=1"
```

**After** — Connect sets the flag itself whenever `aws.enabled` is `true`, so the original config just works. TLS on the DSN keeps the token off the wire in cleartext.

### 2. `aws.endpoint` accepts a bare hostname

**Before** — passing a hostname without a port produces a confusing error from inside the AWS SDK:

```yaml
input:
  mysql_cdc:
    dsn: "user@tcp(mydb.abc123.us-east-1.rds.amazonaws.com:3306)/shop"
    aws:
      enabled: true
      region: us-east-2
      endpoint: mydb.abc123.us-east-1.rds.amazonaws.com   # missing :3306
```
```
ERROR  building IAM auth token: the provided endpoint is missing a port,
       or the provided port is invalid
```

**After** — the port from the DSN is spliced in (or 3306 as a final fallback), so the same config works. Better still, `aws.endpoint` can now be omitted entirely:

```yaml
input:
  mysql_cdc:
    dsn: "user@tcp(mydb.abc123.us-east-1.rds.amazonaws.com:3306)/shop"
    aws:
      enabled: true
      region: us-east-2
      # endpoint inherited from the DSN
```

## Backwards compatibility

**Fully backwards compatible — no breaking changes.** Every previously valid config continues to behave identically.

| Existing config | Before | After |
| --- | --- | --- |
| `aws.enabled: true` + `allowCleartextPasswords=1` in DSN | works | works (the flag is idempotent — setting it twice does nothing extra) |
| `aws.enabled: false` (or unset) | unchanged | unchanged — `AllowCleartextPasswords` is only touched when IAM is enabled |
| `aws.endpoint: "host:3306"` | works | works — values with an explicit port are passed through untouched |
| `aws.endpoint: "host"` (bare hostname) | errored at startup | now works (port derived from DSN, fallback `3306`) |
| `aws.endpoint` omitted | rejected at config parse (field was required) | accepted — falls back to the DSN's address |

The `aws.endpoint` schema change (`required` → `optional` with `""` default) is a relaxation: existing CRDs / config files that set the field continue to parse and validate. Nothing that previously parsed will now fail.

### Implications worth flagging for reviewers

- **Security model is unchanged.** `AllowCleartextPasswords` only lets the driver respond to a server's cleartext-auth challenge — it doesn't downgrade TLS or weaken anything on the connection. RDS IAM auth always pairs with TLS in production; the `dsn` field's updated docstring spells out the recommended setup (`tls=true` + RDS CA bundle in prod, `tls=skip-verify` for local tests).
- **No change for non-IAM users.** If `aws.enabled` is false or unset, the new code paths (cleartext toggle, endpoint normalization) are skipped entirely.
- **No DSN rewrite is visible to the user.** The cleartext flag is set on the parsed `mysql.Config` before the driver opens the connection; nothing is written back into the user's DSN string.
- **No new dependencies.** Only standard-library additions (`net`, `errors`, `strings`).

## Test plan

- [x] \`go test ./internal/impl/mysql/...\`
- [x] \`golangci-lint run ./internal/impl/mysql/...\`
- [ ] Integration test against RDS with \`aws.enabled: true\` and a bare-hostname \`aws.endpoint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)