### PR TITLE
postgres_cdc: relax aws.endpoint to accept bare hostnames

### DIFF
--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -92,7 +92,7 @@ input:
     aws:
       enabled: false
       region: "" # No default (optional)
-      endpoint: "" # No default (required)
+      endpoint: ""
       id: "" # No default (optional)
       secret: "" # No default (optional)
       token: "" # No default (optional)
@@ -484,11 +484,12 @@ The AWS region where the PostgreSQL instance is located. If no region is specifi
 
 === `aws.endpoint`
 
-The PostgreSQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com).
+The PostgreSQL endpoint as `host:port` (for example `mydb.abc123.us-east-1.rds.amazonaws.com:5432`). The AWS IAM token signer requires the port; if it is omitted the port from the DSN is used, falling back to `5432`. When this field is empty the address from the DSN is used.
 
 
 *Type*: `string`
 
+*Default*: `""`
 
 === `aws.id`
 

--- a/internal/impl/postgresql/aws/aws.go
+++ b/internal/impl/postgresql/aws/aws.go
@@ -16,7 +16,11 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -30,6 +34,8 @@ import (
 
 	pgstream "github.com/redpanda-data/connect/v4/internal/impl/postgresql"
 )
+
+const defaultPostgresPort = "5432"
 
 type roleConfig struct {
 	arn        string
@@ -55,6 +61,9 @@ func awsIAMAuth(ctx context.Context, awsConf *service.ParsedConfig, dbConf *pgco
 		opts []func(*awsconfig.LoadOptions) error
 	)
 	if endpoint, err = awsConf.FieldString("endpoint"); err != nil {
+		return nil, err
+	}
+	if endpoint, err = normalizeIAMEndpoint(endpoint, dbConf.Host, dbConf.Port); err != nil {
 		return nil, err
 	}
 	if region, _ = awsConf.FieldString("region"); region != "" {
@@ -147,6 +156,33 @@ func assumeRoleChain(ctx context.Context, awsCfg aws.Config, roles []roleConfig,
 	}
 
 	return currentConfig, nil
+}
+
+// normalizeIAMEndpoint returns a `host:port` value suitable for
+// auth.BuildAuthToken. The AWS SDK rejects an endpoint without a port, so this
+// helper fills one in from the parsed connection config: if `endpoint` is
+// empty the DSN host/port pair is used; if `endpoint` is a bare hostname the
+// DSN's port is appended, with the well-known PostgreSQL port as a final
+// fallback.
+func normalizeIAMEndpoint(endpoint, dsnHost string, dsnPort uint16) (string, error) {
+	if endpoint == "" {
+		if dsnHost == "" {
+			return "", errors.New("aws IAM authentication requires an endpoint and the DSN does not contain a host")
+		}
+		port := defaultPostgresPort
+		if dsnPort != 0 {
+			port = strconv.Itoa(int(dsnPort))
+		}
+		return net.JoinHostPort(dsnHost, port), nil
+	}
+	if strings.Contains(endpoint, ":") {
+		return endpoint, nil
+	}
+	port := defaultPostgresPort
+	if dsnPort != 0 {
+		port = strconv.Itoa(int(dsnPort))
+	}
+	return net.JoinHostPort(endpoint, port), nil
 }
 
 func parseRoleConfig(awsConf *service.ParsedConfig) ([]roleConfig, error) {

--- a/internal/impl/postgresql/aws/aws_test.go
+++ b/internal/impl/postgresql/aws/aws_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeIAMEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		dsnHost  string
+		dsnPort  uint16
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "endpoint already has port",
+			endpoint: "mydb.rds.amazonaws.com:5432",
+			dsnHost:  "mydb.rds.amazonaws.com",
+			dsnPort:  5432,
+			want:     "mydb.rds.amazonaws.com:5432",
+		},
+		{
+			name:     "endpoint missing port, derive from DSN",
+			endpoint: "mydb.rds.amazonaws.com",
+			dsnHost:  "mydb.rds.amazonaws.com",
+			dsnPort:  5433,
+			want:     "mydb.rds.amazonaws.com:5433",
+		},
+		{
+			name:     "endpoint missing port, DSN port zero, fall back to 5432",
+			endpoint: "mydb.rds.amazonaws.com",
+			dsnHost:  "mydb.rds.amazonaws.com",
+			dsnPort:  0,
+			want:     "mydb.rds.amazonaws.com:5432",
+		},
+		{
+			name:     "endpoint empty, fall back to DSN host:port",
+			endpoint: "",
+			dsnHost:  "mydb.rds.amazonaws.com",
+			dsnPort:  5432,
+			want:     "mydb.rds.amazonaws.com:5432",
+		},
+		{
+			name:     "endpoint empty, DSN port zero, append default port",
+			endpoint: "",
+			dsnHost:  "mydb.rds.amazonaws.com",
+			dsnPort:  0,
+			want:     "mydb.rds.amazonaws.com:5432",
+		},
+		{
+			name:     "endpoint empty and DSN host empty errors",
+			endpoint: "",
+			dsnHost:  "",
+			dsnPort:  5432,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeIAMEndpoint(tc.endpoint, tc.dsnHost, tc.dsnPort)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -161,7 +161,8 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 				Description("The AWS region where the PostgreSQL instance is located. If no region is specified then the environment default will be used.").
 				Optional(),
 			service.NewStringField("endpoint").
-				Description("The PostgreSQL endpoint hostname (e.g., mydb.abc123.us-east-1.rds.amazonaws.com)."),
+				Description("The PostgreSQL endpoint as `host:port` (for example `mydb.abc123.us-east-1.rds.amazonaws.com:5432`). The AWS IAM token signer requires the port; if it is omitted the port from the DSN is used, falling back to `5432`. When this field is empty the address from the DSN is used.").
+				Default(""),
 			service.NewStringField("id").
 				Description("The ID of credentials to use.").
 				Optional().Advanced(),


### PR DESCRIPTION
## Summary

Follow-up to #4433 (mysql_cdc). The same `aws.endpoint` papercut exists on `postgres_cdc`: the AWS SDK's RDS token signer requires `host:port` but the field is documented (and rendered in `--help`) as a bare hostname. Users hitting it see:

```
ERROR  building IAM auth token: the provided endpoint is missing a port,
       or the provided port is invalid
```

This PR mirrors the mysql_cdc fix:

- `internal/impl/postgresql/input_pg_stream.go` — endpoint description updated to call out `host:port` and the auto-derive behaviour. Field is now optional with a `""` default.
- `internal/impl/postgresql/aws/aws.go` — new `normalizeIAMEndpoint(endpoint, host, port)` helper. If endpoint is empty, use `pgconn.Config.Host` + `Port`; if it's a bare hostname, splice in the DSN port (`5432` fallback).
- `internal/impl/postgresql/aws/aws_test.go` — table-driven unit tests for the helper.
- `docs/modules/components/pages/inputs/postgres_cdc.adoc` — regenerated via `task docs`.

Only N7 from [the operator PR thread](https://github.com/redpanda-data/redpanda-operator/pull/1337#issuecomment-4464604928) applies to postgres_cdc:
- **N8** (`AllowCleartextPasswords`) is MySQL-driver-specific; pgx accepts the IAM token natively.
- **N9** (`REQUIRE SSL`) is MySQL syntax.

## UX before / after

**Before** — bare hostname produces a confusing SDK error:

```yaml
input:
  postgres_cdc:
    dsn: "postgres://user@mydb.abc123.us-east-1.rds.amazonaws.com:5432/shop?sslmode=require"
    aws:
      enabled: true
      region: us-east-2
      endpoint: mydb.abc123.us-east-1.rds.amazonaws.com   # missing :5432
```
```
ERROR  building IAM auth token: the provided endpoint is missing a port,
       or the provided port is invalid
```

**After** — the port from the DSN is spliced in (or 5432 as a final fallback). `aws.endpoint` can also be omitted entirely:

```yaml
input:
  postgres_cdc:
    dsn: "postgres://user@mydb.abc123.us-east-1.rds.amazonaws.com:5432/shop?sslmode=require"
    aws:
      enabled: true
      region: us-east-2
      # endpoint inherited from the DSN
```

## Backwards compatibility

Fully compatible. `host:port` values are returned unchanged; the new fallbacks only fire when the user supplied a value that previously errored out.

| Existing config | Before | After |
| --- | --- | --- |
| `aws.endpoint: "host:5432"` | works | works (passed through) |
| `aws.endpoint: "host"` (bare hostname) | errored at startup | now works |
| `aws.endpoint` omitted | rejected at config parse (field was required) | accepted — falls back to DSN |
| `aws.enabled: false` (or unset) | unchanged | unchanged |

Field schema goes from required to optional with `""` default — a relaxation; nothing that previously parsed will now fail.

## Test plan

- [x] `go test ./internal/impl/postgresql/...`
- [x] `golangci-lint run ./internal/impl/postgresql/...`
- [x] `task docs` (regenerated postgres_cdc.adoc)
- [ ] Integration test against RDS Postgres with `aws.enabled: true` and a bare-hostname `aws.endpoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
