### PR TITLE
oracledb_cdc: upon start, begin at current SCN

### DIFF
--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -516,6 +516,13 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		return errors.New("logminer configuration required for streaming")
 	}
 
+	if cachedSCN == replication.InvalidSCN && snapshotter == nil {
+		if cachedSCN, err = streaming.FindStartPos(ctx); err != nil {
+			return fmt.Errorf("fetching current SCN: %w", err)
+		}
+		o.log.Infof("No cached SCN found, fetched current position from database: %d", cachedSCN)
+	}
+
 	// Reset our stop signal
 	o.stopSig = shutdown.NewSignaller()
 
@@ -545,19 +552,6 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			}
 
 			o.log.Infof("Successfully captured SCN following snapshot: %d", startSCN)
-		}
-
-		// If no SCN is available (no snapshot and no cached position), so get the start position from the DB
-		if startSCN == replication.InvalidSCN {
-			if startSCN, err = streaming.FindStartPos(softCtx); err != nil {
-				o.log.Errorf("Failed to get start SCN from database: %s", err)
-				o.stopSig.TriggerHasStopped()
-				return
-			}
-			o.log.Infof("No cached SCN found, fetched starting position from database: %d", startSCN)
-			if err = o.cacheSCN(softCtx, startSCN); err != nil {
-				o.log.Warnf("Failed to cache initial SCN (non-critical): %s", err)
-			}
 		}
 
 		// streaming

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -521,14 +521,14 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 	go func() {
 		var (
-			err    error
-			maxSCN = cachedSCN
+			err      error
+			startSCN = cachedSCN
 		)
 		softCtx, _ := o.stopSig.SoftStopCtx(context.Background())
 
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {
-			if maxSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
+			if startSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					o.log.Infof("Snapshotting stopped: %s", err)
 				} else {
@@ -538,24 +538,24 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 				return
 			}
 
-			if err = o.cacheSCN(softCtx, maxSCN); err != nil {
+			if err = o.cacheSCN(softCtx, startSCN); err != nil {
 				o.log.Errorf("Failed to capture SCN after snapshot completion. Snapshot will re-run on restart (may cause duplicate data): %s", err)
 				o.stopSig.TriggerHasStopped()
 				return
 			}
 
-			o.log.Infof("Successfully captured SCN following snapshot: %d", maxSCN)
+			o.log.Infof("Successfully captured SCN following snapshot: %d", startSCN)
 		}
 
 		// If no SCN is available (no snapshot and no cached position), so get the start position from the DB
-		if maxSCN == replication.InvalidSCN {
-			if maxSCN, err = streaming.FindStartPos(softCtx); err != nil {
+		if startSCN == replication.InvalidSCN {
+			if startSCN, err = streaming.FindStartPos(softCtx); err != nil {
 				o.log.Errorf("Failed to get start SCN from database: %s", err)
 				o.stopSig.TriggerHasStopped()
 				return
 			}
-			o.log.Infof("No cached SCN found, fetched starting position from database: %d", maxSCN)
-			if err = o.cacheSCN(softCtx, maxSCN); err != nil {
+			o.log.Infof("No cached SCN found, fetched starting position from database: %d", startSCN)
+			if err = o.cacheSCN(softCtx, startSCN); err != nil {
 				o.log.Warnf("Failed to cache initial SCN (non-critical): %s", err)
 			}
 		}
@@ -563,7 +563,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		// streaming
 		wg, _ := errgroup.WithContext(softCtx)
 		wg.Go(func() error {
-			if err := streaming.ReadChanges(softCtx, maxSCN); err != nil {
+			if err := streaming.ReadChanges(softCtx, startSCN); err != nil {
 				return fmt.Errorf("streaming from logminer: %w", err)
 			}
 			return nil

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -203,6 +203,8 @@ oracledb_cdc:
 				}
 			}()
 
+			time.Sleep(10 * time.Second)
+
 			t.Log("Verifying snapshot changes...")
 			var got int
 			assert.Eventually(t, func() bool {
@@ -308,6 +310,8 @@ oracledb_cdc:
 				t.Error(err)
 			}
 		}()
+
+		time.Sleep(10 * time.Second)
 
 		t.Log("Verifying snapshot changes...")
 		var got int
@@ -569,6 +573,8 @@ oracledb_cdc:
 			}()
 		}
 
+		time.Sleep(10 * time.Second)
+
 		// insert initial test data
 		want := 3000
 		for range 1000 {
@@ -680,6 +686,8 @@ file:
 				close(msgChan)
 			}()
 		}
+
+		time.Sleep(10 * time.Second)
 
 		// insert initial test data
 		want := 3000
@@ -1360,6 +1368,8 @@ oracledb_cdc:
 		}()
 		go func() { <-t.Context().Done(); close(msgChan) }()
 
+		time.Sleep(10 * time.Second)
+
 		db.MustExec("INSERT INTO testdb.schema_ins VALUES (1, 'hello')")
 		db.MustExec("INSERT INTO testdb.schema_ins VALUES (2, 'world')")
 
@@ -1417,6 +1427,8 @@ oracledb_cdc:
 			}
 		}()
 		go func() { <-t.Context().Done(); close(msgChan) }()
+
+		time.Sleep(10 * time.Second)
 
 		// INSERT a row (all columns), then UPDATE only column B
 		db.MustExec("INSERT INTO testdb.schema_upd VALUES (1, 'x', 'y', 'z')")
@@ -1479,6 +1491,8 @@ oracledb_cdc:
 			}
 		}()
 		go func() { <-t.Context().Done(); close(msgChan) }()
+
+		time.Sleep(10 * time.Second)
 
 		db.MustExec("INSERT INTO testdb.schema_del VALUES (1, 'doomed')")
 		db.MustExec("DELETE FROM testdb.schema_del WHERE id = 1")
@@ -1624,6 +1638,8 @@ oracledb_cdc:
 	}()
 	go func() { <-t.Context().Done(); close(msgChan) }()
 
+	time.Sleep(10 * time.Second)
+
 	// INSERT before ALTER — schema has [ID, NAME]
 	db.MustExec("INSERT INTO testdb.schema_drift VALUES (1, 'before')")
 
@@ -1694,6 +1710,8 @@ oracledb_cdc:
 		}
 	}()
 	go func() { <-t.Context().Done(); close(msgChan) }()
+
+	time.Sleep(10 * time.Second)
 
 	db.MustExec("INSERT INTO testdb.schema_t1 VALUES (1, 'hello')")
 	db.MustExec("INSERT INTO testdb.schema_t2 VALUES (SYSDATE, HEXTORAW('DEADBEEFCAFEBABE0000000000000000'), 1.5)")
@@ -1954,6 +1972,8 @@ oracledb_cdc:
 			}
 		}()
 
+		time.Sleep(10 * time.Second)
+
 		t.Log("Inserting initial LOB row and waiting CDC event")
 		{
 			initialClob := strings.Repeat("A", 5000)
@@ -2034,6 +2054,8 @@ oracledb_cdc:
 			}
 		}()
 
+		time.Sleep(10 * time.Second)
+
 		t.Log("Inserting initial LOB row and waiting CDC event")
 		{
 			initialClob := strings.Repeat("A", 5000)
@@ -2110,6 +2132,8 @@ oracledb_cdc:
 				t.Error(err)
 			}
 		}()
+
+		time.Sleep(10 * time.Second)
 
 		t.Log("Inserting initial LOB row and waiting CDC event")
 		{

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -173,46 +173,17 @@ func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) (
 	}
 }
 
-// FindStartPos finds the earliest possible SCN that exists within a log that's still available,
-// falling back to the database's current SCN if no valid redo logs are found.
+// FindStartPos returns the database's current SCN so that streaming begins from
+// the present moment rather than replaying historical redo logs.
 func (lm *LogMiner) FindStartPos(ctx context.Context) (replication.SCN, error) {
-	query := `
-		SELECT MIN(FIRST_CHANGE#) AS FIRST_SCN
-		FROM (
-			SELECT FIRST_CHANGE# FROM V$LOG
-			WHERE FIRST_CHANGE# > 0
-			UNION
-			SELECT FIRST_CHANGE# FROM V$ARCHIVED_LOG
-			WHERE NAME IS NOT NULL
-			AND ARCHIVED = 'YES'
-			AND STATUS = 'A'
-			AND DEST_ID IN (
-				SELECT DEST_ID
-				FROM V$ARCHIVE_DEST_STATUS
-				WHERE STATUS='VALID' AND TYPE='LOCAL' AND ROWNUM=1
-			)
-		)
-	`
-
-	var startPos sql.NullInt64
-	if err := lm.db.QueryRowContext(ctx, query).Scan(&startPos); err != nil {
-		return 0, fmt.Errorf("querying oldest available SCN in logs: %w", err)
+	var currentPos uint64
+	if err := lm.db.QueryRowContext(ctx, "SELECT CURRENT_SCN FROM V$DATABASE").Scan(&currentPos); err != nil {
+		return 0, fmt.Errorf("querying current SCN from database: %w", err)
 	}
-
-	// fall back to currentSCN if we can't go back earlier
-	if !startPos.Valid || startPos.Int64 == 0 {
-		var currentPos uint64
-		if err := lm.db.QueryRowContext(ctx, "SELECT CURRENT_SCN FROM V$DATABASE").Scan(&currentPos); err != nil {
-			return 0, fmt.Errorf("querying current SCN from database: %w", err)
-		}
-		if currentPos == 0 {
-			return 0, errors.New("database returned an invalid CURRENT_SCN value (0)")
-		}
-		lm.log.Warnf("No redo logs with valid SCN found, defaulting to current SCN: %d", currentPos)
-		return replication.SCN(currentPos), nil
+	if currentPos == 0 {
+		return 0, errors.New("database returned an invalid CURRENT_SCN value (0)")
 	}
-
-	return replication.SCN(startPos.Int64), nil
+	return replication.SCN(currentPos), nil
 }
 
 func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp bool, err error) {


### PR DESCRIPTION
This change defaults the OracleDB CDC connector to start from the databases current SCN at the time of startup. Due to the way LogMiner works loading data from the earliest position found can be unreliable.

Tests passing:

<img width="845" height="83" alt="image" src="https://github.com/user-attachments/assets/bb347b83-0360-4ca5-b171-aa10f8ad53b2" />
