### PR TITLE
postgresql_cdc: fix passing of `sslmode=require` via DSN

### DIFF
--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -10,6 +10,7 @@ package pgstream
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -300,10 +301,12 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 	if iamAuthTokenBuilder, err = AWSOptFn(context.Background(), awsConf, pgConnConfig, logger); err != nil {
 		return nil, err
 	}
-	if pgConnConfig.TLSConfig, err = conf.FieldTLS("tls"); err != nil {
+	var tlsConf *tls.Config
+	if tlsConf, err = conf.FieldTLS("tls"); err != nil {
 		return nil, err
 	}
-	if pgConnConfig.TLSConfig != nil {
+	if tlsConf != nil {
+		pgConnConfig.TLSConfig = tlsConf
 		pgConnConfig.TLSConfig.ServerName = pgConnConfig.Host
 	}
 	// This is required for postgres to understand we're interested in replication.


### PR DESCRIPTION
This change addresses an issue where the defaults in the `tls` block would overwrite the DSN configured parameters.

### Proof of Work

Given the following connection string:

<img width="1155" height="482" alt="image" src="https://github.com/user-attachments/assets/a54e9f2b-bfe3-41b8-97b2-dd421b6f6048" />

Before:

<img width="1500" height="676" alt="image" src="https://github.com/user-attachments/assets/7225801d-0014-48e6-ab08-b89cfe738230" />

After:

<img width="1504" height="898" alt="image" src="https://github.com/user-attachments/assets/9f92012c-2dab-4e0c-b6ee-4f1f82e674c3" />