### PR TITLE
kafka: add opt-in rebootstrap field for KIP-899/KIP-1102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `redpanda` and `kafka` inputs and outputs now support an opt-in `rebootstrap` field that enables KIP-899 / KIP-1102 client rebootstrap, allowing seamless failover between Redpanda shadow and primary clusters when `seed_brokers` is a stable DNS endpoint. ([@david-yu](https://github.com/david-yu))
+
 ## 4.94.1 - 2026-05-29
 
 ### Fixed

--- a/docs/modules/components/pages/inputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/inputs/kafka_franz.adoc
@@ -70,6 +70,7 @@ input:
     metadata_max_age: 5m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
+    rebootstrap: false
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
@@ -518,6 +519,16 @@ The rough amount of time to allow connections to idle before they are closed.
 *Type*: `string`
 
 *Default*: `"20s"`
+
+=== `rebootstrap`
+
+When enabled, the client re-resolves its `seed_brokers` and rebootstraps when a broker signals that its cached metadata is stale (the Kafka `REBOOTSTRAP_REQUIRED` error code 129, introduced by KIP-899 and KIP-1102). This is useful for seamless failover when `seed_brokers` is a stable DNS endpoint that can resolve to a different (for example, shadow versus primary) Redpanda cluster.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 4.95.0 or newer
 
 === `topics`
 

--- a/docs/modules/components/pages/inputs/redpanda.adoc
+++ b/docs/modules/components/pages/inputs/redpanda.adoc
@@ -69,6 +69,7 @@ input:
     metadata_max_age: 1m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
+    rebootstrap: false
     tcp:
       connect_timeout: 0s
       keep_alive:
@@ -625,6 +626,16 @@ The rough amount of time to allow connections to idle before they are closed.
 *Type*: `string`
 
 *Default*: `"20s"`
+
+=== `rebootstrap`
+
+When enabled, the client re-resolves its `seed_brokers` and rebootstraps when a broker signals that its cached metadata is stale (the Kafka `REBOOTSTRAP_REQUIRED` error code 129, introduced by KIP-899 and KIP-1102). This is useful for seamless failover when `seed_brokers` is a stable DNS endpoint that can resolve to a different (for example, shadow versus primary) Redpanda cluster.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 4.95.0 or newer
 
 === `tcp`
 

--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -77,6 +77,7 @@ output:
     metadata_max_age: 1m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
+    rebootstrap: false
     tcp:
       connect_timeout: 0s
       keep_alive:
@@ -580,6 +581,16 @@ The rough amount of time to allow connections to idle before they are closed.
 *Type*: `string`
 
 *Default*: `"20s"`
+
+=== `rebootstrap`
+
+When enabled, the client re-resolves its `seed_brokers` and rebootstraps when a broker signals that its cached metadata is stale (the Kafka `REBOOTSTRAP_REQUIRED` error code 129, introduced by KIP-899 and KIP-1102). This is useful for seamless failover when `seed_brokers` is a stable DNS endpoint that can resolve to a different (for example, shadow versus primary) Redpanda cluster.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 4.95.0 or newer
 
 === `tcp`
 

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -75,6 +75,7 @@ output:
     metadata_max_age: 1m
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
+    rebootstrap: false
     tcp:
       connect_timeout: 0s
       keep_alive:
@@ -617,6 +618,16 @@ The rough amount of time to allow connections to idle before they are closed.
 *Type*: `string`
 
 *Default*: `"20s"`
+
+=== `rebootstrap`
+
+When enabled, the client re-resolves its `seed_brokers` and rebootstraps when a broker signals that its cached metadata is stale (the Kafka `REBOOTSTRAP_REQUIRED` error code 129, introduced by KIP-899 and KIP-1102). This is useful for seamless failover when `seed_brokers` is a stable DNS endpoint that can resolve to a different (for example, shadow versus primary) Redpanda cluster.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 4.95.0 or newer
 
 === `tcp`
 

--- a/internal/impl/kafka/franz_client.go
+++ b/internal/impl/kafka/franz_client.go
@@ -36,6 +36,7 @@ const (
 	kfcFieldMetadataMaxAge         = "metadata_max_age"
 	kfcFieldRequestTimeoutOverhead = "request_timeout_overhead"
 	kfcFieldConnIdleTimeout        = "conn_idle_timeout"
+	kfcFieldRebootstrap            = "rebootstrap"
 
 	kfcFieldSeedBrokersDescription = "A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses."
 )
@@ -77,6 +78,11 @@ func FranzConnectionFields() []*service.ConfigField {
 			Description("The rough amount of time to allow connections to idle before they are closed.").
 			Default("20s").
 			Advanced(),
+		service.NewBoolField(kfcFieldRebootstrap).
+			Description("When enabled, the client re-resolves its `seed_brokers` and rebootstraps when a broker signals that its cached metadata is stale (the Kafka `REBOOTSTRAP_REQUIRED` error code 129, introduced by KIP-899 and KIP-1102). This is useful for seamless failover when `seed_brokers` is a stable DNS endpoint that can resolve to a different (for example, shadow versus primary) Redpanda cluster.").
+			Default(false).
+			Advanced().
+			Version("4.95.0"),
 		netutil.DialerConfigSpec(),
 	}
 }
@@ -92,6 +98,7 @@ type FranzConnectionDetails struct {
 	MetaMaxAge             time.Duration
 	RequestTimeoutOverhead time.Duration
 	ConnIdleTimeout        time.Duration
+	Rebootstrap            bool
 	DialerConfig           netutil.DialerConfig
 
 	Logger *service.Logger
@@ -139,6 +146,10 @@ func FranzConnectionDetailsFromConfig(conf *service.ParsedConfig, log *service.L
 		return nil, err
 	}
 
+	if d.Rebootstrap, err = conf.FieldBool(kfcFieldRebootstrap); err != nil {
+		return nil, err
+	}
+
 	if conf.Contains("tcp") {
 		if d.DialerConfig, err = netutil.DialerConfigFromParsed(conf.Namespace("tcp")); err != nil {
 			return nil, err
@@ -164,6 +175,16 @@ func (d *FranzConnectionDetails) FranzOpts() []kgo.Opt {
 		kgo.MetadataMaxAge(d.MetaMaxAge),
 		kgo.RequestTimeoutOverhead(d.RequestTimeoutOverhead),
 		kgo.ConnIdleTimeout(d.ConnIdleTimeout),
+	}
+
+	// Opt in to KIP-899 / KIP-1102 client rebootstrap. When the broker reports
+	// that the client's cached metadata is stale (REBOOTSTRAP_REQUIRED), franz-go
+	// re-resolves the configured seed brokers and reconnects, enabling seamless
+	// failover when seed_brokers points at a stable DNS endpoint.
+	if d.Rebootstrap {
+		opts = append(opts, kgo.OnRebootstrapRequired(func() ([]string, error) {
+			return d.SeedBrokers, nil
+		}))
 	}
 
 	{


### PR DESCRIPTION
## What

Adds an opt-in `rebootstrap` boolean to the shared franz-go connection fields, surfaced on the `redpanda`/`kafka` inputs and outputs. When enabled, the client wires up franz-go's `kgo.OnRebootstrapRequired` (KIP-899, refined by KIP-1102): on a broker `REBOOTSTRAP_REQUIRED` (error code 129) the client re-resolves its configured `seed_brokers` and reconnects.

## Why

franz-go v1.20.7 supports client rebootstrap, but **Connect never registered the callback**, so the broker's `REBOOTSTRAP_REQUIRED` signal was silently ignored (franz-go acts on it only when `OnRebootstrapRequired` is set). This PR lets users opt in.

The target topology is a **single stable DNS endpoint shared by a shadow and primary cluster** (e.g. `rp-cluster.example.com`) whose A-records repoint to the surviving cluster on failover. With `rebootstrap: true`, a `REBOOTSTRAP_REQUIRED` signal causes the client to drop its discovered brokers and re-resolve the seed endpoint (re-running DNS), reconnecting to the cluster the alias now points at.

### Scope note (tested)

A `seed_brokers` list that **statically enumerates both clusters' brokers does _not_ need this flag** — stock franz-go already fails over to a surviving seed via its normal metadata refresh. I verified this with two live Redpanda clusters: killing the active cluster, a client produced to the other in ~300ms **with `rebootstrap` off and the callback never invoked**. So this option is aimed squarely at the DNS-endpoint topology and at honoring broker-initiated `REBOOTSTRAP_REQUIRED`, not at static multi-cluster seed lists.

## Usage

### `redpanda` input — shared DNS endpoint + rebootstrap

```yaml
input:
  redpanda:
    seed_brokers:
      - rp-cluster.example.com:9092   # stable alias; DNS repoints shadow<->primary on failover
    topics:
      - orders
    consumer_group: connect-orders
    rebootstrap: true                 # honor REBOOTSTRAP_REQUIRED and re-resolve the endpoint
```

### `redpanda` output — shared DNS endpoint + rebootstrap

```yaml
output:
  redpanda:
    seed_brokers:
      - rp-cluster.example.com:9092
    topic: orders
    rebootstrap: true
```

`seed_brokers` remains a list (separate items or comma-separated items are both expanded), so you can still provide multiple bootstrap addresses behind/alongside the alias if desired — but note the scope note above re: static multi-cluster lists.

## Notes

- Defaults to `false`; existing configs are unaffected.
- Implemented once in `internal/impl/kafka/franz_client.go` (shared `FranzConnectionFields`), so it applies to both input and output — and to the `kafka_franz` input/output, which share the same connection fields.
- Docs for the `redpanda` and `kafka_franz` input/output pages were updated manually because the full `task docs` generator can't link locally (unrelated `tigerbeetle-go` CGO link error). Other connectors sharing these fields (e.g. the `redpanda` cache and `redpanda_migrator`) will pick up the field when docs are regenerated in CI.

## Follow-up: timeout-based rebootstrap (KIP-1102)

KIP-1102 defines **two** rebootstrap triggers; this PR exposes only the first:

- [x] **Error-code trigger** (`REBOOTSTRAP_REQUIRED`) — implemented here via `rebootstrap: true` (franz-go's `OnRebootstrapRequired`).
- [ ] **Timeout trigger** (`metadata.recovery.rebootstrap.trigger.ms`) — **not** available in franz-go yet (verified through franz-go `master`). Proposed upstream in **twmb/franz-go#1335** (adds `kgo.RebootstrapTrigger`, with a runtime-verified demo on the PR). Once that merges and is released, this connector can bump franz-go and add a companion field (e.g. `rebootstrap_timeout`) to force a re-resolve after a bounded window even when no `REBOOTSTRAP_REQUIRED` is emitted.

This PR is intentionally scoped to the error-code trigger so it can land against the current franz-go release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
