### PR TITLE
protobuf: disable hyperpb PGO to stop profile-retention memory leak

### DIFF
--- a/internal/impl/protobuf/common/decode_common.go
+++ b/internal/impl/protobuf/common/decode_common.go
@@ -35,7 +35,18 @@ type ProfilingOptions struct {
 
 // DefaultProfilingOptions are the standard profiling settings used across all
 // hyperpb decoder call sites.
+//
+// Profile-guided recompilation is currently disabled (RecompileInterval: 0)
+// because hyperpb v0.1.3 leaks profile data across recompiles: MessageType.Recompile
+// clones the previous type's compile options and appends another WithProfile, and
+// CompileMessageDescriptor stores that growing slice in the new type's
+// Library.Metadata. The live type therefore pins every prior generation's profile
+// recorder (a 32 KB ring buffer per field), so memory grows unbounded under
+// sustained throughput. Only the final profile is ever used during compilation, so
+// the retained generations serve no purpose. With recompilation off there is nothing
+// to record into, so Rate is 0 as well to avoid the per-message recording overhead.
+// Re-enable once the upstream leak is fixed.
 var DefaultProfilingOptions = ProfilingOptions{
-	Rate:              0.01,
-	RecompileInterval: 100_000,
+	Rate:              0,
+	RecompileInterval: 0,
 }


### PR DESCRIPTION
hyperpb v0.1.3 leaks profile data across profile-guided recompiles: MessageType.Recompile clones the prior type's compile options and appends another WithProfile, and CompileMessageDescriptor persists that growing slice in the new type's Library.Metadata. The live type therefore pins every prior generation's profile recorder (a 32 KB ring buffer per field), so heap grows unbounded under sustained decode throughput until the pod is OOMKilled. Only the final profile is used during compilation, so the retained generations serve no purpose.

Disable recompilation (RecompileInterval: 0) in the default profiling options used by the protobuf and schema_registry_decode processors, and set Rate to 0 since the never-recompiled profile is never consumed. Re-enable once the upstream hyperpb leak is fixed.