### PR TITLE
oracledb_cdc: add `oracledb_cdc_publish_lag_ns` metric to track publish latency

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -126,7 +126,7 @@ This input adds the following metadata fields to each message:
 - scn: the System Change Number in Oracle.
 - transaction_id: The Oracle transaction ID in `USN.SLOT.SEQ` format, identifying the transaction that produced the change. Not present on snapshot (`read`) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
-- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Not present on snapshot (`read`) messages.
+- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from `V$LOGMNR_CONTENTS.TIMESTAMP` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. Not present on snapshot (`read`) messages.
 - schema: The table schema, for use with schema-aware downstream processors such as `schema_registry_encode`. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -81,7 +81,7 @@ This input adds the following metadata fields to each message:
 - scn: the System Change Number in Oracle.
 - transaction_id: The Oracle transaction ID in ` + "`USN.SLOT.SEQ`" + ` format, identifying the transaction that produced the change. Not present on snapshot (` + "`read`" + `) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
-- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Not present on snapshot (` + "`read`" + `) messages.
+- commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from ` + "`V$LOGMNR_CONTENTS.TIMESTAMP`" + ` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. Not present on snapshot (` + "`read`" + `) messages.
 - schema: The table schema, for use with schema-aware downstream processors such as ` + "`schema_registry_encode`" + `. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -25,11 +25,14 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
 )
 
-// https://docs.oracle.com/en/error-help/db/ora-01291/
-var errCodeMissingLogFile = 1291
-
-// https://docs.oracle.com/en/error-help/db/ora-01368/
-var errCodeRedoLogHeaderMismatch = 1368
+var (
+	// captures the time between DB commit and publish
+	publishLatencyMetric = "oracledb_cdc_publish_lag_ns"
+	// https://docs.oracle.com/en/error-help/db/ora-01291/
+	errCodeMissingLogFile = 1291
+	// https://docs.oracle.com/en/error-help/db/ora-01368/
+	errCodeRedoLogHeaderMismatch = 1368
+)
 
 // LogMiner tracks and streams all change events from the configured change
 // tables tracked in tables.
@@ -37,7 +40,6 @@ type LogMiner struct {
 	cfg           *Config
 	tables        []replication.UserTable
 	publisher     replication.ChangePublisher
-	log           *service.Logger
 	logCollector  *LogFileCollector
 	currentSCN    uint64
 	sessionMgr    *SessionManager
@@ -55,6 +57,9 @@ type LogMiner struct {
 	// lob types are split between redo log lines, we use lobStates to track them
 	// until we have all data to merge into published INSERT or UPDATE event.
 	lobStates map[sqlredo.TransactionID]*sqlredo.TxnLOBState
+
+	publishLagMetric *service.MetricTimer
+	log              *service.Logger
 }
 
 // NewMiner creates a new instance of LogMiner responsible for paging through change events based on the tables param.
@@ -109,12 +114,13 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 		log:       logger,
 
 		// logminer specific
-		logMinerQuery: logMinerQuery,
-		logCollector:  NewLogFileCollector(),
-		sessionMgr:    NewSessionManager(cfg, logger),
-		txnCache:      txnCache,
-		dmlParser:     sqlredo.NewParser(),
-		lobStates:     make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		logMinerQuery:    logMinerQuery,
+		logCollector:     NewLogFileCollector(),
+		sessionMgr:       NewSessionManager(cfg, logger),
+		txnCache:         txnCache,
+		dmlParser:        sqlredo.NewParser(),
+		lobStates:        make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		publishLagMetric: metrics.NewTimer(publishLatencyMetric),
 	}
 	if lm.txnCache == nil {
 		lm.txnCache = NewInMemoryCache(cfg.MaxTransactionEvents, metrics, logger)
@@ -510,6 +516,7 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 				if err := lm.publisher.Publish(ctx, msg); err != nil {
 					return fmt.Errorf("publishing event with SCN '%d': %w", redoEvent.SCN, err)
 				}
+				lm.publishLagMetric.Timing(time.Since(redoEvent.Timestamp).Nanoseconds())
 			}
 
 			if err := lm.txnCache.CommitTransaction(ctx, redoEvent.TransactionID); err != nil {


### PR DESCRIPTION
This change adds a `oracledb_cdc_publish_lag_ns` metric that allows users to monitor the latency between changes being made to the database and the subsequent change event being published.

### Proof of Work:

<img width="2665" height="1414" alt="image" src="https://github.com/user-attachments/assets/71a8d54b-d337-4b3d-8586-57a05f8da76c" />