### PR TITLE
deps: bump to Go 1.26.4 to address security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/v4
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 


### PR DESCRIPTION
https://go.dev/doc/devel/release#go1.26.4