### PR TITLE
dynamodb_cdc: paginate DescribeStream to discover all shards

### DIFF
--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1299,24 +1299,56 @@ func (d *dynamoDBCDCInput) connectWithSnapshot(ctx context.Context, tableName st
 	return nil
 }
 
+// describeStreamPager is the minimum surface of *dynamodbstreams.Client
+// needed by describeStreamAllShards. Defined so tests can supply a fake
+// without depending on the concrete AWS SDK client.
+type describeStreamPager interface {
+	DescribeStream(ctx context.Context, in *dynamodbstreams.DescribeStreamInput, opts ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error)
+}
+
+// describeStreamAllShards calls DescribeStream repeatedly, chaining
+// ExclusiveStartShardId = LastEvaluatedShardId from the previous response,
+// and accumulates shards across all pages. DescribeStream returns at most
+// 100 shards per call; on high-write streams the lifetime shard count
+// exceeds the page size within hours, and a single un-paginated call hides
+// the currently-open shards behind the LastEvaluatedShardId boundary.
+func describeStreamAllShards(ctx context.Context, c describeStreamPager, streamArn *string) ([]types.Shard, error) {
+	var (
+		all     []types.Shard
+		startID *string
+	)
+	for {
+		out, err := c.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
+			StreamArn:             streamArn,
+			ExclusiveStartShardId: startID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.StreamDescription.Shards...)
+		startID = out.StreamDescription.LastEvaluatedShardId
+		if startID == nil {
+			return all, nil
+		}
+	}
+}
+
 // isCDCCheckpointStale checks if any CDC checkpoint points to expired stream data.
 // Returns true if any checkpoint is stale (stream data no longer available).
 // This happens when the connector was down >24 hours (DynamoDB Streams retention limit).
 func (d *dynamoDBCDCInput) isCDCCheckpointStale(ctx context.Context) (bool, error) {
-	// Get current shards from the stream
-	streamDesc, err := d.streamsClient.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
-		StreamArn: d.streamArn,
-	})
+	// Get current shards from the stream (paginated; see describeStreamAllShards).
+	shards, err := describeStreamAllShards(ctx, d.streamsClient, d.streamArn)
 	if err != nil {
 		return false, fmt.Errorf("describing stream: %w", err)
 	}
 
-	if len(streamDesc.StreamDescription.Shards) == 0 {
+	if len(shards) == 0 {
 		// No shards = no data = checkpoint doesn't matter
 		return false, nil
 	}
 
-	for _, shard := range streamDesc.StreamDescription.Shards {
+	for _, shard := range shards {
 		shardID := *shard.ShardId
 
 		// Check if we have a checkpoint for this shard
@@ -1347,9 +1379,7 @@ func (d *dynamoDBCDCInput) isCDCCheckpointStale(ctx context.Context) (bool, erro
 }
 
 func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
-	streamDesc, err := d.streamsClient.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
-		StreamArn: d.streamArn,
-	})
+	shards, err := describeStreamAllShards(ctx, d.streamsClient, d.streamArn)
 	if err != nil {
 		return err
 	}
@@ -1361,7 +1391,7 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 	}
 	var newShards []shardToAdd
 
-	for _, shard := range streamDesc.StreamDescription.Shards {
+	for _, shard := range shards {
 		shardID := *shard.ShardId
 
 		// Check if shard already exists (minimize lock hold time)
@@ -1634,9 +1664,7 @@ func (d *dynamoDBCDCInput) startTableStreamCoordinator(ctx context.Context, tabl
 
 // refreshTableShards refreshes shard information for a specific table
 func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName string, ts *tableStream) error {
-	streamDesc, err := d.streamsClient.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
-		StreamArn: &ts.streamArn,
-	})
+	shards, err := describeStreamAllShards(ctx, d.streamsClient, &ts.streamArn)
 	if err != nil {
 		return err
 	}
@@ -1648,7 +1676,7 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 	}
 	var newShards []shardToAdd
 
-	for _, shard := range streamDesc.StreamDescription.Shards {
+	for _, shard := range shards {
 		shardID := *shard.ShardId
 
 		// Check if shard already exists

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1306,31 +1306,53 @@ type describeStreamPager interface {
 	DescribeStream(ctx context.Context, in *dynamodbstreams.DescribeStreamInput, opts ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error)
 }
 
+// maxDescribeStreamPages caps describeStreamAllShards iterations as a
+// defense against a misbehaving AWS API returning valid different
+// continuation tokens indefinitely. 1000 pages = 100k shards, three orders
+// of magnitude beyond any realistic DynamoDB Streams workload (real streams
+// rotate ~24 shards per 4h shard lifecycle).
+const maxDescribeStreamPages = 1000
+
 // describeStreamAllShards calls DescribeStream repeatedly, chaining
 // ExclusiveStartShardId = LastEvaluatedShardId from the previous response,
 // and accumulates shards across all pages. DescribeStream returns at most
 // 100 shards per call; on high-write streams the lifetime shard count
 // exceeds the page size within hours, and a single un-paginated call hides
 // the currently-open shards behind the LastEvaluatedShardId boundary.
-func describeStreamAllShards(ctx context.Context, c describeStreamPager, streamArn *string) ([]types.Shard, error) {
+func describeStreamAllShards(ctx context.Context, client describeStreamPager, streamArn *string) ([]types.Shard, error) {
 	var (
 		all     []types.Shard
 		startID *string
 	)
-	for {
-		out, err := c.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
+	for page := range maxDescribeStreamPages {
+		out, err := client.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
 			StreamArn:             streamArn,
 			ExclusiveStartShardId: startID,
 		})
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, out.StreamDescription.Shards...)
-		startID = out.StreamDescription.LastEvaluatedShardId
-		if startID == nil {
+		for _, s := range out.StreamDescription.Shards {
+			if s.ShardId == nil {
+				continue
+			}
+			all = append(all, s)
+		}
+		next := out.StreamDescription.LastEvaluatedShardId
+		// AWS signals end-of-pagination via nil; also treat a non-nil
+		// pointer to the empty string as terminal to defend against
+		// interposing proxies that materialize the field.
+		if next == nil || *next == "" {
 			return all, nil
 		}
+		// Guard against a misbehaving service that returns the same
+		// cursor we just sent — would otherwise spin forever.
+		if startID != nil && *next == *startID {
+			return nil, fmt.Errorf("DescribeStream returned same LastEvaluatedShardId %q on page %d; aborting", *next, page)
+		}
+		startID = next
 	}
+	return nil, fmt.Errorf("describeStreamAllShards: exceeded %d pages without nil LastEvaluatedShardId; aborting", maxDescribeStreamPages)
 }
 
 // isCDCCheckpointStale checks if any CDC checkpoint points to expired stream data.

--- a/internal/impl/aws/dynamodb/input_cdc_pagination_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_pagination_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStreamPager is a configurable test double for describeStreamPager.
+type fakeStreamPager struct {
+	// pages is consumed FIFO; each call to DescribeStream returns one page.
+	pages []*dynamodbstreams.DescribeStreamOutput
+	// errs[i] is returned by the i-th call if non-nil. Nil means no error.
+	errs []error
+	// inputs records each DescribeStreamInput received by the fake.
+	inputs []*dynamodbstreams.DescribeStreamInput
+	calls  int
+}
+
+func (f *fakeStreamPager) DescribeStream(_ context.Context, in *dynamodbstreams.DescribeStreamInput, _ ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error) {
+	f.inputs = append(f.inputs, in)
+	idx := f.calls
+	f.calls++
+	if idx < len(f.errs) && f.errs[idx] != nil {
+		return nil, f.errs[idx]
+	}
+	if idx >= len(f.pages) {
+		return nil, errors.New("fakeStreamPager: ran out of pages")
+	}
+	return f.pages[idx], nil
+}
+
+func shardWithID(id string) types.Shard {
+	return types.Shard{ShardId: &id}
+}
+
+func TestDescribeStreamAllShards(t *testing.T) {
+	arn := "stream-arn"
+
+	t.Run("empty stream returns empty slice", func(t *testing.T) {
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{Shards: nil}},
+			},
+		}
+		shards, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		assert.Empty(t, shards)
+		assert.Equal(t, 1, fake.calls)
+	})
+
+	t.Run("single page returns all shards", func(t *testing.T) {
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards: []types.Shard{shardWithID("s1"), shardWithID("s2"), shardWithID("s3")},
+				}},
+			},
+		}
+		shards, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		require.Len(t, shards, 3)
+		assert.Equal(t, "s1", *shards[0].ShardId)
+		assert.Equal(t, "s2", *shards[1].ShardId)
+		assert.Equal(t, "s3", *shards[2].ShardId)
+		assert.Equal(t, 1, fake.calls)
+	})
+
+	t.Run("multiple pages accumulated", func(t *testing.T) {
+		last1 := "s100"
+		last2 := "s200"
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("s1"), shardWithID("s2")},
+					LastEvaluatedShardId: &last1,
+				}},
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("s3"), shardWithID("s4")},
+					LastEvaluatedShardId: &last2,
+				}},
+				{StreamDescription: &types.StreamDescription{
+					Shards: []types.Shard{shardWithID("s5")},
+				}},
+			},
+		}
+		shards, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		require.Len(t, shards, 5)
+		for i, want := range []string{"s1", "s2", "s3", "s4", "s5"} {
+			assert.Equal(t, want, *shards[i].ShardId, "index %d", i)
+		}
+		assert.Equal(t, 3, fake.calls)
+	})
+
+	t.Run("ExclusiveStartShardId chained from LastEvaluatedShardId", func(t *testing.T) {
+		last := "from-page-1"
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("a")},
+					LastEvaluatedShardId: &last,
+				}},
+				{StreamDescription: &types.StreamDescription{
+					Shards: []types.Shard{shardWithID("b")},
+				}},
+			},
+		}
+		_, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		require.Len(t, fake.inputs, 2)
+		assert.Nil(t, fake.inputs[0].ExclusiveStartShardId, "first call must not set ExclusiveStartShardId")
+		require.NotNil(t, fake.inputs[1].ExclusiveStartShardId, "second call must set ExclusiveStartShardId")
+		assert.Equal(t, last, *fake.inputs[1].ExclusiveStartShardId)
+		// StreamArn must be carried on every call.
+		require.NotNil(t, fake.inputs[0].StreamArn)
+		require.NotNil(t, fake.inputs[1].StreamArn)
+		assert.Equal(t, arn, *fake.inputs[0].StreamArn)
+		assert.Equal(t, arn, *fake.inputs[1].StreamArn)
+	})
+
+	t.Run("error mid-pagination returns error", func(t *testing.T) {
+		last := "s100"
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("s1")},
+					LastEvaluatedShardId: &last,
+				}},
+			},
+			errs: []error{nil, errors.New("network failure")},
+		}
+		_, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "network failure")
+		assert.Equal(t, 2, fake.calls)
+	})
+
+	t.Run("error on first call returns error immediately", func(t *testing.T) {
+		fake := &fakeStreamPager{
+			errs: []error{errors.New("auth failure")},
+		}
+		_, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auth failure")
+		assert.Equal(t, 1, fake.calls)
+	})
+}

--- a/internal/impl/aws/dynamodb/input_cdc_pagination_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_pagination_test.go
@@ -11,6 +11,7 @@ package dynamodb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams"
@@ -30,7 +31,10 @@ type fakeStreamPager struct {
 	calls  int
 }
 
-func (f *fakeStreamPager) DescribeStream(_ context.Context, in *dynamodbstreams.DescribeStreamInput, _ ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error) {
+func (f *fakeStreamPager) DescribeStream(ctx context.Context, in *dynamodbstreams.DescribeStreamInput, _ ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	f.inputs = append(f.inputs, in)
 	idx := f.calls
 	f.calls++
@@ -158,4 +162,99 @@ func TestDescribeStreamAllShards(t *testing.T) {
 		assert.Contains(t, err.Error(), "auth failure")
 		assert.Equal(t, 1, fake.calls)
 	})
+
+	t.Run("empty-string LastEvaluatedShardId terminates pagination", func(t *testing.T) {
+		empty := ""
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("s1")},
+					LastEvaluatedShardId: &empty,
+				}},
+			},
+		}
+		shards, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		require.Len(t, shards, 1)
+		assert.Equal(t, 1, fake.calls, "must not loop on empty-string cursor")
+	})
+
+	t.Run("repeated LastEvaluatedShardId aborts to avoid infinite loop", func(t *testing.T) {
+		stuck := "stuck"
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("a")},
+					LastEvaluatedShardId: &stuck,
+				}},
+				{StreamDescription: &types.StreamDescription{
+					Shards:               []types.Shard{shardWithID("b")},
+					LastEvaluatedShardId: &stuck,
+				}},
+			},
+		}
+		_, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "LastEvaluatedShardId")
+		assert.Equal(t, 2, fake.calls)
+	})
+
+	t.Run("shards with nil ShardId are filtered out", func(t *testing.T) {
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards: []types.Shard{shardWithID("s1"), {ShardId: nil}, shardWithID("s2")},
+				}},
+			},
+		}
+		shards, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.NoError(t, err)
+		require.Len(t, shards, 2)
+		assert.Equal(t, "s1", *shards[0].ShardId)
+		assert.Equal(t, "s2", *shards[1].ShardId)
+	})
+
+	t.Run("cancelled context aborts before any call", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		fake := &fakeStreamPager{
+			pages: []*dynamodbstreams.DescribeStreamOutput{
+				{StreamDescription: &types.StreamDescription{
+					Shards: []types.Shard{shardWithID("s1")},
+				}},
+			},
+		}
+		_, err := describeStreamAllShards(ctx, fake, &arn)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 0, fake.calls)
+	})
+
+	t.Run("exceeds page cap returns error", func(t *testing.T) {
+		// An adversarial fake that always returns a valid different
+		// continuation token — exercises the iteration cap that defends
+		// against an API legitimately paginating forever.
+		fake := &infiniteStreamPager{}
+		_, err := describeStreamAllShards(context.Background(), fake, &arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded")
+		assert.Equal(t, maxDescribeStreamPages, fake.calls)
+	})
+}
+
+// infiniteStreamPager returns a new valid continuation token on every call,
+// forcing describeStreamAllShards to hit its page cap.
+type infiniteStreamPager struct {
+	calls int
+}
+
+func (f *infiniteStreamPager) DescribeStream(_ context.Context, _ *dynamodbstreams.DescribeStreamInput, _ ...func(*dynamodbstreams.Options)) (*dynamodbstreams.DescribeStreamOutput, error) {
+	f.calls++
+	next := fmt.Sprintf("page-%d", f.calls)
+	return &dynamodbstreams.DescribeStreamOutput{
+		StreamDescription: &types.StreamDescription{
+			Shards:               []types.Shard{shardWithID(fmt.Sprintf("s%d", f.calls))},
+			LastEvaluatedShardId: &next,
+		},
+	}, nil
 }


### PR DESCRIPTION
  DescribeStream returns at most 100 shards per response and uses
  LastEvaluatedShardId for continuation. The three call sites in
  input_cdc.go read only the first page, so on streams with more than
  ~100 lifetime shards the connector never discovers the currently-open
  shards: readers drain, the input silently stalls, no errors logged.

  Introduce describeStreamAllShards, a helper that loops DescribeStream
  chaining ExclusiveStartShardId = LastEvaluatedShardId until the token
  is nil, and route isCDCCheckpointStale, refreshShards, and
  refreshTableShards through it. Unit tests cover empty, single-page,
  multi-page accumulation, token chaining, and error paths.