### PR TITLE
oracledb: emit CDC decimal values as canonical strings in both modes

### DIFF
--- a/internal/impl/oracledb/integration_datatypes_test.go
+++ b/internal/impl/oracledb/integration_datatypes_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package oracledb_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/sijms/go-ora/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/schema"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	oracledbtest "github.com/redpanda-data/connect/v4/internal/impl/oracledb/oracledbtest"
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+// capturedMessage holds a single emitted CDC message decoded for type analysis
+// alongside the common schema that travelled with it in metadata.
+type capturedMessage struct {
+	// body is the JSON payload decoded with UseNumber() so that a bare JSON
+	// number surfaces as json.Number and a quoted JSON string surfaces as a Go
+	// string — exactly the distinction that the schema_registry_encode Avro
+	// path is sensitive to.
+	body   map[string]any
+	schema schema.Common
+}
+
+// decodeWithNumber mirrors how benthos parses message bytes downstream (via
+// json.Decoder.UseNumber), so we observe the same Go types a downstream
+// processor such as schema_registry_encode would see.
+func decodeWithNumber(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	var m map[string]any
+	require.NoError(t, dec.Decode(&m), "decoding message body %q", raw)
+	return m
+}
+
+// TestIntegrationOracleDBCDCDataTypeConsistency verifies that the snapshot
+// (sql.Scan) and streaming (LogMiner) paths agree on both the yielded schema
+// and the Go type of every column value, and that the value is consistent with
+// the schema. In particular decimal columns must surface as canonical string
+// values (never a bare JSON number / json.Number), since downstream Avro
+// encoding rejects json.Number for string-typed fields.
+func TestIntegrationOracleDBCDCDataTypeConsistency(t *testing.T) {
+	integration.CheckSkip(t)
+
+	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+
+	const fullTable = "testdb.all_types"
+	create := `CREATE TABLE testdb.all_types (
+		id          NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+		num_plain   NUMBER,
+		num_38      NUMBER(38),
+		num_38_0    NUMBER(38,0),
+		num_38_2    NUMBER(38,2),
+		num_10_2    NUMBER(10,2),
+		num_5_0     NUMBER(5,0),
+		num_int     INTEGER,
+		flt         FLOAT,
+		bin_float   BINARY_FLOAT,
+		bin_double  BINARY_DOUBLE,
+		vc          VARCHAR2(100),
+		ch          CHAR(5),
+		nvc         NVARCHAR2(100),
+		dt          DATE,
+		ts          TIMESTAMP,
+		ts_tz       TIMESTAMP WITH TIME ZONE,
+		rw          RAW(16)
+	)`
+	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), fullTable, create))
+
+	// A single literal INSERT so we control exactly what Oracle stores and what
+	// LogMiner SQL_REDO reports. Used once before launch (snapshot) and once
+	// after launch (streaming).
+	insertSQL := `INSERT INTO testdb.all_types
+		(num_plain, num_38, num_38_0, num_38_2, num_10_2, num_5_0, num_int, flt, bin_float, bin_double, vc, ch, nvc, dt, ts, ts_tz, rw)
+		VALUES (
+			12345.678,
+			123456789012345678901234567890,
+			678,
+			12.34,
+			56.78,
+			42,
+			99,
+			3.5,
+			1.5,
+			2.5,
+			'hello', 'abc', 'world',
+			TO_DATE('2024-01-15','YYYY-MM-DD'),
+			TO_TIMESTAMP('2024-01-15 10:30:00','YYYY-MM-DD HH24:MI:SS'),
+			TO_TIMESTAMP_TZ('2024-01-15 10:30:00.000000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM'),
+			HEXTORAW('48656C6C6F')
+		)`
+
+	// An UPDATE whose SET clause assigns bare numeric literals (including
+	// integer-valued assignments to fractional decimal columns and negatives).
+	// UPDATE SET redo is the path most likely to surface bare numerics that the
+	// streaming converter turns into int64/json.Number.
+	updateSQL := `UPDATE testdb.all_types SET
+		num_plain  = 100,
+		num_38     = 200,
+		num_38_0   = 300,
+		num_38_2   = 5,
+		num_10_2   = -7,
+		num_5_0    = -42,
+		num_int    = 0,
+		flt        = 9,
+		vc         = 'updated'`
+
+	// Seed one row for the snapshot.
+	db.MustExec(insertSQL)
+
+	var (
+		mu       sync.Mutex
+		captured []capturedMessage
+		stream   *service.Stream
+		err      error
+	)
+
+	collect := func(_ context.Context, mb service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range mb {
+			b, aErr := msg.AsBytes()
+			assert.NoError(t, aErr)
+			captured = append(captured, capturedMessage{
+				body:   decodeWithNumber(t, string(b)),
+				schema: oracledbtest.ExtractSchema(t, msg),
+			})
+		}
+		return nil
+	}
+
+	waitForMessage := func() capturedMessage {
+		t.Helper()
+		assert.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(captured) >= 1
+		}, time.Minute*5, time.Second)
+		mu.Lock()
+		defer mu.Unlock()
+		require.GreaterOrEqual(t, len(captured), 1)
+		msg := captured[0]
+		captured = nil
+		return msg
+	}
+
+	cfg := `
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: true
+  snapshot_max_batch_size: 10
+  logminer:
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.ALL_TYPES"]`
+
+	{
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: WARN`))
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(collect))
+
+		stream, err = streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if rErr := stream.Run(t.Context()); rErr != nil && !errors.Is(rErr, context.Canceled) {
+				t.Error(rErr)
+			}
+		}()
+	}
+
+	// Capture one message per phase: snapshot read, streaming INSERT, streaming UPDATE.
+	phases := map[string]capturedMessage{}
+	phases["snapshot"] = waitForMessage()
+
+	db.MustExec(insertSQL)
+	phases["stream-insert"] = waitForMessage()
+
+	db.MustExec(updateSQL)
+	phases["stream-update"] = waitForMessage()
+
+	require.NoError(t, stream.StopWithin(time.Second*10))
+
+	phaseNames := []string{"snapshot", "stream-insert", "stream-update"}
+
+	// Use the snapshot schema as the reference for column types; assert all
+	// phases that carry a schema agree with it.
+	refSchema := childTypeMap(phases["snapshot"].schema)
+	require.NotEmpty(t, refSchema, "snapshot message carried no schema")
+
+	// Gather the union of columns observed across every phase.
+	cols := map[string]struct{}{}
+	for _, p := range phaseNames {
+		for k := range phases[p].body {
+			cols[k] = struct{}{}
+		}
+	}
+	sortedCols := make([]string, 0, len(cols))
+	for k := range cols {
+		sortedCols = append(sortedCols, k)
+	}
+	sort.Strings(sortedCols)
+
+	// Diagnostic table: value Go type per column per phase.
+	{
+		var b strings.Builder
+		fmt.Fprintf(&b, "%-14s | %-12s", "COLUMN", "schema")
+		for _, p := range phaseNames {
+			fmt.Fprintf(&b, " | %-18s", p)
+		}
+		t.Log(b.String())
+	}
+	for _, col := range sortedCols {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%-14s | %-12s", col, refSchema[col].String())
+		for _, p := range phaseNames {
+			v, ok := phases[p].body[col]
+			if !ok {
+				fmt.Fprintf(&b, " | %-18s", "(absent)")
+				continue
+			}
+			fmt.Fprintf(&b, " | %-18s", fmt.Sprintf("%T", v))
+		}
+		t.Log(b.String())
+	}
+
+	for _, col := range sortedCols {
+		t.Run(col, func(t *testing.T) {
+			// Schema for the column must agree across all phases that carry one.
+			for _, p := range phaseNames {
+				ps := childTypeMap(phases[p].schema)
+				if len(ps) == 0 {
+					continue
+				}
+				assert.Equalf(t, refSchema[col], ps[col],
+					"schema type for %q in phase %q differs from snapshot", col, p)
+			}
+
+			// Establish the reference Go type from the snapshot value, then
+			// require every other phase to match it (NULLs excepted).
+			refVal, refOK := phases["snapshot"].body[col]
+			refType := fmt.Sprintf("%T", refVal)
+			for _, p := range phaseNames {
+				v, ok := phases[p].body[col]
+				if !ok || v == nil || !refOK || refVal == nil {
+					continue
+				}
+				assert.Equalf(t, refType, fmt.Sprintf("%T", v),
+					"value Go type for %q in phase %q (%v) differs from snapshot (%v)",
+					col, p, v, refVal)
+			}
+
+			// Decimal / BigDecimal columns must be canonical strings — never a
+			// bare JSON number (json.Number) — in EVERY phase. This is the bug
+			// under test: a leaked json.Number breaks downstream Avro encoding
+			// into string-typed fields.
+			if ct := refSchema[col]; ct == schema.Decimal || ct == schema.BigDecimal {
+				for _, p := range phaseNames {
+					v, ok := phases[p].body[col]
+					if !ok || v == nil {
+						continue
+					}
+					_, isStr := v.(string)
+					assert.Truef(t, isStr, "decimal column %q in phase %q is %T, want string", col, p, v)
+				}
+			}
+		})
+	}
+}
+
+// childTypeMap indexes a record schema's children by name → CommonType.
+func childTypeMap(c schema.Common) map[string]schema.CommonType {
+	out := map[string]schema.CommonType{}
+	for i := range c.Children {
+		out[c.Children[i].Name] = c.Children[i].Type
+	}
+	return out
+}

--- a/internal/impl/oracledb/replication/oracletypes.go
+++ b/internal/impl/oracledb/replication/oracletypes.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication
+
+import "github.com/redpanda-data/benthos/v4/public/schema"
+
+// NumberToCommon builds the schema.Common entry for an Oracle NUMBER-family
+// column from its precision and scale. It is the single source of truth for
+// NUMBER → common-type derivation, shared by the snapshot path (which reads
+// precision/scale from go-ora's sql.ColumnType) and the streaming schema cache
+// (which reads them from ALL_TAB_COLUMNS), so both modes agree on whether a
+// column is an Int64, a bounded Decimal, or an arbitrary-precision BigDecimal.
+//
+// The mapping picks the most specific lossless representation:
+//   - !hasDecimalInfo: BigDecimal — Oracle's "floating decimal" with no
+//     declared precision/scale.
+//   - scale > precision (driver sentinel for undeclared scale, e.g. go-ora's
+//     (38, 255) for bare NUMBER): BigDecimal.
+//   - scale == 0 && 0 < precision <= 18: Int64 (scale-0 NUMBER fits losslessly
+//     in int64).
+//   - scale < 0: rounded to Decimal(precision, 0) — Avro/Parquet/Iceberg can't
+//     represent negative scale.
+//   - otherwise: Decimal(precision, scale), falling back to BigDecimal when the
+//     precision exceeds the bounded Decimal cap.
+func NumberToCommon(name string, precision, scale int64, hasDecimalInfo bool) schema.Common {
+	if !hasDecimalInfo {
+		return schema.NewBigDecimal(name, true)
+	}
+	if scale < 0 {
+		scale = 0
+	}
+	// Treat scale-greater-than-precision as undeclared (driver sentinel).
+	if scale > precision {
+		return schema.NewBigDecimal(name, true)
+	}
+	if scale == 0 && precision > 0 && precision <= MaxInt64DecimalPrecision {
+		return schema.Common{Name: name, Type: schema.Int64, Optional: true}
+	}
+	if c, err := schema.NewDecimal(name, int32(precision), int32(scale), true); err == nil {
+		return c
+	}
+	// Precision out of bounds for the bounded Decimal type — fall back to
+	// BigDecimal so the source remains lossless.
+	return schema.NewBigDecimal(name, true)
+}

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/redpanda-data/benthos/v4/public/schema"
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/sqlutil"
@@ -433,36 +434,26 @@ func prepSnapshotScannerAndMappers(cols []*sql.ColumnType) (values []any, mapper
 				return s.Time, nil
 			}
 		case "NUMBER", "INTEGER", "INT", "SMALLINT", "FLOAT":
-			// Oracle NUMBER type can represent both integers and decimals.
-			// For integer-width columns (scale=0, precision<=18), scan as int64
-			// to match the streaming path's ParseInt behavior.
-			// Decimals with a declared (p, s) — that is, scale within the
-			// precision and within the bounded Decimal type — emit canonical
-			// decimal strings; everything else (undeclared NUMBER, the
-			// go-ora "any scale" sentinel where DecimalSize reports
-			// scale > precision, or precision exceeding the Decimal cap)
-			// falls back to BigDecimal so the source remains lossless.
+			// Classify the column with the same NumberToCommon the streaming
+			// schema cache uses, so snapshot and streaming agree on whether a
+			// NUMBER is an Int64, a bounded Decimal, or a BigDecimal — and so
+			// the emitted value type matches the schema in both modes.
 			precision, scale, ok := col.DecimalSize()
 			colName := col.Name()
-			withinDecimal := ok && precision > 0 && scale >= 0 && scale <= precision && precision <= 38
-			switch {
-			case withinDecimal && scale == 0 && precision <= MaxInt64DecimalPrecision:
+			common := NumberToCommon(colName, precision, scale, ok)
+			switch common.Type {
+			case schema.Int64:
+				// Scan integer-width columns natively; go-ora handles the
+				// NUMBER → int64 conversion robustly without a string round-trip.
 				val = new(sql.Null[int64])
 				mapper = snapshotValueMapper[int64]
-			case withinDecimal:
-				p, s := int32(precision), int32(scale)
-				val = new(sql.NullString)
-				mapper = stringMapping(func(text string) (any, error) {
-					out, err := sqlutil.CanonicaliseDecimal(text, p, s)
-					if err != nil {
-						return nil, fmt.Errorf("column %s: %w", colName, err)
-					}
-					return out, nil
-				})
 			default:
+				// Decimal / BigDecimal: scan as text and canonicalise to a
+				// string via the shared coercion (never a bare number), so
+				// downstream Avro string-field encoding accepts the value.
 				val = new(sql.NullString)
 				mapper = stringMapping(func(text string) (any, error) {
-					out, err := sqlutil.CanonicaliseBigDecimal(text)
+					out, err := sqlutil.CoerceToCommon(common, text)
 					if err != nil {
 						return nil, fmt.Errorf("column %s: %w", colName, err)
 					}

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -11,10 +11,7 @@ package oracledb
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
-	"math"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -46,37 +43,11 @@ func oracleTypeToCommonType(dataType string) schema.CommonType {
 	}
 }
 
-// oracleNumberToCommon builds a schema.Common entry for a NUMBER column.
-// The mapping picks the most specific representation:
-//   - !hasDecimalInfo: BigDecimal — Oracle's "floating decimal" with no
-//     declared precision/scale.
-//   - scale > precision (driver sentinel for undeclared scale, e.g. go-ora's
-//     (38, 255) for bare NUMBER): BigDecimal.
-//   - scale == 0 && 0 < precision <= 18: Int64 (existing optimisation —
-//     scale-0 NUMBER fits losslessly in int64).
-//   - scale < 0: rounded to Decimal(precision, 0) since Avro/Parquet/Iceberg
-//     can't represent negative scale.
-//   - otherwise: Decimal(precision, scale).
+// oracleNumberToCommon builds a schema.Common entry for a NUMBER column. It
+// delegates to replication.NumberToCommon so the streaming schema cache and the
+// snapshot value mapper derive identical types from the same precision/scale.
 func oracleNumberToCommon(name string, precision, scale int64, hasDecimalInfo bool) schema.Common {
-	if !hasDecimalInfo {
-		return schema.NewBigDecimal(name, true)
-	}
-	if scale < 0 {
-		scale = 0
-	}
-	// Treat scale-greater-than-precision as undeclared (driver sentinel).
-	if scale > precision {
-		return schema.NewBigDecimal(name, true)
-	}
-	if scale == 0 && precision > 0 && precision <= replication.MaxInt64DecimalPrecision {
-		return schema.Common{Name: name, Type: schema.Int64, Optional: true}
-	}
-	if c, err := schema.NewDecimal(name, int32(precision), int32(scale), true); err == nil {
-		return c
-	}
-	// Precision out of bounds for the bounded Decimal type — fall back to
-	// BigDecimal so the source remains lossless.
-	return schema.NewBigDecimal(name, true)
+	return replication.NumberToCommon(name, precision, scale, hasDecimalInfo)
 }
 
 // isNumberType reports whether dataType is one of Oracle's numeric type names
@@ -310,18 +281,21 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 // Streaming value coercion
 // ---------------------------------------------------------------------------
 
-// coerceStreamingValues converts string values from LogMiner SQL_REDO parsing
-// to their proper Go types based on schema column metadata. This ensures type
+// coerceStreamingValues converts values from LogMiner SQL_REDO parsing to their
+// proper Go types based on schema column metadata. This ensures type
 // consistency between snapshot (which returns native Go types via sql.Scan) and
-// streaming (which returns strings because LogMiner quotes all INSERT values).
+// streaming (whose redo values arrive as quoted strings, bare int64 integer
+// literals, or json.Number floats depending on the value and Oracle version).
 //
-// Numeric types are coerced as follows: Int64 becomes int64, Float32/Float64
-// become float64, Decimal/BigDecimal become canonical decimal strings.
-// Columns mapped to schema.String are left as-is since they're indistinguishable
-// from VARCHAR2 once they reach this layer.
+// All numeric inputs — string, int64, or json.Number — are routed through the
+// shared sqlutil.CoerceToCommon so that Int64 columns become int64,
+// Float32/Float64 become float64, and Decimal/BigDecimal become canonical
+// decimal strings. In particular a bare integer literal (int64) destined for a
+// Decimal column is canonicalised to a string rather than leaking as a JSON
+// number, which downstream Avro string-field encoding rejects.
 //
-// The data map is mutated in place. On parse failure, the original string value
-// is preserved and a warning is logged.
+// The data map is mutated in place. On a recoverable parse failure the original
+// value is preserved and a warning is logged.
 func coerceStreamingValues(data map[string]any, info *columnTypeInfo, log *service.Logger) {
 	if info == nil {
 		return
@@ -331,69 +305,11 @@ func coerceStreamingValues(data map[string]any, info *columnTypeInfo, log *servi
 		if !known {
 			continue
 		}
-
-		// Handle json.Number values produced by ConvertValue for bare float
-		// literals (e.g. BINARY_FLOAT/BINARY_DOUBLE). These need to be
-		// converted to float64 to match the snapshot path.
-		if jn, ok := val.(json.Number); ok {
-			switch c.Type {
-			case schema.Float32, schema.Float64:
-				if f, err := jn.Float64(); err == nil {
-					data[col] = f
-				}
-			case schema.Int64:
-				if n, err := jn.Int64(); err == nil {
-					data[col] = n
-				}
-			case schema.Decimal:
-				if c.Logical != nil && c.Logical.Decimal != nil {
-					if canonical, err := sqlutil.CanonicaliseDecimal(jn.String(), c.Logical.Decimal.Precision, c.Logical.Decimal.Scale); err == nil {
-						data[col] = canonical
-					} else {
-						log.Warnf("coerce %s: cannot canonicalise decimal %q: %v", col, jn.String(), err)
-					}
-				}
-			case schema.BigDecimal:
-				if canonical, err := sqlutil.CanonicaliseBigDecimal(jn.String()); err == nil {
-					data[col] = canonical
-				} else {
-					log.Warnf("coerce %s: cannot canonicalise big decimal %q: %v", col, jn.String(), err)
-				}
-			}
+		coerced, err := sqlutil.CoerceToCommon(c, val)
+		if err != nil {
+			log.Warnf("coerce %s: %v", col, err)
 			continue
 		}
-
-		s, ok := val.(string)
-		if !ok {
-			continue // already typed (nil, int64, time.Time, etc.)
-		}
-		switch c.Type {
-		case schema.Int64:
-			if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-				data[col] = n
-			} else {
-				log.Warnf("coerce %s: cannot parse %q as int64: %v", col, s, err)
-			}
-		case schema.Float32, schema.Float64:
-			if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-				data[col] = f
-			} else if err != nil {
-				log.Warnf("coerce %s: cannot parse %q as float64: %v", col, s, err)
-			}
-		case schema.Decimal:
-			if c.Logical != nil && c.Logical.Decimal != nil {
-				if canonical, err := sqlutil.CanonicaliseDecimal(s, c.Logical.Decimal.Precision, c.Logical.Decimal.Scale); err == nil {
-					data[col] = canonical
-				} else {
-					log.Warnf("coerce %s: cannot canonicalise decimal %q: %v", col, s, err)
-				}
-			}
-		case schema.BigDecimal:
-			if canonical, err := sqlutil.CanonicaliseBigDecimal(s); err == nil {
-				data[col] = canonical
-			} else {
-				log.Warnf("coerce %s: cannot canonicalise big decimal %q: %v", col, s, err)
-			}
-		}
+		data[col] = coerced
 	}
 }

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -23,7 +23,7 @@ import (
 )
 
 // oracleTypeToCommonType maps an Oracle DATA_TYPE string to a schema.CommonType.
-// For NUMBER columns, callers should use oracleNumberToCommonType which
+// For NUMBER columns, callers should use replication.NumberToCommon which
 // considers precision and scale for a more specific mapping.
 func oracleTypeToCommonType(dataType string) schema.CommonType {
 	switch strings.ToUpper(dataType) {
@@ -41,13 +41,6 @@ func oracleTypeToCommonType(dataType string) schema.CommonType {
 	default:
 		return schema.String
 	}
-}
-
-// oracleNumberToCommon builds a schema.Common entry for a NUMBER column. It
-// delegates to replication.NumberToCommon so the streaming schema cache and the
-// snapshot value mapper derive identical types from the same precision/scale.
-func oracleNumberToCommon(name string, precision, scale int64, hasDecimalInfo bool) schema.Common {
-	return replication.NumberToCommon(name, precision, scale, hasDecimalInfo)
 }
 
 // isNumberType reports whether dataType is one of Oracle's numeric type names
@@ -133,7 +126,7 @@ ORDER BY COLUMN_ID`
 
 		var common schema.Common
 		if isNumberType(dataType) {
-			common = oracleNumberToCommon(colName, precision.Int64, scale.Int64, precision.Valid && scale.Valid)
+			common = replication.NumberToCommon(colName, precision.Int64, scale.Int64, precision.Valid && scale.Valid)
 		} else {
 			common = schema.Common{
 				Name:     colName,
@@ -255,7 +248,7 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 	for _, m := range meta {
 		var common schema.Common
 		if isNumberType(m.TypeName) {
-			common = oracleNumberToCommon(m.Name, m.Precision, m.Scale, m.HasDecimalSize)
+			common = replication.NumberToCommon(m.Name, m.Precision, m.Scale, m.HasDecimalSize)
 		} else {
 			common = schema.Common{
 				Name:     m.Name,

--- a/internal/impl/oracledb/schema_test.go
+++ b/internal/impl/oracledb/schema_test.go
@@ -404,6 +404,35 @@ func TestCoerceStreamingValues(t *testing.T) {
 			want: map[string]any{"amount": "12345.67890"},
 		},
 		{
+			// Regression: a bare integer literal (int64, as produced by the
+			// redo-log converter) for a Decimal column must be canonicalised to
+			// a string rather than leaking as a JSON number that downstream Avro
+			// string-field encoding rejects.
+			name: "decimal int64 canonicalised to string",
+			data: map[string]any{"amount": int64(2)},
+			info: &columnTypeInfo{
+				colTypes: map[string]schema.Common{
+					"amount": {
+						Type: schema.Decimal,
+						Logical: &schema.LogicalParams{
+							Decimal: &schema.DecimalParams{Precision: 10, Scale: 2},
+						},
+					},
+				},
+			},
+			want: map[string]any{"amount": "2.00"},
+		},
+		{
+			name: "big decimal int64 canonicalised to string",
+			data: map[string]any{"amount": int64(678)},
+			info: &columnTypeInfo{
+				colTypes: map[string]schema.Common{
+					"amount": {Type: schema.BigDecimal},
+				},
+			},
+			want: map[string]any{"amount": "678"},
+		},
+		{
 			name: "varchar2 string not coerced",
 			data: map[string]any{"name": "hello"},
 			info: &columnTypeInfo{

--- a/internal/impl/oracledb/schema_test.go
+++ b/internal/impl/oracledb/schema_test.go
@@ -134,7 +134,7 @@ func TestOracleNumberToCommonType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := oracleNumberToCommon("col", tt.precision, tt.scale, tt.hasInfo)
+			c := replication.NumberToCommon("col", tt.precision, tt.scale, tt.hasInfo)
 			assert.Equal(t, tt.wantType, c.Type)
 		})
 	}

--- a/internal/sqlutil/coerce.go
+++ b/internal/sqlutil/coerce.go
@@ -18,16 +18,16 @@ import (
 )
 
 // CoerceToCommon converts a raw value — as produced by a SQL driver scan or a
-// CDC redo-log parse — into the canonical Go representation for the given
-// common-schema column. It is the single coercion point shared by the SQL-CDC
-// snapshot (sql.Scan) and streaming (redo parse) paths so that both yield
-// identical value types for the same column.
+// CDC change-event parse — into the canonical Go representation for the given
+// common-schema column. It is the shared coercion point for the SQL-CDC
+// sources so that differently-typed inputs for the same column converge on a
+// single representation.
 //
 // Numeric inputs are accepted as any Go numeric type (int64, float64,
-// json.Number, or a numeric string), which matters because the two paths
-// surface numbers differently: snapshot scans produce typed Go values while
-// redo parsing produces int64 / json.Number / quoted strings. The output is
-// keyed solely on the column's common type:
+// json.Number, or a numeric string), which matters because sources surface
+// numbers differently: a driver scan yields typed Go values, while a
+// change-event parser may yield int64, json.Number, or quoted strings. The
+// output is keyed solely on the column's common type:
 //
 //   - Int64               → int64
 //   - Float32 / Float64   → float64

--- a/internal/sqlutil/coerce.go
+++ b/internal/sqlutil/coerce.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package sqlutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+// CoerceToCommon converts a raw value — as produced by a SQL driver scan or a
+// CDC redo-log parse — into the canonical Go representation for the given
+// common-schema column. It is the single coercion point shared by the SQL-CDC
+// snapshot (sql.Scan) and streaming (redo parse) paths so that both yield
+// identical value types for the same column.
+//
+// Numeric inputs are accepted as any Go numeric type (int64, float64,
+// json.Number, or a numeric string), which matters because the two paths
+// surface numbers differently: snapshot scans produce typed Go values while
+// redo parsing produces int64 / json.Number / quoted strings. The output is
+// keyed solely on the column's common type:
+//
+//   - Int64               → int64
+//   - Float32 / Float64   → float64
+//   - Decimal             → canonical decimal string (never a bare number)
+//   - BigDecimal          → canonical big-decimal string (never a bare number)
+//   - anything else       → returned unchanged
+//
+// A nil value is returned as-is. On a recoverable conversion failure (e.g. a
+// non-numeric string for a numeric column) the original value is returned
+// alongside a non-nil error so callers can log and preserve the input rather
+// than emitting a wrong type.
+func CoerceToCommon(c schema.Common, v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	switch c.Type {
+	case schema.Int64:
+		n, err := toInt64(v)
+		if err != nil {
+			return v, err
+		}
+		return n, nil
+	case schema.Float32, schema.Float64:
+		f, err := toFloat64(v)
+		if err != nil {
+			return v, err
+		}
+		return f, nil
+	case schema.Decimal:
+		// Without precision/scale we cannot canonicalise; leave the value be.
+		if c.Logical == nil || c.Logical.Decimal == nil {
+			return v, nil
+		}
+		s, ok := numericText(v)
+		if !ok {
+			return v, nil
+		}
+		out, err := CanonicaliseDecimal(s, c.Logical.Decimal.Precision, c.Logical.Decimal.Scale)
+		if err != nil {
+			return v, err
+		}
+		return out, nil
+	case schema.BigDecimal:
+		s, ok := numericText(v)
+		if !ok {
+			return v, nil
+		}
+		out, err := CanonicaliseBigDecimal(s)
+		if err != nil {
+			return v, err
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// numericText renders a numeric value as the decimal text the canonicaliser
+// expects. json.Number is already its own textual form; integers and floats
+// are formatted without scientific notation so the big.Rat/decimal parsers
+// accept them. Returns false for non-numeric inputs (e.g. time.Time, []byte),
+// which the caller leaves untouched.
+func numericText(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case json.Number:
+		return t.String(), true
+	case int:
+		return strconv.FormatInt(int64(t), 10), true
+	case int32:
+		return strconv.FormatInt(int64(t), 10), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	case float32:
+		return strconv.FormatFloat(float64(t), 'f', -1, 32), true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+func toInt64(v any) (int64, error) {
+	switch t := v.(type) {
+	case int64:
+		return t, nil
+	case int:
+		return int64(t), nil
+	case int32:
+		return int64(t), nil
+	case json.Number:
+		return t.Int64()
+	case string:
+		return strconv.ParseInt(t, 10, 64)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int64", v)
+	}
+}
+
+func toFloat64(v any) (float64, error) {
+	var f float64
+	switch t := v.(type) {
+	case float64:
+		f = t
+	case float32:
+		f = float64(t)
+	case int64:
+		f = float64(t)
+	case json.Number:
+		parsed, err := t.Float64()
+		if err != nil {
+			return 0, err
+		}
+		f = parsed
+	case string:
+		parsed, err := strconv.ParseFloat(t, 64)
+		if err != nil {
+			return 0, err
+		}
+		f = parsed
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", v)
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("non-finite float value %v", v)
+	}
+	return f, nil
+}

--- a/internal/sqlutil/coerce_test.go
+++ b/internal/sqlutil/coerce_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package sqlutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+func decimalCommon(precision, scale int32) schema.Common {
+	c, err := schema.NewDecimal("col", precision, scale, true)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func TestCoerceToCommon(t *testing.T) {
+	tests := []struct {
+		name    string
+		common  schema.Common
+		in      any
+		want    any
+		wantErr bool
+	}{
+		// Int64.
+		{name: "int64 from string", common: schema.Common{Type: schema.Int64}, in: "42", want: int64(42)},
+		{name: "int64 from int64", common: schema.Common{Type: schema.Int64}, in: int64(42), want: int64(42)},
+		{name: "int64 from json.Number", common: schema.Common{Type: schema.Int64}, in: json.Number("42"), want: int64(42)},
+		{name: "int64 from non-numeric string preserved", common: schema.Common{Type: schema.Int64}, in: "nope", want: "nope", wantErr: true},
+
+		// Float.
+		{name: "float64 from string", common: schema.Common{Type: schema.Float64}, in: "3.14", want: float64(3.14)},
+		{name: "float32 widens to float64", common: schema.Common{Type: schema.Float32}, in: "1.5", want: float64(1.5)},
+		{name: "float from json.Number", common: schema.Common{Type: schema.Float64}, in: json.Number("2.5"), want: float64(2.5)},
+		{name: "float from int64", common: schema.Common{Type: schema.Float64}, in: int64(7), want: float64(7)},
+		{name: "float NaN preserved", common: schema.Common{Type: schema.Float64}, in: "NaN", want: "NaN", wantErr: true},
+
+		// Decimal: every numeric input shape must become a canonical string.
+		{name: "decimal from string", common: decimalCommon(10, 2), in: "12.5", want: "12.50"},
+		{name: "decimal from json.Number fractional", common: decimalCommon(10, 2), in: json.Number("12.5"), want: "12.50"},
+		// The regression: a bare integer (int64) for a Decimal column must be
+		// canonicalised to a string, not left as a JSON number.
+		{name: "decimal from int64", common: decimalCommon(10, 2), in: int64(2), want: "2.00"},
+		{name: "decimal from json.Number integer", common: decimalCommon(38, 2), in: json.Number("2"), want: "2.00"},
+		{name: "decimal without logical params left alone", common: schema.Common{Type: schema.Decimal}, in: int64(2), want: int64(2)},
+
+		// BigDecimal.
+		{name: "bigdecimal from string", common: schema.Common{Type: schema.BigDecimal}, in: "12.50", want: "12.50"},
+		{name: "bigdecimal from int64", common: schema.Common{Type: schema.BigDecimal}, in: int64(678), want: "678"},
+		{name: "bigdecimal from json.Number", common: schema.Common{Type: schema.BigDecimal}, in: json.Number("3.14159"), want: "3.14159"},
+
+		// Passthroughs.
+		{name: "string column untouched", common: schema.Common{Type: schema.String}, in: "hello", want: "hello"},
+		{name: "nil untouched", common: decimalCommon(10, 2), in: nil, want: nil},
+		{name: "byte slice on bytearray untouched", common: schema.Common{Type: schema.ByteArray}, in: []byte{1, 2}, want: []byte{1, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CoerceToCommon(tt.common, tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

The Oracle CDC snapshot (`sql.Scan`) and streaming (LogMiner redo) paths derived NUMBER column types and coerced their values through separate code, which could disagree. Most importantly, an integer-valued decimal arriving from the redo log as a bare numeric literal was converted to an `int64` and emitted as a **bare JSON number** rather than a canonical decimal string. Downstream Avro encoding into a string-typed field rejects a JSON number, failing with `cannot use json.Number with Avro type string`.

## How

- Introduce a single shared coercion, `sqlutil.CoerceToCommon`, mapping any numeric Go type (`string`, `int64`, `float64`, `json.Number`) to the canonical form for a common-schema column: `Int64`→`int64`, `Float`→`float64`, and `Decimal`/`BigDecimal`→canonical decimal **strings** (never a bare number).
- Unify type derivation behind `replication.NumberToCommon` so both modes classify a NUMBER identically.
- Streaming value coercion now routes every numeric input through the shared helper.
- The snapshot mapper classifies columns with `NumberToCommon`, keeping the native `int64` scan for integer-width columns and routing `Decimal`/`BigDecimal` columns through the shared string coercion. This also resolves a latent drift where negative-scale NUMBER columns emitted a value type inconsistent with their schema.

## Tests

- Unit tests for the shared coercion and the streaming path (including the integer-valued-decimal regression).
- An integration test asserting that snapshot and streaming agree on both the yielded schema and the value type for every column, and that decimals are always strings.

## Note

`Int64`-classified columns (`NUMBER(p,0)` with p ≤ 18) and `BINARY_FLOAT`/`BINARY_DOUBLE` are still emitted as JSON numbers by design, consistent with their common schema; this change scopes to `Decimal`/`BigDecimal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)