### PR TITLE
oracledb_cdc: exclude LogMiner meta events for unmonitored tables when LOB is enabled

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -2048,4 +2048,73 @@ oracledb_cdc:
 		}
 		require.NoError(t, stream.StopWithin(time.Second*10))
 	})
+
+	t.Run("Filtering excludes unmonitored tables", func(t *testing.T) {
+		// Two tables with out-of-line LOB columns. DISABLE STORAGE IN ROW forces Oracle to
+		// emit SELECT_LOB_LOCATOR / LOB_WRITE op codes (9/10/11) on every insert — exactly
+		// the operation class that was previously unfiltered by the LogMiner SQL query, allowing
+		// LOB writes to unmonitored tables to leak into the output.
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.lobfilter_included",
+			`CREATE TABLE testdb.lobfilter_included (id NUMBER GENERATED ALWAYS AS IDENTITY (NOCACHE) PRIMARY KEY, data NCLOB) LOB(data) STORE AS BASICFILE (DISABLE STORAGE IN ROW)`))
+		require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.lobfilter_excluded",
+			`CREATE TABLE testdb.lobfilter_excluded (id NUMBER GENERATED ALWAYS AS IDENTITY (NOCACHE) PRIMARY KEY, data NCLOB) LOB(data) STORE AS BASICFILE (DISABLE STORAGE IN ROW)`))
+
+		var batch oracledbtest.Batch
+
+		// Only lobfilter_included is in the include list; lobfilter_excluded must produce no output.
+		cfg := fmt.Sprintf(`
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  logminer:
+    lob_enabled: true
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.LOBFILTER_INCLUDED"]`, connStr)
+
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(cfg))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			batch.Lock()
+			defer batch.Unlock()
+			for _, msg := range mb {
+				msgBytes, err := msg.AsBytes()
+				assert.NoError(t, err)
+				batch.Msgs = append(batch.Msgs, string(msgBytes))
+			}
+			return nil
+		}))
+
+		stream, err := streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		// Allow LogMiner to start up and reach the current SCN before producing data.
+		time.Sleep(10 * time.Second)
+
+		lobVal := strings.Repeat("X", 5000)
+		for range 5 {
+			db.MustExec("INSERT INTO testdb.lobfilter_included (data) VALUES (:1)", lobVal)
+			db.MustExec("INSERT INTO testdb.lobfilter_excluded (data) VALUES (:1)", lobVal)
+		}
+
+		// Exactly 5 messages must arrive — those from lobfilter_included only.
+		assert.Eventually(t, func() bool {
+			return batch.Count() == 5
+		}, time.Minute*2, time.Millisecond*500, "timed out waiting for 5 messages from included table")
+
+		// No messages from lobfilter_excluded should leak through.
+		assert.Never(t, func() bool {
+			return batch.Count() > 5
+		}, time.Second*3, time.Millisecond*200, "received unexpected messages from excluded table")
+
+		require.NoError(t, stream.StopWithin(time.Second*10))
+	})
 }

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -57,17 +57,19 @@ type LogMiner struct {
 // NewMiner creates a new instance of LogMiner responsible for paging through change events based on the tables param.
 func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replication.ChangePublisher, cfg *Config, metrics *service.Metrics, logger *service.Logger) *LogMiner {
 	// Build table filter condition once
-	// Only filter DML operations (1=INSERT, 2=DELETE, 3=UPDATE) by table
 	// Transaction control operations (6=START, 7=COMMIT, 36=ROLLBACK) don't have table info
+	// and must pass unfiltered. DML (1=INSERT, 2=DELETE, 3=UPDATE) and LOB operations
+	// (9=SELECT_LOB_LOCATOR, 10=LOB_WRITE, 11=LOB_TRIM) all carry SEG_OWNER/TABLE_NAME
+	// and must be restricted to configured tables to avoid capturing Oracle internal tables.
 	var buf strings.Builder
 	if len(userTables) > 0 {
-		opCodes := "6, 7, 36"
+		buf.WriteString(" AND (OPERATION_CODE IN (6, 7, 36)")
+		// DML and LOB operations carry the real table name — filter by configured tables.
+		dmlCodes := "1, 2, 3"
 		if cfg.LOBEnabled {
-			opCodes += ", 9, 10, 11"
+			dmlCodes += ", 9, 10, 11"
 		}
-		buf.WriteString(" AND (OPERATION_CODE IN (" + opCodes + ")")
-		// DML carries the real table name — filter by configured tables.
-		buf.WriteString(" OR (OPERATION_CODE IN (1, 2, 3) AND (") // Filter DML by table
+		buf.WriteString(" OR (OPERATION_CODE IN (" + dmlCodes + ") AND (") // Filter DML/LOB by table
 		for i, t := range userTables {
 			if i > 0 {
 				buf.WriteString(" OR ")


### PR DESCRIPTION
Occasionally it's possible that, under certain conditions, LogMiner meta events find their way into the event stream though they're not related to any of the filtered tables (this appears to be when lob_enabled is true, when we see a lot more activity in LogMiner). This change plugs that leak and includes an integration test to verify and catch any future regressions.

<img width="1192" height="729" alt="image" src="https://github.com/user-attachments/assets/27f6d19f-1471-40cd-a809-dcbd4960af4c" />
