### PR TITLE
telemetry: pin common-go/telemetry to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/redpanda-data/common-go/license v0.0.0-20260318014216-2bbd72bde0a0
 	github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0
 	github.com/redpanda-data/common-go/secrets v0.1.15
-	github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d
+	github.com/redpanda-data/common-go/telemetry v0.1.0
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0
 	github.com/rs/xid v1.6.0
 	github.com/sashabaranov/go-openai v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -1561,8 +1561,8 @@ github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0 h1:lyLHsAMI4Ns8
 github.com/redpanda-data/common-go/redpanda-otel-exporter v0.4.0/go.mod h1:kzFoUX1Abv6ccz8wuTUUpmBlGwQcwNjSxYCuDLA4IyQ=
 github.com/redpanda-data/common-go/secrets v0.1.15 h1:sbyZrOKdb6JI2BFzoHI7OZvoUUwk3x9rR21oEt25aac=
 github.com/redpanda-data/common-go/secrets v0.1.15/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
-github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d h1:jQGseB551fWF6LrbTgZBkDp4RuShsRMk1M8ODD+61po=
-github.com/redpanda-data/common-go/telemetry v0.0.0-20260610110850-da889a76852d/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
+github.com/redpanda-data/common-go/telemetry v0.1.0 h1:j+2mIuSXW/1ouIloaKModskNjFQVZnBQTXdrmKhVRi0=
+github.com/redpanda-data/common-go/telemetry v0.1.0/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0 h1:asiPje6R/1+y4x3/hKBVJCEPV/tNlMGwK1QCL+wvtbY=
 github.com/redpanda-data/connect/public/bundle/free/v4 v4.84.0/go.mod h1:nl1fwRHtWRJyRPO5uwr1y727113eYnmp6gLqU5iheSk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
## What

Pins `github.com/redpanda-data/common-go/telemetry` to the released **v0.1.0** tag, bumping from the pre-release commit pseudo-version that #4494 adopted.

This is a dependency-only change — go.mod/go.sum only, no code changes. The shared client's exported API is unchanged between the pseudo-version and v0.1.0; v0.1.0 additionally includes review-driven hardening (disabled-client short-circuit, explicit retry-disable semantics, per-cycle collection timeout), none of which alter Connect's usage.

## Context

Follow-up to redpanda-data/connect#4494 (merged), which adopted the shared telemetry client. The companion consumers are pinned to the same tag: redpanda-data/redpanda-operator#1586 and redpanda-data/console-enterprise#795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)