### PR TITLE
bigquery: raise schema_resolve_timeout default and pin the auto-create test

### DIFF
--- a/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
@@ -94,7 +94,7 @@ output:
     stream_idle_timeout: 5m
     stream_sweep_interval: 1m
     max_cached_streams: 1024
-    schema_resolve_timeout: 5s
+    schema_resolve_timeout: 15s
     schema_evolution_timeout: 30s
     endpoint:
       http: ""
@@ -505,12 +505,12 @@ Soft cap on the number of cached streams. When the cache exceeds this size, the 
 
 === `schema_resolve_timeout`
 
-How long a single BigQuery table-metadata fetch can run before being aborted. Coalesced concurrent resolves share one fetch, so this bounds the time a wedged backend can stall every batch routing to the same table.
+How long a single BigQuery table-metadata fetch can run before being aborted. Coalesced concurrent resolves share one fetch, so this bounds the time a wedged backend can stall every batch routing to the same table. On the auto_create_table path the budget covers Metadata→Create→Metadata, so it needs to absorb transient backend slowness on top of the metadata fetch itself.
 
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `"15s"`
 
 === `schema_evolution_timeout`
 

--- a/internal/impl/gcp/enterprise/bigquery/integration_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/integration_test.go
@@ -286,6 +286,10 @@ gcp_bigquery_write_api:
   time_partitioning:
     type: DAY
   clustering: [tenant_id]
+  # The auto-create path runs Metadata→Create→Metadata inside one budget;
+  # CI runners under load have flaked the default repeatedly. 30s gives the
+  # emulator plenty of headroom without changing real-world write behavior.
+  schema_resolve_timeout: 30s
   endpoint:
     http: %s
     grpc: %s

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -260,9 +260,11 @@ When migrating from the load-jobs based `+"`gcp_bigquery`"+` output to CDC mode,
 			service.NewDurationField(bqwaFieldSchemaResolveTimeout).
 				Description("How long a single BigQuery table-metadata fetch can run before being aborted."+
 					" Coalesced concurrent resolves share one fetch, so this bounds the time a wedged backend"+
-					" can stall every batch routing to the same table.").
+					" can stall every batch routing to the same table. On the auto_create_table path"+
+					" the budget covers Metadata→Create→Metadata, so it needs to absorb transient backend"+
+					" slowness on top of the metadata fetch itself.").
 				Advanced().
-				Default("5s"),
+				Default("15s"),
 			service.NewDurationField(bqwaFieldSchemaEvolutionTimeout).
 				Description("Total time budget for a single schema evolution attempt (Metadata + Update"+
 					" across all CAS retries on HTTP 412). Bounds how long the WriteBatch retry loop can be"+

--- a/internal/impl/gcp/enterprise/bigquery/output_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/output_test.go
@@ -73,7 +73,7 @@ table: my_table
 	assert.Empty(t, cfg.Delegates)
 	assert.Equal(t, 5*time.Minute, cfg.StreamIdleTimeout)
 	assert.Equal(t, 1*time.Minute, cfg.StreamSweepInterval)
-	assert.Equal(t, 5*time.Second, cfg.SchemaResolveTimeout)
+	assert.Equal(t, 15*time.Second, cfg.SchemaResolveTimeout)
 	assert.Equal(t, 30*time.Second, cfg.SchemaEvolutionTimeout)
 	assert.Empty(t, cfg.EndpointHTTP)
 	assert.Empty(t, cfg.EndpointGRPC)


### PR DESCRIPTION
    bigquery: raise schema_resolve_timeout default and pin the auto-create test

    The 5s default for schema_resolve_timeout is the budget for the entire
    Metadata-Create-Metadata round on the auto_create_table path, not just
    a single metadata fetch. Nightly CI runs have flaked
    TestIntegrationAutoCreateTable on this exact deadline since at least
    2026-06-05.

    - Raise the default from 5s to 15s and clarify the description.
    - Add an explicit 30s override in TestIntegrationAutoCreateTable so
      the auto-create round survives slow CI runners.