### PR TITLE
bigquery: reject CDC writes when a pre-existing table lacks a PRIMARY KEY

### DIFF
--- a/docs/modules/components/pages/outputs/bigquery_cdc_migration.adoc
+++ b/docs/modules/components/pages/outputs/bigquery_cdc_migration.adoc
@@ -65,6 +65,11 @@ primary_keys: [id]
 Composite primary keys are supported with up to 16 columns. The column order in `primary_keys` is significant for composite keys.
 ====
 
+[WARNING]
+====
+`primary_keys` does not add a `PRIMARY KEY` to a pre-existing table — it only applies when `auto_create_table` creates the table. For an existing table without one, run `ALTER TABLE … ADD PRIMARY KEY (…) NOT ENFORCED` first. When `primary_keys` is set and the table already declares a `PRIMARY KEY`, the two must match exactly (same columns, same order).
+====
+
 == Snapshot vs streaming
 
 BigQuery's CDC contract does not permit mixing INSERT (unspecified `_CHANGE_TYPE`) and UPSERT/DELETE rows in the same write. For initial backfills, recommendations are:

--- a/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
+++ b/docs/modules/components/pages/outputs/gcp_bigquery_write_api.adoc
@@ -217,7 +217,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `primary_keys`
 
-Optional list of primary-key column names. Required when `auto_create_table` is true and `write_mode` is `upsert` or `upsert_delete`. When the target table is pre-existing, the connector falls back to the PRIMARY KEY declared on the table. Up to 16 columns; composite keys are supported in the same order they are listed.
+Optional list of primary-key column names. Required when `auto_create_table` is true and `write_mode` is `upsert` or `upsert_delete`. A pre-existing table must already declare its PRIMARY KEY — this field cannot add one; when both are set they must match exactly (same columns, same order). Up to 16 columns; composite keys are supported in the same order they are listed.
 
 
 *Type*: `array`

--- a/internal/impl/gcp/enterprise/bigquery/cdc.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc.go
@@ -144,13 +144,19 @@ func injectCDCJSON(jsonBytes []byte, changeType, changeSeq string) ([]byte, erro
 // validateCDCPrimaryKeys enforces BigQuery's CDC contract that the destination
 // table must have a PRIMARY KEY. configPKs is the user-declared list (may be
 // nil), tablePKs is what BigQuery reports for the table (may be nil if no
-// constraint is declared). The function fails if neither source has PKs, and
-// fails on mismatch when both are present.
+// constraint is declared). Only the table's declared PKs satisfy the contract:
+// primary_keys is materialized exclusively when auto_create_table creates the
+// table, so a pre-existing table without a PRIMARY KEY fails even when
+// primary_keys is set. When both sources are present they must match.
 func validateCDCPrimaryKeys(configPKs, tablePKs []string, tableID string) error {
-	if len(configPKs) == 0 && len(tablePKs) == 0 {
-		return fmt.Errorf("CDC mode requires a PRIMARY KEY on table %q; declare one via primary_keys config or `ALTER TABLE … ADD PRIMARY KEY`", tableID)
+	if len(tablePKs) == 0 {
+		if len(configPKs) > 0 {
+			return fmt.Errorf("table %q has no PRIMARY KEY; primary_keys cannot add one to an existing table (it only applies when auto_create_table creates the table) — run `ALTER TABLE %s ADD PRIMARY KEY (%s) NOT ENFORCED` first",
+				tableID, tableID, strings.Join(configPKs, ", "))
+		}
+		return fmt.Errorf("CDC mode requires a PRIMARY KEY on table %q; declare one via `ALTER TABLE … ADD PRIMARY KEY`", tableID)
 	}
-	if len(configPKs) > 0 && len(tablePKs) > 0 {
+	if len(configPKs) > 0 {
 		// Order-sensitive: BigQuery PKs are positional (column order matches the
 		// declaration in ALTER TABLE … ADD PRIMARY KEY), so the config list must
 		// match the table list exactly, not just as a set.

--- a/internal/impl/gcp/enterprise/bigquery/cdc_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/cdc_test.go
@@ -190,8 +190,11 @@ func TestCDCInjectorValidateAndResolve(t *testing.T) {
 }
 
 func TestValidateCDCPrimaryKeys(t *testing.T) {
-	t.Run("config only", func(t *testing.T) {
-		require.NoError(t, validateCDCPrimaryKeys([]string{"id"}, nil, "t"))
+	t.Run("config only fails for pre-existing table without PK", func(t *testing.T) {
+		err := validateCDCPrimaryKeys([]string{"id"}, nil, "t")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PRIMARY KEY")
+		assert.Contains(t, err.Error(), "ALTER TABLE t ADD PRIMARY KEY (id) NOT ENFORCED")
 	})
 	t.Run("table only", func(t *testing.T) {
 		require.NoError(t, validateCDCPrimaryKeys(nil, []string{"id"}, "t"))

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -171,7 +171,8 @@ When migrating from the load-jobs based `+"`gcp_bigquery`"+` output to CDC mode,
 			service.NewStringListField(bqwaFieldPrimaryKeys).
 				Description("Optional list of primary-key column names."+
 					" Required when `auto_create_table` is true and `write_mode` is `upsert` or `upsert_delete`."+
-					" When the target table is pre-existing, the connector falls back to the PRIMARY KEY declared on the table."+
+					" A pre-existing table must already declare its PRIMARY KEY — this field cannot add one;"+
+					" when both are set they must match exactly (same columns, same order)."+
 					" Up to 16 columns; composite keys are supported in the same order they are listed.").
 				Optional(),
 			service.NewBoolField(bqwaFieldAutoCreateTable).


### PR DESCRIPTION
bigquery: reject CDC writes when a pre-existing table lacks a PRIMARY KEY