### PR TITLE
feat: Add option for using elasticsearch API keys

### DIFF
--- a/docs/modules/components/pages/outputs/elasticsearch_v8.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch_v8.adoc
@@ -42,6 +42,7 @@ output:
     action: "" # No default (required)
     id: ${!counter()}-${!timestamp_unix()} # No default (required)
     max_in_flight: 64
+    api_key: ""
     batching:
       count: 0
       byte_size: 0
@@ -74,6 +75,7 @@ output:
       root_cas_file: ""
       client_certs: []
     max_in_flight: 64
+    api_key: ""
     basic_auth:
       enabled: false
       username: ""
@@ -196,6 +198,23 @@ output:
     index: "cool-bug-facts"
     action: "index"
     id: ${! meta("s3_key") }
+```
+
+--
+Authenticating with an API key::
++
+--
+
+Set the `api_key` field to authenticate requests with an Elasticsearch API key. If `api_key` is set, it supersedes the `basic_auth` configuration.
+
+```yaml
+output:
+  elasticsearch_v8:
+    urls: ['https://localhost:9200']
+    index: "things"
+    action: "index"
+    id: ${! json("id") }
+    api_key: "${ELASTICSEARCH_API_KEY}"
 ```
 
 --
@@ -484,6 +503,20 @@ The maximum number of messages to have in flight at a given time. Increase this 
 *Type*: `int`
 
 *Default*: `64`
+
+=== `api_key`
+
+An API key to authenticate with. If set, it supersedes basic authentication.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `basic_auth`
 

--- a/docs/modules/components/pages/outputs/elasticsearch_v9.adoc
+++ b/docs/modules/components/pages/outputs/elasticsearch_v9.adoc
@@ -42,6 +42,7 @@ output:
     action: "" # No default (required)
     id: ${!counter()}-${!timestamp_unix()} # No default (required)
     max_in_flight: 64
+    api_key: ""
     batching:
       count: 0
       byte_size: 0
@@ -74,6 +75,7 @@ output:
       root_cas_file: ""
       client_certs: []
     max_in_flight: 64
+    api_key: ""
     basic_auth:
       enabled: false
       username: ""
@@ -196,6 +198,23 @@ output:
     index: "cool-bug-facts"
     action: "index"
     id: ${! meta("s3_key") }
+```
+
+--
+Authenticating with an API key::
++
+--
+
+Set the `api_key` field to authenticate requests with an Elasticsearch API key. If `api_key` is set, it supersedes the `basic_auth` configuration.
+
+```yaml
+output:
+  elasticsearch_v9:
+    urls: ['https://localhost:9200']
+    index: "things"
+    action: "index"
+    id: ${! json("id") }
+    api_key: "${ELASTICSEARCH_API_KEY}"
 ```
 
 --
@@ -484,6 +503,20 @@ The maximum number of messages to have in flight at a given time. Increase this 
 *Type*: `int`
 
 *Default*: `64`
+
+=== `api_key`
+
+An API key to authenticate with. If set, it supersedes basic authentication.
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
+====
+
+
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `basic_auth`
 

--- a/internal/impl/elasticsearch/v8/output.go
+++ b/internal/impl/elasticsearch/v8/output.go
@@ -53,6 +53,7 @@ const (
 	esFieldAuthEnabled     = "enabled"
 	esFieldAuthUsername    = "username"
 	esFieldAuthPassword    = "password"
+	esFieldAPIKey          = "api_key"
 	esFieldBatching        = "batching"
 )
 
@@ -128,6 +129,9 @@ func esConfigFromParsed(pConf *service.ParsedConfig) (*esConfig, error) {
 	if conf.retryOnConflict, err = pConf.FieldInt(esFieldRetryOnConflict); err != nil {
 		return nil, err
 	}
+	if conf.clientOpts.APIKey, err = pConf.FieldString(esFieldAPIKey); err != nil {
+		return nil, err
+	}
 
 	return conf, nil
 }
@@ -164,6 +168,9 @@ Both the `+"`id` and `index`"+` fields can be dynamically set using function int
 				Default(0),
 			service.NewTLSToggledField(esFieldTLS),
 			service.NewOutputMaxInFlightField(),
+			service.NewStringField(esFieldAPIKey).
+				Description("An API key to authenticate with. If set, it supersedes basic authentication.").
+				Default("").Secret(),
 		).
 		Fields(
 			service.NewObjectField(esFieldAuth,
@@ -254,6 +261,15 @@ output:
     index: "cool-bug-facts"
     action: "index"
     id: ${! meta("s3_key") }
+`).
+		Example("Authenticating with an API key", "Set the `api_key` field to authenticate requests with an Elasticsearch API key. If `api_key` is set, it supersedes the `basic_auth` configuration.", `
+output:
+  elasticsearch_v8:
+    urls: ['https://localhost:9200']
+    index: "things"
+    action: "index"
+    id: ${! json("id") }
+    api_key: "${ELASTICSEARCH_API_KEY}"
 `).
 		Example("Create Documents", "When using the `create` action, a new document will be created if the document ID does not already exist. If the document ID already exists, the operation will fail.", `
 output:

--- a/internal/impl/elasticsearch/v9/output.go
+++ b/internal/impl/elasticsearch/v9/output.go
@@ -53,6 +53,7 @@ const (
 	esFieldAuthEnabled     = "enabled"
 	esFieldAuthUsername    = "username"
 	esFieldAuthPassword    = "password"
+	esFieldAPIKey          = "api_key"
 	esFieldBatching        = "batching"
 )
 
@@ -128,6 +129,9 @@ func esConfigFromParsed(pConf *service.ParsedConfig) (*esConfig, error) {
 	if conf.retryOnConflict, err = pConf.FieldInt(esFieldRetryOnConflict); err != nil {
 		return nil, err
 	}
+	if conf.clientOpts.APIKey, err = pConf.FieldString(esFieldAPIKey); err != nil {
+		return nil, err
+	}
 
 	return conf, nil
 }
@@ -164,6 +168,9 @@ Both the `+"`id` and `index`"+` fields can be dynamically set using function int
 				Default(0),
 			service.NewTLSToggledField(esFieldTLS),
 			service.NewOutputMaxInFlightField(),
+			service.NewStringField(esFieldAPIKey).
+				Description("An API key to authenticate with. If set, it supersedes basic authentication.").
+				Default("").Secret(),
 		).
 		Fields(
 			service.NewObjectField(esFieldAuth,
@@ -254,6 +261,15 @@ output:
     index: "cool-bug-facts"
     action: "index"
     id: ${! meta("s3_key") }
+`).
+		Example("Authenticating with an API key", "Set the `api_key` field to authenticate requests with an Elasticsearch API key. If `api_key` is set, it supersedes the `basic_auth` configuration.", `
+output:
+  elasticsearch_v9:
+    urls: ['https://localhost:9200']
+    index: "things"
+    action: "index"
+    id: ${! json("id") }
+    api_key: "${ELASTICSEARCH_API_KEY}"
 `).
 		Example("Create Documents", "When using the `create` action, a new document will be created if the document ID does not already exist. If the document ID already exists, the operation will fail.", `
 output:


### PR DESCRIPTION
Modern Elasticsearch (particularly in elastic cloud) supports API key authentication.  In particular this is the only mechanism (other than mTLS) that Elastic Cloud Serverless supports.  This adds the option to specify an api key for both versions of the Elasticsearch connector.

I wanted to avoid changing the current basic_auth schema so I have added this under a new section, but not sure whether this is the pattern you want to follow.

Fixes #4495 