### PR TITLE
telemetry: adopt shared common-go/telemetry client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,9 +98,7 @@ require (
 	github.com/getsentry/sentry-go v0.44.1
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/go-git/go-git/v5 v5.19.1
-	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-mysql-org/go-mysql v1.14.0
-	github.com/go-resty/resty/v2 v2.17.2
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gocql/gocql v1.7.0
@@ -149,6 +147,7 @@ require (
 	github.com/redpanda-data/common-go/license v0.0.0-20260318014216-2bbd72bde0a0
 	github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0
 	github.com/redpanda-data/common-go/secrets v0.1.15
+	github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0
 	github.com/rs/xid v1.6.0
 	github.com/sashabaranov/go-openai v1.41.2
@@ -258,7 +257,9 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 // indirect
+	github.com/go-resty/resty/v2 v2.17.2 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/wire v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1561,6 +1561,8 @@ github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0 h1:lyLHsAMI4Ns8
 github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0/go.mod h1:kzFoUX1Abv6ccz8wuTUUpmBlGwQcwNjSxYCuDLA4IyQ=
 github.com/redpanda-data/common-go/secrets v0.1.15 h1:sbyZrOKdb6JI2BFzoHI7OZvoUUwk3x9rR21oEt25aac=
 github.com/redpanda-data/common-go/secrets v0.1.15/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
+github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d h1:jQGseB551fWF6LrbTgZBkDp4RuShsRMk1M8ODD+61po=
+github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0 h1:asiPje6R/1+y4x3/hKBVJCEPV/tNlMGwK1QCL+wvtbY=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0/go.mod h1:nl1fwRHtWRJyRPO5uwr1y727113eYnmp6gLqU5iheSk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -14,20 +14,22 @@
 
 package telemetry
 
-import "github.com/redpanda-data/benthos/v4/public/service"
+import (
+	"fmt"
 
-type logWrapper struct {
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// benthosLogger adapts a benthos *service.Logger to the telemetry.Logger
+// interface expected by the shared common-go/telemetry client.
+type benthosLogger struct {
 	l *service.Logger
 }
 
-func (l *logWrapper) Errorf(format string, v ...any) {
-	l.l.With("component", "resty").Debugf(format, v...)
-}
-
-func (*logWrapper) Warnf(string, ...any) {
-	// Ignore
-}
-
-func (*logWrapper) Debugf(string, ...any) {
-	// Ignore
+func (b benthosLogger) Debug(msg string, kv ...any) {
+	logger := b.l
+	for i := 0; i+1 < len(kv); i += 2 {
+		logger = logger.With(fmt.Sprint(kv[i]), kv[i+1])
+	}
+	logger.Debug(msg)
 }

--- a/internal/telemetry/payload.go
+++ b/internal/telemetry/payload.go
@@ -17,7 +17,6 @@ package telemetry
 import (
 	"fmt"
 	"runtime"
-	"time"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -102,21 +101,4 @@ func extractPayload(identifier, deploymentType, tenantID string, logger *service
 	}
 
 	return &p, nil
-}
-
-// This function runs asynchronously and is solely where telemetry data is
-// exported.
-func exporterLoop(p *payload, exportDelay, exportPeriod time.Duration, exporter *telemetryExporter) {
-	started := time.Now()
-
-	// First, wait until after the export delay has passed.
-	time.Sleep(exportDelay)
-
-	for {
-		p.Uptime = int64(time.Since(started) / time.Second)
-		exporter.export(p)
-
-		// Now wait for the next export.
-		time.Sleep(exportPeriod)
-	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -96,7 +96,7 @@ func ActivateExporter(identifier, version, deploymentType, tenantID string, logg
 		JWTHeaders:    map[string]any{"key_generation": 1},
 	})
 	if err != nil {
-		logger.With("error", err).Debug("failed to build telemetry client")
+		logger.With("error", err).Debug("Failed to build telemetry client")
 		return
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -15,15 +15,10 @@
 package telemetry
 
 import (
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
+	"context"
 	"time"
 
-	"github.com/go-jose/go-jose/v4"
-	josejwt "github.com/go-jose/go-jose/v4/jwt"
-	"github.com/go-resty/resty/v2"
+	commontelemetry "github.com/redpanda-data/common-go/telemetry"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
@@ -57,32 +52,6 @@ const (
 	defaultExportPeriod = time.Hour * 24
 )
 
-// ParseRSAPrivateKeyFromPEM parses a PEM encoded PKCS1 or PKCS8 private key.
-func ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error) {
-	var err error
-
-	// Parse PEM block
-	var block *pem.Block
-	if block, _ = pem.Decode(key); block == nil {
-		return nil, errors.New("cert must be pem encoded")
-	}
-
-	var parsedKey any
-	if parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
-		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
-			return nil, err
-		}
-	}
-
-	var pkey *rsa.PrivateKey
-	var ok bool
-	if pkey, ok = parsedKey.(*rsa.PrivateKey); !ok {
-		return nil, errors.New("not a RSA private key")
-	}
-
-	return pkey, nil
-}
-
 // ActivateExporter runs the telemetry exporter asynchronously, provided all
 // conditions for telemetry are satisfied.
 func ActivateExporter(identifier, version, deploymentType, tenantID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) {
@@ -92,20 +61,8 @@ func ActivateExporter(identifier, version, deploymentType, tenantID string, logg
 		return
 	}
 
-	// Parse private key for signing the JWT payload before sending it to our telemetry endpoint.
-	rsaPrivateKey, err := ParseRSAPrivateKeyFromPEM([]byte(privateKey))
-	if err != nil {
-		logger.With("error", err).Debug("Failed to parse private key")
-		return
-	}
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: rsaPrivateKey},
-		(&jose.SignerOptions{}).WithHeader("key_generation", 1))
-	if err != nil {
-		logger.With("error", err).Debug("Failed to create JWT signer")
-		return
-	}
-
 	// Parse export delay and periods.
+	var err error
 	exportDelay, exportPeriod := defaultExportDelay, defaultExportPeriod
 	if ExportDelay != "" {
 		if exportDelay, err = time.ParseDuration(ExportDelay); err != nil {
@@ -125,52 +82,35 @@ func ActivateExporter(identifier, version, deploymentType, tenantID string, logg
 		exportHost = ExportHost
 	}
 
-	tExporter := &telemetryExporter{
-		logger: logger,
-		Resty: resty.New().
-			SetHeader("User-Agent", "RedpandaConnect/"+version).
-			SetHeader("Accept-Encoding", "gzip").
-			SetHeader("Content-Type", "text/plain").
-			SetHeader("Accept", "application/json").
-			SetBaseURL(exportHost).
-			SetTimeout(10 * time.Second).
-			SetLogger(&logWrapper{l: logger}).
-			SetRetryCount(3),
-		JWTBuilder: josejwt.Signed(signer),
-	}
-
-	payload, err := extractPayload(identifier, deploymentType, tenantID, logger, schema, conf)
+	p, err := extractPayload(identifier, deploymentType, tenantID, logger, schema, conf)
 	if err != nil {
 		logger.With("error", err).Debug("Failed to create telemetry payload")
 		return
 	}
 
-	go exporterLoop(payload, exportDelay, exportPeriod, tExporter)
-}
-
-type telemetryExporter struct {
-	logger *service.Logger
-
-	Resty      *resty.Client
-	JWTBuilder josejwt.Builder
-}
-
-// Send telemetry payload to a hardcoded HTTP endpoint.
-func (t *telemetryExporter) export(p *payload) {
-	tokenStr, err := t.JWTBuilder.Claims(p).Serialize()
+	client, err := commontelemetry.New(commontelemetry.Config{
+		Endpoint:      exportHost,
+		Path:          "/connect/telemetry",
+		UserAgent:     "RedpandaConnect/" + version,
+		SigningKeyPEM: []byte(privateKey),
+		JWTHeaders:    map[string]any{"key_generation": 1},
+	})
 	if err != nil {
-		t.logger.With("error", err).Debug("Failed to get token string")
+		logger.With("error", err).Debug("failed to build telemetry client")
 		return
 	}
 
-	response, err := t.Resty.NewRequest().
-		SetBody(tokenStr).
-		Post("/connect/telemetry")
-	if err != nil {
-		t.logger.With("error", err).Debug("Failed to send request")
-		return
+	started := time.Now()
+	reporter := &commontelemetry.Reporter{
+		Client: client,
+		Delay:  exportDelay,
+		Period: exportPeriod,
+		Logger: benthosLogger{l: logger},
+		Collector: func(_ context.Context) (any, error) {
+			p.Uptime = int64(time.Since(started) / time.Second)
+			return p, nil
+		},
 	}
-	if response.IsError() {
-		t.logger.With("status_code", response.StatusCode()).Debug("Failed to send request")
-	}
+
+	go func() { _ = reporter.Run(context.Background()) }()
 }


### PR DESCRIPTION
## What

Replaces the bespoke telemetry transport (resty + go-jose signing + hand-rolled export loop) in `internal/telemetry` with the shared client from [`github.com/redpanda-data/common-go/telemetry`](https://github.com/redpanda-data/common-go/pull/172).

**Behavior-preserving.** Everything observable stays the same:
- `ActivateExporter` signature and the `internal/cli/enterprise.go` call site are unchanged.
- Early return when the embedded `key.pem` is empty (dev builds send nothing).
- `ExportHost`/`ExportDelay`/`ExportPeriod` overrides and their defaults (`https://m.rp.vectorized.io`, 5m delay, 24h period) preserved.
- Same wire contract: POST `/connect/telemetry`, `User-Agent: RedpandaConnect/<version>`, RS256 JWT signed with the embedded key, `key_generation: 1` protected header, identical payload (ID, uptime, components, host info, deployment type, tenant ID) with uptime recomputed each export.
- Payload extraction (`payload.go`) untouched; drop-on-error semantics retained via the shared `Reporter`.

Deleted: `telemetryExporter`, `export`, `exporterLoop`, local RSA parsing, and the resty log adapter (~65 lines of plumbing). Added: a 10-line benthos→`telemetry.Logger` shim.

### Two intentional, benign deltas
- The JWT protected header now also carries the conventional `"typ":"JWT"` (added by the shared signer). The ingestion service's JWT parsing ignores unknown header fields.
- The export cadence uses a ticker instead of `sleep`, so the interval no longer drifts by the send duration.

## Dependencies / merge order
**DEPENDS ON** redpanda-data/common-go#172. `go.mod` pins `github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d` (the PR branch head) — CI stays red until that PR merges to `main`; re-pin to the merge commit if it lands with a different SHA. `resty`/`go-jose` moved to indirect requires as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)