### PR TITLE
BigQuery: cdc upsert

### DIFF
--- a/docs/modules/components/pages/outputs/bigquery_cdc_migration.adoc
+++ b/docs/modules/components/pages/outputs/bigquery_cdc_migration.adoc
@@ -1,0 +1,90 @@
+= Migrating from `gcp_bigquery` to `gcp_bigquery_write_api` (CDC)
+:description: Migrate a CDC pipeline from the load-jobs based gcp_bigquery output to the Storage Write API gcp_bigquery_write_api output.
+
+The `gcp_bigquery_write_api` output supports BigQuery's Change Data Capture (CDC) ingestion via the Storage Write API. Compared to the load-jobs based `gcp_bigquery` output, the Storage Write API delivers:
+
+* Seconds-scale ingest latency instead of minutes (no batch-and-load cycle).
+* Per-row UPSERT and DELETE operations without writing intermediate files.
+* Sequence-number-based out-of-order resolution via `_CHANGE_SEQUENCE_NUMBER`.
+
+== Config translation
+
+[source,yaml]
+----
+# BEFORE: load-jobs based output
+output:
+  gcp_bigquery:
+    project: my-project
+    dataset: my_dataset
+    table: events
+    format: NEWLINE_DELIMITED_JSON
+    batching:
+      count: 10000
+      period: 30s
+
+# AFTER: Storage Write API CDC mode
+output:
+  gcp_bigquery_write_api:
+    project: my-project
+    dataset: my_dataset
+    table: events
+    write_mode: upsert_delete
+    change_type: ${! metadata("operation") }
+    change_sequence_number: ${! metadata("scn") }
+    primary_keys: [id]
+    batching:
+      count: 500
+      period: 1s
+----
+
+The `change_type` expression must resolve to `UPSERT` or `DELETE` per message (case-insensitive). `change_sequence_number` is optional but recommended for any pipeline where out-of-order delivery is possible.
+
+== Schema requirements
+
+The destination table must have a `PRIMARY KEY` declared. To add one to an existing table:
+
+[source,sql]
+----
+ALTER TABLE my_dataset.events
+ADD PRIMARY KEY (id) NOT ENFORCED;
+----
+
+For new tables, use the `auto_create_table` option with `primary_keys`:
+
+[source,yaml]
+----
+auto_create_table: true
+schema:
+  - { name: id, type: STRING, mode: REQUIRED }
+  - { name: payload, type: JSON }
+primary_keys: [id]
+----
+
+[NOTE]
+====
+Composite primary keys are supported with up to 16 columns. The column order in `primary_keys` is significant for composite keys.
+====
+
+== Snapshot vs streaming
+
+BigQuery's CDC contract does not permit mixing INSERT (unspecified `_CHANGE_TYPE`) and UPSERT/DELETE rows in the same write. For initial backfills, recommendations are:
+
+. *UPSERT for everything.* The simplest path: write snapshot rows with `change_type: UPSERT` like any other CDC row. Idempotent; tolerates retries; pays the per-PK merge cost on every snapshot row. Suitable for tables up to ~10M rows.
+. *Separate snapshot pipeline.* Land snapshot rows via a second `gcp_bigquery_write_api` instance with `write_mode: default_stream` into a separate staging table, then `CREATE TABLE … AS SELECT` into the CDC-active table once the snapshot completes. Avoids the merge cost on the snapshot but adds operational complexity.
+
+== Operational differences
+
+[WARNING]
+====
+Tables with active CDC do not support DML statements (`DELETE`, `UPDATE`, `MERGE`). If your existing pipeline relies on post-load DML for cleanup, that pattern will no longer work. Move cleanup to BigQuery scheduled queries against a non-CDC table or pre-process rows in the connector.
+====
+
+* BigQuery does not enforce primary-key uniqueness; the producer is responsible.
+* DELETEs are retained for a two-day window for point-in-time recovery before being permanently dropped.
+* The `_CHANGE_TYPE` and `_CHANGE_SEQUENCE_NUMBER` pseudo-columns are injected by the connector; do not declare them in `schema`.
+* CDC ingestion requires the default write stream. The `write_mode: pending_stream` exactly-once mode is not compatible with CDC and is rejected at config parse time.
+
+== Related
+
+* xref:outputs/gcp_bigquery_write_api.adoc[`gcp_bigquery_write_api` output reference]
+* https://cloud.google.com/bigquery/docs/change-data-capture[BigQuery CDC documentation]

--- a/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
@@ -43,6 +43,9 @@ output:
     dataset: "" # No default (required)
     table: "" # No default (required)
     message_format: json
+    change_type: "" # No default (optional)
+    change_sequence_number: "" # No default (optional)
+    primary_keys: [] # No default (optional)
     max_in_flight: 4
     batching:
       count: 0
@@ -67,6 +70,9 @@ output:
     table: "" # No default (required)
     message_format: json
     write_mode: default_stream
+    change_type: "" # No default (optional)
+    change_sequence_number: "" # No default (optional)
+    primary_keys: [] # No default (optional)
     auto_create_table: false
     schema: []
     time_partitioning:
@@ -128,6 +134,10 @@ When `auto_create_table` is true, the output creates missing tables on the fly u
 
 The exactly-once guarantee of `pending_stream` is "exactly-once within a stream". If a BatchCommitWriteStreams RPC succeeds but its response is lost to a network failure, benthos retries the batch through a new pending stream and the data lands twice. This is a fundamental limitation of the BigQuery Storage Write API exactly-once contract and applies to every implementation.
 
+== CDC migration
+
+When migrating from the load-jobs based `gcp_bigquery` output to CDC mode, see the xref:outputs/bigquery_cdc_migration.adoc[CDC migration guide].
+
 
 == Fields
 
@@ -173,7 +183,7 @@ Options:
 
 === `write_mode`
 
-How the output writes to BigQuery. `default_stream` uses the multiplexed default stream (at-least-once, lowest latency). `pending_stream` allocates a per-batch pending stream that commits atomically, providing exactly-once semantics within a single committed batch.
+How the output writes to BigQuery. `default_stream` uses the multiplexed default stream (at-least-once, lowest latency). `pending_stream` allocates a per-batch pending stream that commits atomically, providing exactly-once semantics within a single committed batch. `upsert` writes UPSERT-only rows to a BigQuery CDC-enabled table; the target table must have a PRIMARY KEY. `upsert_delete` allows both UPSERT and DELETE rows. Both CDC modes use the default stream as required by BigQuery.
 
 
 *Type*: `string`
@@ -183,7 +193,35 @@ How the output writes to BigQuery. `default_stream` uses the multiplexed default
 Options:
 `default_stream`
 , `pending_stream`
+, `upsert`
+, `upsert_delete`
 .
+
+=== `change_type`
+
+Bloblang expression resolving to the `_CHANGE_TYPE` pseudo-column value for each row. Must resolve to `UPSERT` or `DELETE` (case-insensitive). Required when `write_mode` is `upsert` or `upsert_delete`. Example: `${! metadata("operation") }`.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+
+=== `change_sequence_number`
+
+Optional Bloblang expression resolving to the `_CHANGE_SEQUENCE_NUMBER` pseudo-column value. Format: 1 to 4 sections of 1 to 16 hexadecimal characters each, separated by `/`. Example: `${! metadata("scn") }` or `${! "0/0/0/0" }`. When unset, BigQuery resolves ordering by arrival time.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+
+=== `primary_keys`
+
+Optional list of primary-key column names. Required when `auto_create_table` is true and `write_mode` is `upsert` or `upsert_delete`. When the target table is pre-existing, the connector falls back to the PRIMARY KEY declared on the table. Up to 16 columns; composite keys are supported in the same order they are listed.
+
+
+*Type*: `array`
+
 
 === `auto_create_table`
 

--- a/internal/impl/gcp/enterprise/bigquery/cdc.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// validateChangeType normalises and validates a Bloblang-resolved _CHANGE_TYPE
+// value against BigQuery's CDC contract. BigQuery only accepts UPSERT and
+// DELETE; INSERT is expressed by omitting the pseudo-column entirely, and
+// mixing INSERT with UPSERT/DELETE in the same write is unsupported.
+// allowDelete is true for write_mode=upsert_delete.
+func validateChangeType(raw string, allowDelete bool) (string, error) {
+	v := strings.ToUpper(strings.TrimSpace(raw))
+	switch v {
+	case "UPSERT":
+		return v, nil
+	case "DELETE":
+		if !allowDelete {
+			return "", errors.New("change_type DELETE is only valid when write_mode is upsert_delete")
+		}
+		return v, nil
+	case "":
+		return "", errors.New("change_type resolved to an empty value")
+	default:
+		return "", fmt.Errorf("change_type %q is not UPSERT or DELETE", raw)
+	}
+}
+
+// changeSequenceNumberPattern matches BigQuery's _CHANGE_SEQUENCE_NUMBER format:
+// 1 to 4 sections of 1 to 16 hexadecimal characters each, separated by '/'.
+var changeSequenceNumberPattern = regexp.MustCompile(`^[0-9A-Fa-f]{1,16}(/[0-9A-Fa-f]{1,16}){0,3}$`)
+
+// validateChangeSequenceNumber checks that raw conforms to BigQuery's CDC
+// sequence-number format. BigQuery rejects values that do not match this
+// format with INVALID_ARGUMENT at AppendRows time, so we validate per-message
+// before the network round trip.
+func validateChangeSequenceNumber(raw string) error {
+	if !changeSequenceNumberPattern.MatchString(raw) {
+		return fmt.Errorf("change_sequence_number %q does not match BigQuery format (1-4 sections of 1-16 hex chars separated by /)", raw)
+	}
+	return nil
+}
+
+// wrapDescriptorForCDC returns a copy of base with `_CHANGE_TYPE` and
+// optionally `_CHANGE_SEQUENCE_NUMBER` appended as STRING fields at the next
+// free field numbers (max existing + 1, +2). The base descriptor is left
+// untouched. Injection is name-based (see injectCDCJSON), so the field numbers
+// don't need to be returned — they only need to be valid and unused.
+func wrapDescriptorForCDC(base *descriptorpb.DescriptorProto, withSequenceNumber bool) (*descriptorpb.DescriptorProto, error) {
+	if base == nil {
+		return nil, errors.New("wrapDescriptorForCDC: nil base descriptor")
+	}
+	var maxNum int32
+	for _, f := range base.Field {
+		if n := f.GetNumber(); n > maxNum {
+			maxNum = n
+		}
+	}
+	changeTypeFieldNumber := maxNum + 1
+	wrapped := proto.Clone(base).(*descriptorpb.DescriptorProto)
+	wrapped.Field = append(wrapped.Field, &descriptorpb.FieldDescriptorProto{
+		Name:   new("_CHANGE_TYPE"),
+		Number: new(changeTypeFieldNumber),
+		Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+		Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+	})
+	if withSequenceNumber {
+		changeSeqFieldNumber := maxNum + 2
+		wrapped.Field = append(wrapped.Field, &descriptorpb.FieldDescriptorProto{
+			Name:   new("_CHANGE_SEQUENCE_NUMBER"),
+			Number: new(changeSeqFieldNumber),
+			Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		})
+	}
+	return wrapped, nil
+}
+
+// cdcInjector holds the immutable per-output CDC configuration: validated
+// Bloblang fields and the allowDelete flag. Safe to share across concurrent
+// WriteBatch goroutines because all fields are read-only after construction.
+type cdcInjector struct {
+	log         *service.Logger
+	changeType  *service.InterpolatedString
+	changeSeq   *service.InterpolatedString // nil when not configured
+	allowDelete bool                        // true for write_mode=upsert_delete
+}
+
+// injectCDCJSON injects _CHANGE_TYPE (and _CHANGE_SEQUENCE_NUMBER when seq is
+// non-empty) into the JSON object bytes without round-tripping through a Go
+// value tree. Using json.RawMessage preserves the exact byte representation of
+// every user field — int64 strings stay strings, NUMERIC strings keep their
+// precision, base64 BYTES stay base64. Returns an error if jsonBytes is not a
+// JSON object, or if the payload already carries a key the injector would
+// otherwise overwrite (forces explicit user remediation rather than silent
+// data loss).
+func injectCDCJSON(jsonBytes []byte, changeType, changeSeq string) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(jsonBytes))
+	var raw map[string]json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+	if raw == nil {
+		// Empty map after decoding a JSON null — reject; CDC needs an object.
+		return nil, errors.New("payload is not a JSON object")
+	}
+	if _, exists := raw["_CHANGE_TYPE"]; exists {
+		return nil, errors.New("payload already contains _CHANGE_TYPE; remove it before CDC injection")
+	}
+	encodedCT, err := json.Marshal(changeType)
+	if err != nil {
+		return nil, fmt.Errorf("encoding change_type: %w", err)
+	}
+	raw["_CHANGE_TYPE"] = encodedCT
+	if changeSeq != "" {
+		if _, exists := raw["_CHANGE_SEQUENCE_NUMBER"]; exists {
+			return nil, errors.New("payload already contains _CHANGE_SEQUENCE_NUMBER; remove it before CDC injection")
+		}
+		encodedSeq, err := json.Marshal(changeSeq)
+		if err != nil {
+			return nil, fmt.Errorf("encoding change_sequence_number: %w", err)
+		}
+		raw["_CHANGE_SEQUENCE_NUMBER"] = encodedSeq
+	}
+	return json.Marshal(raw)
+}
+
+// validateCDCPrimaryKeys enforces BigQuery's CDC contract that the destination
+// table must have a PRIMARY KEY. configPKs is the user-declared list (may be
+// nil), tablePKs is what BigQuery reports for the table (may be nil if no
+// constraint is declared). The function fails if neither source has PKs, and
+// fails on mismatch when both are present.
+func validateCDCPrimaryKeys(configPKs, tablePKs []string, tableID string) error {
+	if len(configPKs) == 0 && len(tablePKs) == 0 {
+		return fmt.Errorf("CDC mode requires a PRIMARY KEY on table %q; declare one via primary_keys config or `ALTER TABLE … ADD PRIMARY KEY`", tableID)
+	}
+	if len(configPKs) > 0 && len(tablePKs) > 0 {
+		if !equalStringSlices(configPKs, tablePKs) {
+			return fmt.Errorf("primary_keys config %v does not match table %q PRIMARY KEY %v",
+				configPKs, tableID, tablePKs)
+		}
+	}
+	return nil
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// validateAndResolveCDC validates the resolved Bloblang values for a single
+// row and returns the normalised change_type plus the original sequence
+// number string. The caller is responsible for passing the validated values
+// to injectCDCJSON. Returns an error suitable for BatchError.Failed.
+func (i *cdcInjector) validateAndResolveCDC(rawChangeType, rawSeq string) (changeType string, seq string, err error) {
+	ct, err := validateChangeType(rawChangeType, i.allowDelete)
+	if err != nil {
+		return "", "", err
+	}
+	if i.changeSeq != nil {
+		if err := validateChangeSequenceNumber(rawSeq); err != nil {
+			return "", "", err
+		}
+		return ct, rawSeq, nil
+	}
+	return ct, "", nil
+}

--- a/internal/impl/gcp/enterprise/bigquery/cdc.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -150,24 +151,15 @@ func validateCDCPrimaryKeys(configPKs, tablePKs []string, tableID string) error 
 		return fmt.Errorf("CDC mode requires a PRIMARY KEY on table %q; declare one via primary_keys config or `ALTER TABLE … ADD PRIMARY KEY`", tableID)
 	}
 	if len(configPKs) > 0 && len(tablePKs) > 0 {
-		if !equalStringSlices(configPKs, tablePKs) {
+		// Order-sensitive: BigQuery PKs are positional (column order matches the
+		// declaration in ALTER TABLE … ADD PRIMARY KEY), so the config list must
+		// match the table list exactly, not just as a set.
+		if !slices.Equal(configPKs, tablePKs) {
 			return fmt.Errorf("primary_keys config %v does not match table %q PRIMARY KEY %v",
 				configPKs, tableID, tablePKs)
 		}
 	}
 	return nil
-}
-
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // validateAndResolveCDC validates the resolved Bloblang values for a single

--- a/internal/impl/gcp/enterprise/bigquery/cdc.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc.go
@@ -9,7 +9,6 @@
 package bigquery
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -98,7 +97,6 @@ func wrapDescriptorForCDC(base *descriptorpb.DescriptorProto, withSequenceNumber
 // Bloblang fields and the allowDelete flag. Safe to share across concurrent
 // WriteBatch goroutines because all fields are read-only after construction.
 type cdcInjector struct {
-	log         *service.Logger
 	changeType  *service.InterpolatedString
 	changeSeq   *service.InterpolatedString // nil when not configured
 	allowDelete bool                        // true for write_mode=upsert_delete
@@ -113,9 +111,8 @@ type cdcInjector struct {
 // otherwise overwrite (forces explicit user remediation rather than silent
 // data loss).
 func injectCDCJSON(jsonBytes []byte, changeType, changeSeq string) ([]byte, error) {
-	dec := json.NewDecoder(bytes.NewReader(jsonBytes))
 	var raw map[string]json.RawMessage
-	if err := dec.Decode(&raw); err != nil {
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
 		return nil, fmt.Errorf("parsing JSON: %w", err)
 	}
 	if raw == nil {

--- a/internal/impl/gcp/enterprise/bigquery/cdc_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package bigquery
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestValidateChangeType(t *testing.T) {
+	t.Run("upsert mode accepts UPSERT only", func(t *testing.T) {
+		v, err := validateChangeType("UPSERT", false)
+		require.NoError(t, err)
+		assert.Equal(t, "UPSERT", v)
+
+		v, err = validateChangeType("upsert", false)
+		require.NoError(t, err)
+		assert.Equal(t, "UPSERT", v)
+
+		_, err = validateChangeType("DELETE", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DELETE")
+	})
+
+	t.Run("upsert_delete mode accepts UPSERT and DELETE", func(t *testing.T) {
+		v, err := validateChangeType("UPSERT", true)
+		require.NoError(t, err)
+		assert.Equal(t, "UPSERT", v)
+
+		v, err = validateChangeType("delete", true)
+		require.NoError(t, err)
+		assert.Equal(t, "DELETE", v)
+	})
+
+	t.Run("rejects INSERT", func(t *testing.T) {
+		_, err := validateChangeType("INSERT", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "INSERT")
+	})
+
+	t.Run("rejects empty", func(t *testing.T) {
+		_, err := validateChangeType("", true)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects arbitrary string", func(t *testing.T) {
+		_, err := validateChangeType("MAYBE", true)
+		require.Error(t, err)
+	})
+}
+
+func TestValidateChangeSequenceNumber(t *testing.T) {
+	t.Run("accepts valid formats", func(t *testing.T) {
+		for _, in := range []string{
+			"0",
+			"FF",
+			"abcd",
+			"FFFFFFFFFFFFFFFF",
+			"0/0",
+			"A/B/C",
+			"A/B/C/D",
+			"FFFFFFFFFFFFFFFF/FFFFFFFFFFFFFFFF/FFFFFFFFFFFFFFFF/FFFFFFFFFFFFFFFF",
+		} {
+			t.Run(in, func(t *testing.T) {
+				require.NoError(t, validateChangeSequenceNumber(in))
+			})
+		}
+	})
+
+	t.Run("rejects invalid formats", func(t *testing.T) {
+		for _, in := range []string{
+			"",
+			"G",
+			"/0",
+			"0/",
+			"0/0/0/0/0",
+			"FFFFFFFFFFFFFFFFA",
+			"0/FFFFFFFFFFFFFFFFA",
+			"0 0",
+			"0/0 /0",
+		} {
+			t.Run(in, func(t *testing.T) {
+				err := validateChangeSequenceNumber(in)
+				require.Error(t, err, "expected error for input %q", in)
+			})
+		}
+	})
+}
+
+func TestWrapDescriptorForCDC(t *testing.T) {
+	base := &descriptorpb.DescriptorProto{
+		Name: new("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   new("id"),
+				Number: new(int32(1)),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			},
+		},
+	}
+
+	t.Run("appends _CHANGE_TYPE only when no sequence configured", func(t *testing.T) {
+		wrapped, err := wrapDescriptorForCDC(base, false)
+		require.NoError(t, err)
+		require.Len(t, wrapped.Field, 2)
+		assert.Equal(t, "_CHANGE_TYPE", wrapped.Field[1].GetName())
+		assert.Equal(t, int32(2), wrapped.Field[1].GetNumber())
+		assert.Equal(t, descriptorpb.FieldDescriptorProto_TYPE_STRING, wrapped.Field[1].GetType())
+	})
+
+	t.Run("appends both pseudo-columns when sequence configured", func(t *testing.T) {
+		wrapped, err := wrapDescriptorForCDC(base, true)
+		require.NoError(t, err)
+		require.Len(t, wrapped.Field, 3)
+		assert.Equal(t, "_CHANGE_TYPE", wrapped.Field[1].GetName())
+		assert.Equal(t, int32(2), wrapped.Field[1].GetNumber())
+		assert.Equal(t, "_CHANGE_SEQUENCE_NUMBER", wrapped.Field[2].GetName())
+		assert.Equal(t, int32(3), wrapped.Field[2].GetNumber())
+	})
+
+	t.Run("preserves base descriptor", func(t *testing.T) {
+		_, err := wrapDescriptorForCDC(base, true)
+		require.NoError(t, err)
+		require.Len(t, base.Field, 1)
+		assert.Equal(t, "id", base.Field[0].GetName())
+	})
+
+	t.Run("picks next field number above max", func(t *testing.T) {
+		withGap := &descriptorpb.DescriptorProto{
+			Name: new("WithGap"),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{Name: new("a"), Number: new(int32(1)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+				{Name: new("b"), Number: new(int32(7)), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(), Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum()},
+			},
+		}
+		wrapped, err := wrapDescriptorForCDC(withGap, true)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8), wrapped.Field[2].GetNumber())
+		assert.Equal(t, int32(9), wrapped.Field[3].GetNumber())
+	})
+}
+
+func TestCDCInjectorValidateAndResolve(t *testing.T) {
+	t.Run("returns normalised change_type and sequence", func(t *testing.T) {
+		inj := &cdcInjector{
+			allowDelete: true,
+			changeSeq:   &service.InterpolatedString{},
+		}
+		ct, seq, err := inj.validateAndResolveCDC("upsert", "0/0")
+		require.NoError(t, err)
+		assert.Equal(t, "UPSERT", ct)
+		assert.Equal(t, "0/0", seq)
+	})
+
+	t.Run("rejects bad change_type", func(t *testing.T) {
+		inj := &cdcInjector{allowDelete: true}
+		_, _, err := inj.validateAndResolveCDC("MAYBE", "")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects bad sequence number", func(t *testing.T) {
+		inj := &cdcInjector{allowDelete: true, changeSeq: &service.InterpolatedString{}}
+		_, _, err := inj.validateAndResolveCDC("UPSERT", "not-hex")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "change_sequence_number")
+	})
+
+	t.Run("returns empty seq when not configured", func(t *testing.T) {
+		inj := &cdcInjector{allowDelete: true}
+		ct, seq, err := inj.validateAndResolveCDC("UPSERT", "")
+		require.NoError(t, err)
+		assert.Equal(t, "UPSERT", ct)
+		assert.Empty(t, seq)
+	})
+}
+
+func TestValidateCDCPrimaryKeys(t *testing.T) {
+	t.Run("config only", func(t *testing.T) {
+		require.NoError(t, validateCDCPrimaryKeys([]string{"id"}, nil, "t"))
+	})
+	t.Run("table only", func(t *testing.T) {
+		require.NoError(t, validateCDCPrimaryKeys(nil, []string{"id"}, "t"))
+	})
+	t.Run("matching config and table", func(t *testing.T) {
+		require.NoError(t, validateCDCPrimaryKeys([]string{"tenant_id", "id"}, []string{"tenant_id", "id"}, "t"))
+	})
+	t.Run("mismatched", func(t *testing.T) {
+		err := validateCDCPrimaryKeys([]string{"id"}, []string{"tenant_id"}, "t")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+	t.Run("mismatched order", func(t *testing.T) {
+		err := validateCDCPrimaryKeys([]string{"a", "b"}, []string{"b", "a"}, "t")
+		require.Error(t, err)
+	})
+	t.Run("neither set", func(t *testing.T) {
+		err := validateCDCPrimaryKeys(nil, nil, "events")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PRIMARY KEY")
+		assert.Contains(t, err.Error(), "events")
+	})
+}
+
+func TestInjectCDCJSON(t *testing.T) {
+	t.Run("appends pseudo-columns to non-empty object", func(t *testing.T) {
+		out, err := injectCDCJSON([]byte(`{"id":"x","age":"30"}`), "UPSERT", "0/1")
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(out, &got))
+		assert.Equal(t, "x", got["id"])
+		assert.Equal(t, "30", got["age"]) // string preserved, not coerced to number
+		assert.Equal(t, "UPSERT", got["_CHANGE_TYPE"])
+		assert.Equal(t, "0/1", got["_CHANGE_SEQUENCE_NUMBER"])
+	})
+
+	t.Run("omits sequence when empty", func(t *testing.T) {
+		out, err := injectCDCJSON([]byte(`{"id":"x"}`), "DELETE", "")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"_CHANGE_TYPE":"DELETE"`)
+		assert.NotContains(t, string(out), `_CHANGE_SEQUENCE_NUMBER`)
+	})
+
+	t.Run("preserves int-as-string fidelity", func(t *testing.T) {
+		// 2^53 + 1 — would lose precision through float64 round-trip.
+		out, err := injectCDCJSON([]byte(`{"id":"9007199254740993"}`), "UPSERT", "")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"9007199254740993"`)
+	})
+
+	t.Run("rejects non-object payload", func(t *testing.T) {
+		_, err := injectCDCJSON([]byte(`[1,2,3]`), "UPSERT", "")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects malformed JSON", func(t *testing.T) {
+		_, err := injectCDCJSON([]byte(`{not json`), "UPSERT", "")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects JSON null", func(t *testing.T) {
+		_, err := injectCDCJSON([]byte(`null`), "UPSERT", "")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects user payload already containing _CHANGE_TYPE", func(t *testing.T) {
+		_, err := injectCDCJSON([]byte(`{"id":"x","_CHANGE_TYPE":"DELETE"}`), "UPSERT", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "_CHANGE_TYPE")
+	})
+
+	t.Run("rejects user payload already containing _CHANGE_SEQUENCE_NUMBER", func(t *testing.T) {
+		_, err := injectCDCJSON([]byte(`{"id":"x","_CHANGE_SEQUENCE_NUMBER":"FF"}`), "UPSERT", "0/1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "_CHANGE_SEQUENCE_NUMBER")
+	})
+
+	t.Run("ignores _CHANGE_SEQUENCE_NUMBER in payload when sequence not configured", func(t *testing.T) {
+		// changeSeq="" means user didn't configure change_sequence_number,
+		// so a pre-existing field is not a collision the injector cares about.
+		// (The descriptor was wrapped without _CHANGE_SEQUENCE_NUMBER, so the
+		// AppendRows call will reject it server-side as an unknown field —
+		// that's the right error surface, not a client-side rewrite.)
+		out, err := injectCDCJSON([]byte(`{"id":"x","_CHANGE_SEQUENCE_NUMBER":"FF"}`), "UPSERT", "")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"_CHANGE_TYPE":"UPSERT"`)
+	})
+}
+
+func TestErrPermanentPropagatesThroughClassify(t *testing.T) {
+	// Sanity check: classifyBQError must recognize errPermanent-wrapped errors
+	// as permanent so CDC config failures route the batch to DLQ instead of
+	// being retried forever.
+	wrapped := fmt.Errorf("%w: %w", errPermanent, errors.New("simulated CDC config failure"))
+	assert.True(t, classifyBQError(wrapped).IsPermanent())
+}

--- a/internal/impl/gcp/enterprise/bigquery/integration_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/integration_test.go
@@ -502,25 +502,25 @@ gcp_bigquery_write_api:
 // CDC integration tests require a real BigQuery instance. The goccy emulator
 // does not implement the _CHANGE_TYPE / _CHANGE_SEQUENCE_NUMBER pseudo-columns,
 // PRIMARY KEY constraints, or the UPSERT/DELETE semantics that CDC mode
-// depends on. These tests are gated with t.Skip so the package compiles
+// depends on. These subtests are gated with t.Skip so the package compiles
 // against the real BQ API and so a future real-BQ test job can flip the gate.
-
-func TestIntegrationCDCUpsert(t *testing.T) {
+func TestIntegrationCDC(t *testing.T) {
 	integration.CheckSkip(t)
-	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
-}
+	const skipReason = "BigQuery CDC requires a real BigQuery instance; goccy emulator does not support CDC pseudo-columns"
 
-func TestIntegrationCDCUpsertDelete(t *testing.T) {
-	integration.CheckSkip(t)
-	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
-}
+	t.Run("upsert", func(t *testing.T) {
+		t.Skip(skipReason)
+	})
 
-func TestIntegrationCDCOutOfOrder(t *testing.T) {
-	integration.CheckSkip(t)
-	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_SEQUENCE_NUMBER")
-}
+	t.Run("upsert_delete", func(t *testing.T) {
+		t.Skip(skipReason)
+	})
 
-func TestIntegrationCDCMixedBatch(t *testing.T) {
-	integration.CheckSkip(t)
-	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
+	t.Run("out_of_order", func(t *testing.T) {
+		t.Skip(skipReason)
+	})
+
+	t.Run("mixed_batch", func(t *testing.T) {
+		t.Skip(skipReason)
+	})
 }

--- a/internal/impl/gcp/enterprise/bigquery/integration_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/integration_test.go
@@ -498,3 +498,29 @@ gcp_bigquery_write_api:
 		return count >= 1
 	}, 30*time.Second, 500*time.Millisecond)
 }
+
+// CDC integration tests require a real BigQuery instance. The goccy emulator
+// does not implement the _CHANGE_TYPE / _CHANGE_SEQUENCE_NUMBER pseudo-columns,
+// PRIMARY KEY constraints, or the UPSERT/DELETE semantics that CDC mode
+// depends on. These tests are gated with t.Skip so the package compiles
+// against the real BQ API and so a future real-BQ test job can flip the gate.
+
+func TestIntegrationCDCUpsert(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
+}
+
+func TestIntegrationCDCUpsertDelete(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
+}
+
+func TestIntegrationCDCOutOfOrder(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_SEQUENCE_NUMBER")
+}
+
+func TestIntegrationCDCMixedBatch(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Skip("BigQuery CDC requires a real BigQuery instance; goccy emulator does not support _CHANGE_TYPE")
+}

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -53,6 +53,9 @@ const (
 	bqwaFieldStreamSweepInterval    = "stream_sweep_interval"
 	bqwaFieldMaxCachedStreams       = "max_cached_streams"
 	bqwaFieldWriteMode              = "write_mode"
+	bqwaFieldChangeType             = "change_type"
+	bqwaFieldChangeSequenceNumber   = "change_sequence_number"
+	bqwaFieldPrimaryKeys            = "primary_keys"
 	bqwaFieldAutoCreateTable        = "auto_create_table"
 	bqwaFieldSchema                 = "schema"
 	bqwaSchemaFieldName             = "name"
@@ -123,6 +126,10 @@ When `+"`auto_create_table`"+` is true, the output creates missing tables on the
 == Exactly-once caveat
 
 The exactly-once guarantee of `+"`pending_stream`"+` is "exactly-once within a stream". If a BatchCommitWriteStreams RPC succeeds but its response is lost to a network failure, benthos retries the batch through a new pending stream and the data lands twice. This is a fundamental limitation of the BigQuery Storage Write API exactly-once contract and applies to every implementation.
+
+== CDC migration
+
+When migrating from the load-jobs based `+"`gcp_bigquery`"+` output to CDC mode, see the xref:outputs/bigquery_cdc_migration.adoc[CDC migration guide].
 `).
 		Fields(
 			service.NewStringField(bqwaFieldProject).
@@ -140,13 +147,33 @@ The exactly-once guarantee of `+"`pending_stream`"+` is "exactly-once within a s
 					" Use 'json' to have the component convert JSON to proto automatically."+
 					" Use 'protobuf' to supply raw proto-encoded bytes.").
 				Default("json"),
-			service.NewStringEnumField(bqwaFieldWriteMode, "default_stream", "pending_stream").
+			service.NewStringEnumField(bqwaFieldWriteMode, "default_stream", "pending_stream", "upsert", "upsert_delete").
 				Description("How the output writes to BigQuery."+
 					" `default_stream` uses the multiplexed default stream (at-least-once, lowest latency)."+
 					" `pending_stream` allocates a per-batch pending stream that commits atomically,"+
-					" providing exactly-once semantics within a single committed batch.").
+					" providing exactly-once semantics within a single committed batch."+
+					" `upsert` writes UPSERT-only rows to a BigQuery CDC-enabled table; the target table must have a PRIMARY KEY."+
+					" `upsert_delete` allows both UPSERT and DELETE rows. Both CDC modes use the default stream as required by BigQuery.").
 				Default("default_stream").
 				Advanced(),
+			service.NewInterpolatedStringField(bqwaFieldChangeType).
+				Description("Bloblang expression resolving to the `_CHANGE_TYPE` pseudo-column value for each row."+
+					" Must resolve to `UPSERT` or `DELETE` (case-insensitive)."+
+					" Required when `write_mode` is `upsert` or `upsert_delete`."+
+					" Example: `${! metadata(\"operation\") }`.").
+				Optional(),
+			service.NewInterpolatedStringField(bqwaFieldChangeSequenceNumber).
+				Description("Optional Bloblang expression resolving to the `_CHANGE_SEQUENCE_NUMBER` pseudo-column value."+
+					" Format: 1 to 4 sections of 1 to 16 hexadecimal characters each, separated by `/`."+
+					" Example: `${! metadata(\"scn\") }` or `${! \"0/0/0/0\" }`."+
+					" When unset, BigQuery resolves ordering by arrival time.").
+				Optional(),
+			service.NewStringListField(bqwaFieldPrimaryKeys).
+				Description("Optional list of primary-key column names."+
+					" Required when `auto_create_table` is true and `write_mode` is `upsert` or `upsert_delete`."+
+					" When the target table is pre-existing, the connector falls back to the PRIMARY KEY declared on the table."+
+					" Up to 16 columns; composite keys are supported in the same order they are listed.").
+				Optional(),
 			service.NewBoolField(bqwaFieldAutoCreateTable).
 				Description("If true and the target table does not exist, the output creates it using the configured `schema`, `time_partitioning`, and `clustering`."+
 					" AlreadyExists errors from concurrent creators are treated as success."+
@@ -281,6 +308,9 @@ type bigQueryWriteAPIConfig struct {
 	DatasetID              string
 	MessageFormat          string
 	WriteMode              string
+	ChangeType             *service.InterpolatedString
+	ChangeSequenceNumber   *service.InterpolatedString
+	PrimaryKeys            []string
 	AutoCreateTable        bool
 	Schema                 []bqSchemaField
 	TimePartitioning       bqTimePartitioningConfig
@@ -426,6 +456,45 @@ func bigQueryWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bigQuer
 	if conf.WriteMode, err = pConf.FieldString(bqwaFieldWriteMode); err != nil {
 		return
 	}
+	if pConf.Contains(bqwaFieldChangeType) {
+		if conf.ChangeType, err = pConf.FieldInterpolatedString(bqwaFieldChangeType); err != nil {
+			return
+		}
+	}
+	if pConf.Contains(bqwaFieldChangeSequenceNumber) {
+		if conf.ChangeSequenceNumber, err = pConf.FieldInterpolatedString(bqwaFieldChangeSequenceNumber); err != nil {
+			return
+		}
+	}
+	if conf.PrimaryKeys, err = pConf.FieldStringList(bqwaFieldPrimaryKeys); err != nil {
+		return
+	}
+	isCDC := conf.WriteMode == "upsert" || conf.WriteMode == "upsert_delete"
+	if isCDC && conf.ChangeType == nil {
+		err = fmt.Errorf("%s is required when %s is %q", bqwaFieldChangeType, bqwaFieldWriteMode, conf.WriteMode)
+		return
+	}
+	if isCDC && conf.MessageFormat != "json" {
+		// CDC mode injects pseudo-columns via JSON byte rewriting. Raw protobuf
+		// payloads would require deserialising via dynamicpb, setting the
+		// fields, and re-serialising — extra cost the user can avoid by
+		// converting upstream.
+		err = fmt.Errorf("%s is not supported when %s is %q (use message_format: json)",
+			bqwaFieldMessageFormat, bqwaFieldWriteMode, conf.WriteMode)
+		return
+	}
+	if !isCDC && conf.ChangeType != nil {
+		err = fmt.Errorf("%s is only valid when %s is upsert or upsert_delete", bqwaFieldChangeType, bqwaFieldWriteMode)
+		return
+	}
+	if !isCDC && conf.ChangeSequenceNumber != nil {
+		err = fmt.Errorf("%s is only valid when %s is upsert or upsert_delete", bqwaFieldChangeSequenceNumber, bqwaFieldWriteMode)
+		return
+	}
+	if len(conf.PrimaryKeys) > 16 {
+		err = fmt.Errorf("%s accepts at most 16 columns, got %d", bqwaFieldPrimaryKeys, len(conf.PrimaryKeys))
+		return
+	}
 	if conf.AutoCreateTable, err = pConf.FieldBool(bqwaFieldAutoCreateTable); err != nil {
 		return
 	}
@@ -439,6 +508,29 @@ func bigQueryWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bigQuer
 	if conf.AutoCreateTable && len(conf.Schema) == 0 {
 		err = fmt.Errorf("%s requires %s to be non-empty", bqwaFieldAutoCreateTable, bqwaFieldSchema)
 		return
+	}
+	if isCDC && conf.AutoCreateTable && len(conf.PrimaryKeys) == 0 {
+		err = fmt.Errorf("%s is required when %s is true and %s is %q",
+			bqwaFieldPrimaryKeys, bqwaFieldAutoCreateTable, bqwaFieldWriteMode, conf.WriteMode)
+		return
+	}
+	if len(conf.PrimaryKeys) > 0 && len(conf.Schema) > 0 {
+		cols := make(map[string]string, len(conf.Schema))
+		for _, f := range conf.Schema {
+			cols[f.Name] = f.Mode
+		}
+		for _, pk := range conf.PrimaryKeys {
+			mode, ok := cols[pk]
+			if !ok {
+				err = fmt.Errorf("%s column %q is not in %s", bqwaFieldPrimaryKeys, pk, bqwaFieldSchema)
+				return
+			}
+			if mode != "REQUIRED" {
+				err = fmt.Errorf("%s column %q must have mode REQUIRED in %s (got %q)",
+					bqwaFieldPrimaryKeys, pk, bqwaFieldSchema, mode)
+				return
+			}
+		}
 	}
 	// time_partitioning.type has no default, so a missing type — either via an
 	// absent block or a block without `type:` — leaves Type empty and the
@@ -583,14 +675,23 @@ func (e bqError) IsRetryable() bool      { return e.kind == bqErrorTransient }
 func (e bqError) IsPermanent() bool      { return e.kind == bqErrorPermanent }
 func (e bqError) IsSchemaMismatch() bool { return e.kind == bqErrorSchemaMismatch }
 
+// errPermanent is a sentinel that callers can wrap into errors that have no
+// underlying gRPC/googleapi classification (e.g. CDC config validation) so
+// classifyBQError surfaces them as permanent and the WriteBatch loop routes
+// the batch to DLQ instead of retrying forever.
+var errPermanent = errors.New("permanent error")
+
 // classifyBQError inspects err and returns a bqError carrying its retry
 // classification. gRPC permanent codes (InvalidArgument, NotFound,
 // PermissionDenied, AlreadyExists, FailedPrecondition, Unimplemented,
 // Unauthenticated) and REST 4xx codes (except 408 timeout and 429 throttling)
 // are treated as permanent; SCHEMA_MISMATCH_EXTRA_FIELDS surfaces separately;
-// everything else falls back to transient so the benthos retry loop gets a
-// chance.
+// errors wrapped with errPermanent are also treated as permanent; everything
+// else falls back to transient so the benthos retry loop gets a chance.
 func classifyBQError(err error) bqError {
+	if errors.Is(err, errPermanent) {
+		return bqError{kind: bqErrorPermanent, err: err}
+	}
 	if st, ok := grpcstatus.FromError(err); ok {
 		for _, detail := range st.Details() {
 			if storageErr, ok := detail.(*storagepb.StorageError); ok {
@@ -647,6 +748,10 @@ type bigQueryWriteAPIOutput struct {
 	// lifecycle. Nil-checked rather than gated on conf, so a pending-mode write
 	// against a disconnected output cleanly returns ErrNotConnected.
 	pending *pendingStreamWriter
+	// cdc is non-nil when write_mode is upsert or upsert_delete. Holds the
+	// Bloblang fields and the wrapped descriptor; injected per-row into
+	// writeBatchCDC.
+	cdc *cdcInjector
 
 	// Lock ordering: connMu must always be acquired before streamsMu to
 	// prevent deadlocks. Close() acquires connMu then streamsMu;
@@ -683,6 +788,16 @@ func bigQueryWriteAPIOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 		return nil, err
 	}
 
+	var cdc *cdcInjector
+	if cfg.WriteMode == "upsert" || cfg.WriteMode == "upsert_delete" {
+		cdc = &cdcInjector{
+			log:         mgr.Logger(),
+			changeType:  cfg.ChangeType,
+			changeSeq:   cfg.ChangeSequenceNumber,
+			allowDelete: cfg.WriteMode == "upsert_delete",
+		}
+	}
+
 	return &bigQueryWriteAPIOutput{
 		conf:        cfg,
 		tableInterp: tableInterp,
@@ -695,6 +810,7 @@ func bigQueryWriteAPIOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 			creator:        creator,
 		},
 		evolver: &schemaEvolver{log: mgr.Logger(), evolveTimeout: cfg.SchemaEvolutionTimeout},
+		cdc:     cdc,
 	}, nil
 }
 
@@ -794,6 +910,13 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 		return fmt.Errorf("getting stream for table %q: %w", tableID, err)
 	}
 
+	// CDC write modes inject _CHANGE_TYPE (and optionally _CHANGE_SEQUENCE_NUMBER)
+	// per row. Bad rows go to DLQ via BatchError.Failed(i, err) so good rows in
+	// the same batch still get written.
+	if o.cdc != nil {
+		return o.writeBatchCDC(ctx, client, swd, cacheKey, batch, tableID, start)
+	}
+
 	rows := make([][]byte, 0, len(batch))
 	for i, msg := range batch {
 		msgBytes, err := msg.AsBytes()
@@ -863,7 +986,9 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 
 	if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
 		o.metrics.rowsFailed.Incr(int64(len(rowErrs)))
-		o.metrics.rowsSent.Incr(int64(len(batch) - len(rowErrs)))
+		// Clamp: BQ shouldn't return more row errors than rows in the request,
+		// but guard the metric counter against a negative delta if it ever did.
+		o.metrics.rowsSent.Incr(int64(max(0, len(batch)-len(rowErrs))))
 		batchErr := service.NewBatchError(batch, errors.New("row errors from BigQuery"))
 		for _, re := range rowErrs {
 			idx := int(re.GetIndex())
@@ -888,6 +1013,137 @@ func permanentBatchError(batch service.MessageBatch, err error) error {
 		batchErr = batchErr.Failed(i, err)
 	}
 	return batchErr
+}
+
+// appendRowFailure lazily constructs and appends to a BatchError so the caller
+// can collect per-row failures without committing to a sentinel error when
+// there are no failures. headline becomes the BatchError's underlying error
+// when the first failure is appended; it's ignored on subsequent calls.
+func appendRowFailure(be *service.BatchError, batch service.MessageBatch, headline string, idx int, err error) *service.BatchError {
+	if be == nil {
+		be = service.NewBatchError(batch, errors.New(headline))
+	}
+	return be.Failed(idx, err)
+}
+
+// writeBatchCDC executes the CDC write path: per row, resolve the Bloblang
+// fields, validate the values, inject _CHANGE_TYPE (and optionally
+// _CHANGE_SEQUENCE_NUMBER) into the JSON payload, marshal to proto via the
+// wrapped descriptor, and AppendRows the result. Per-row validation failures
+// are collected into a BatchError so good rows in the same batch are still
+// written.
+func (o *bigQueryWriteAPIOutput) writeBatchCDC(
+	ctx context.Context,
+	client *bigquery.Client,
+	swd *streamWithDescriptor,
+	cacheKey string,
+	batch service.MessageBatch,
+	tableID string,
+	start time.Time,
+) error {
+	if o.conf.MessageFormat != "json" {
+		// Defensive — the parser already rejects message_format != json in CDC
+		// modes. If this fires it means the parser missed a case.
+		return permanentBatchError(batch, fmt.Errorf("CDC modes require message_format: json (got %q)", o.conf.MessageFormat))
+	}
+
+	var batchErr *service.BatchError
+	rows := make([][]byte, 0, len(batch))
+	rowIndex := make([]int, 0, len(batch))
+	validationFailures := 0
+
+	const cdcValidationHeadline = "CDC row validation errors"
+	for i, msg := range batch {
+		ct, err := batch.TryInterpolatedString(i, o.cdc.changeType)
+		if err != nil {
+			batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, fmt.Errorf("interpolating change_type: %w", err))
+			validationFailures++
+			continue
+		}
+		var seq string
+		if o.cdc.changeSeq != nil {
+			seq, err = batch.TryInterpolatedString(i, o.cdc.changeSeq)
+			if err != nil {
+				batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, fmt.Errorf("interpolating change_sequence_number: %w", err))
+				validationFailures++
+				continue
+			}
+		}
+
+		validatedCT, validatedSeq, err := o.cdc.validateAndResolveCDC(ct, seq)
+		if err != nil {
+			batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, err)
+			validationFailures++
+			continue
+		}
+
+		msgBytes, err := msg.AsBytes()
+		if err != nil {
+			batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, fmt.Errorf("reading message: %w", err))
+			validationFailures++
+			continue
+		}
+
+		injectedBytes, err := injectCDCJSON(msgBytes, validatedCT, validatedSeq)
+		if err != nil {
+			batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, err)
+			validationFailures++
+			continue
+		}
+		protoBytes, err := jsonToProtoBytes(injectedBytes, swd.descriptor)
+		if err != nil {
+			batchErr = appendRowFailure(batchErr, batch, cdcValidationHeadline, i, fmt.Errorf("converting JSON to proto: %w", err))
+			validationFailures++
+			continue
+		}
+		rows = append(rows, protoBytes)
+		rowIndex = append(rowIndex, i)
+	}
+
+	if validationFailures > 0 {
+		o.metrics.rowsFailed.Incr(int64(validationFailures))
+	}
+
+	if len(rows) == 0 {
+		if batchErr != nil {
+			return batchErr
+		}
+		return nil
+	}
+
+	result, err := swd.stream.AppendRows(ctx, rows)
+	if err != nil {
+		o.evictStream(cacheKey)
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "appending CDC rows")
+	}
+	resp, err := result.FullResponse(ctx)
+	if err != nil {
+		o.evictStream(cacheKey)
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "waiting for CDC append result")
+	}
+
+	o.metrics.batchLatency.Timing(time.Since(start).Nanoseconds())
+	if resp.GetUpdatedSchema() != nil {
+		o.log.Infof("BigQuery reported schema update for table %q, evicting cached stream", tableID)
+		o.evictStream(cacheKey)
+		o.resolver.Evict(tableID)
+	}
+
+	if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
+		for _, re := range rowErrs {
+			idx := int(re.GetIndex())
+			if idx >= 0 && idx < len(rowIndex) {
+				batchErr = appendRowFailure(batchErr, batch, "row errors from BigQuery", rowIndex[idx], fmt.Errorf("row %d: code %d: %s", idx, re.GetCode(), re.GetMessage()))
+			}
+		}
+		o.metrics.rowsFailed.Incr(int64(len(rowErrs)))
+	}
+	o.metrics.batchesSent.Incr(1)
+	o.metrics.rowsSent.Incr(int64(max(0, len(rows)-len(resp.GetRowErrors()))))
+	if batchErr != nil {
+		return batchErr
+	}
+	return nil
 }
 
 // handleWriteError classifies a gRPC error from an append or response and
@@ -1055,7 +1311,13 @@ func (o *bigQueryWriteAPIOutput) closeStreamAsync(s *managedwriter.ManagedStream
 }
 
 func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, client *bigquery.Client, projectID, tableID string) (*streamWithDescriptor, string, error) {
-	cacheKey := o.tableCacheKey(projectID, tableID)
+	// parentPath is the BigQuery resource path used as the AppendRows
+	// destination. cacheKey adds a write-mode suffix so a CDC pipeline and a
+	// non-CDC pipeline pointed at the same table cannot share a stream — the
+	// underlying ManagedStream is bound to its schema descriptor, and the CDC
+	// path wraps the descriptor with pseudo-columns.
+	parentPath := o.tableCacheKey(projectID, tableID)
+	cacheKey := parentPath + "#mode=" + o.conf.WriteMode
 
 	now := time.Now()
 
@@ -1069,7 +1331,7 @@ func (o *bigQueryWriteAPIOutput) getOrCreateStream(ctx context.Context, client *
 	o.streamsMu.RUnlock()
 
 	// Slow path: create stream without holding the lock (network I/O).
-	swd, err := o.createStream(ctx, client, cacheKey, tableID)
+	swd, err := o.createStream(ctx, client, parentPath, tableID)
 	if err != nil {
 		return nil, cacheKey, err
 	}
@@ -1182,7 +1444,7 @@ func (o *bigQueryWriteAPIOutput) sweepIdleStreams(stop <-chan struct{}) {
 	}
 }
 
-func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigquery.Client, cacheKey, tableID string) (*streamWithDescriptor, error) {
+func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigquery.Client, parentPath, tableID string) (*streamWithDescriptor, error) {
 	o.connMu.RLock()
 	storageClient := o.storageClient
 	o.connMu.RUnlock()
@@ -1196,24 +1458,51 @@ func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigqu
 		return nil, err
 	}
 
+	// In CDC mode, append _CHANGE_TYPE (and optionally _CHANGE_SEQUENCE_NUMBER)
+	// to the user's descriptor and use the wrapped version for the managed
+	// stream. The resolver's cached descriptor stays unchanged so non-CDC
+	// pipelines sharing the resolver are not affected.
+	descriptorProto := rs.descriptorProto
+	descriptor := rs.messageDescriptor
+	if o.cdc != nil {
+		// CDC requires at least one PK source. If primary_keys is configured
+		// AND the table already declares PKs, both must agree. These are
+		// config-level errors with no underlying gRPC/googleapi classification,
+		// so wrap them with errPermanent to short-circuit the retry loop and
+		// route the batch to DLQ — the spec says these should fail loudly.
+		if err := validateCDCPrimaryKeys(o.conf.PrimaryKeys, rs.primaryKeys, tableID); err != nil {
+			return nil, fmt.Errorf("%w: %w", errPermanent, err)
+		}
+		wrapped, err := wrapDescriptorForCDC(rs.descriptorProto, o.cdc.changeSeq != nil)
+		if err != nil {
+			return nil, fmt.Errorf("%w: wrapping descriptor for CDC: %w", errPermanent, err)
+		}
+		wrappedMD, err := descriptorProtoToMessageDescriptor(wrapped)
+		if err != nil {
+			return nil, fmt.Errorf("%w: building wrapped message descriptor: %w", errPermanent, err)
+		}
+		descriptorProto = wrapped
+		descriptor = wrappedMD
+	}
+
 	// Detach from the per-batch ctx: the cached stream outlives this WriteBatch
 	// and is reused by every subsequent batch routing to the same table. If the
 	// stream were bound to this ctx, cancellation of the first batch (per-message
 	// deadline, source shutdown, ack timeout) would block all later AppendRows
 	// against the cached stream until the idle sweeper evicted it.
 	ms, err := storageClient.NewManagedStream(context.WithoutCancel(ctx),
-		managedwriter.WithDestinationTable(cacheKey),
+		managedwriter.WithDestinationTable(parentPath),
 		managedwriter.WithType(managedwriter.DefaultStream),
-		managedwriter.WithSchemaDescriptor(rs.descriptorProto),
+		managedwriter.WithSchemaDescriptor(descriptorProto),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("creating managed stream for %q: %w", cacheKey, err)
+		return nil, fmt.Errorf("creating managed stream for %q: %w", parentPath, err)
 	}
 
 	return &streamWithDescriptor{
 		stream:          ms,
-		descriptor:      rs.messageDescriptor,
-		descriptorProto: rs.descriptorProto,
+		descriptor:      descriptor,
+		descriptorProto: descriptorProto,
 	}, nil
 }
 

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -791,7 +791,6 @@ func bigQueryWriteAPIOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 	var cdc *cdcInjector
 	if cfg.WriteMode == "upsert" || cfg.WriteMode == "upsert_delete" {
 		cdc = &cdcInjector{
-			log:         mgr.Logger(),
 			changeType:  cfg.ChangeType,
 			changeSeq:   cfg.ChangeSequenceNumber,
 			allowDelete: cfg.WriteMode == "upsert_delete",

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -303,7 +303,7 @@ type bqTimePartitioningConfig struct {
 	RequireFilter bool
 }
 
-type bigQueryWriteAPIConfig struct {
+type bqWriteAPIConfig struct {
 	ProjectID              string
 	DatasetID              string
 	MessageFormat          string
@@ -360,7 +360,7 @@ var validBQFieldModes = map[string]struct{}{
 // columns reference columns declared in the schema, and that the partition
 // field has a partition-eligible type. The checks only fire when columns are
 // actually configured (clustering empty / partition field empty is a no-op).
-func validateSchemaReferences(conf bigQueryWriteAPIConfig) error {
+func validateSchemaReferences(conf bqWriteAPIConfig) error {
 	if conf.TimePartitioning.Field == "" && len(conf.Clustering) == 0 {
 		return nil
 	}
@@ -440,7 +440,7 @@ func parseSchemaFields(confs []*service.ParsedConfig) ([]bqSchemaField, error) {
 	return out, nil
 }
 
-func bigQueryWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bigQueryWriteAPIConfig, err error) {
+func bqWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bqWriteAPIConfig, err error) {
 	if conf.ProjectID, err = pConf.FieldString(bqwaFieldProject); err != nil {
 		return
 	}
@@ -725,14 +725,19 @@ func classifyBQError(err error) bqError {
 }
 
 type streamWithDescriptor struct {
-	stream          *managedwriter.ManagedStream
-	descriptor      protoreflect.MessageDescriptor
+	stream     *managedwriter.ManagedStream
+	descriptor protoreflect.MessageDescriptor
+	// baseDescriptor is the user table's descriptor without the CDC pseudo-column
+	// wrap. Equal to descriptor for non-CDC streams. Used by handleWriteError so
+	// schema evolution diffs against the actual table schema rather than trying
+	// to add _CHANGE_TYPE / _CHANGE_SEQUENCE_NUMBER as real columns.
+	baseDescriptor  protoreflect.MessageDescriptor
 	descriptorProto *descriptorpb.DescriptorProto // needed by pendingStreamWriter (write_mode=pending_stream)
 	lastUsed        atomic.Int64                  // UnixNano timestamp, safe for concurrent access
 }
 
 type bigQueryWriteAPIOutput struct {
-	conf        bigQueryWriteAPIConfig
+	conf        bqWriteAPIConfig
 	tableInterp *service.InterpolatedString
 	log         *service.Logger
 	metrics     *bqwaMetrics
@@ -774,7 +779,7 @@ func bigQueryWriteAPIOutputFromConfig(conf *service.ParsedConfig, mgr *service.R
 	if err := license.CheckRunningEnterprise(mgr); err != nil {
 		return nil, err
 	}
-	cfg, err := bigQueryWriteAPIConfigFromParsed(conf)
+	cfg, err := bqWriteAPIConfigFromParsed(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -1113,12 +1118,16 @@ func (o *bigQueryWriteAPIOutput) writeBatchCDC(
 	result, err := swd.stream.AppendRows(ctx, rows)
 	if err != nil {
 		o.evictStream(cacheKey)
-		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "appending CDC rows")
+		// Pass baseDescriptor (not the CDC-wrapped one) so schema evolution
+		// diffs against the real table schema; otherwise Evolve would see
+		// _CHANGE_TYPE / _CHANGE_SEQUENCE_NUMBER as "missing" columns and
+		// try to ALTER TABLE to add them.
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.baseDescriptor, "appending CDC rows")
 	}
 	resp, err := result.FullResponse(ctx)
 	if err != nil {
 		o.evictStream(cacheKey)
-		return o.handleWriteError(ctx, client, err, batch, tableID, swd.descriptor, "waiting for CDC append result")
+		return o.handleWriteError(ctx, client, err, batch, tableID, swd.baseDescriptor, "waiting for CDC append result")
 	}
 
 	o.metrics.batchLatency.Timing(time.Since(start).Nanoseconds())
@@ -1501,6 +1510,7 @@ func (o *bigQueryWriteAPIOutput) createStream(ctx context.Context, client *bigqu
 	return &streamWithDescriptor{
 		stream:          ms,
 		descriptor:      descriptor,
+		baseDescriptor:  rs.messageDescriptor,
 		descriptorProto: descriptorProto,
 	}, nil
 }

--- a/internal/impl/gcp/enterprise/bigquery/output_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/output_test.go
@@ -59,7 +59,7 @@ table: my_table
 	require.NoError(t, err)
 
 	// When we parse the config.
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 
 	// Then defaults are applied correctly.
@@ -106,7 +106,7 @@ endpoint:
 	require.NoError(t, err)
 
 	// When we parse the config.
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 
 	// Then all values are parsed correctly.
@@ -138,7 +138,7 @@ change_type: ${! metadata("operation") }
 `, mode)
 			pConf, err := spec.ParseYAML(yaml, nil)
 			require.NoError(t, err)
-			cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+			cfg, err := bqWriteAPIConfigFromParsed(pConf)
 			require.NoError(t, err)
 			assert.Equal(t, mode, cfg.WriteMode)
 		})
@@ -156,7 +156,7 @@ write_mode: upsert
 change_type: ${! metadata("operation") }
 `, nil)
 		require.NoError(t, err)
-		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		cfg, err := bqWriteAPIConfigFromParsed(pConf)
 		require.NoError(t, err)
 		require.NotNil(t, cfg.ChangeType)
 	})
@@ -168,7 +168,7 @@ table: my_table
 write_mode: upsert
 `, nil)
 		require.NoError(t, err)
-		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		_, err = bqWriteAPIConfigFromParsed(pConf)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "change_type")
 	})
@@ -179,7 +179,7 @@ dataset: my_dataset
 table: my_table
 `, nil)
 		require.NoError(t, err)
-		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		cfg, err := bqWriteAPIConfigFromParsed(pConf)
 		require.NoError(t, err)
 		assert.Nil(t, cfg.ChangeType)
 	})
@@ -195,7 +195,7 @@ change_type: ${! metadata("operation") }
 change_sequence_number: ${! metadata("scn") }
 `, nil)
 	require.NoError(t, err)
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 	require.NotNil(t, cfg.ChangeSequenceNumber)
 }
@@ -212,7 +212,7 @@ change_type: ${! metadata("operation") }
 primary_keys: [id, tenant_id]
 `, nil)
 		require.NoError(t, err)
-		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		cfg, err := bqWriteAPIConfigFromParsed(pConf)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"id", "tenant_id"}, cfg.PrimaryKeys)
 	})
@@ -230,7 +230,7 @@ change_type: ${! metadata("operation") }
 primary_keys: [%s]
 `, strings.Join(keys, ", ")), nil)
 		require.NoError(t, err)
-		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		_, err = bqWriteAPIConfigFromParsed(pConf)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "16")
 	})
@@ -246,7 +246,7 @@ schema:
   - { name: id, type: STRING, mode: REQUIRED }
 `, nil)
 		require.NoError(t, err)
-		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		_, err = bqWriteAPIConfigFromParsed(pConf)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "primary_keys")
 	})
@@ -263,7 +263,7 @@ schema:
 primary_keys: [unknown_col]
 `, nil)
 		require.NoError(t, err)
-		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		_, err = bqWriteAPIConfigFromParsed(pConf)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown_col")
 	})
@@ -280,7 +280,7 @@ schema:
 primary_keys: [id]
 `, nil)
 		require.NoError(t, err)
-		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		_, err = bqWriteAPIConfigFromParsed(pConf)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "REQUIRED")
 	})
@@ -328,7 +328,7 @@ message_format: protobuf
 		t.Run(tc.name, func(t *testing.T) {
 			pConf, err := spec.ParseYAML(tc.yaml, nil)
 			require.NoError(t, err)
-			_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+			_, err = bqWriteAPIConfigFromParsed(pConf)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -392,7 +392,7 @@ delegates:
 		t.Run(tc.name, func(t *testing.T) {
 			pConf, err := spec.ParseYAML(tc.yaml, nil)
 			require.NoError(t, err)
-			_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+			_, err = bqWriteAPIConfigFromParsed(pConf)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -417,7 +417,7 @@ schema:
 `, nil)
 	require.NoError(t, err)
 
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 	require.Len(t, cfg.Schema, 4)
 	assert.Equal(t, "id", cfg.Schema[0].Name)
@@ -487,7 +487,7 @@ schema:
 		t.Run(tc.name, func(t *testing.T) {
 			pConf, err := spec.ParseYAML(tc.yaml, nil)
 			require.NoError(t, err)
-			_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+			_, err = bqWriteAPIConfigFromParsed(pConf)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -515,7 +515,7 @@ clustering:
 `, nil)
 	require.NoError(t, err)
 
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 	assert.Equal(t, "HOUR", cfg.TimePartitioning.Type)
 	assert.Equal(t, "created_at", cfg.TimePartitioning.Field)
@@ -532,7 +532,7 @@ dataset: my_dataset
 table: my_table
 `, nil)
 	require.NoError(t, err)
-	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	cfg, err := bqWriteAPIConfigFromParsed(pConf)
 	require.NoError(t, err)
 	assert.Empty(t, cfg.TimePartitioning.Type)
 	assert.Empty(t, cfg.TimePartitioning.Field)
@@ -599,7 +599,7 @@ clustering: [a, b, c, d, e]
 		t.Run(tc.name, func(t *testing.T) {
 			pConf, err := spec.ParseYAML(tc.yaml, nil)
 			require.NoError(t, err)
-			_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+			_, err = bqWriteAPIConfigFromParsed(pConf)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})

--- a/internal/impl/gcp/enterprise/bigquery/output_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/output_test.go
@@ -11,6 +11,7 @@ package bigquery
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -123,6 +124,215 @@ endpoint:
 	assert.Equal(t, 45*time.Second, cfg.SchemaEvolutionTimeout)
 	assert.Equal(t, "http://localhost:9050", cfg.EndpointHTTP)
 	assert.Equal(t, "localhost:9060", cfg.EndpointGRPC)
+}
+
+func TestBigQueryWriteAPIConfigParsingWriteModeUpsert(t *testing.T) {
+	spec := bigQueryWriteAPISpec()
+	for _, mode := range []string{"upsert", "upsert_delete"} {
+		t.Run(mode, func(t *testing.T) {
+			yaml := fmt.Sprintf(`
+dataset: my_dataset
+table: my_table
+write_mode: %s
+change_type: ${! metadata("operation") }
+`, mode)
+			pConf, err := spec.ParseYAML(yaml, nil)
+			require.NoError(t, err)
+			cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+			require.NoError(t, err)
+			assert.Equal(t, mode, cfg.WriteMode)
+		})
+	}
+}
+
+func TestBigQueryWriteAPIConfigChangeType(t *testing.T) {
+	spec := bigQueryWriteAPISpec()
+
+	t.Run("change_type parsed for upsert mode", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+`, nil)
+		require.NoError(t, err)
+		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.ChangeType)
+	})
+
+	t.Run("change_type required when upsert", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+`, nil)
+		require.NoError(t, err)
+		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "change_type")
+	})
+
+	t.Run("change_type not required when default_stream", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+`, nil)
+		require.NoError(t, err)
+		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.ChangeType)
+	})
+}
+
+func TestBigQueryWriteAPIConfigChangeSequenceNumber(t *testing.T) {
+	spec := bigQueryWriteAPISpec()
+	pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+change_sequence_number: ${! metadata("scn") }
+`, nil)
+	require.NoError(t, err)
+	cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.ChangeSequenceNumber)
+}
+
+func TestBigQueryWriteAPIConfigPrimaryKeys(t *testing.T) {
+	spec := bigQueryWriteAPISpec()
+
+	t.Run("primary_keys parsed", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+primary_keys: [id, tenant_id]
+`, nil)
+		require.NoError(t, err)
+		cfg, err := bigQueryWriteAPIConfigFromParsed(pConf)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"id", "tenant_id"}, cfg.PrimaryKeys)
+	})
+
+	t.Run("max 16 columns", func(t *testing.T) {
+		keys := make([]string, 17)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("c%d", i)
+		}
+		pConf, err := spec.ParseYAML(fmt.Sprintf(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+primary_keys: [%s]
+`, strings.Join(keys, ", ")), nil)
+		require.NoError(t, err)
+		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "16")
+	})
+
+	t.Run("required when auto_create_table and CDC mode", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+auto_create_table: true
+schema:
+  - { name: id, type: STRING, mode: REQUIRED }
+`, nil)
+		require.NoError(t, err)
+		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "primary_keys")
+	})
+
+	t.Run("PK column must exist in schema when both set", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+auto_create_table: true
+schema:
+  - { name: id, type: STRING, mode: REQUIRED }
+primary_keys: [unknown_col]
+`, nil)
+		require.NoError(t, err)
+		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown_col")
+	})
+
+	t.Run("PK column must be REQUIRED when both set", func(t *testing.T) {
+		pConf, err := spec.ParseYAML(`
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+auto_create_table: true
+schema:
+  - { name: id, type: STRING, mode: NULLABLE }
+primary_keys: [id]
+`, nil)
+		require.NoError(t, err)
+		_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "REQUIRED")
+	})
+}
+
+func TestBigQueryWriteAPIConfigCDCIncompatibilities(t *testing.T) {
+	spec := bigQueryWriteAPISpec()
+	cases := []struct {
+		name   string
+		yaml   string
+		errMsg string
+	}{
+		{
+			name: "pending_stream rejects change_type",
+			yaml: `
+dataset: my_dataset
+table: my_table
+write_mode: pending_stream
+change_type: ${! metadata("operation") }
+`,
+			errMsg: "change_type",
+		},
+		{
+			name: "default_stream rejects change_sequence_number",
+			yaml: `
+dataset: my_dataset
+table: my_table
+change_sequence_number: ${! metadata("scn") }
+`,
+			errMsg: "change_sequence_number",
+		},
+		{
+			name: "upsert rejects message_format: protobuf",
+			yaml: `
+dataset: my_dataset
+table: my_table
+write_mode: upsert
+change_type: ${! metadata("operation") }
+message_format: protobuf
+`,
+			errMsg: "message_format",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pConf, err := spec.ParseYAML(tc.yaml, nil)
+			require.NoError(t, err)
+			_, err = bigQueryWriteAPIConfigFromParsed(pConf)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
 }
 
 func TestBigQueryWriteAPIConfigParsingRejectsNonPositiveDurations(t *testing.T) {

--- a/internal/impl/gcp/enterprise/bigquery/schema_resolver.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_resolver.go
@@ -28,10 +28,12 @@ import (
 )
 
 // resolvedSchema holds both descriptor forms (DescriptorProto for the managed
-// writer, MessageDescriptor for JSON-to-proto conversion).
+// writer, MessageDescriptor for JSON-to-proto conversion) plus the table's
+// declared primary keys (nil when the table has no PK constraint).
 type resolvedSchema struct {
 	descriptorProto   *descriptorpb.DescriptorProto
 	messageDescriptor protoreflect.MessageDescriptor
+	primaryKeys       []string
 }
 
 // schemaResolver caches resolved schemas per table and deduplicates concurrent
@@ -161,5 +163,23 @@ func resolveFromBQTable(ctx context.Context, client *bq.Client, creator *tableCr
 	return &resolvedSchema{
 		descriptorProto:   normalized,
 		messageDescriptor: md,
+		primaryKeys:       extractPrimaryKeysFromMetadata(meta),
 	}, nil
+}
+
+// extractPrimaryKeysFromMetadata reads the PRIMARY KEY declaration from a
+// fetched BigQuery table metadata. Returns nil if the table has no primary
+// key declared. The returned slice preserves the column order declared in
+// BigQuery, which is significant for composite keys.
+func extractPrimaryKeysFromMetadata(meta *bq.TableMetadata) []string {
+	if meta == nil || meta.TableConstraints == nil || meta.TableConstraints.PrimaryKey == nil {
+		return nil
+	}
+	cols := meta.TableConstraints.PrimaryKey.Columns
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make([]string, len(cols))
+	copy(out, cols)
+	return out
 }

--- a/internal/impl/gcp/enterprise/bigquery/schema_resolver_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/schema_resolver_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -165,6 +166,29 @@ func TestResolverConcurrentStress(t *testing.T) {
 	// any access path is unsafe. The build/test passes when atomic + lock
 	// invariants hold.
 	assert.GreaterOrEqual(t, r.generation.Load(), int64(0))
+}
+
+func TestExtractPrimaryKeysFromMetadata(t *testing.T) {
+	t.Run("returns columns in declared order", func(t *testing.T) {
+		meta := &bigquery.TableMetadata{
+			TableConstraints: &bigquery.TableConstraints{
+				PrimaryKey: &bigquery.PrimaryKey{Columns: []string{"tenant_id", "id"}},
+			},
+		}
+		pks := extractPrimaryKeysFromMetadata(meta)
+		assert.Equal(t, []string{"tenant_id", "id"}, pks)
+	})
+
+	t.Run("returns nil when no constraints", func(t *testing.T) {
+		assert.Nil(t, extractPrimaryKeysFromMetadata(&bigquery.TableMetadata{}))
+		assert.Nil(t, extractPrimaryKeysFromMetadata(&bigquery.TableMetadata{
+			TableConstraints: &bigquery.TableConstraints{},
+		}))
+	})
+
+	t.Run("returns nil on nil metadata", func(t *testing.T) {
+		assert.Nil(t, extractPrimaryKeysFromMetadata(nil))
+	})
 }
 
 // buildTestMessageDescriptor creates a simple (name STRING, age INT64)

--- a/internal/impl/gcp/enterprise/bigquery/table_creator.go
+++ b/internal/impl/gcp/enterprise/bigquery/table_creator.go
@@ -85,6 +85,7 @@ type tableCreator struct {
 	partitioning           *bigquery.TimePartitioning
 	clustering             *bigquery.Clustering
 	requirePartitionFilter bool
+	primaryKeys            []string
 	log                    *service.Logger
 }
 
@@ -104,21 +105,34 @@ func newTableCreator(conf bigQueryWriteAPIConfig, log *service.Logger) (*tableCr
 		partitioning:           yamlTimePartitioningToBQ(conf.TimePartitioning),
 		clustering:             yamlClusteringToBQ(conf.Clustering),
 		requirePartitionFilter: conf.TimePartitioning.RequireFilter,
+		primaryKeys:            conf.PrimaryKeys,
 		log:                    log,
 	}, nil
 }
 
-// Ensure creates the table if it does not exist. AlreadyExists (HTTP 409) is
-// treated as success so concurrent creators race-tolerantly. Other errors
-// propagate so the caller (schemaResolver) can classify and retry.
-func (tc *tableCreator) Ensure(ctx context.Context, client *bigquery.Client, datasetID, tableID string) error {
+// buildMetadata returns the bigquery.TableMetadata used by Ensure. Extracted
+// from the inline literal so unit tests can exercise the PrimaryKey wiring
+// without going through Create.
+func (tc *tableCreator) buildMetadata() *bigquery.TableMetadata {
 	meta := &bigquery.TableMetadata{
 		Schema:                 tc.schema,
 		TimePartitioning:       tc.partitioning,
 		Clustering:             tc.clustering,
 		RequirePartitionFilter: tc.requirePartitionFilter,
 	}
-	if err := client.Dataset(datasetID).Table(tableID).Create(ctx, meta); err != nil {
+	if len(tc.primaryKeys) > 0 {
+		meta.TableConstraints = &bigquery.TableConstraints{
+			PrimaryKey: &bigquery.PrimaryKey{Columns: append([]string{}, tc.primaryKeys...)},
+		}
+	}
+	return meta
+}
+
+// Ensure creates the table if it does not exist. AlreadyExists (HTTP 409) is
+// treated as success so concurrent creators race-tolerantly. Other errors
+// propagate so the caller (schemaResolver) can classify and retry.
+func (tc *tableCreator) Ensure(ctx context.Context, client *bigquery.Client, datasetID, tableID string) error {
+	if err := client.Dataset(datasetID).Table(tableID).Create(ctx, tc.buildMetadata()); err != nil {
 		// Extract googleapi diagnostics (HTTP status + GCP-side error details)
 		// for a richer error message; fall back to the bare error otherwise.
 		var apiErr *googleapi.Error

--- a/internal/impl/gcp/enterprise/bigquery/table_creator.go
+++ b/internal/impl/gcp/enterprise/bigquery/table_creator.go
@@ -92,7 +92,7 @@ type tableCreator struct {
 // newTableCreator builds a tableCreator from the parsed config. Returns nil
 // when auto_create_table is disabled — callers nil-check to skip the create
 // path entirely.
-func newTableCreator(conf bigQueryWriteAPIConfig, log *service.Logger) (*tableCreator, error) {
+func newTableCreator(conf bqWriteAPIConfig, log *service.Logger) (*tableCreator, error) {
 	if !conf.AutoCreateTable {
 		return nil, nil
 	}

--- a/internal/impl/gcp/enterprise/bigquery/table_creator_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/table_creator_test.go
@@ -110,3 +110,26 @@ func TestYAMLSchemaTypeMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestTableCreatorBuildsPrimaryKey(t *testing.T) {
+	creator := &tableCreator{
+		schema: bigquery.Schema{
+			{Name: "id", Type: bigquery.StringFieldType, Required: true},
+		},
+		primaryKeys: []string{"id"},
+	}
+	meta := creator.buildMetadata()
+	require.NotNil(t, meta.TableConstraints)
+	require.NotNil(t, meta.TableConstraints.PrimaryKey)
+	assert.Equal(t, []string{"id"}, meta.TableConstraints.PrimaryKey.Columns)
+}
+
+func TestTableCreatorNoPrimaryKey(t *testing.T) {
+	creator := &tableCreator{
+		schema: bigquery.Schema{
+			{Name: "id", Type: bigquery.StringFieldType, Required: true},
+		},
+	}
+	meta := creator.buildMetadata()
+	assert.Nil(t, meta.TableConstraints)
+}


### PR DESCRIPTION

Implements CON-395 on top of the pending-streams branch. Two new
opt-in write modes layered onto gcp_bigquery_write_api: upsert and
upsert_delete. Both inject BigQuery's _CHANGE_TYPE pseudo-column
per row and optionally _CHANGE_SEQUENCE_NUMBER for out-of-order
resolution.

Write modes
- write_mode: upsert — UPSERT-only rows.
- write_mode: upsert_delete — UPSERT and DELETE rows.
- Both use the default stream (the only stream type BigQuery's CDC
  contract supports). pending_stream + CDC is rejected at parse time.

Pseudo-column injection
- change_type: Bloblang field resolving per row to UPSERT or DELETE
  (case-insensitive; INSERT is rejected — BigQuery doesn't allow
  mixing INSERT and UPSERT/DELETE in the same write).
- change_sequence_number: optional Bloblang field. Validated against
  BigQuery's 1-to-4-sections-of-1-to-16-hex-chars format.
- Injection happens at the JSON byte level via map[string]json.RawMessage
  so user values (int-as-string, base64 bytes, RFC3339 timestamps)
  pass through byte-exact. No round-trip through map[string]any that
  would corrupt int64 strings above 2^53.
- Per-row validation failures route to DLQ via BatchError.Failed
  so a single bad row never poisons the batch. rowsFailed metric
  counts every reject path.

Primary keys
- New primary_keys config (≤16 columns). Required when auto_create_table
  is true; otherwise the connector reads the table's declared PKs via
  TableConstraints.PrimaryKey and uses those.
- When both config and table-declared PKs are present, they must match
  (same columns, same order). Mismatches fail loudly at createStream.
- CDC mode without any PK source fails at createStream with a message
  pointing users to ALTER TABLE … ADD PRIMARY KEY.

Descriptor wrapping
- _CHANGE_TYPE and _CHANGE_SEQUENCE_NUMBER (when configured) are
  appended as proto fields at max(existing)+1, +2 in the user's
  descriptor. Wrapped descriptors live on the per-stream
  streamWithDescriptor so concurrent createStream calls cannot race.
- Stream cache keying includes the write_mode suffix so CDC and
  non-CDC pipelines pointed at the same table cannot share a stream.

message_format
- CDC modes require message_format: json. The protobuf path is
  rejected at parse time (and defensively at runtime) because the
  injection works on JSON bytes.

Docs and tests
- New migration guide at docs/modules/components/pages/outputs/
  bigquery_cdc_migration.adoc covering config translation, schema
  requirements, snapshot vs streaming tradeoffs, and the DML
  restriction on CDC tables. Bidirectional xref with the output page.
- Unit tests cover: validateChangeType, validateChangeSequenceNumber,
  validateCDCPrimaryKeys, wrapDescriptorForCDC, injectCDCJSON (incl.
  byte-fidelity for >2^53 integers), cdcInjector.validateAndResolveCDC,
  extractPrimaryKeysFromMetadata, tableCreator.buildMetadata with PKs,
  and config parsing for the five new fields plus cross-field
  validation.
- Integration tests stubbed (t.Skip) — goccy emulator does not
  implement CDC; real-BQ verification deferred.