### PR TITLE
oracledb_cdc: buffer out of order LOB_WRITE events until corresponding INSERT/UPDATE events are received

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -52,6 +52,10 @@ type LogMiner struct {
 	// lob types are split between redo log lines, we use lobStates to track them
 	// until we have all data to merge into published INSERT or UPDATE event.
 	lobStates map[sqlredo.TransactionID]*sqlredo.TxnLOBState
+	// pendingLOBWrites buffers LOB_WRITE events that arrived before their matching
+	// INSERT/UPDATE (BASICFILE DISABLE STORAGE IN ROW ordering). Drained when the
+	// INSERT/UPDATE is subsequently processed.
+	pendingLOBWrites map[sqlredo.TransactionID][]*sqlredo.RedoEvent
 }
 
 // NewMiner creates a new instance of LogMiner responsible for paging through change events based on the tables param.
@@ -109,8 +113,9 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 		logCollector:  NewLogFileCollector(),
 		sessionMgr:    NewSessionManager(cfg, logger),
 		txnCache:      NewInMemoryCache(cfg.MaxTransactionEvents, metrics, logger),
-		dmlParser:     sqlredo.NewParser(),
-		lobStates:     make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		dmlParser:        sqlredo.NewParser(),
+		lobStates:        make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		pendingLOBWrites: make(map[sqlredo.TransactionID][]*sqlredo.RedoEvent),
 	}
 	return lm
 }
@@ -273,6 +278,10 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 
 		lm.txnCache.AddEvent(redoEvent.TransactionID, redoEvent.SCN, &event)
 
+		if lm.cfg.LOBEnabled && (redoEvent.Operation == sqlredo.OpInsert || redoEvent.Operation == sqlredo.OpUpdate) {
+			lm.drainPendingLOBWrites(redoEvent.TransactionID)
+		}
+
 	case sqlredo.OpSelectLobLocator:
 		if !lm.cfg.LOBEnabled {
 			return nil
@@ -384,7 +393,8 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 		state, exists := lm.lobStates[redoEvent.TransactionID]
 		if !exists || state.ActiveKey == nil {
 			if !lm.inferLOBLocator(redoEvent) {
-				lm.log.Warnf("Received LOB_WRITE without active LOB locator (scn=%d, txn=%s)", redoEvent.SCN, redoEvent.TransactionID)
+				// INSERT not yet seen — buffer for retry once it arrives.
+				lm.pendingLOBWrites[redoEvent.TransactionID] = append(lm.pendingLOBWrites[redoEvent.TransactionID], redoEvent)
 				return nil
 			}
 			state = lm.lobStates[redoEvent.TransactionID]
@@ -508,18 +518,19 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 			lm.txnCache.CommitTransaction(redoEvent.TransactionID)
 		}
 
-		// Always clean up lobStates on commit, including for transactions discarded by
-		// the cache (GetTransaction returns nil when MaxTransactionEvents is exceeded).
-		// Without this, LOB events that bypass the cache continue to accumulate in
-		// lobStates and are never freed.
+		// Always clean up lobStates and pendingLOBWrites on commit, including for
+		// transactions discarded by the cache (GetTransaction returns nil when
+		// MaxTransactionEvents is exceeded).
 		if lm.cfg.LOBEnabled {
 			delete(lm.lobStates, redoEvent.TransactionID)
+			delete(lm.pendingLOBWrites, redoEvent.TransactionID)
 		}
 
 	case sqlredo.OpRollback:
 		// Discard all buffered events for this transaction
 		if lm.cfg.LOBEnabled {
 			delete(lm.lobStates, redoEvent.TransactionID)
+			delete(lm.pendingLOBWrites, redoEvent.TransactionID)
 		}
 		lm.txnCache.RollbackTransaction(redoEvent.TransactionID)
 	}
@@ -732,6 +743,49 @@ func (lm *LogMiner) inferLOBLocator(event *sqlredo.RedoEvent) bool {
 	}
 
 	return false
+}
+
+// drainPendingLOBWrites retries LOB_WRITE events that were buffered because their
+// INSERT had not yet been processed. Called after each INSERT or UPDATE is added
+// to the transaction cache, at which point inferLOBLocator should succeed.
+func (lm *LogMiner) drainPendingLOBWrites(txnID sqlredo.TransactionID) {
+	pending := lm.pendingLOBWrites[txnID]
+	if len(pending) == 0 {
+		return
+	}
+
+	var remaining []*sqlredo.RedoEvent
+	for _, event := range pending {
+		state, exists := lm.lobStates[txnID]
+		if !exists || state.ActiveKey == nil {
+			if !lm.inferLOBLocator(event) {
+				remaining = append(remaining, event)
+				continue
+			}
+			state = lm.lobStates[txnID]
+		}
+		acc := state.Accumulators[*state.ActiveKey]
+		if acc == nil {
+			remaining = append(remaining, event)
+			continue
+		}
+		if !event.SQLRedo.Valid || event.SQLRedo.String == "" {
+			continue
+		}
+		writeInfo, err := sqlredo.ParseLobWrite(event.SQLRedo.String, acc.IsBinary)
+		if err != nil {
+			lm.log.Warnf("Failed to parse buffered LOB_WRITE SQL (scn=%d, txn=%s): %v\nSQL: %.500s", event.SCN, txnID, err, event.SQLRedo.String)
+			continue
+		}
+		acc.AddFragment(writeInfo.Offset, writeInfo.Data)
+		lm.log.Debugf("Drained buffered LOB_WRITE for %s.%s.%s (txn=%s)", acc.Schema, acc.Table, acc.Column, txnID)
+	}
+
+	if len(remaining) == 0 {
+		delete(lm.pendingLOBWrites, txnID)
+	} else {
+		lm.pendingLOBWrites[txnID] = remaining
+	}
 }
 
 func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, startSCN, endSCN uint64, processEvent func(context.Context, *sqlredo.RedoEvent) error) error {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -422,7 +422,7 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 		// not as HEXTORAW. Only BLOB uses binary/hex encoding.
 		writeInfo, err := sqlredo.ParseLobWrite(redoEvent.SQLRedo.String, acc.IsBinary)
 		if err != nil {
-			return fmt.Errorf("parsing LOB_WRITE SQL (scn=%d, txn=%s): %v\nSQL: %.500s", redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
+			return fmt.Errorf("parsing LOB_WRITE SQL (scn=%d, txn=%s): %w\nSQL: %.500s", redoEvent.SCN, redoEvent.TransactionID, err, redoEvent.SQLRedo.String)
 		}
 		acc.AddFragment(writeInfo.Offset, writeInfo.Data)
 
@@ -793,7 +793,7 @@ func (lm *LogMiner) drainPendingLOBWrites(ctx context.Context, txnID sqlredo.Tra
 		}
 		writeInfo, err := sqlredo.ParseLobWrite(event.SQLRedo.String, acc.IsBinary)
 		if err != nil {
-			return fmt.Errorf("parsing buffered LOB_WRITE SQL (scn=%d, txn=%s): %v\nSQL: %.500s", event.SCN, txnID, err, event.SQLRedo.String)
+			return fmt.Errorf("parsing buffered LOB_WRITE SQL (scn=%d, txn=%s): %w\nSQL: %.500s", event.SCN, txnID, err, event.SQLRedo.String)
 		}
 		acc.AddFragment(writeInfo.Offset, writeInfo.Data)
 		lm.log.Debugf("Drained buffered LOB_WRITE for %s.%s.%s (txn=%s)", acc.Schema, acc.Table, acc.Column, txnID)

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -713,22 +714,24 @@ func (lm *LogMiner) inferLOBLocator(ctx context.Context, event *sqlredo.RedoEven
 
 		pkString := sqlredo.FormatPKString(pkValues)
 
-		// Candidate LOB columns are those with an EMPTY_CLOB()/EMPTY_BLOB()
-		// placeholder (parsed as empty []byte). For INSERTs, BASICFILE columns
-		// with DISABLE STORAGE IN ROW emit NULL in SQL_REDO instead — the column
-		// is absent from Data — so iterate every known LOB column for the table.
-		for k, lobType := range lm.lobColTypes {
+		// Candidate LOB columns are those absent from Data or present as nil.
+		// BASICFILE out-of-row LOBs may appear as NULL or be omitted entirely
+		// from INSERT SQL_REDO. Columns with a non-nil value — including []byte{}
+		// from EMPTY_CLOB()/EMPTY_BLOB() — are inline LOBs whose LOB_WRITEs
+		// arrive after the INSERT, not before, so they are never candidates here.
+		// Iterate in sorted key order for deterministic column assignment.
+		for _, k := range slices.Sorted(maps.Keys(lm.lobColTypes)) {
 			if !strings.HasPrefix(k, prefix) {
 				continue
 			}
+			lobType := lm.lobColTypes[k]
 			col := k[len(prefix):]
 			val, present := ev.Data[col]
 			switch {
-			case present:
-				if b, ok := val.([]byte); !ok || len(b) != 0 {
-					continue
-				}
-			case ev.Operation != sqlredo.OpInsert:
+			case present && val != nil:
+				// Column has a non-nil value (including []byte{} inline LOB placeholders).
+				continue
+			case !present && ev.Operation != sqlredo.OpInsert:
 				continue
 			}
 

--- a/internal/impl/oracledb/logminer/logminer_test.go
+++ b/internal/impl/oracledb/logminer/logminer_test.go
@@ -10,6 +10,7 @@ package logminer
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"testing"
 
@@ -94,14 +95,69 @@ func TestProcessRedoEventWithInMemoryCache(t *testing.T) {
 	})
 }
 
+// TestLOBWriteBeforeInsert verifies that LOB_WRITE events buffered before their matching
+// INSERT (BASICFILE DISABLE STORAGE IN ROW ordering) are correctly assembled when the
+// INSERT is subsequently processed and drained.
+func TestLOBWriteBeforeInsert(t *testing.T) {
+	cache := NewInMemoryCache(0, service.MockResources().Metrics(), service.NewLoggerFromSlog(slog.Default()))
+	pub := &publisherStub{}
+	lm := newLogMiner(pub, cache)
+	lm.cfg.LOBEnabled = true
+	lm.lobColTypes = map[string]string{
+		"TESTDB.ORDERS.NOTES": "CLOB",
+	}
+
+	ctx := t.Context()
+
+	// OpStart
+	require.NoError(t, lm.processRedoEvent(ctx, &sqlredo.RedoEvent{
+		SCN: 100, Operation: sqlredo.OpStart, TransactionID: "tx1",
+	}))
+
+	// Two LOB_WRITE fragments arrive BEFORE the INSERT — BASICFILE out-of-line ordering.
+	for _, fragSQL := range []string{
+		"buf_c := 'Hello ';\ndbms_lob.write(loc_c, 6, 1, buf_c);",
+		"buf_c := 'World';\ndbms_lob.write(loc_c, 5, 7, buf_c);",
+	} {
+		require.NoError(t, lm.processRedoEvent(ctx, &sqlredo.RedoEvent{
+			SCN:           101,
+			Operation:     sqlredo.OpLobWrite,
+			TransactionID: "tx1",
+			SchemaName:    sql.NullString{String: "TESTDB", Valid: true},
+			TableName:     sql.NullString{String: "ORDERS", Valid: true},
+			SQLRedo:       sql.NullString{String: fragSQL, Valid: true},
+		}))
+	}
+
+	// INSERT arrives after the LOB_WRITEs; NOTES column is absent from SQL_REDO
+	// because BASICFILE out-of-line storage omits the column from the INSERT row.
+	require.NoError(t, lm.processRedoEvent(ctx, &sqlredo.RedoEvent{
+		SCN:           102,
+		Operation:     sqlredo.OpInsert,
+		TransactionID: "tx1",
+		SchemaName:    sql.NullString{String: "TESTDB", Valid: true},
+		TableName:     sql.NullString{String: "ORDERS", Valid: true},
+		SQLRedo:       sql.NullString{String: `insert into "TESTDB"."ORDERS"("ID","STATUS") values (42,'open')`, Valid: true},
+	}))
+
+	// Commit
+	require.NoError(t, lm.processRedoEvent(ctx, &sqlredo.RedoEvent{
+		SCN: 103, Operation: sqlredo.OpCommit, TransactionID: "tx1",
+	}))
+
+	require.Len(t, pub.messages, 1)
+	assert.Equal(t, "Hello World", pub.messages[0].Data.(map[string]any)["NOTES"])
+}
+
 func newLogMiner(pub replication.ChangePublisher, cache TransactionCache) *LogMiner {
 	return &LogMiner{
-		publisher: pub,
-		txnCache:  cache,
-		dmlParser: sqlredo.NewParser(),
-		log:       service.NewLoggerFromSlog(slog.Default()),
-		cfg:       NewDefaultConfig(),
-		lobStates: make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		publisher:        pub,
+		txnCache:         cache,
+		dmlParser:        sqlredo.NewParser(),
+		log:              service.NewLoggerFromSlog(slog.Default()),
+		cfg:              NewDefaultConfig(),
+		lobStates:        make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		pendingLOBWrites: make(map[sqlredo.TransactionID][]*sqlredo.RedoEvent),
 	}
 }
 


### PR DESCRIPTION
This change fixes an issue where lob writes can be out of order (though only occasionally appeared to fail in the CI pipeline). Now we buffer the lob writes until we see their corresponding insert or update.

Following the fix I've run the CI job numerous times and it appears to fix the issue.

<img width="1354" height="527" alt="image" src="https://github.com/user-attachments/assets/b08a2b10-857a-4d15-a8b0-8c79f1b64ec7" />
