### PR TITLE
oracledb_cdc: fallback to current SCN if earlier can't be found to fix flakey tests

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -173,12 +173,14 @@ func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) (
 	}
 }
 
-// FindStartPos finds the earliest possible SCN that exists within a log that's still available.
+// FindStartPos finds the earliest possible SCN that exists within a log that's still available,
+// falling back to the database's current SCN if no valid redo logs are found.
 func (lm *LogMiner) FindStartPos(ctx context.Context) (replication.SCN, error) {
 	query := `
 		SELECT MIN(FIRST_CHANGE#) AS FIRST_SCN
 		FROM (
 			SELECT FIRST_CHANGE# FROM V$LOG
+			WHERE FIRST_CHANGE# > 0
 			UNION
 			SELECT FIRST_CHANGE# FROM V$ARCHIVED_LOG
 			WHERE NAME IS NOT NULL
@@ -192,12 +194,25 @@ func (lm *LogMiner) FindStartPos(ctx context.Context) (replication.SCN, error) {
 		)
 	`
 
-	var firstSCN uint64
-	if err := lm.db.QueryRowContext(ctx, query).Scan(&firstSCN); err != nil {
+	// Use NullInt64 to distinguish SQL NULL (empty result set) from 0 — both
+	// indicate no valid redo logs and require a fallback to CURRENT_SCN.
+	var startPos sql.NullInt64
+	if err := lm.db.QueryRowContext(ctx, query).Scan(&startPos); err != nil {
 		return 0, fmt.Errorf("querying oldest available SCN in logs: %w", err)
 	}
+	if !startPos.Valid || startPos.Int64 == 0 {
+		var currentPos uint64
+		if err := lm.db.QueryRowContext(ctx, "SELECT CURRENT_SCN FROM V$DATABASE").Scan(&currentPos); err != nil {
+			return 0, fmt.Errorf("querying current SCN from database: %w", err)
+		}
+		if currentPos == 0 {
+			return 0, errors.New("database returned an invalid CURRENT_SCN value (0)")
+		}
+		lm.log.Warnf("No redo logs with valid SCN found, defaulting to current SCN: %d", currentPos)
+		return replication.SCN(currentPos), nil
+	}
 
-	return replication.SCN(firstSCN), nil
+	return replication.SCN(startPos.Int64), nil
 }
 
 func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp bool, err error) {


### PR DESCRIPTION
This change improves the start position discovery (when snapshotting is disabled and no cached SCN is available) by falling back to the current SCN when no valid redo logs are found. This only appears in tests as it takes some time for log data to appear in LogMiner, at which point the component has already started.