### PR TITLE
kafka: prevent spurious offset commits for revoked partitions

### DIFF
--- a/internal/impl/kafka/franz_reader_ordered.go
+++ b/internal/impl/kafka/franz_reader_ordered.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,6 +174,13 @@ type partitionCache struct {
 	cacheSize       uint64
 	checkpointer    *checkpoint.Uncapped[*kgo.Record]
 	commitFn        func(r *kgo.Record)
+	// revoked is set once this partition has been revoked from the consumer
+	// (cooperative rebalance) or otherwise lost. Once set, offsets for this
+	// partition must never be committed, because the partition may already be
+	// owned by another consumer. It is guarded by mut so that the revoked check
+	// and the commit within a batch's ack callback are atomic with respect to
+	// revocation. See markRevoked for the full rationale.
+	revoked bool
 }
 
 func newPartitionCache(commitFn func(r *kgo.Record)) *partitionCache {
@@ -280,12 +287,21 @@ func (p *partitionCache) pop() *batchWithAckFn {
 	releaseFn := p.checkpointer.Track(nextBatch.b[len(nextBatch.b)-1].r, int64(len(nextBatch.b)))
 	onAck := func() {
 		p.mut.Lock()
+		defer p.mut.Unlock()
+
 		releaseRecord := releaseFn()
 		delete(p.pendingDispatch, batchID)
 		p.cacheSize -= nextBatch.size
-		p.mut.Unlock()
 
-		if releaseRecord != nil && *releaseRecord != nil {
+		// Only commit if the partition has not been revoked. After a revoke,
+		// franz-go deletes the partition from its uncommitted map once
+		// OnPartitionsRevoked returns, so a late MarkCommitRecords here would
+		// silently re-insert it and the next autocommit would advance the
+		// offset past records the new owner has not yet processed, causing data
+		// loss. Holding mut across the revoked check and the commit makes this
+		// atomic with respect to markRevoked, which runs before the revoke
+		// handler returns.
+		if !p.revoked && releaseRecord != nil && *releaseRecord != nil {
 			p.commitFn(*releaseRecord)
 		}
 	}
@@ -301,6 +317,21 @@ func (p *partitionCache) pauseFetch(limit uint64) (pauseFetch bool) {
 	pauseFetch = p.cacheSize >= limit
 	p.mut.Unlock()
 	return
+}
+
+// markRevoked flags the partition so that no further offsets are committed for
+// it. It must be called before the partition is removed from the tracker during
+// a revoke or loss, which happens inside the OnPartitionsRevoked/OnPartitionsLost
+// callbacks before franz-go cleans up its own uncommitted state. Because the
+// revoked flag is set (and read in the ack callback) under mut, any in-flight
+// ack either commits before this returns — and therefore before the revoke
+// callback returns and franz-go performs its cleanup — or observes the flag and
+// skips the commit entirely. Either way no offset can outlive the revoke and be
+// auto-committed for a partition we no longer own.
+func (p *partitionCache) markRevoked() {
+	p.mut.Lock()
+	p.revoked = true
+	p.mut.Unlock()
 }
 
 //------------------------------------------------------------------------------
@@ -381,6 +412,9 @@ func (c *partitionState) removeTopicPartitions(m map[string][]int32) {
 			continue
 		}
 		for _, lostPartition := range lostTopic {
+			if partCache, exists := trackedTopic[lostPartition]; exists {
+				partCache.markRevoked()
+			}
 			delete(trackedTopic, lostPartition)
 		}
 		if len(trackedTopic) == 0 {

--- a/internal/impl/kafka/franz_reader_ordered_test.go
+++ b/internal/impl/kafka/franz_reader_ordered_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,4 +207,77 @@ func TestPartitionCacheBatching(t *testing.T) {
 	assert.Equal(t, []string{"iiiiiiii"}, popOutStrs(pCache))
 
 	assert.Equal(t, []string(nil), popOutStrs(pCache))
+}
+
+// orderedBatch builds a batchWithRecords of `count` sequential records starting
+// at `startOffset` for the given topic/partition.
+func orderedBatch(topic string, partition int32, startOffset, count int64) *batchWithRecords {
+	b := &batchWithRecords{}
+	for i := startOffset; i < startOffset+count; i++ {
+		b.b = append(b.b, &messageWithRecord{
+			m:    service.NewMessage([]byte("x")),
+			r:    &kgo.Record{Topic: topic, Partition: partition, Offset: i},
+			size: 1,
+		})
+		b.size++
+	}
+	return b
+}
+
+// TestOrderedCacheRevokedBlocksCommit verifies that a partitionCache flagged as
+// revoked does not commit a late ack, while an equivalent non-revoked cache
+// does. This is the ordered-reader analogue of the unordered data-loss fix:
+// without the guard a late MarkCommitRecords after a revoke would advance the
+// committed offset past records the new owner has not processed.
+func TestOrderedCacheRevokedBlocksCommit(t *testing.T) {
+	rec := newCommitRecorder()
+
+	pc := newPartitionCache(rec.commitFunc)
+	require.False(t, pc.push(1<<20, 10, orderedBatch("t", 0, 0, 3)))
+	ack := pc.pop()
+	require.NotNil(t, ack)
+
+	pc.markRevoked()
+	ack.onAck()
+	assert.Empty(t, rec.offsetsFor("t", 0), "revoked cache must not commit any offset")
+
+	// Control: a non-revoked cache commits the head of its batch as normal.
+	pc2 := newPartitionCache(rec.commitFunc)
+	require.False(t, pc2.push(1<<20, 10, orderedBatch("t", 1, 0, 3)))
+	ack2 := pc2.pop()
+	require.NotNil(t, ack2)
+	ack2.onAck()
+	assert.Equal(t, []int64{2}, rec.offsetsFor("t", 1), "non-revoked cache commits the batch head offset")
+}
+
+// TestOrderedReassignedPartitionUsesFreshCache proves the per-cache design is
+// immune to the same-member reassignment race: after revoke and reassignment a
+// fresh partitionCache is created and commits resume, while a stale ack still
+// referencing the old (revoked) cache can never commit.
+func TestOrderedReassignedPartitionUsesFreshCache(t *testing.T) {
+	rec := newCommitRecorder()
+	ps := newPartitionState(rec.commitFunc)
+	const bufSize, maxBatch = uint64(1 << 20), uint64(10)
+
+	// Old generation: a record on t/0 at offset 5, left in flight (not acked).
+	require.False(t, ps.addRecords("t", 0, orderedBatch("t", 0, 5, 1), bufSize, maxBatch))
+	oldAck := ps.pop()
+	require.NotNil(t, oldAck)
+
+	// Revoke t/0.
+	ps.removeTopicPartitions(map[string][]int32{"t": {0}})
+
+	// Reassignment: a new record on t/0 at offset 100 creates a fresh cache.
+	require.False(t, ps.addRecords("t", 0, orderedBatch("t", 0, 100, 1), bufSize, maxBatch))
+	newAck := ps.pop()
+	require.NotNil(t, newAck)
+
+	// New generation commits.
+	newAck.onAck()
+	assert.Equal(t, []int64{100}, rec.offsetsFor("t", 0), "reassigned partition commits via fresh cache")
+
+	// Stale old-generation ack must not commit.
+	oldAck.onAck()
+	assert.Equal(t, []int64{100}, rec.offsetsFor("t", 0), "stale ack from revoked cache must not commit")
+	assert.NotContains(t, rec.offsetsFor("t", 0), int64(5), "old offset 5 must never be committed")
 }

--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -185,6 +185,13 @@ type partitionTracker struct {
 
 	checkpointerLock sync.Mutex
 	checkpointer     *checkpoint.Uncapped[*kgo.Record]
+	// revoked is set once this partition has been revoked from the consumer
+	// (cooperative rebalance) or otherwise lost. Once set, offsets for this
+	// partition must never be committed, because the partition may already be
+	// owned by another consumer. It is guarded by checkpointerLock so that the
+	// revoked check and the commit within a batch's ack callback are atomic
+	// with respect to revocation. See markRevoked for the full rationale.
+	revoked bool
 
 	outBatchChan chan<- batchWithAckFn
 	commitFn     func(r *kgo.Record)
@@ -294,10 +301,19 @@ func (p *partitionTracker) sendBatch(ctx context.Context, b service.MessageBatch
 		batch: b,
 		onAck: func() {
 			p.checkpointerLock.Lock()
-			releaseRecord := releaseFn()
-			p.checkpointerLock.Unlock()
+			defer p.checkpointerLock.Unlock()
 
-			if releaseRecord != nil && *releaseRecord != nil {
+			releaseRecord := releaseFn()
+
+			// Only commit if the partition has not been revoked. After a
+			// revoke, franz-go deletes the partition from its uncommitted map
+			// once OnPartitionsRevoked returns, so a late MarkCommitRecords
+			// here would silently re-insert it and the next autocommit would
+			// advance the offset past records the new owner has not yet
+			// processed, causing data loss. Holding checkpointerLock across the
+			// revoked check and the commit makes this atomic with respect to
+			// markRevoked, which runs before the revoke handler returns.
+			if !p.revoked && releaseRecord != nil && *releaseRecord != nil {
 				p.commitFn(*releaseRecord)
 			}
 		},
@@ -346,6 +362,21 @@ func (p *partitionTracker) pauseFetch(limit int) (pauseFetch bool) {
 	pauseFetch = p.checkpointer.Pending() >= int64(limit)
 	p.checkpointerLock.Unlock()
 	return
+}
+
+// markRevoked flags the partition so that no further offsets are committed for
+// it. It must be called before the partition is removed from the tracker during
+// a revoke or loss, which happens inside the OnPartitionsRevoked/OnPartitionsLost
+// callbacks before franz-go cleans up its own uncommitted state. Because the
+// revoked flag is set (and read in the ack callback) under checkpointerLock, any
+// in-flight ack either commits before this returns — and therefore before the
+// revoke callback returns and franz-go performs its cleanup — or observes the
+// flag and skips the commit entirely. Either way no offset can outlive the
+// revoke and be auto-committed for a partition we no longer own.
+func (p *partitionTracker) markRevoked() {
+	p.checkpointerLock.Lock()
+	p.revoked = true
+	p.checkpointerLock.Unlock()
 }
 
 func (p *partitionTracker) close(ctx context.Context) error {
@@ -450,6 +481,7 @@ func (c *checkpointTracker) removeTopicPartitions(ctx context.Context, m map[str
 		}
 		for _, lostPartition := range lostTopic {
 			if trackedPartition, exists := trackedTopic[lostPartition]; exists {
+				trackedPartition.markRevoked()
 				_ = trackedPartition.close(ctx)
 			}
 			delete(trackedTopic, lostPartition)

--- a/internal/impl/kafka/franz_reader_unordered_test.go
+++ b/internal/impl/kafka/franz_reader_unordered_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// committedRecord captures the topic/partition/offset of a record that the
+// reader decided to commit, so tests can assert exactly what was (and was not)
+// committed.
+type committedRecord struct {
+	topic     string
+	partition int32
+	offset    int64
+}
+
+type commitRecorder struct {
+	mu         sync.Mutex
+	committed  []committedRecord
+	commitFunc func(r *kgo.Record)
+}
+
+func newCommitRecorder() *commitRecorder {
+	c := &commitRecorder{}
+	c.commitFunc = func(r *kgo.Record) {
+		c.mu.Lock()
+		c.committed = append(c.committed, committedRecord{r.Topic, r.Partition, r.Offset})
+		c.mu.Unlock()
+	}
+	return c
+}
+
+func (c *commitRecorder) offsetsFor(topic string, partition int32) []int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []int64
+	for _, r := range c.committed {
+		if r.topic == topic && r.partition == partition {
+			out = append(out, r.offset)
+		}
+	}
+	return out
+}
+
+// drainBatches collects every batch currently available on the channel without
+// acking them, so tests can control ack ordering relative to a revoke.
+func drainBatches(ch <-chan batchWithAckFn, n int) []batchWithAckFn {
+	out := make([]batchWithAckFn, 0, n)
+	for range n {
+		out = append(out, <-ch)
+	}
+	return out
+}
+
+func unorderedRecord(topic string, partition int32, offset int64) *msgWithRecord {
+	return &msgWithRecord{
+		msg: service.NewMessage([]byte("hello")),
+		r:   &kgo.Record{Topic: topic, Partition: partition, Offset: offset},
+	}
+}
+
+// TestUnorderedRevokedPartitionBlocksCommit verifies that once a partition is
+// revoked, a late ack for an in-flight batch of that partition does not commit
+// its offset, while other partitions are unaffected.
+func TestUnorderedRevokedPartitionBlocksCommit(t *testing.T) {
+	rec := newCommitRecorder()
+	batchChan := make(chan batchWithAckFn, 100)
+	ct := newCheckpointTracker(service.MockResources(), batchChan, rec.commitFunc, service.BatchPolicy{})
+
+	ctx := context.Background()
+	const limit = 1024
+
+	// Three records on each of two partitions. With a noop batch policy each
+	// record is dispatched as its own batch immediately.
+	for i := range int64(3) {
+		ct.addRecord(ctx, unorderedRecord("t", 0, i), limit)
+		ct.addRecord(ctx, unorderedRecord("t", 1, i), limit)
+	}
+
+	batches := drainBatches(batchChan, 6)
+
+	// Revoke partition 0 only.
+	ct.removeTopicPartitions(ctx, map[string][]int32{"t": {0}})
+
+	// Ack everything in flight, after the revoke.
+	for _, b := range batches {
+		b.onAck()
+	}
+
+	assert.Empty(t, rec.offsetsFor("t", 0), "revoked partition 0 must not commit any offsets")
+	assert.Equal(t, []int64{0, 1, 2}, rec.offsetsFor("t", 1), "partition 1 should commit normally")
+}
+
+// TestUnorderedReassignedPartitionUsesFreshTracker is the critical test for the
+// per-tracker design: after a partition is revoked and then reassigned, a new
+// tracker object is created and commits resume for it, while a stale ack still
+// holding the old (revoked) tracker can never commit. A design using a shared
+// revoked-set keyed by topic/partition (cleared on reassignment) would fail
+// this test, because the stale ack would slip through after the clear.
+func TestUnorderedReassignedPartitionUsesFreshTracker(t *testing.T) {
+	rec := newCommitRecorder()
+	batchChan := make(chan batchWithAckFn, 100)
+	ct := newCheckpointTracker(service.MockResources(), batchChan, rec.commitFunc, service.BatchPolicy{})
+
+	ctx := context.Background()
+	const limit = 1024
+
+	// Old generation: a record on t/0 at offset 5, left in flight (not acked).
+	ct.addRecord(ctx, unorderedRecord("t", 0, 5), limit)
+	oldBatch := <-batchChan
+
+	// Revoke t/0.
+	ct.removeTopicPartitions(ctx, map[string][]int32{"t": {0}})
+
+	// Reassignment: a new record on t/0 at offset 100 creates a fresh tracker.
+	ct.addRecord(ctx, unorderedRecord("t", 0, 100), limit)
+	newBatch := <-batchChan
+
+	// Ack the new generation: commit must go through.
+	newBatch.onAck()
+	assert.Equal(t, []int64{100}, rec.offsetsFor("t", 0), "reassigned partition should commit via fresh tracker")
+
+	// Ack the stale old-generation batch: must NOT commit.
+	oldBatch.onAck()
+	assert.Equal(t, []int64{100}, rec.offsetsFor("t", 0), "stale ack from revoked tracker must not commit")
+	assert.NotContains(t, rec.offsetsFor("t", 0), int64(5), "old offset 5 must never be committed")
+}
+
+// TestUnorderedRevokeRaceNoCommitLeak exercises concurrent acks racing against a
+// revoke under the race detector. The invariant checked is that committed
+// offsets are always a subset of delivered offsets and that no data race occurs
+// on the revoked flag or the tracker maps.
+func TestUnorderedRevokeRaceNoCommitLeak(t *testing.T) {
+	rec := newCommitRecorder()
+	batchChan := make(chan batchWithAckFn, 1000)
+	ct := newCheckpointTracker(service.MockResources(), batchChan, rec.commitFunc, service.BatchPolicy{})
+
+	ctx := context.Background()
+	const limit = 1 << 20
+	const n = 200
+
+	delivered := map[int64]struct{}{}
+	for i := range int64(n) {
+		ct.addRecord(ctx, unorderedRecord("t", 0, i), limit)
+		delivered[i] = struct{}{}
+	}
+	batches := drainBatches(batchChan, n)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		ct.removeTopicPartitions(ctx, map[string][]int32{"t": {0}})
+	})
+	for _, b := range batches {
+		wg.Go(func() {
+			b.onAck()
+		})
+	}
+	wg.Wait()
+
+	for _, off := range rec.offsetsFor("t", 0) {
+		_, ok := delivered[off]
+		require.True(t, ok, "committed offset %d was never delivered", off)
+	}
+}


### PR DESCRIPTION
## Summary

The franz-based Kafka readers can commit offsets for a partition **after** it has been revoked from the consumer. During a cooperative rebalance, franz-go invokes `OnPartitionsRevoked` (where we commit marked offsets and tear down our per-partition trackers) and then deletes the revoked partitions from its internal uncommitted map. An in-flight batch whose ack lands *after* the revoke handler returns calls `MarkCommitRecords` for the now-unowned partition. franz-go performs no ownership check there, so the offset is re-inserted into the uncommitted map and advanced by the next autocommit cycle.

This weakens the at-least-once contract: we commit offsets for partitions another consumer now owns.

## Fix

A per-tracker `revoked` flag in both readers:

- **Unordered** (`partitionTracker`): flag guarded by `checkpointerLock`.
- **Ordered** (`partitionCache`): flag guarded by its `mut`.

The flag is set in `removeTopicPartitions` **under the same lock that guards the commit in the ack callback**, so the check-and-commit is atomic with respect to revocation. A late ack therefore either commits *before* the revoke handler returns (and is consequently cleaned up by franz-go's own post-revoke uncommitted-map cleanup) or observes the flag and skips the commit. Because a reassigned partition gets a fresh tracker object, commits resume normally for the new generation — there is no shared revoked state to reset, and no same-member-reassignment race.

Tests cover, for both readers:
- a revoked partition never commits a late ack, while other partitions are unaffected;
- a revoked-then-reassigned partition commits via a fresh tracker while a stale ack from the old generation stays blocked;
- a race test exercising concurrent acks against a revoke under `-race`.

## History / relationship to prior work

This supersedes #4009, which targeted the same underlying behaviour. The differences:

- It fixes the **ordered** reader as well as the unordered one. The ordered reader is the default code path for the `redpanda` input and has the identical commit-after-revoke shape; #4009 only touched the unordered reader.
- The guard is attached to the per-partition tracker object rather than a shared revoked-set keyed by topic/partition. This removes the need for a `clearRevoked`/`OnPartitionsAssigned` reset step and is immune to the same-member reassignment case, where a shared set cleared on reassignment could let a stale ack slip through.
- It does **not** include the SoftStop batcher-flush change from #4009. Buffered-but-unflushed batcher records are never tracked or committed, so the new owner re-reads them after a revoke; flushing them synchronously into an unbuffered channel from within the revoke handler risks stalling the rebalance, for no correctness gain.

## A note on framing

#4009 / #4010 describe this as a **data-loss** bug. We have not been able to confirm a mechanism by which it drops data. Every offset these readers commit is backed by a successful downstream delivery (the checkpointer only releases an offset once it and all prior offsets have been acked, and acks fire only on durable output success via `AutoRetryNacksBatched`). A late commit therefore advances the offset only to a value that was *delivered*, and the batcher-discard path loses only *uncommitted* data that the new owner re-reads. The observable effect of this bug is spurious commits for unowned partitions and a weakened redelivery window — not message loss.

We are nonetheless treating it as a correctness fix worth landing, and would welcome additional detail from the reporters (see #4010) to settle the data-loss question definitively.
