### PR TITLE
schema_registry_decode: add `coerce_data` for JSON Schema type fidelity

### DIFF
--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -47,6 +47,8 @@ schema_registry_decode:
     emit_unpopulated: false
     emit_default_values: false
     serialize_to_json: true
+  json:
+    coerce_data: false
   cache_duration: 10m
   url: "" # No default (required)
   default_schema_id: 0 # No default (optional)
@@ -87,6 +89,8 @@ schema_registry_decode:
     emit_unpopulated: false
     emit_default_values: false
     serialize_to_json: true
+  json:
+    coerce_data: false
   cache_duration: 10m
   url: "" # No default (required)
   default_schema_id: 0 # No default (optional)
@@ -325,6 +329,24 @@ If messages should be serialized to JSON bytes. If false then the message is kep
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `json`
+
+Configuration for how to decode schemas that are of type JSON.
+
+
+*Type*: `object`
+
+
+=== `json.coerce_data`
+
+Whether decoded values should be coerced to match the types declared in the JSON Schema. By default JSON Schema decoding only validates the message and leaves it untouched, which means numbers are later interpreted as floating point (`double`) and date-time values as strings. When set to `true` the decoder rebuilds the message so that values match the schema: `integer` fields become 64-bit integers, `number` fields stay floating point, `string` fields with `format: date-time` become timestamps, and any `default` values declared in the schema are applied to absent fields. This is useful for downstream components that infer their schema from the decoded values, such as the `iceberg` outputs, which will then create `bigint` columns for integer fields rather than `double`. Note that, unlike the default behaviour, this is no longer a read-only operation: the message contents are transformed. Because coercion is stricter than validation, a message that passes validation may still fail coercion (for example an integer that overflows a 64-bit value, or a `date-time` string that is not valid RFC 3339), in which case the error can be caught using xref:configuration:error_handling.adoc[error handling methods].
+
+
+*Type*: `bool`
+
+*Default*: `false`
+Requires version 4.97.0 or newer
 
 === `cache_duration`
 

--- a/internal/impl/confluent/json_schema_coerce.go
+++ b/internal/impl/confluent/json_schema_coerce.go
@@ -1,0 +1,644 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	franz_sr "github.com/twmb/franz-go/pkg/sr"
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/confluent/sr"
+)
+
+// jsonSchemaCoercer rebuilds decoded JSON data using native Go types that match
+// the declared JSON Schema. A plain JSON decode turns every number into
+// float64 and leaves date-time values as strings, which causes downstream
+// components that infer their schema from Go values (such as the iceberg sink)
+// to map JSON-schema integers to double rather than bigint. Coercing the data
+// against the schema produces int64 for `integer` fields, time.Time for
+// `date-time` strings, and so on, restoring fidelity with the declared schema.
+type jsonSchemaCoercer struct {
+	// rawSchema is the parsed root JSON Schema document.
+	rawSchema map[string]any
+	// refs maps schema-registry reference names to their parsed documents, for
+	// resolving external `$ref`s.
+	refs map[string]map[string]any
+	// compiledBranches memoises gojsonschema schemas used for oneOf/anyOf branch
+	// validation, keyed by the branch's marshalled JSON. Branch schemas are
+	// immutable for the life of the coercer, so compiling them once (rather than
+	// per message) avoids repeating the expensive schema compilation on a hot
+	// path. The map is safe for the concurrent Process calls that share a
+	// coercer.
+	compiledBranches sync.Map
+}
+
+// maxCoerceDepth bounds the number of `$ref` resolutions along a single
+// coercion path. Non-`$ref` nesting is bounded by the (finite) schema, so only
+// reference chains can recurse without limit; a cyclic or self-referential
+// `$ref` is caught here rather than overflowing the stack.
+const maxCoerceDepth = 1000
+
+// buildJSONSchemaCoercer parses the given schema (and any of its registry
+// references) into walkable documents for coercion.
+func buildJSONSchemaCoercer(ctx context.Context, cl *sr.Client, schema franz_sr.Schema) (*jsonSchemaCoercer, error) {
+	refs := map[string]string{}
+	if len(schema.References) > 0 {
+		if err := cl.WalkReferences(ctx, schema.References, func(_ context.Context, name string, s franz_sr.Schema) error {
+			refs[name] = s.Schema
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return newJSONSchemaCoercer(schema.Schema, refs)
+}
+
+// newJSONSchemaCoercer parses a root JSON Schema document and any named
+// references (as raw schema strings) into walkable documents. It is the
+// client-independent core of buildJSONSchemaCoercer.
+func newJSONSchemaCoercer(root string, refs map[string]string) (*jsonSchemaCoercer, error) {
+	var rootDoc map[string]any
+	if err := json.Unmarshal([]byte(root), &rootDoc); err != nil {
+		return nil, fmt.Errorf("parsing JSON schema for coercion: %w", err)
+	}
+
+	parsed := make(map[string]map[string]any, len(refs))
+	for name, s := range refs {
+		var doc map[string]any
+		if err := json.Unmarshal([]byte(s), &doc); err != nil {
+			return nil, fmt.Errorf("parsing referenced JSON schema %q: %w", name, err)
+		}
+		parsed[name] = doc
+	}
+
+	return &jsonSchemaCoercer{rawSchema: rootDoc, refs: parsed}, nil
+}
+
+// coerceMessage decodes raw JSON bytes preserving numeric precision (via
+// UseNumber, so large integers are not truncated through float64) and returns
+// the value coerced against the schema, ready for SetStructuredMut.
+func (c *jsonSchemaCoercer) coerceMessage(b []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return nil, fmt.Errorf("decoding message for coercion: %w", err)
+	}
+	return c.coerce(data, c.rawSchema, c.rawSchema, 0)
+}
+
+// coerce walks data against the schema node, returning the value rebuilt with
+// native Go types. doc is the document that node belongs to, used to resolve
+// local (`#/...`) references. depth counts `$ref` resolutions on the current
+// path to bound cyclic references.
+func (c *jsonSchemaCoercer) coerce(data any, node, doc map[string]any, depth int) (any, error) {
+	if node == nil {
+		return c.passthrough(data), nil
+	}
+
+	// Resolve `$ref` before anything else.
+	if ref, ok := node["$ref"].(string); ok {
+		if depth >= maxCoerceDepth {
+			return nil, fmt.Errorf("maximum $ref resolution depth (%d) exceeded resolving %q; the schema may contain a cyclic reference", maxCoerceDepth, ref)
+		}
+		target, targetDoc, err := c.resolveRef(ref, doc)
+		if err != nil {
+			return nil, err
+		}
+		return c.coerce(data, target, targetDoc, depth+1)
+	}
+
+	// Schema combiners.
+	if raw, ok := node["allOf"]; ok {
+		return c.coerceAllOf(data, raw, doc, depth)
+	}
+	if raw, ok := node["oneOf"]; ok {
+		return c.coerceBranch(data, raw, doc, "oneOf", depth)
+	}
+	if raw, ok := node["anyOf"]; ok {
+		return c.coerceBranch(data, raw, doc, "anyOf", depth)
+	}
+
+	types, _ := nodeType(node)
+
+	// A null/absent value is preserved regardless of the declared type so that
+	// nullable fields (`"type": ["integer", "null"]`) round-trip.
+	if data == nil {
+		return nil, nil
+	}
+
+	var typ string
+	switch len(types) {
+	case 0:
+		typ = ""
+	case 1:
+		typ = types[0]
+	default:
+		// Ambiguous union (e.g. ["integer","string"]): pick the type matching
+		// the value's kind, else fall through to passthrough.
+		typ = matchTypeToValue(types, data)
+	}
+
+	switch typ {
+	case "integer":
+		return toInt64(data)
+	case "number":
+		return toFloat64(data)
+	case "boolean":
+		return toBool(data)
+	case "string":
+		return coerceString(data, node)
+	case "null":
+		return nil, nil
+	case "object":
+		return c.coerceObject(data, node, doc, depth)
+	case "array":
+		return c.coerceArray(data, node, doc, depth)
+	case "":
+		// No explicit type: infer structural intent from keywords, otherwise
+		// pass the value through with numbers normalised to float64.
+		if _, ok := node["properties"]; ok {
+			return c.coerceObject(data, node, doc, depth)
+		}
+		if _, ok := node["items"]; ok {
+			return c.coerceArray(data, node, doc, depth)
+		}
+		return c.passthrough(data), nil
+	default:
+		return c.passthrough(data), nil
+	}
+}
+
+func (c *jsonSchemaCoercer) coerceObject(data any, node, doc map[string]any, depth int) (any, error) {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("cannot coerce %T to object", data)
+	}
+
+	props, _ := node["properties"].(map[string]any)
+	addl, _ := node["additionalProperties"].(map[string]any)
+
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		switch ps, ok := props[k].(map[string]any); {
+		case ok:
+			cv, err := c.coerce(v, ps, doc, depth)
+			if err != nil {
+				return nil, fmt.Errorf("property %q: %w", k, err)
+			}
+			out[k] = cv
+		case addl != nil:
+			cv, err := c.coerce(v, addl, doc, depth)
+			if err != nil {
+				return nil, fmt.Errorf("additional property %q: %w", k, err)
+			}
+			out[k] = cv
+		default:
+			out[k] = c.passthrough(v)
+		}
+	}
+
+	// Apply defaults for properties absent from the data.
+	for k, ps := range props {
+		if _, present := m[k]; present {
+			continue
+		}
+		psm, ok := ps.(map[string]any)
+		if !ok {
+			continue
+		}
+		def, ok := psm["default"]
+		if !ok {
+			continue
+		}
+		cv, err := c.coerce(def, psm, doc, depth)
+		if err != nil {
+			return nil, fmt.Errorf("default for property %q: %w", k, err)
+		}
+		out[k] = cv
+	}
+
+	return out, nil
+}
+
+func (c *jsonSchemaCoercer) coerceArray(data any, node, doc map[string]any, depth int) (any, error) {
+	arr, ok := data.([]any)
+	if !ok {
+		return nil, fmt.Errorf("cannot coerce %T to array", data)
+	}
+
+	out := make([]any, len(arr))
+	switch items := node["items"].(type) {
+	case map[string]any:
+		for i, e := range arr {
+			cv, err := c.coerce(e, items, doc, depth)
+			if err != nil {
+				return nil, fmt.Errorf("array index %d: %w", i, err)
+			}
+			out[i] = cv
+		}
+	case []any:
+		// Tuple validation: coerce positionally, pass through any extras.
+		for i, e := range arr {
+			if i < len(items) {
+				if is, ok := items[i].(map[string]any); ok {
+					cv, err := c.coerce(e, is, doc, depth)
+					if err != nil {
+						return nil, fmt.Errorf("array index %d: %w", i, err)
+					}
+					out[i] = cv
+					continue
+				}
+			}
+			out[i] = c.passthrough(e)
+		}
+	default:
+		for i, e := range arr {
+			out[i] = c.passthrough(e)
+		}
+	}
+
+	return out, nil
+}
+
+func (c *jsonSchemaCoercer) coerceAllOf(data, raw any, doc map[string]any, depth int) (any, error) {
+	subs, ok := raw.([]any)
+	if !ok {
+		return c.passthrough(data), nil
+	}
+	out := data
+	for i, s := range subs {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		var err error
+		if out, err = c.coerce(out, sm, doc, depth); err != nil {
+			return nil, fmt.Errorf("allOf[%d]: %w", i, err)
+		}
+	}
+	return out, nil
+}
+
+// coerceBranch handles oneOf/anyOf by selecting the first branch the data
+// validates against and coercing against it.
+func (c *jsonSchemaCoercer) coerceBranch(data, raw any, doc map[string]any, kw string, depth int) (any, error) {
+	subs, ok := raw.([]any)
+	if !ok {
+		return c.passthrough(data), nil
+	}
+
+	normalised := normaliseForValidation(data)
+	for i, s := range subs {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Resolve a branch that is itself a bare `$ref` for validation only; the
+		// coercion below re-resolves it via coerce so the depth guard applies.
+		resolved := sm
+		if ref, ok := sm["$ref"].(string); ok {
+			target, _, err := c.resolveRef(ref, doc)
+			if err != nil {
+				return nil, err
+			}
+			resolved = target
+		}
+
+		match, err := c.validatesAgainst(resolved, normalised)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			cv, err := c.coerce(data, sm, doc, depth)
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d]: %w", kw, i, err)
+			}
+			return cv, nil
+		}
+	}
+
+	return nil, fmt.Errorf("value does not match any %s branch", kw)
+}
+
+// resolveRef resolves a JSON Schema `$ref`, returning the target node and the
+// document it lives within (so that further local references resolve correctly).
+func (c *jsonSchemaCoercer) resolveRef(ref string, doc map[string]any) (node, refDoc map[string]any, err error) {
+	if ref == "" {
+		return nil, nil, errors.New("empty $ref")
+	}
+
+	// Local reference within the current document.
+	if strings.HasPrefix(ref, "#") {
+		n, err := resolvePointer(doc, ref)
+		return n, doc, err
+	}
+
+	// External reference, optionally with a fragment ("Name#/path").
+	name, fragment := ref, ""
+	if i := strings.IndexByte(ref, '#'); i >= 0 {
+		name, fragment = ref[:i], ref[i:]
+	}
+	extDoc, ok := c.refs[name]
+	if !ok {
+		return nil, nil, fmt.Errorf("unresolved $ref %q", ref)
+	}
+	if fragment == "" || fragment == "#" {
+		return extDoc, extDoc, nil
+	}
+	n, err := resolvePointer(extDoc, fragment)
+	return n, extDoc, err
+}
+
+// resolvePointer walks a JSON Pointer fragment (e.g. "#/definitions/Foo")
+// within doc and returns the schema object it points to.
+func resolvePointer(doc map[string]any, ref string) (map[string]any, error) {
+	ptr := strings.TrimPrefix(strings.TrimPrefix(ref, "#"), "/")
+	if ptr == "" {
+		return doc, nil
+	}
+
+	var cur any = doc
+	for token := range strings.SplitSeq(ptr, "/") {
+		token = strings.ReplaceAll(token, "~1", "/")
+		token = strings.ReplaceAll(token, "~0", "~")
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("cannot resolve $ref %q: %q is not an object", ref, token)
+		}
+		if cur, ok = m[token]; !ok {
+			return nil, fmt.Errorf("cannot resolve $ref %q: token %q not found", ref, token)
+		}
+	}
+
+	node, ok := cur.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("$ref %q does not point to a schema object", ref)
+	}
+	return node, nil
+}
+
+// passthrough returns the value with numbers normalised to float64 (matching a
+// plain JSON decode) and nested containers recursed into, for data the schema
+// does not type.
+func (c *jsonSchemaCoercer) passthrough(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, e := range t {
+			out[k] = c.passthrough(e)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = c.passthrough(e)
+		}
+		return out
+	case json.Number:
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+		return t.String()
+	default:
+		return v
+	}
+}
+
+func coerceString(data any, node map[string]any) (any, error) {
+	s, ok := data.(string)
+	if !ok {
+		return nil, fmt.Errorf("cannot coerce %T to string", data)
+	}
+	// A date-time string maps to a timestamp downstream; other formats (date,
+	// time, uuid, ...) stay strings because the iceberg inferrer would
+	// misidentify a date-only time.Time as a timestamp with timezone.
+	if format, _ := node["format"].(string); format == "date-time" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return nil, fmt.Errorf("parsing date-time %q: %w", s, err)
+		}
+		return t, nil
+	}
+	return s, nil
+}
+
+func toInt64(v any) (any, error) {
+	switch n := v.(type) {
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i, nil
+		}
+		f, err := n.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("value %q is not a valid integer", n.String())
+		}
+		return floatToInt64(f)
+	case float64:
+		return floatToInt64(n)
+	case int:
+		return int64(n), nil
+	case int64:
+		return n, nil
+	default:
+		return nil, fmt.Errorf("cannot coerce %T to integer", v)
+	}
+}
+
+func floatToInt64(f float64) (any, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil, fmt.Errorf("value %v is not an integer", f)
+	}
+	if f != math.Trunc(f) {
+		return nil, fmt.Errorf("value %v is not an integer", f)
+	}
+	// math.MaxInt64 is not exactly representable as a float64 (it rounds up to
+	// 2^63), so comparing against it would let 2^63 itself slip through and then
+	// wrap on conversion. 2^63 is exact, so use it as the first overflowing
+	// value; -2^63 (== math.MinInt64) is exact and valid.
+	if f >= (1<<63) || f < -(1<<63) {
+		return nil, fmt.Errorf("value %v overflows int64", f)
+	}
+	return int64(f), nil
+}
+
+func toFloat64(v any) (any, error) {
+	switch n := v.(type) {
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("value %q is not a valid number", n.String())
+		}
+		return f, nil
+	case float64:
+		return n, nil
+	case float32:
+		return float64(n), nil
+	case int:
+		return float64(n), nil
+	case int64:
+		return float64(n), nil
+	default:
+		return nil, fmt.Errorf("cannot coerce %T to number", v)
+	}
+}
+
+func toBool(v any) (any, error) {
+	b, ok := v.(bool)
+	if !ok {
+		return nil, fmt.Errorf("cannot coerce %T to boolean", v)
+	}
+	return b, nil
+}
+
+// nodeType returns the declared non-null JSON Schema types for a node (handling
+// `type` given as a string or an array) and whether "null" was permitted.
+func nodeType(node map[string]any) (types []string, nullable bool) {
+	switch t := node["type"].(type) {
+	case string:
+		return []string{t}, false
+	case []any:
+		for _, e := range t {
+			s, _ := e.(string)
+			if s == "null" {
+				nullable = true
+				continue
+			}
+			if s != "" {
+				types = append(types, s)
+			}
+		}
+		return types, nullable
+	}
+	return nil, false
+}
+
+// matchTypeToValue chooses, from an ambiguous multi-type union (e.g.
+// `["integer","string"]`), the declared type that matches the runtime kind of
+// data. It returns "" when no candidate matches, so the value is passed through
+// uncoerced rather than forced into an incorrect (and possibly failing)
+// coercion.
+func matchTypeToValue(types []string, data any) string {
+	switch data.(type) {
+	case string:
+		if slices.Contains(types, "string") {
+			return "string"
+		}
+	case bool:
+		if slices.Contains(types, "boolean") {
+			return "boolean"
+		}
+	case map[string]any:
+		if slices.Contains(types, "object") {
+			return "object"
+		}
+	case []any:
+		if slices.Contains(types, "array") {
+			return "array"
+		}
+	case json.Number, float64:
+		// Prefer integer for integral values when both are allowed.
+		if slices.Contains(types, "integer") && isIntegralNumber(data) {
+			return "integer"
+		}
+		if slices.Contains(types, "number") {
+			return "number"
+		}
+		if slices.Contains(types, "integer") {
+			return "integer"
+		}
+	}
+	return ""
+}
+
+func isIntegralNumber(data any) bool {
+	switch n := data.(type) {
+	case json.Number:
+		if _, err := n.Int64(); err == nil {
+			return true
+		}
+		f, err := n.Float64()
+		return err == nil && f == math.Trunc(f)
+	case float64:
+		return n == math.Trunc(n)
+	}
+	return false
+}
+
+// normaliseForValidation deep-converts json.Number values to float64 so that
+// gojsonschema (which expects standard JSON primitives) can validate data that
+// was decoded with UseNumber.
+func normaliseForValidation(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, e := range t {
+			out[k] = normaliseForValidation(e)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = normaliseForValidation(e)
+		}
+		return out
+	case json.Number:
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+		return t.String()
+	default:
+		return v
+	}
+}
+
+// validatesAgainst reports whether data conforms to the given schema node,
+// compiling (and caching) the node's schema so repeated branch checks across
+// messages do not recompile it.
+func (c *jsonSchemaCoercer) validatesAgainst(node map[string]any, data any) (bool, error) {
+	b, err := json.Marshal(node)
+	if err != nil {
+		return false, err
+	}
+
+	key := string(b)
+	var schema *gojsonschema.Schema
+	if cached, ok := c.compiledBranches.Load(key); ok {
+		schema = cached.(*gojsonschema.Schema)
+	} else {
+		if schema, err = gojsonschema.NewSchema(gojsonschema.NewBytesLoader(b)); err != nil {
+			return false, err
+		}
+		c.compiledBranches.Store(key, schema)
+	}
+
+	res, err := schema.Validate(gojsonschema.NewGoLoader(data))
+	if err != nil {
+		return false, err
+	}
+	return res.Valid(), nil
+}

--- a/internal/impl/confluent/json_schema_coerce_bench_test.go
+++ b/internal/impl/confluent/json_schema_coerce_bench_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import "testing"
+
+// benchCoerce builds the coercer once (as the transcoder does per schema) and
+// measures only the per-message coercion cost.
+func benchCoerce(b *testing.B, schema string, refs map[string]string, msg string) {
+	b.Helper()
+	c, err := newJSONSchemaCoercer(schema, refs)
+	if err != nil {
+		b.Fatal(err)
+	}
+	data := []byte(msg)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.coerceMessage(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCoerceFlatObject is the common case: a flat object of scalars (the
+// Old Mutual Payment shape).
+func BenchmarkCoerceFlatObject(b *testing.B) {
+	schema := `{"type":"object","properties":{"payment_id":{"type":"string"},"amount_cents":{"type":"integer"},"currency":{"type":"string"},"initiated_at":{"type":"integer"}}}`
+	msg := `{"payment_id":"p-1","amount_cents":123456789012345,"currency":"ZAR","initiated_at":1777990438791}`
+	benchCoerce(b, schema, nil, msg)
+}
+
+// BenchmarkCoerceOneOf exercises the union path, where each branch schema is
+// compiled per message by validatesAgainst.
+func BenchmarkCoerceOneOf(b *testing.B) {
+	schema := `{"type":"object","properties":{"v":{"oneOf":[{"type":"integer"},{"type":"string"}]}}}`
+	msg := `{"v":5}`
+	benchCoerce(b, schema, nil, msg)
+}

--- a/internal/impl/confluent/json_schema_coerce_test.go
+++ b/internal/impl/confluent/json_schema_coerce_test.go
@@ -1,0 +1,648 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confluent
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCoercer(t *testing.T, schemaStr string, refs map[string]string) *jsonSchemaCoercer {
+	t.Helper()
+	c, err := newJSONSchemaCoercer(schemaStr, refs)
+	require.NoError(t, err)
+	return c
+}
+
+func mustCoerce(t *testing.T, schemaStr, dataStr string) any {
+	t.Helper()
+	out, err := newTestCoercer(t, schemaStr, nil).coerceMessage([]byte(dataStr))
+	require.NoError(t, err)
+	return out
+}
+
+func coerceErr(t *testing.T, schemaStr, dataStr string) error {
+	t.Helper()
+	_, err := newTestCoercer(t, schemaStr, nil).coerceMessage([]byte(dataStr))
+	require.Error(t, err)
+	return err
+}
+
+//------------------------------------------------------------------------------
+// Scalars and nullability
+
+func TestCoerceScalars(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		data   string
+		want   any
+	}{
+		{
+			name:   "integer to int64",
+			schema: `{"type":"object","properties":{"n":{"type":"integer"}}}`,
+			data:   `{"n":42}`,
+			want:   map[string]any{"n": int64(42)},
+		},
+		{
+			name:   "large integer keeps precision",
+			schema: `{"type":"object","properties":{"n":{"type":"integer"}}}`,
+			// 9007199254740993 == 2^53 + 1, not representable as a float64.
+			data: `{"n":9007199254740993}`,
+			want: map[string]any{"n": int64(9007199254740993)},
+		},
+		{
+			name:   "negative integer",
+			schema: `{"type":"object","properties":{"n":{"type":"integer"}}}`,
+			data:   `{"n":-17}`,
+			want:   map[string]any{"n": int64(-17)},
+		},
+		{
+			name:   "max int64 round-trips",
+			schema: `{"type":"object","properties":{"n":{"type":"integer"}}}`,
+			data:   `{"n":9223372036854775807}`,
+			want:   map[string]any{"n": int64(9223372036854775807)},
+		},
+		{
+			name:   "number stays float64",
+			schema: `{"type":"object","properties":{"n":{"type":"number"}}}`,
+			data:   `{"n":3.5}`,
+			want:   map[string]any{"n": float64(3.5)},
+		},
+		{
+			name:   "integer-valued number stays float64",
+			schema: `{"type":"object","properties":{"n":{"type":"number"}}}`,
+			data:   `{"n":3}`,
+			want:   map[string]any{"n": float64(3)},
+		},
+		{
+			name:   "boolean",
+			schema: `{"type":"object","properties":{"b":{"type":"boolean"}}}`,
+			data:   `{"b":true}`,
+			want:   map[string]any{"b": true},
+		},
+		{
+			name:   "plain string",
+			schema: `{"type":"object","properties":{"s":{"type":"string"}}}`,
+			data:   `{"s":"hello"}`,
+			want:   map[string]any{"s": "hello"},
+		},
+		{
+			name:   "date string stays string",
+			schema: `{"type":"object","properties":{"d":{"type":"string","format":"date"}}}`,
+			data:   `{"d":"2021-01-02"}`,
+			want:   map[string]any{"d": "2021-01-02"},
+		},
+		{
+			name:   "uuid string stays string",
+			schema: `{"type":"object","properties":{"u":{"type":"string","format":"uuid"}}}`,
+			data:   `{"u":"00000000-0000-0000-0000-000000000000"}`,
+			want:   map[string]any{"u": "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			name:   "explicit null type",
+			schema: `{"type":"object","properties":{"n":{"type":"null"}}}`,
+			data:   `{"n":null}`,
+			want:   map[string]any{"n": nil},
+		},
+		{
+			name:   "nullable integer with null value",
+			schema: `{"type":"object","properties":{"n":{"type":["integer","null"]}}}`,
+			data:   `{"n":null}`,
+			want:   map[string]any{"n": nil},
+		},
+		{
+			name:   "nullable integer with value",
+			schema: `{"type":"object","properties":{"n":{"type":["integer","null"]}}}`,
+			data:   `{"n":8}`,
+			want:   map[string]any{"n": int64(8)},
+		},
+		{
+			name:   "null-first type union picks string",
+			schema: `{"type":"object","properties":{"s":{"type":["null","string"]}}}`,
+			data:   `{"s":"x"}`,
+			want:   map[string]any{"s": "x"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mustCoerce(t, tc.schema, tc.data))
+		})
+	}
+}
+
+func TestCoerceDateTime(t *testing.T) {
+	out := mustCoerce(t,
+		`{"type":"object","properties":{"ts":{"type":"string","format":"date-time"}}}`,
+		`{"ts":"2021-01-02T15:04:05Z"}`)
+
+	m, ok := out.(map[string]any)
+	require.True(t, ok)
+	ts, ok := m["ts"].(time.Time)
+	require.True(t, ok, "expected time.Time, got %T", m["ts"])
+	assert.Equal(t, time.Date(2021, 1, 2, 15, 4, 5, 0, time.UTC), ts.UTC())
+}
+
+//------------------------------------------------------------------------------
+// Structures: objects, arrays, additional/unknown properties
+
+func TestCoerceNestedObject(t *testing.T) {
+	out := mustCoerce(t,
+		`{"type":"object","properties":{"inner":{"type":"object","properties":{"count":{"type":"integer"}}}}}`,
+		`{"inner":{"count":11}}`)
+	assert.Equal(t, map[string]any{"inner": map[string]any{"count": int64(11)}}, out)
+}
+
+func TestCoerceArrays(t *testing.T) {
+	t.Run("array of integers", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"vals":{"type":"array","items":{"type":"integer"}}}}`,
+			`{"vals":[1,2,3]}`)
+		assert.Equal(t, map[string]any{"vals": []any{int64(1), int64(2), int64(3)}}, out)
+	})
+
+	t.Run("array of objects with date-time", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"array","items":{"type":"object","properties":{"id":{"type":"integer"},"at":{"type":"string","format":"date-time"}}}}`,
+			`[{"id":1,"at":"2021-01-02T15:04:05Z"}]`)
+		arr, ok := out.([]any)
+		require.True(t, ok)
+		require.Len(t, arr, 1)
+		m := arr[0].(map[string]any)
+		assert.Equal(t, int64(1), m["id"])
+		assert.IsType(t, time.Time{}, m["at"])
+	})
+
+	t.Run("tuple items with extra passthrough", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"array","items":[{"type":"integer"},{"type":"string"}]}`,
+			`[1,"two",3.5]`)
+		// First two coerced positionally; the extra element falls through with
+		// the number normalised to float64.
+		assert.Equal(t, []any{int64(1), "two", float64(3.5)}, out)
+	})
+
+	t.Run("array without items schema passes through", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"array"}`,
+			`[1,2.5,"x"]`)
+		assert.Equal(t, []any{float64(1), float64(2.5), "x"}, out)
+	})
+}
+
+func TestCoerceAdditionalProperties(t *testing.T) {
+	t.Run("schema coerces extra props", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"known":{"type":"string"}},"additionalProperties":{"type":"integer"}}`,
+			`{"known":"a","extra":5}`)
+		assert.Equal(t, map[string]any{"known": "a", "extra": int64(5)}, out)
+	})
+
+	t.Run("false leaves unknown props as decoded float", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"known":{"type":"integer"}},"additionalProperties":false}`,
+			`{"known":1,"extra":2}`)
+		assert.Equal(t, map[string]any{"known": int64(1), "extra": float64(2)}, out)
+	})
+
+	t.Run("absent leaves unknown props as decoded float", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"known":{"type":"integer"}}}`,
+			`{"known":1,"extra":2}`)
+		assert.Equal(t, map[string]any{"known": int64(1), "extra": float64(2)}, out)
+	})
+}
+
+func TestCoerceUntypedPassthrough(t *testing.T) {
+	t.Run("empty schema scalar", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"any":{}}}`,
+			`{"any":7}`)
+		assert.Equal(t, map[string]any{"any": float64(7)}, out)
+	})
+
+	t.Run("empty schema nested container", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"any":{}}}`,
+			`{"any":{"a":[1,2],"b":3}}`)
+		assert.Equal(t, map[string]any{"any": map[string]any{
+			"a": []any{float64(1), float64(2)},
+			"b": float64(3),
+		}}, out)
+	})
+}
+
+func TestCoerceDefaults(t *testing.T) {
+	t.Run("scalar default applied and coerced", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer","default":7}}}`,
+			`{"a":1}`)
+		assert.Equal(t, map[string]any{"a": int64(1), "b": int64(7)}, out)
+	})
+
+	t.Run("date-time default coerced to time", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"ts":{"type":"string","format":"date-time","default":"2020-06-01T00:00:00Z"}}}`,
+			`{}`)
+		m := out.(map[string]any)
+		assert.IsType(t, time.Time{}, m["ts"])
+	})
+
+	t.Run("present value not overridden by default", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"b":{"type":"integer","default":7}}}`,
+			`{"b":3}`)
+		assert.Equal(t, map[string]any{"b": int64(3)}, out)
+	})
+}
+
+//------------------------------------------------------------------------------
+// Combinators: allOf / oneOf / anyOf
+
+func TestCoerceAllOf(t *testing.T) {
+	t.Run("merges object properties across subschemas", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"allOf":[{"type":"object","properties":{"a":{"type":"integer"}}},{"type":"object","properties":{"b":{"type":"integer"}}}]}`,
+			`{"a":1,"b":2}`)
+		assert.Equal(t, map[string]any{"a": int64(1), "b": int64(2)}, out)
+	})
+
+	t.Run("refines a scalar", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"type":"object","properties":{"n":{"allOf":[{"type":"integer"},{"minimum":0}]}}}`,
+			`{"n":5}`)
+		assert.Equal(t, map[string]any{"n": int64(5)}, out)
+	})
+}
+
+func TestCoerceOneOf(t *testing.T) {
+	schema := `{"type":"object","properties":{"v":{"oneOf":[{"type":"integer"},{"type":"string"}]}}}`
+
+	t.Run("integer branch", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": int64(5)}, mustCoerce(t, schema, `{"v":5}`))
+	})
+	t.Run("string branch", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": "hello"}, mustCoerce(t, schema, `{"v":"hello"}`))
+	})
+}
+
+func TestCoerceAnyOf(t *testing.T) {
+	t.Run("scalar branches", func(t *testing.T) {
+		schema := `{"type":"object","properties":{"v":{"anyOf":[{"type":"integer"},{"type":"string"}]}}}`
+		assert.Equal(t, map[string]any{"v": int64(9)}, mustCoerce(t, schema, `{"v":9}`))
+	})
+
+	t.Run("object branch exercises validation of nested data", func(t *testing.T) {
+		schema := `{"anyOf":[{"type":"object","properties":{"x":{"type":"integer"}}},{"type":"string"}]}`
+		out := mustCoerce(t, schema, `{"x":5}`)
+		assert.Equal(t, map[string]any{"x": int64(5)}, out)
+	})
+}
+
+func TestCoerceBranchNoMatch(t *testing.T) {
+	// A boolean matches neither the integer nor the string branch.
+	err := coerceErr(t,
+		`{"type":"object","properties":{"v":{"oneOf":[{"type":"integer"},{"type":"string"}]}}}`,
+		`{"v":true}`)
+	assert.Contains(t, err.Error(), "does not match any oneOf branch")
+}
+
+//------------------------------------------------------------------------------
+// References
+
+func TestCoerceRef(t *testing.T) {
+	c := newTestCoercer(t,
+		`{"type":"object","properties":{"amount":{"$ref":"Money"}}}`,
+		map[string]string{"Money": `{"type":"integer"}`})
+	out, err := c.coerceMessage([]byte(`{"amount":100}`))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"amount": int64(100)}, out)
+}
+
+func TestCoerceLocalRef(t *testing.T) {
+	out := mustCoerce(t,
+		`{"type":"object","definitions":{"Id":{"type":"integer"}},"properties":{"id":{"$ref":"#/definitions/Id"}}}`,
+		`{"id":99}`)
+	assert.Equal(t, map[string]any{"id": int64(99)}, out)
+}
+
+func TestCoerceExternalRefWithFragment(t *testing.T) {
+	c := newTestCoercer(t,
+		`{"type":"object","properties":{"id":{"$ref":"common#/definitions/Id"}}}`,
+		map[string]string{"common": `{"definitions":{"Id":{"type":"integer"}}}`})
+	out, err := c.coerceMessage([]byte(`{"id":7}`))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"id": int64(7)}, out)
+}
+
+func TestCoercePointerEscapes(t *testing.T) {
+	// A definition key containing a slash must be referenced via the ~1 escape.
+	out := mustCoerce(t,
+		`{"type":"object","definitions":{"a/b":{"type":"integer"}},"properties":{"id":{"$ref":"#/definitions/a~1b"}}}`,
+		`{"id":4}`)
+	assert.Equal(t, map[string]any{"id": int64(4)}, out)
+}
+
+func TestCoerceRecursiveRefTerminates(t *testing.T) {
+	// A self-referential schema with finite data must terminate and coerce at
+	// every level without tripping the depth guard.
+	c := newTestCoercer(t,
+		`{"$ref":"Node"}`,
+		map[string]string{"Node": `{"type":"object","properties":{"val":{"type":"integer"},"next":{"$ref":"Node"}}}`})
+	out, err := c.coerceMessage([]byte(`{"val":1,"next":{"val":2,"next":{"val":3}}}`))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"val": int64(1),
+		"next": map[string]any{
+			"val":  int64(2),
+			"next": map[string]any{"val": int64(3)},
+		},
+	}, out)
+}
+
+func TestCoerceCyclicRefErrors(t *testing.T) {
+	// A reference that resolves to itself with no data progress must fail with a
+	// clear error rather than overflowing the stack.
+	c := newTestCoercer(t,
+		`{"$ref":"Node"}`,
+		map[string]string{"Node": `{"$ref":"Node"}`})
+	_, err := c.coerceMessage([]byte(`{"anything":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cyclic reference")
+}
+
+//------------------------------------------------------------------------------
+// Error and edge paths
+
+func TestCoerceErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		data   string
+	}{
+		{"non-integral for integer", `{"type":"object","properties":{"n":{"type":"integer"}}}`, `{"n":1.5}`},
+		{"overflow for integer", `{"type":"object","properties":{"n":{"type":"integer"}}}`, `{"n":1e30}`},
+		// 9223372036854775808 == 2^63 == math.MaxInt64 + 1: must error, not wrap.
+		{"overflow at 2^63 boundary", `{"type":"object","properties":{"n":{"type":"integer"}}}`, `{"n":9223372036854775808}`},
+		{"string for integer", `{"type":"object","properties":{"n":{"type":"integer"}}}`, `{"n":"abc"}`},
+		{"bool for number", `{"type":"object","properties":{"n":{"type":"number"}}}`, `{"n":true}`},
+		{"number for boolean", `{"type":"object","properties":{"b":{"type":"boolean"}}}`, `{"b":1}`},
+		{"number for string", `{"type":"object","properties":{"s":{"type":"string"}}}`, `{"s":5}`},
+		{"scalar for object", `{"type":"object","properties":{"o":{"type":"object","properties":{"x":{"type":"integer"}}}}}`, `{"o":5}`},
+		{"scalar for array", `{"type":"object","properties":{"a":{"type":"array","items":{"type":"integer"}}}}`, `{"a":5}`},
+		{"bad date-time", `{"type":"object","properties":{"ts":{"type":"string","format":"date-time"}}}`, `{"ts":"not-a-date"}`},
+		{"unresolved ref", `{"$ref":"Missing"}`, `{"x":1}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = coerceErr(t, tc.schema, tc.data)
+		})
+	}
+}
+
+func TestCoerceMessageDecodeError(t *testing.T) {
+	_, err := newTestCoercer(t, `{"type":"object"}`, nil).coerceMessage([]byte(`{not valid json`))
+	require.Error(t, err)
+}
+
+func TestCoerceRootLevelScalar(t *testing.T) {
+	out := mustCoerce(t, `{"type":"integer"}`, `42`)
+	assert.Equal(t, int64(42), out)
+}
+
+//------------------------------------------------------------------------------
+// Constructor
+
+func TestNewJSONSchemaCoercerErrors(t *testing.T) {
+	t.Run("invalid root schema", func(t *testing.T) {
+		_, err := newJSONSchemaCoercer(`{not json`, nil)
+		require.Error(t, err)
+	})
+	t.Run("invalid reference schema", func(t *testing.T) {
+		_, err := newJSONSchemaCoercer(`{"type":"object"}`, map[string]string{"bad": `{not json`})
+		require.Error(t, err)
+	})
+}
+
+//------------------------------------------------------------------------------
+// Helper-level unit tests for branches not reachable via JSON input
+
+func TestNodeType(t *testing.T) {
+	tests := []struct {
+		name      string
+		node      map[string]any
+		wantTypes []string
+		wantNull  bool
+	}{
+		{"string type", map[string]any{"type": "integer"}, []string{"integer"}, false},
+		{"nullable union", map[string]any{"type": []any{"integer", "null"}}, []string{"integer"}, true},
+		{"null-first union", map[string]any{"type": []any{"null", "string"}}, []string{"string"}, true},
+		{"multi-type union", map[string]any{"type": []any{"integer", "string"}}, []string{"integer", "string"}, false},
+		{"no type", map[string]any{}, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			types, nullable := nodeType(tc.node)
+			assert.Equal(t, tc.wantTypes, types)
+			assert.Equal(t, tc.wantNull, nullable)
+		})
+	}
+}
+
+func TestCoerceMultiTypeUnion(t *testing.T) {
+	intOrStr := `{"type":"object","properties":{"v":{"type":["integer","string"]}}}`
+	numOrInt := `{"type":"object","properties":{"v":{"type":["number","integer"]}}}`
+
+	t.Run("string value picks string", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": "hi"}, mustCoerce(t, intOrStr, `{"v":"hi"}`))
+	})
+	t.Run("integer value picks integer", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": int64(5)}, mustCoerce(t, intOrStr, `{"v":5}`))
+	})
+	t.Run("integral value prefers integer over number", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": int64(5)}, mustCoerce(t, numOrInt, `{"v":5}`))
+	})
+	t.Run("fractional value falls to number", func(t *testing.T) {
+		assert.Equal(t, map[string]any{"v": float64(5.5)}, mustCoerce(t, numOrInt, `{"v":5.5}`))
+	})
+	t.Run("kind with no matching type passes through", func(t *testing.T) {
+		// A boolean matches neither integer nor string; it is left untouched
+		// rather than forced (and failing) into a coercion.
+		assert.Equal(t, map[string]any{"v": true}, mustCoerce(t, intOrStr, `{"v":true}`))
+	})
+}
+
+func TestFloatToInt64(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		v, err := floatToInt64(42)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), v)
+	})
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), 1.5, 1e30, -1e30} {
+		_, err := floatToInt64(f)
+		assert.Error(t, err, "expected error for %v", f)
+	}
+}
+
+func TestToInt64(t *testing.T) {
+	for _, tc := range []struct {
+		in   any
+		want int64
+	}{
+		{json.Number("9"), 9},
+		{int(5), 5},
+		{int64(7), 7},
+		{float64(3), 3},
+	} {
+		v, err := toInt64(tc.in)
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, v)
+	}
+	_, err := toInt64(true)
+	assert.Error(t, err)
+}
+
+func TestToFloat64(t *testing.T) {
+	for _, tc := range []struct {
+		in   any
+		want float64
+	}{
+		{json.Number("3.5"), 3.5},
+		{json.Number("3"), 3},
+		{float64(2), 2},
+		{float32(2), 2},
+		{int(5), 5},
+		{int64(6), 6},
+	} {
+		v, err := toFloat64(tc.in)
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, v)
+	}
+	_, err := toFloat64("x")
+	assert.Error(t, err)
+}
+
+//------------------------------------------------------------------------------
+// Second round: defensive branches, $ref-in-combinator, malformed schemas.
+
+func TestCoerceBranchWithRef(t *testing.T) {
+	t.Run("oneOf branch is a $ref", func(t *testing.T) {
+		c := newTestCoercer(t,
+			`{"oneOf":[{"$ref":"IntType"},{"type":"string"}]}`,
+			map[string]string{"IntType": `{"type":"integer"}`})
+		out, err := c.coerceMessage([]byte(`5`))
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), out)
+	})
+
+	t.Run("oneOf branch $ref is unresolved", func(t *testing.T) {
+		c := newTestCoercer(t, `{"oneOf":[{"$ref":"Missing"}]}`, nil)
+		_, err := c.coerceMessage([]byte(`5`))
+		require.Error(t, err)
+	})
+
+	t.Run("anyOf with array data normalises and coerces", func(t *testing.T) {
+		out := mustCoerce(t,
+			`{"anyOf":[{"type":"array","items":{"type":"integer"}},{"type":"string"}]}`,
+			`[1,2]`)
+		assert.Equal(t, []any{int64(1), int64(2)}, out)
+	})
+}
+
+func TestCoerceBranchInvalidSchema(t *testing.T) {
+	// A oneOf branch that is not a valid JSON Schema (type must be a string or
+	// array, not a number) surfaces as an error from the validation step.
+	err := coerceErr(t,
+		`{"type":"object","properties":{"v":{"oneOf":[{"type":12345}]}}}`,
+		`{"v":1}`)
+	require.Error(t, err)
+}
+
+func TestCoerceMalformedCombinators(t *testing.T) {
+	// oneOf/allOf declared as a non-array are malformed; the coercer passes the
+	// value through rather than panicking.
+	t.Run("oneOf not an array", func(t *testing.T) {
+		assert.Equal(t, float64(5), mustCoerce(t, `{"oneOf":{"type":"integer"}}`, `5`))
+	})
+	t.Run("allOf not an array", func(t *testing.T) {
+		assert.Equal(t, float64(5), mustCoerce(t, `{"allOf":{"type":"integer"}}`, `5`))
+	})
+}
+
+func TestCoerceUnknownTypePassthrough(t *testing.T) {
+	// An unrecognised type keyword falls through to passthrough.
+	out := mustCoerce(t,
+		`{"type":"object","properties":{"x":{"type":"frobnicate"}}}`,
+		`{"x":5}`)
+	assert.Equal(t, map[string]any{"x": float64(5)}, out)
+}
+
+func TestCoerceEmptyRefErrors(t *testing.T) {
+	err := coerceErr(t,
+		`{"type":"object","properties":{"id":{"$ref":""}}}`,
+		`{"id":1}`)
+	assert.Contains(t, err.Error(), "empty $ref")
+}
+
+func TestResolvePointerErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{
+			name:   "token not found",
+			schema: `{"type":"object","properties":{"id":{"$ref":"#/definitions/Missing"}}}`,
+		},
+		{
+			name:   "intermediate is not an object",
+			schema: `{"title":"X","type":"object","properties":{"id":{"$ref":"#/title/x"}}}`,
+		},
+		{
+			name:   "ref does not point to a schema object",
+			schema: `{"title":"X","type":"object","properties":{"id":{"$ref":"#/title"}}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = coerceErr(t, tc.schema, `{"id":1}`)
+		})
+	}
+}
+
+//------------------------------------------------------------------------------
+// Regression: the originating Old Mutual Payment schema.
+
+func TestCoercePaymentRegression(t *testing.T) {
+	schema := `{"type":"object","title":"Payment","properties":{"payment_id":{"type":"string"},"from_account":{"type":"string"},"to_account":{"type":"string"},"amount_cents":{"type":"integer"},"currency":{"type":"string"},"status":{"type":"string","enum":["PENDING","COMPLETED","FAILED"]},"initiated_at":{"type":"integer","description":"epoch millis"}},"required":["payment_id","from_account","to_account","amount_cents","currency","status","initiated_at"]}`
+
+	data := `{"payment_id":"p-1","from_account":"a","to_account":"b","amount_cents":123456789012345,"currency":"ZAR","status":"COMPLETED","initiated_at":1777990438791}`
+
+	out := mustCoerce(t, schema, data)
+	m, ok := out.(map[string]any)
+	require.True(t, ok)
+
+	assert.IsType(t, int64(0), m["amount_cents"])
+	assert.Equal(t, int64(123456789012345), m["amount_cents"])
+	assert.IsType(t, int64(0), m["initiated_at"])
+	assert.Equal(t, int64(1777990438791), m["initiated_at"])
+	assert.Equal(t, "COMPLETED", m["status"])
+}

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -177,6 +177,15 @@ root = this.apply("debeziumTimestampToAvroTimestamp")
 					Default(true),
 			).Description("Configuration for how to decode schemas that are of type PROTOBUF."),
 		).
+		Fields(
+			service.NewObjectField(
+				"json",
+				service.NewBoolField("coerce_data").
+					Description("Whether decoded values should be coerced to match the types declared in the JSON Schema. By default JSON Schema decoding only validates the message and leaves it untouched, which means numbers are later interpreted as floating point (`double`) and date-time values as strings. When set to `true` the decoder rebuilds the message so that values match the schema: `integer` fields become 64-bit integers, `number` fields stay floating point, `string` fields with `format: date-time` become timestamps, and any `default` values declared in the schema are applied to absent fields. This is useful for downstream components that infer their schema from the decoded values, such as the `iceberg` outputs, which will then create `bigint` columns for integer fields rather than `double`. Note that, unlike the default behaviour, this is no longer a read-only operation: the message contents are transformed. Because coercion is stricter than validation, a message that passes validation may still fail coercion (for example an integer that overflows a 64-bit value, or a `date-time` string that is not valid RFC 3339), in which case the error can be caught using xref:configuration:error_handling.adoc[error handling methods].").
+					Default(false).
+					Version("4.97.0"),
+			).Description("Configuration for how to decode schemas that are of type JSON."),
+		).
 		Field(
 			service.NewDurationField("cache_duration").
 				Description("The duration after which a schema is considered stale and will be removed from the cache.").
@@ -212,7 +221,10 @@ type decodingConfig struct {
 		mapping                    *bloblang.Executor
 		storeSchemaMeta            string
 	}
-	protobuf        protobufOptions
+	protobuf protobufOptions
+	json     struct {
+		coerceData bool
+	}
 	defaultSchemaID int
 }
 
@@ -290,6 +302,11 @@ func newSchemaRegistryDecoderFromConfig(conf *service.ParsedConfig, mgr *service
 		return nil, err
 	}
 	cfg.protobuf.serializeToJSON, err = conf.FieldBool("protobuf", "serialize_to_json")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.json.coerceData, err = conf.FieldBool("json", "coerce_data")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/confluent/serde_json.go
+++ b/internal/impl/confluent/serde_json.go
@@ -47,21 +47,30 @@ func resolveJSONSchema(ctx context.Context, client *sr.Client, schema franz_sr.S
 }
 
 func (s *schemaRegistryEncoder) getJSONEncoder(ctx context.Context, schema franz_sr.Schema) (schemaEncoder, error) {
-	return getJSONTranscoder(ctx, s.client, schema)
+	// Encoding never coerces: the message is validated and passed through as-is.
+	return getJSONTranscoder(ctx, s.client, schema, false)
 }
 
 func (s *schemaRegistryDecoder) getJSONDecoder(ctx context.Context, schema franz_sr.Schema) (schemaDecoder, error) {
-	return getJSONTranscoder(ctx, s.client, schema)
+	return getJSONTranscoder(ctx, s.client, schema, s.cfg.json.coerceData)
 }
 
-func getJSONTranscoder(ctx context.Context, cl *sr.Client, schema franz_sr.Schema) (func(m *service.Message) error, error) {
+func getJSONTranscoder(ctx context.Context, cl *sr.Client, schema franz_sr.Schema, coerce bool) (func(m *service.Message) error, error) {
 	sch, err := resolveJSONSchema(ctx, cl, schema)
 	if err != nil {
 		return nil, err
 	}
 
-	// -- we only need to verify if the message is valid since the input format which benthos uses (json) is the same
-	// -- as the output format
+	// When coercion is disabled we only need to verify that the message is
+	// valid, since the input format benthos uses (json) is the same as the
+	// output format and the message is left unchanged.
+	var coercer *jsonSchemaCoercer
+	if coerce {
+		if coercer, err = buildJSONSchemaCoercer(ctx, cl, schema); err != nil {
+			return nil, err
+		}
+	}
+
 	return func(m *service.Message) error {
 		b, err := m.AsBytes()
 		if err != nil {
@@ -76,6 +85,18 @@ func getJSONTranscoder(ctx context.Context, cl *sr.Client, schema franz_sr.Schem
 
 		if !res.Valid() {
 			return fmt.Errorf("json message does not conform to schema: %v", res.Errors())
+		}
+
+		// When enabled, rebuild the message using Go types that match the
+		// declared schema (e.g. integer -> int64) so downstream components
+		// infer the correct types. This makes decoding a transforming rather
+		// than validate-only operation.
+		if coercer != nil {
+			out, err := coercer.coerceMessage(b)
+			if err != nil {
+				return fmt.Errorf("coercing message to schema: %w", err)
+			}
+			m.SetStructuredMut(out)
 		}
 
 		return nil


### PR DESCRIPTION
## Summary

By default the `schema_registry_decode` processor only *validates* JSON Schema messages and leaves the bytes untouched. Downstream components that infer types from decoded values therefore see every JSON number as a float (`double`) and `date-time` values as plain strings — so an `integer`-typed field lands in an `iceberg` sink as a `double` column where a `bigint` is expected.

This PR adds an opt-in `coerce_data` boolean to the decoder's `json` configuration block. When enabled, after validation succeeds the decoder rebuilds the message using Go types that match the declared schema, so sinks infer the correct column types.

## Behaviour

When `coerce_data: true`:

- `integer` → `int64` (decoded via `UseNumber`, so large integers keep full precision)
- `number` → `float64`
- `boolean` → `bool`
- `string` with `format: date-time` → timestamp (other formats stay strings)
- declared `default` values are applied to absent fields
- nested objects/arrays, `$ref` (local pointers and registry references), `allOf`/`oneOf`/`anyOf`, `additionalProperties`, and nullable/multi-type unions are all handled
- cyclic `$ref` resolution is bounded, and compiled branch schemas are cached so union validation does not recompile per message

Because coercion is stricter than validation (e.g. an integer that overflows 64 bits, or a `date-time` string that is not valid RFC 3339), a message that passes validation may still fail coercion; the error is catchable via the usual error-handling methods.

Coercion is **opt-in and default-off** — the existing validate-only behaviour is completely unchanged for current configurations.

## Testing

- Unit tests covering every type, combinator, reference form, default handling, nullable/multi-type unions, the numeric-precision and overflow boundaries, cyclic-`$ref` protection, and the error paths.
- Benchmarks for the flat-object and `oneOf` coercion paths.
- `task fmt`, `task lint`, `task test` (unit + race) all green; docs regenerated via `task docs`.
