### PR TITLE
bigquery: fix CDC row-error indexing and metric consistency

### DIFF
--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -619,8 +619,10 @@ func bqWriteAPIConfigFromParsed(pConf *service.ParsedConfig) (conf bqWriteAPICon
 }
 
 type bqwaMetrics struct {
-	rowsSent                *service.MetricCounter
-	rowsFailed              *service.MetricCounter
+	rowsSent   *service.MetricCounter
+	rowsFailed *service.MetricCounter
+	// batchesSent counts batches whose append RPC succeeded, including batches
+	// with per-row failures — row-level detail lives in rowsSent/rowsFailed.
 	batchesSent             *service.MetricCounter
 	batchLatency            *service.MetricTimer
 	retries                 *service.MetricCounter
@@ -995,10 +997,13 @@ func (o *bigQueryWriteAPIOutput) WriteBatch(ctx context.Context, batch service.M
 		// Clamp: BQ shouldn't return more row errors than rows in the request,
 		// but guard the metric counter against a negative delta if it ever did.
 		o.metrics.rowsSent.Incr(int64(max(0, len(batch)-len(rowErrs))))
+		// The append RPC itself succeeded, so the batch counts as sent — the
+		// CDC path does the same; row-level detail lives in rowsSent/rowsFailed.
+		o.metrics.batchesSent.Incr(1)
 		batchErr := service.NewBatchError(batch, errors.New("row errors from BigQuery"))
 		for _, re := range rowErrs {
 			idx := int(re.GetIndex())
-			if idx < len(batch) {
+			if idx >= 0 && idx < len(batch) {
 				batchErr = batchErr.Failed(idx, fmt.Errorf("row %d: code %d: %s", idx, re.GetCode(), re.GetMessage()))
 			}
 		}
@@ -1106,12 +1111,13 @@ func (o *bigQueryWriteAPIOutput) writeBatchCDC(
 		rowIndex = append(rowIndex, i)
 	}
 
-	if validationFailures > 0 {
-		o.metrics.rowsFailed.Incr(int64(validationFailures))
-	}
-
+	// validationFailures is counted into rowsFailed only on the paths that
+	// surface batchErr (below, and after a successful append). On the
+	// handleWriteError paths the whole batch is retried or DLQ'd, and counting
+	// before AppendRows would re-count the same failures on every retry.
 	if len(rows) == 0 {
 		if batchErr != nil {
+			o.metrics.rowsFailed.Incr(int64(validationFailures))
 			return batchErr
 		}
 		return nil
@@ -1143,10 +1149,15 @@ func (o *bigQueryWriteAPIOutput) writeBatchCDC(
 		for _, re := range rowErrs {
 			idx := int(re.GetIndex())
 			if idx >= 0 && idx < len(rowIndex) {
-				batchErr = appendRowFailure(batchErr, batch, "row errors from BigQuery", rowIndex[idx], fmt.Errorf("row %d: code %d: %s", idx, re.GetCode(), re.GetMessage()))
+				// re.GetIndex() is the position within the sent rows; report the
+				// original batch index so the message matches the failed message.
+				batchErr = appendRowFailure(batchErr, batch, "row errors from BigQuery", rowIndex[idx], fmt.Errorf("row %d: code %d: %s", rowIndex[idx], re.GetCode(), re.GetMessage()))
 			}
 		}
 		o.metrics.rowsFailed.Incr(int64(len(rowErrs)))
+	}
+	if validationFailures > 0 {
+		o.metrics.rowsFailed.Incr(int64(validationFailures))
 	}
 	o.metrics.batchesSent.Incr(1)
 	o.metrics.rowsSent.Incr(int64(max(0, len(rows)-len(resp.GetRowErrors()))))

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -1037,6 +1037,24 @@ func appendRowFailure(be *service.BatchError, batch service.MessageBatch, headli
 	return be.Failed(idx, err)
 }
 
+// mapRowErrorsToBatch attaches BigQuery per-row errors to batchErr. Each
+// RowError's index refers to its position within the rows that were actually
+// sent (good rows only, after validation drops), so it is translated back to
+// the original batch index via rowIndex; both the attached failure and its
+// message reference that original index so they agree with the failed message.
+// Indices outside rowIndex are ignored.
+func mapRowErrorsToBatch(batchErr *service.BatchError, batch service.MessageBatch, rowIndex []int, rowErrs []*storagepb.RowError) *service.BatchError {
+	for _, re := range rowErrs {
+		idx := int(re.GetIndex())
+		if idx >= 0 && idx < len(rowIndex) {
+			origIdx := rowIndex[idx]
+			batchErr = appendRowFailure(batchErr, batch, "row errors from BigQuery", origIdx,
+				fmt.Errorf("row %d: code %d: %s", origIdx, re.GetCode(), re.GetMessage()))
+		}
+	}
+	return batchErr
+}
+
 // writeBatchCDC executes the CDC write path: per row, resolve the Bloblang
 // fields, validate the values, inject _CHANGE_TYPE (and optionally
 // _CHANGE_SEQUENCE_NUMBER) into the JSON payload, marshal to proto via the
@@ -1058,10 +1076,12 @@ func (o *bigQueryWriteAPIOutput) writeBatchCDC(
 		return permanentBatchError(batch, fmt.Errorf("CDC modes require message_format: json (got %q)", o.conf.MessageFormat))
 	}
 
-	var batchErr *service.BatchError
-	rows := make([][]byte, 0, len(batch))
-	rowIndex := make([]int, 0, len(batch))
-	validationFailures := 0
+	var (
+		batchErr           *service.BatchError
+		rows               = make([][]byte, 0, len(batch))
+		rowIndex           = make([]int, 0, len(batch))
+		validationFailures = 0
+	)
 
 	const cdcValidationHeadline = "CDC row validation errors"
 	for i, msg := range batch {
@@ -1146,14 +1166,7 @@ func (o *bigQueryWriteAPIOutput) writeBatchCDC(
 	}
 
 	if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
-		for _, re := range rowErrs {
-			idx := int(re.GetIndex())
-			if idx >= 0 && idx < len(rowIndex) {
-				// re.GetIndex() is the position within the sent rows; report the
-				// original batch index so the message matches the failed message.
-				batchErr = appendRowFailure(batchErr, batch, "row errors from BigQuery", rowIndex[idx], fmt.Errorf("row %d: code %d: %s", rowIndex[idx], re.GetCode(), re.GetMessage()))
-			}
-		}
+		batchErr = mapRowErrorsToBatch(batchErr, batch, rowIndex, rowErrs)
 		o.metrics.rowsFailed.Incr(int64(len(rowErrs)))
 	}
 	if validationFailures > 0 {

--- a/internal/impl/gcp/enterprise/bigquery/output_test.go
+++ b/internal/impl/gcp/enterprise/bigquery/output_test.go
@@ -687,6 +687,87 @@ table: my_table
 	assert.NoError(t, err)
 }
 
+func TestMapRowErrorsToBatch(t *testing.T) {
+	rowErr := func(idx int64, msg string) *storagepb.RowError {
+		return &storagepb.RowError{
+			Index:   idx,
+			Code:    storagepb.RowError_FIELDS_ERROR,
+			Message: msg,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		batchSize int
+		// rowIndex maps sent-row position -> original batch index, as built by
+		// writeBatchCDC after some rows are dropped during validation.
+		rowIndex []int
+		rowErrs  []*storagepb.RowError
+		// wantFailures maps the original batch index that should carry a failure
+		// to a substring its error message must contain.
+		wantFailures map[int]string
+	}{
+		{
+			name:      "sent position maps back to original index",
+			batchSize: 5,
+			// Originals 0 and 2 failed validation, so only 1, 3 and 4 were sent.
+			rowIndex: []int{1, 3, 4},
+			// A BigQuery error at sent position 1 refers to original index 3.
+			rowErrs:      []*storagepb.RowError{rowErr(1, "bad field")},
+			wantFailures: map[int]string{3: "row 3: code 1: bad field"},
+		},
+		{
+			name:         "multiple row errors map independently",
+			batchSize:    4,
+			rowIndex:     []int{0, 2, 3},
+			rowErrs:      []*storagepb.RowError{rowErr(0, "a"), rowErr(2, "b")},
+			wantFailures: map[int]string{0: "row 0: code 1: a", 3: "row 3: code 1: b"},
+		},
+		{
+			name:         "out of range indices are ignored",
+			batchSize:    3,
+			rowIndex:     []int{0, 1},
+			rowErrs:      []*storagepb.RowError{rowErr(5, "too big"), rowErr(-1, "negative")},
+			wantFailures: map[int]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			batch := make(service.MessageBatch, tc.batchSize)
+			for i := range batch {
+				batch[i] = service.NewMessage(fmt.Appendf(nil, "row-%d", i))
+			}
+			// Index before building the error: Index() tags the batch parts in
+			// place, and the error must be built from the tagged parts so the
+			// walk below can resolve each failure back to its original index.
+			index := batch.Index()
+
+			batchErr := mapRowErrorsToBatch(nil, batch, tc.rowIndex, tc.rowErrs)
+
+			if len(tc.wantFailures) == 0 {
+				require.Nil(t, batchErr, "expected no batch error when all indices are out of range")
+				return
+			}
+			require.NotNil(t, batchErr)
+
+			got := map[int]string{}
+			batchErr.WalkMessagesIndexedBy(index, func(i int, _ *service.Message, err error) bool {
+				if err != nil {
+					got[i] = err.Error()
+				}
+				return true
+			})
+
+			require.Len(t, got, len(tc.wantFailures), "unexpected set of failed indices: %v", got)
+			for idx, want := range tc.wantFailures {
+				require.Contains(t, got, idx, "expected a failure pinned to original index %d", idx)
+				assert.Equal(t, want, got[idx], "message should reference the original index, not the sent position")
+			}
+		})
+	}
+}
+
 func TestCloseNilClients(t *testing.T) {
 	// Given an output that has never connected.
 	out := newTestOutput(t, `


### PR DESCRIPTION
Report the original batch index in CDC row-error messages, count batchesSent on partial row failures in the non-CDC path to match the CDC path, and stop re-counting CDC validation failures into rowsFailed on every transient retry of the same batch.