### PR TITLE
doris_stream_load: update version the connector was released in

### DIFF
--- a/cmd/tools/integration/packages.json
+++ b/cmd/tools/integration/packages.json
@@ -16,7 +16,7 @@
   {"path":"./internal/impl/couchbase"},
   {"path":"./internal/impl/cyborgdb","skip":true},
   {"path":"./internal/impl/cypher","skip":true},
-  {"path":"./internal/impl/doris"},
+  {"path":"./internal/impl/doris", "skip":true},
   {"path":"./internal/impl/elasticsearch/v8"},
   {"path":"./internal/impl/elasticsearch/v9"},
   {"path":"./internal/impl/gcp"},

--- a/docs/modules/components/pages/outputs/doris_stream_load.adoc
+++ b/docs/modules/components/pages/outputs/doris_stream_load.adoc
@@ -25,7 +25,7 @@ component_type_dropdown::[]
 
 Writes batches of messages into Apache Doris using Stream Load.
 
-Introduced in version 4.86.0.
+Introduced in version 4.96.0.
 
 
 [tabs]

--- a/internal/impl/doris/output_stream_load.go
+++ b/internal/impl/doris/output_stream_load.go
@@ -177,7 +177,7 @@ func dorisStreamLoadSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
-		Version("4.86.0").
+		Version("4.96.0").
 		Summary("Writes batches of messages into Apache Doris using Stream Load.").
 		Description(dorisStreamLoadDescription()).
 		Field(service.NewStringField(dsFieldURL).


### PR DESCRIPTION
Closes: https://github.com/redpanda-data/connect/issues/4519

This change also skips the `doris_stream_load` integration tests as they fail in CI due to JVM/Doris memory requirements