### PR TITLE
aws_dynamodb_cdc: support DynamoDB Global Tables for the checkpoint t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - oracledb_cdc: Oracle CDC connector now publishes an oracledb_cdc_publish_lag_ns metric tracking latency between database commits and event publication. ([@josephwoodward](https://github.com/josephwoodward), [#4520](https://github.com/redpanda-data/connect/pull/4520))
 - oracledb_cdc: Oracle CDC connector now supports a configurable min_scn_window_size parameter to skip mining cycles when the SCN gap is too small. ([@josephwoodward](https://github.com/josephwoodward), [#4530](https://github.com/redpanda-data/connect/pull/4530))
 - aws_bedrock_embeddings: Support Cohere input_type and v4 response. ([@squiidz](https://github.com/squiidz), [#4473](https://github.com/redpanda-data/connect/pull/4473))
+- aws_dynamodb_cdc: The auto-created checkpoint table can now be provisioned as a DynamoDB Global Table via `global_table` / `global_table_replicas`, enabling low-RPO multi-region failover. ([@squiidz](https://github.com/squiidz), [#4529](https://github.com/redpanda-data/connect/pull/4529))
 
 ### Fixed
 

--- a/config/examples/dynamodb_cdc_global_table.yaml
+++ b/config/examples/dynamodb_cdc_global_table.yaml
@@ -1,0 +1,14 @@
+# Example: stream DynamoDB CDC with a multi-region (Global Table) checkpoint table.
+# Run the same config in two regions; after a regional failover the secondary
+# resumes near the last committed position instead of replaying the whole stream.
+input:
+  aws_dynamodb_cdc:
+    tables: [orders]
+    checkpoint_table: redpanda_dynamodb_checkpoints
+    global_table: true
+    global_table_replicas:
+      - us-west-2
+    region: us-east-1
+
+output:
+  stdout: {}

--- a/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
@@ -60,6 +60,8 @@ input:
     table_tag_filter: ""
     table_discovery_interval: 5m
     checkpoint_table: redpanda_dynamodb_checkpoints
+    global_table: false
+    global_table_replicas: []
     batch_size: 1000
     poll_interval: 1s
     start_from: trim_horizon
@@ -149,6 +151,7 @@ This input adds the following metadata fields to each message:
 
 - `dynamodb_shard_id` - The shard ID from which the record was read (empty for snapshot records)
 - `dynamodb_sequence_number` - The sequence number of the record in the stream (empty for snapshot records)
+- `dynamodb_approximate_creation_time` - RFC3339 approximate creation time of the stream record (empty for snapshot records)
 - `dynamodb_event_name` - The type of change: INSERT, MODIFY, REMOVE, or READ (for snapshot records)
 - `dynamodb_table` - The name of the DynamoDB table
 
@@ -164,6 +167,13 @@ This input emits the following metrics:
 - `dynamodb_cdc_snapshot_buffer_overflow` - Incremented when the deduplication buffer exceeds its size limit, disabling dedup (counter)
 - `dynamodb_cdc_snapshot_segment_duration` - Time taken by each snapshot scan segment to complete (timer)
 - `dynamodb_cdc_checkpoint_failures` - Number of failed checkpoint writes to the checkpoint table (counter)
+- `dynamodb_cdc_failover_skipped` - Records skipped during global-table failover replay because they predate the resumed cutoff (counter)
+
+### Global Table Checkpoints (multi-region failover)
+
+In active/active or active/passive multi-region deployments, set `global_table: true` and list the other regions in `global_table_replicas` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. This only affects table creation — it is a no-op if the checkpoint table already exists.
+
+When `global_table` is enabled the principal additionally needs `dynamodb:CreateTable`, `dynamodb:UpdateTable`, `dynamodb:DescribeTable`, `dynamodb:DescribeLimits`, `iam:CreateServiceLinkedRole`, and create/describe permissions in each replica region.
 
 
 == Examples
@@ -320,6 +330,24 @@ DynamoDB table name for storing checkpoints. Will be created if it doesn't exist
 *Type*: `string`
 
 *Default*: `"redpanda_dynamodb_checkpoints"`
+
+=== `global_table`
+
+When the checkpoint table is auto-created, provision it as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. No effect if the checkpoint table already exists.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `global_table_replicas`
+
+Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Only used when the checkpoint table is created.
+
+
+*Type*: `array`
+
+*Default*: `[]`
 
 === `batch_size`
 

--- a/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
@@ -171,7 +171,7 @@ This input emits the following metrics:
 
 ### Global Table Checkpoints (multi-region failover)
 
-In active/active or active/passive multi-region deployments, set `global_table: true` and list the other regions in `global_table_replicas` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. This only affects table creation — it is a no-op if the checkpoint table already exists.
+In active/active or active/passive multi-region deployments, set `global_table: true` and list the other regions in `global_table_replicas` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. If the checkpoint table already exists, enabling `global_table` reconciles it towards the desired configuration: any missing replica regions are added via `UpdateTable`. The existing table must have been created in global mode (it must use a `TableId` hash key); pointing `global_table` at a pre-existing non-global checkpoint table fails fast with a clear error rather than mutating it.
 
 When `global_table` is enabled the principal additionally needs `dynamodb:CreateTable`, `dynamodb:UpdateTable`, `dynamodb:DescribeTable`, `dynamodb:DescribeLimits`, `iam:CreateServiceLinkedRole`, and create/describe permissions in each replica region.
 
@@ -333,7 +333,7 @@ DynamoDB table name for storing checkpoints. Will be created if it doesn't exist
 
 === `global_table`
 
-When the checkpoint table is auto-created, provision it as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. No effect if the checkpoint table already exists.
+Provision the checkpoint table as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. When the table is auto-created it is created as a global table; when it already exists, its replicas are reconciled (missing regions are added via `UpdateTable`). The existing table must have been created in global mode (`TableId` hash key) — enabling this against a pre-existing non-global checkpoint table fails fast with a clear error.
 
 
 *Type*: `bool`
@@ -342,7 +342,7 @@ When the checkpoint table is auto-created, provision it as a DynamoDB Global Tab
 
 === `global_table_replicas`
 
-Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Only used when the checkpoint table is created.
+Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Applied both when the checkpoint table is created and, for an existing global table, when reconciling replicas (missing regions are added; this list is not used to remove regions).
 
 
 *Type*: `array`

--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -78,6 +78,15 @@ type shardAckTracker struct {
 	frontier string
 	// persisted is the last sequence written to the checkpoint store.
 	persisted string
+	// seqTimes maps a tracked batch's checkpoint sequence to that record's
+	// ApproximateCreationDateTime (RFC3339Nano). Used to persist the timestamp
+	// alongside the frontier in global-table mode; entries are pruned once the
+	// frontier advances past them. Only the batch frontier can advance, which
+	// may differ from the batch currently being acked, so the lookup must be by
+	// sequence rather than off the acked batch.
+	seqTimes map[string]string
+	// frontierTime is the ApproximateCreationDateTime of the current frontier.
+	frontierTime string
 }
 
 // NewRecordBatcher creates a new [RecordBatcher] for DynamoDB CDC.
@@ -119,11 +128,14 @@ func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) 
 
 	st, ok := b.shards[shardID]
 	if !ok {
-		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string]()}
+		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string](), seqTimes: map[string]string{}}
 		b.shards[shardID] = st
 	}
 
-	seq, _ := batch[len(batch)-1].MetaGet("dynamodb_sequence_number")
+	last := batch[len(batch)-1]
+	seq, _ := last.MetaGet("dynamodb_sequence_number")
+	approxCreationTime, _ := last.MetaGet("dynamodb_approximate_creation_time")
+	st.seqTimes[seq] = approxCreationTime
 	tb := &trackedBatch{
 		shardID: shardID,
 		size:    len(batch),
@@ -164,8 +176,20 @@ func (b *RecordBatcher) RemoveMessages(batch service.MessageBatch) {
 }
 
 type checkpointer interface {
-	Set(ctx context.Context, shardID, sequenceNumber string) error
+	Set(ctx context.Context, shardID, sequenceNumber, approxCreationTime string) error
 	CheckpointLimit() int
+}
+
+// advanceFrontier records the resolved contiguous frontier and its associated
+// record timestamp, pruning seqTimes entries the frontier has passed.
+func (st *shardAckTracker) advanceFrontier(frontier string) {
+	st.frontier = frontier
+	st.frontierTime = st.seqTimes[frontier]
+	for seq := range st.seqTimes {
+		if seq <= frontier {
+			delete(st.seqTimes, seq)
+		}
+	}
 }
 
 // AckMessages marks a batch as acknowledged, advances the shard's contiguous
@@ -196,7 +220,7 @@ func (b *RecordBatcher) AckMessages(
 
 	st := b.shards[tb.shardID]
 	if frontier := tb.resolve(); frontier != nil {
-		st.frontier = *frontier
+		st.advanceFrontier(*frontier)
 	}
 	st.pending += tb.size
 
@@ -204,7 +228,7 @@ func (b *RecordBatcher) AckMessages(
 	// the last persisted position. A pinned frontier (nacked batch ahead of
 	// us in stream order) accumulates pending acks without persisting.
 	if st.pending >= cp.CheckpointLimit() && st.frontier != "" && st.frontier != st.persisted {
-		if err := cp.Set(ctx, tb.shardID, st.frontier); err != nil {
+		if err := cp.Set(ctx, tb.shardID, st.frontier, st.frontierTime); err != nil {
 			return err
 		}
 		st.persisted = st.frontier
@@ -218,14 +242,17 @@ func (b *RecordBatcher) AckMessages(
 // PendingCheckpoints returns, per shard, the highest contiguous acked
 // sequence that has not been persisted yet. Used to flush checkpoints on
 // shutdown.
-func (b *RecordBatcher) PendingCheckpoints() map[string]string {
+func (b *RecordBatcher) PendingCheckpoints() map[string]CheckpointValue {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	checkpoints := make(map[string]string, len(b.shards))
+	checkpoints := make(map[string]CheckpointValue, len(b.shards))
 	for shardID, st := range b.shards {
 		if st.frontier != "" && st.frontier != st.persisted {
-			checkpoints[shardID] = st.frontier
+			checkpoints[shardID] = CheckpointValue{
+				SequenceNumber:     st.frontier,
+				ApproxCreationTime: st.frontierTime,
+			}
 		}
 	}
 	return checkpoints

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -38,17 +38,22 @@ func createTestMessages(count int, shardID string, startSeq int) service.Message
 type mockCheckpointer struct {
 	mu              sync.Mutex
 	checkpoints     map[string]string
+	timestamps      map[string]string
 	checkpointLimit int
 	setCallCount    int
 }
 
-func (m *mockCheckpointer) Set(_ context.Context, shardID, sequenceNumber string) error {
+func (m *mockCheckpointer) Set(_ context.Context, shardID, sequenceNumber, approxCreationTime string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.checkpoints == nil {
 		m.checkpoints = make(map[string]string)
 	}
+	if m.timestamps == nil {
+		m.timestamps = make(map[string]string)
+	}
 	m.checkpoints[shardID] = sequenceNumber
+	m.timestamps[shardID] = approxCreationTime
 	m.setCallCount++
 	return nil
 }
@@ -63,10 +68,64 @@ func (m *mockCheckpointer) get(shardID string) string {
 	return m.checkpoints[shardID]
 }
 
+func (m *mockCheckpointer) timestamp(shardID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.timestamps[shardID]
+}
+
 func (m *mockCheckpointer) calls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.setCallCount
+}
+
+// msgWithTime builds a single-message batch carrying both a sequence number and
+// an approximate creation time, for exercising timestamp persistence.
+func msgWithTime(shardID, seq, approxTime string) service.MessageBatch {
+	msg := service.NewMessage(nil)
+	msg.MetaSetMut("dynamodb_shard_id", shardID)
+	msg.MetaSetMut("dynamodb_sequence_number", seq)
+	msg.MetaSetMut("dynamodb_approximate_creation_time", approxTime)
+	return service.MessageBatch{msg}
+}
+
+// Global-table mode persists the record timestamp alongside the frontier
+// sequence so a failed-over region can resume by time.
+func TestBatcher_PersistsApproxCreationTimeWithFrontier(t *testing.T) {
+	b := NewRecordBatcher(10000, 1, service.MockResources().Logger())
+	cp := &mockCheckpointer{checkpointLimit: 1}
+
+	batch := msgWithTime("shard-001", "00001", "2026-06-16T10:00:00Z")
+	b.AddMessages(batch, "shard-001")
+	require.NoError(t, b.AckMessages(context.Background(), cp, batch))
+
+	assert.Equal(t, "00001", cp.get("shard-001"))
+	assert.Equal(t, "2026-06-16T10:00:00Z", cp.timestamp("shard-001"))
+}
+
+// When acks complete out of order, the persisted timestamp must be the one of
+// the contiguous frontier record, not of the batch whose ack moved the
+// frontier.
+func TestBatcher_FrontierTimestampFollowsContiguousSequence(t *testing.T) {
+	b := NewRecordBatcher(10000, 1, service.MockResources().Logger())
+	cp := &mockCheckpointer{checkpointLimit: 1}
+
+	b1 := msgWithTime("shard-001", "00001", "2026-06-16T10:00:00Z")
+	b2 := msgWithTime("shard-001", "00002", "2026-06-16T10:01:00Z")
+	b.AddMessages(b1, "shard-001")
+	b.AddMessages(b2, "shard-001")
+
+	// Ack the second batch first: frontier is pinned (b1 still outstanding), so
+	// nothing is persisted yet.
+	require.NoError(t, b.AckMessages(context.Background(), cp, b2))
+	assert.Equal(t, 0, cp.calls(), "frontier pinned until the earlier batch acks")
+
+	// Ack the first batch: frontier jumps to 00002, and the persisted timestamp
+	// must be 00002's (10:01), not b1's (10:00).
+	require.NoError(t, b.AckMessages(context.Background(), cp, b1))
+	assert.Equal(t, "00002", cp.get("shard-001"))
+	assert.Equal(t, "2026-06-16T10:01:00Z", cp.timestamp("shard-001"))
 }
 
 func TestBatcherAddMessages(t *testing.T) {
@@ -281,9 +340,9 @@ func TestBatcherPendingCheckpointsFlush(t *testing.T) {
 	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch2))
 
 	pending := batcher.PendingCheckpoints()
-	assert.Equal(t, map[string]string{
-		"shard-001": "00002",
-		"shard-002": "00002",
+	assert.Equal(t, map[string]CheckpointValue{
+		"shard-001": {SequenceNumber: "00002"},
+		"shard-002": {SequenceNumber: "00002"},
 	}, pending)
 
 	// Low limit: the next ack persists immediately, leaving nothing pending
@@ -295,7 +354,7 @@ func TestBatcherPendingCheckpointsFlush(t *testing.T) {
 	assert.Equal(t, "00004", lowLimit.get("shard-001"))
 
 	pending = batcher.PendingCheckpoints()
-	assert.Equal(t, map[string]string{"shard-002": "00002"}, pending)
+	assert.Equal(t, map[string]CheckpointValue{"shard-002": {SequenceNumber: "00002"}}, pending)
 }
 
 // Test concurrent access to batcher.

--- a/internal/impl/aws/dynamodb/checkpoint.go
+++ b/internal/impl/aws/dynamodb/checkpoint.go
@@ -23,6 +23,15 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
+// Checkpoint table key attribute names. The hash key differs by mode: the
+// default mode keys checkpoints by the current stream ARN, while global mode
+// keys by the source table name so the key is portable across regions.
+const (
+	checkpointHashKeyDefault = "StreamArn"
+	checkpointHashKeyGlobal  = "TableId"
+	checkpointRangeKey       = "ShardID"
+)
+
 // checkpointDynamoAPI is the subset of the DynamoDB client the Checkpointer
 // uses. *dynamodb.Client satisfies it; tests provide a fake.
 type checkpointDynamoAPI interface {
@@ -93,13 +102,44 @@ func NewCheckpointer(
 	return c, nil
 }
 
+// hashKeyName returns the name of a table's HASH (partition) key, or "" if the
+// description has no hash key.
+func hashKeyName(table *types.TableDescription) string {
+	if table == nil {
+		return ""
+	}
+	for _, k := range table.KeySchema {
+		if k.KeyType == types.KeyTypeHash {
+			return aws.ToString(k.AttributeName)
+		}
+	}
+	return ""
+}
+
+// validateGlobalTableSchema ensures a pre-existing checkpoint table can be used
+// in global mode. A table created without global_table uses a StreamArn hash
+// key, whereas global mode keys checkpoints by TableId; reusing it would write
+// rows under a key the schema doesn't define and reconcile replicas onto an
+// incompatible table. Fail fast with an actionable error instead.
+func validateGlobalTableSchema(table *types.TableDescription) error {
+	if got := hashKeyName(table); got != checkpointHashKeyGlobal {
+		return fmt.Errorf("checkpoint table %s already exists with hash key %q, but global_table mode requires hash key %q; the table was created without global_table enabled and cannot be reused (point global_table at a new checkpoint table or recreate this one)",
+			aws.ToString(table.TableName), got, checkpointHashKeyGlobal)
+	}
+	return nil
+}
+
 func (c *Checkpointer) ensureTableExists(ctx context.Context) error {
 	desc, err := c.svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(c.tableName),
 	})
 	if err == nil {
-		// Table exists. In global mode, reconcile missing replicas only.
+		// Table exists. In global mode, validate the schema is compatible and
+		// reconcile any missing replicas.
 		if c.globalTable {
+			if err := validateGlobalTableSchema(desc.Table); err != nil {
+				return err
+			}
 			return c.reconcileReplicas(ctx, desc.Table)
 		}
 		return nil
@@ -109,19 +149,19 @@ func (c *Checkpointer) ensureTableExists(ctx context.Context) error {
 	}
 
 	// Table doesn't exist, create it.
-	hashAttr := "StreamArn"
+	hashAttr := checkpointHashKeyDefault
 	if c.globalTable {
-		hashAttr = "TableId"
+		hashAttr = checkpointHashKeyGlobal
 	}
 	input := &dynamodb.CreateTableInput{
 		AttributeDefinitions: []types.AttributeDefinition{
 			{AttributeName: aws.String(hashAttr), AttributeType: types.ScalarAttributeTypeS},
-			{AttributeName: aws.String("ShardID"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String(checkpointRangeKey), AttributeType: types.ScalarAttributeTypeS},
 		},
 		BillingMode: types.BillingModePayPerRequest,
 		KeySchema: []types.KeySchemaElement{
 			{AttributeName: aws.String(hashAttr), KeyType: types.KeyTypeHash},
-			{AttributeName: aws.String("ShardID"), KeyType: types.KeyTypeRange},
+			{AttributeName: aws.String(checkpointRangeKey), KeyType: types.KeyTypeRange},
 		},
 		TableName: aws.String(c.tableName),
 	}
@@ -212,13 +252,13 @@ func (c *Checkpointer) waitForTableActive(ctx context.Context) error {
 func (c *Checkpointer) checkpointKey(shardID string) map[string]types.AttributeValue {
 	if c.globalTable {
 		return map[string]types.AttributeValue{
-			"TableId": &types.AttributeValueMemberS{Value: c.sourceTable},
-			"ShardID": &types.AttributeValueMemberS{Value: shardID},
+			checkpointHashKeyGlobal: &types.AttributeValueMemberS{Value: c.sourceTable},
+			checkpointRangeKey:      &types.AttributeValueMemberS{Value: shardID},
 		}
 	}
 	return map[string]types.AttributeValue{
-		"StreamArn": &types.AttributeValueMemberS{Value: c.streamArn},
-		"ShardID":   &types.AttributeValueMemberS{Value: shardID},
+		checkpointHashKeyDefault: &types.AttributeValueMemberS{Value: c.streamArn},
+		checkpointRangeKey:       &types.AttributeValueMemberS{Value: shardID},
 	}
 }
 

--- a/internal/impl/aws/dynamodb/checkpoint.go
+++ b/internal/impl/aws/dynamodb/checkpoint.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -21,30 +23,65 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
+// checkpointDynamoAPI is the subset of the DynamoDB client the Checkpointer
+// uses. *dynamodb.Client satisfies it; tests provide a fake.
+type checkpointDynamoAPI interface {
+	DescribeTable(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
+	CreateTable(context.Context, *dynamodb.CreateTableInput, ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
+	UpdateTable(context.Context, *dynamodb.UpdateTableInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error)
+	GetItem(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	PutItem(context.Context, *dynamodb.PutItemInput, ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+// CheckpointerConfig carries the construction inputs for a Checkpointer.
+type CheckpointerConfig struct {
+	TableName       string // checkpoint table name
+	SourceTable     string // source table name (portable key in global mode)
+	StreamArn       string // current region's stream ARN
+	CheckpointLimit int
+	GlobalTable     bool
+	Region          string   // pipeline's own region (global mode)
+	ReplicaRegions  []string // other regions to replicate to (global mode)
+}
+
 // Checkpointer manages checkpoints for DynamoDB CDC shards in a DynamoDB table.
 // It stores the last processed sequence number for each shard, enabling resumption
 // from the last checkpoint after restarts.
 type Checkpointer struct {
 	tableName       string
+	sourceTable     string
 	streamArn       string
 	checkpointLimit int
-	svc             *dynamodb.Client
+	globalTable     bool
+	region          string
+	replicaRegions  []string
+	svc             checkpointDynamoAPI
 	log             *service.Logger
+
+	// resume resolution cache (global mode only)
+	resumeOnce     sync.Once
+	resumeErr      error
+	ownSeqs        map[string]string
+	hasForeignRows bool
+	cutoff         time.Time
 }
 
 // NewCheckpointer creates a new [Checkpointer] for DynamoDB CDC.
 func NewCheckpointer(
 	ctx context.Context,
-	svc *dynamodb.Client,
-	tableName,
-	streamArn string,
-	checkpointLimit int,
+	svc checkpointDynamoAPI,
+	cfg CheckpointerConfig,
 	log *service.Logger,
 ) (*Checkpointer, error) {
 	c := &Checkpointer{
-		tableName:       tableName,
-		streamArn:       streamArn,
-		checkpointLimit: checkpointLimit,
+		tableName:       cfg.TableName,
+		sourceTable:     cfg.SourceTable,
+		streamArn:       cfg.StreamArn,
+		checkpointLimit: cfg.CheckpointLimit,
+		globalTable:     cfg.GlobalTable,
+		region:          cfg.Region,
+		replicaRegions:  cfg.ReplicaRegions,
 		svc:             svc,
 		log:             log,
 	}
@@ -57,44 +94,139 @@ func NewCheckpointer(
 }
 
 func (c *Checkpointer) ensureTableExists(ctx context.Context) error {
-	_, err := c.svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+	desc, err := c.svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(c.tableName),
 	})
-
-	if _, ok := errors.AsType[*types.ResourceNotFoundException](err); err == nil || !ok {
+	if err == nil {
+		// Table exists. In global mode, reconcile missing replicas only.
+		if c.globalTable {
+			return c.reconcileReplicas(ctx, desc.Table)
+		}
+		return nil
+	}
+	if _, ok := errors.AsType[*types.ResourceNotFoundException](err); !ok {
 		return err
 	}
 
-	// Table doesn't exist, create it
+	// Table doesn't exist, create it.
+	hashAttr := "StreamArn"
+	if c.globalTable {
+		hashAttr = "TableId"
+	}
 	input := &dynamodb.CreateTableInput{
 		AttributeDefinitions: []types.AttributeDefinition{
-			{AttributeName: aws.String("StreamArn"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String(hashAttr), AttributeType: types.ScalarAttributeTypeS},
 			{AttributeName: aws.String("ShardID"), AttributeType: types.ScalarAttributeTypeS},
 		},
 		BillingMode: types.BillingModePayPerRequest,
 		KeySchema: []types.KeySchemaElement{
-			{AttributeName: aws.String("StreamArn"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String(hashAttr), KeyType: types.KeyTypeHash},
 			{AttributeName: aws.String("ShardID"), KeyType: types.KeyTypeRange},
 		},
 		TableName: aws.String(c.tableName),
+	}
+	if c.globalTable {
+		// Global Tables v2 require DynamoDB Streams with NEW_AND_OLD_IMAGES.
+		input.StreamSpecification = &types.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: types.StreamViewTypeNewAndOldImages,
+		}
 	}
 
 	if _, err = c.svc.CreateTable(ctx, input); err != nil {
 		return fmt.Errorf("creating checkpoint table: %w", err)
 	}
-
 	c.log.Infof("Created checkpoint table: %s", c.tableName)
+
+	if c.globalTable {
+		if err := c.waitForTableActive(ctx); err != nil {
+			return err
+		}
+		desc, derr := c.svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(c.tableName)})
+		if derr != nil {
+			return fmt.Errorf("describing checkpoint table after create: %w", derr)
+		}
+		return c.reconcileReplicas(ctx, desc.Table)
+	}
 	return nil
+}
+
+// desiredReplicaRegions returns the home region plus configured replicas.
+func (c *Checkpointer) desiredReplicaRegions() []string {
+	out := []string{c.region}
+	for _, r := range c.replicaRegions {
+		if r != c.region {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// reconcileReplicas adds any configured replica region (excluding the home
+// region, which is the table's own region) that is not already present. One
+// replica is created per UpdateTable call, waiting for ACTIVE between calls.
+func (c *Checkpointer) reconcileReplicas(ctx context.Context, table *types.TableDescription) error {
+	existing := map[string]struct{}{}
+	if table != nil {
+		for _, r := range table.Replicas {
+			existing[aws.ToString(r.RegionName)] = struct{}{}
+		}
+	}
+	for _, region := range c.desiredReplicaRegions() {
+		if region == c.region {
+			continue // home region is implicit, never added as a replica
+		}
+		if _, ok := existing[region]; ok {
+			continue
+		}
+		c.log.Infof("Adding global table replica %s to %s", region, c.tableName)
+		if _, err := c.svc.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+			TableName: aws.String(c.tableName),
+			ReplicaUpdates: []types.ReplicationGroupUpdate{
+				{Create: &types.CreateReplicationGroupMemberAction{RegionName: aws.String(region)}},
+			},
+		}); err != nil {
+			return fmt.Errorf("adding replica %s to checkpoint table: %w", region, err)
+		}
+		if err := c.waitForTableActive(ctx); err != nil {
+			return fmt.Errorf("waiting for replica %s to become active: %w", region, err)
+		}
+	}
+	return nil
+}
+
+// waitForTableActive blocks until the checkpoint table reports ACTIVE.
+func (c *Checkpointer) waitForTableActive(ctx context.Context) error {
+	waiter := dynamodb.NewTableExistsWaiter(c.svc)
+	if err := waiter.Wait(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(c.tableName),
+	}, 5*time.Minute); err != nil {
+		return fmt.Errorf("waiting for checkpoint table %s to become active: %w", c.tableName, err)
+	}
+	return nil
+}
+
+// checkpointKey builds the primary key for a shard's checkpoint row. In global
+// mode the hash key is the source table name (portable across regions); in the
+// default mode it is the current stream ARN.
+func (c *Checkpointer) checkpointKey(shardID string) map[string]types.AttributeValue {
+	if c.globalTable {
+		return map[string]types.AttributeValue{
+			"TableId": &types.AttributeValueMemberS{Value: c.sourceTable},
+			"ShardID": &types.AttributeValueMemberS{Value: shardID},
+		}
+	}
+	return map[string]types.AttributeValue{
+		"StreamArn": &types.AttributeValueMemberS{Value: c.streamArn},
+		"ShardID":   &types.AttributeValueMemberS{Value: shardID},
+	}
 }
 
 // Get retrieves the checkpoint for a shard.
 func (c *Checkpointer) Get(ctx context.Context, shardID string) (string, error) {
 	result, err := c.svc.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(c.tableName),
-		Key: map[string]types.AttributeValue{
-			"StreamArn": &types.AttributeValueMemberS{Value: c.streamArn},
-			"ShardID":   &types.AttributeValueMemberS{Value: shardID},
-		},
+		Key:       c.checkpointKey(shardID),
 	})
 	if err != nil {
 		if _, ok := errors.AsType[*types.ResourceNotFoundException](err); ok {
@@ -115,15 +247,21 @@ func (c *Checkpointer) Get(ctx context.Context, shardID string) (string, error) 
 	return "", nil
 }
 
-// Set stores a checkpoint for a shard.
-func (c *Checkpointer) Set(ctx context.Context, shardID, sequenceNumber string) error {
+// Set stores a checkpoint for a shard. approxCreationTime is the RFC3339Nano
+// ApproximateCreationDateTime of the checkpointed record (empty if unknown); it
+// is persisted only in global mode, where it drives time-based failover resume.
+func (c *Checkpointer) Set(ctx context.Context, shardID, sequenceNumber, approxCreationTime string) error {
+	item := c.checkpointKey(shardID)
+	item["SequenceNumber"] = &types.AttributeValueMemberS{Value: sequenceNumber}
+	if c.globalTable {
+		item["StreamArn"] = &types.AttributeValueMemberS{Value: c.streamArn}
+		if approxCreationTime != "" {
+			item["ApproximateCreationTime"] = &types.AttributeValueMemberS{Value: approxCreationTime}
+		}
+	}
 	_, err := c.svc.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(c.tableName),
-		Item: map[string]types.AttributeValue{
-			"StreamArn":      &types.AttributeValueMemberS{Value: c.streamArn},
-			"ShardID":        &types.AttributeValueMemberS{Value: shardID},
-			"SequenceNumber": &types.AttributeValueMemberS{Value: sequenceNumber},
-		},
+		Item:      item,
 	})
 	if err != nil {
 		return fmt.Errorf("setting checkpoint for table=%s stream=%s shard=%s seq=%s: %w",
@@ -137,17 +275,131 @@ func (c *Checkpointer) CheckpointLimit() int {
 	return c.checkpointLimit
 }
 
+type resumeMode int
+
+const (
+	// resumeDefault: no usable checkpoint; caller applies start_from.
+	resumeDefault resumeMode = iota
+	// resumeExact: resume via AfterSequenceNumber (in-region restart).
+	resumeExact
+	// resumeFailover: resume from TrimHorizon, skipping records at/under Cutoff.
+	resumeFailover
+)
+
+// ResumeDecision tells the caller how to begin reading a shard.
+type ResumeDecision struct {
+	Mode           resumeMode
+	SequenceNumber string    // set when Mode == resumeExact
+	Cutoff         time.Time // set when Mode == resumeFailover (zero => no skip)
+}
+
+// ResolveResume decides how to resume the given shard. In the default
+// (non-global) mode it preserves today's behavior exactly. In global mode it
+// queries the table-name partition once, caches the result, and returns an
+// exact resume if rows exist for the current stream, a time-based failover
+// resume if only another region's rows exist, or default otherwise.
+func (c *Checkpointer) ResolveResume(ctx context.Context, shardID string) (ResumeDecision, error) {
+	if !c.globalTable {
+		seq, err := c.Get(ctx, shardID)
+		if err != nil {
+			return ResumeDecision{}, err
+		}
+		if seq != "" {
+			return ResumeDecision{Mode: resumeExact, SequenceNumber: seq}, nil
+		}
+		return ResumeDecision{Mode: resumeDefault}, nil
+	}
+
+	c.resumeOnce.Do(func() { c.resumeErr = c.prepareResume(ctx) })
+	if c.resumeErr != nil {
+		return ResumeDecision{}, c.resumeErr
+	}
+
+	if len(c.ownSeqs) > 0 {
+		if seq, ok := c.ownSeqs[shardID]; ok {
+			return ResumeDecision{Mode: resumeExact, SequenceNumber: seq}, nil
+		}
+		return ResumeDecision{Mode: resumeDefault}, nil
+	}
+	if c.hasForeignRows {
+		return ResumeDecision{Mode: resumeFailover, Cutoff: c.cutoff}, nil
+	}
+	return ResumeDecision{Mode: resumeDefault}, nil
+}
+
+// prepareResume queries the whole table-name partition once and classifies rows
+// into "own" (current stream) sequence numbers and the minimum
+// ApproximateCreationTime across foreign-stream shard rows.
+func (c *Checkpointer) prepareResume(ctx context.Context) error {
+	c.ownSeqs = map[string]string{}
+	var cutoffSet bool
+
+	var startKey map[string]types.AttributeValue
+	for {
+		out, err := c.svc.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String(c.tableName),
+			KeyConditionExpression: aws.String("TableId = :hash"),
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":hash": &types.AttributeValueMemberS{Value: c.sourceTable},
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			if _, ok := errors.AsType[*types.ResourceNotFoundException](err); ok {
+				return nil
+			}
+			return fmt.Errorf("querying checkpoint partition for %s: %w", c.sourceTable, err)
+		}
+		for _, item := range out.Items {
+			seqAttr, isShardRow := item["SequenceNumber"].(*types.AttributeValueMemberS)
+			if !isShardRow {
+				continue // snapshot row, not a shard checkpoint
+			}
+			shardAttr, _ := item["ShardID"].(*types.AttributeValueMemberS)
+			streamAttr, _ := item["StreamArn"].(*types.AttributeValueMemberS)
+			if streamAttr != nil && streamAttr.Value == c.streamArn {
+				if shardAttr != nil {
+					c.ownSeqs[shardAttr.Value] = seqAttr.Value
+				}
+				continue
+			}
+			// Foreign-stream row: contribute to the low-water-mark cutoff.
+			c.hasForeignRows = true
+			if tsAttr, ok := item["ApproximateCreationTime"].(*types.AttributeValueMemberS); ok && tsAttr.Value != "" {
+				if ts, perr := time.Parse(time.RFC3339Nano, tsAttr.Value); perr == nil {
+					if !cutoffSet || ts.Before(c.cutoff) {
+						c.cutoff = ts
+						cutoffSet = true
+					}
+				}
+			}
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+	return nil
+}
+
+// CheckpointValue is the persisted state for one shard: the sequence number and
+// the ApproximateCreationDateTime (RFC3339Nano) of that record.
+type CheckpointValue struct {
+	SequenceNumber     string
+	ApproxCreationTime string
+}
+
 // FlushCheckpoints writes all pending checkpoints to DynamoDB.
-func (c *Checkpointer) FlushCheckpoints(ctx context.Context, checkpoints map[string]string) error {
-	for shardID, seq := range checkpoints {
-		if seq == "" {
+func (c *Checkpointer) FlushCheckpoints(ctx context.Context, checkpoints map[string]CheckpointValue) error {
+	for shardID, v := range checkpoints {
+		if v.SequenceNumber == "" {
 			continue
 		}
-		if err := c.Set(ctx, shardID, seq); err != nil {
+		if err := c.Set(ctx, shardID, v.SequenceNumber, v.ApproxCreationTime); err != nil {
 			c.log.Errorf("Failed to flush checkpoint for shard %s: %v", shardID, err)
 			return err
 		}
-		c.log.Infof("Flushed checkpoint for shard %s at sequence %s", shardID, seq)
+		c.log.Infof("Flushed checkpoint for shard %s at sequence %s", shardID, v.SequenceNumber)
 	}
 	return nil
 }
@@ -158,10 +410,7 @@ func (c *Checkpointer) SnapshotProgress(ctx context.Context) (*SnapshotCheckpoin
 
 	res, err := c.svc.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(c.tableName),
-		Key: map[string]types.AttributeValue{
-			"StreamArn": &types.AttributeValueMemberS{Value: c.streamArn},
-			"ShardID":   &types.AttributeValueMemberS{Value: "snapshot#complete"},
-		},
+		Key:       c.checkpointKey("snapshot#complete"),
 	})
 	if err != nil {
 		if _, ok := errors.AsType[*types.ResourceNotFoundException](err); !ok {
@@ -176,11 +425,15 @@ func (c *Checkpointer) SnapshotProgress(ctx context.Context) (*SnapshotCheckpoin
 		}
 	}
 
+	hashName, hashVal := "StreamArn", c.streamArn
+	if c.globalTable {
+		hashName, hashVal = "TableId", c.sourceTable
+	}
 	queryRes, err := c.svc.Query(ctx, &dynamodb.QueryInput{
 		TableName:              aws.String(c.tableName),
-		KeyConditionExpression: aws.String("StreamArn = :stream_arn AND begins_with(ShardID, :snapshot_prefix)"),
+		KeyConditionExpression: aws.String(hashName + " = :hash AND begins_with(ShardID, :snapshot_prefix)"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":stream_arn":      &types.AttributeValueMemberS{Value: c.streamArn},
+			":hash":            &types.AttributeValueMemberS{Value: hashVal},
 			":snapshot_prefix": &types.AttributeValueMemberS{Value: "snapshot#segment#"},
 		},
 	})
@@ -230,11 +483,8 @@ func (c *Checkpointer) SnapshotProgress(ctx context.Context) (*SnapshotCheckpoin
 func (c *Checkpointer) UpdateSnapshotProgress(ctx context.Context, segment int, lastKey map[string]types.AttributeValue, recordsRead int64) error {
 	shardID := fmt.Sprintf("snapshot#segment#%d", segment)
 
-	item := map[string]types.AttributeValue{
-		"StreamArn":   &types.AttributeValueMemberS{Value: c.streamArn},
-		"ShardID":     &types.AttributeValueMemberS{Value: shardID},
-		"RecordsRead": &types.AttributeValueMemberN{Value: strconv.FormatInt(recordsRead, 10)},
-	}
+	item := c.checkpointKey(shardID)
+	item["RecordsRead"] = &types.AttributeValueMemberN{Value: strconv.FormatInt(recordsRead, 10)}
 
 	if lastKey == nil {
 		// Segment complete
@@ -258,13 +508,11 @@ func (c *Checkpointer) UpdateSnapshotProgress(ctx context.Context, segment int, 
 
 // MarkSnapshotComplete marks the entire snapshot as complete.
 func (c *Checkpointer) MarkSnapshotComplete(ctx context.Context) error {
+	item := c.checkpointKey("snapshot#complete")
+	item["Complete"] = &types.AttributeValueMemberBOOL{Value: true}
 	_, err := c.svc.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(c.tableName),
-		Item: map[string]types.AttributeValue{
-			"StreamArn": &types.AttributeValueMemberS{Value: c.streamArn},
-			"ShardID":   &types.AttributeValueMemberS{Value: "snapshot#complete"},
-			"Complete":  &types.AttributeValueMemberBOOL{Value: true},
-		},
+		Item:      item,
 	})
 	if err != nil {
 		return fmt.Errorf("marking snapshot complete: %w", err)

--- a/internal/impl/aws/dynamodb/checkpoint_test.go
+++ b/internal/impl/aws/dynamodb/checkpoint_test.go
@@ -88,7 +88,9 @@ func TestCheckpointer_GlobalModeSetUsesPortableKey(t *testing.T) {
 	api := &fakeCheckpointAPI{
 		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
 			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableName:   aws.String("cps"),
 				TableStatus: types.TableStatusActive,
+				KeySchema:   globalTableKeySchema(),
 				Replicas: []types.ReplicaDescription{
 					{RegionName: aws.String("us-east-1")},
 					{RegionName: aws.String("us-west-2")},
@@ -170,7 +172,12 @@ func TestEnsureTable_GlobalReconcilesMissingReplicaWhenTableExists(t *testing.T)
 			for _, r := range added {
 				reps = append(reps, types.ReplicaDescription{RegionName: aws.String(r), ReplicaStatus: types.ReplicaStatusActive})
 			}
-			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{TableStatus: types.TableStatusActive, Replicas: reps}}, nil
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableName:   aws.String("cps"),
+				TableStatus: types.TableStatusActive,
+				KeySchema:   globalTableKeySchema(),
+				Replicas:    reps,
+			}}, nil
 		},
 		createTable: func(context.Context, *dynamodb.CreateTableInput, ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
 			return nil, errors.New("CreateTable must not be called when table exists")
@@ -192,12 +199,56 @@ func TestEnsureTable_GlobalReconcilesMissingReplicaWhenTableExists(t *testing.T)
 	require.Equal(t, []string{"us-west-2"}, added)
 }
 
+func TestEnsureTable_GlobalRejectsExistingNonGlobalTable(t *testing.T) {
+	updateCalled := false
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			// A table created without global_table mode uses a StreamArn hash key.
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableName:   aws.String("cps"),
+				TableStatus: types.TableStatusActive,
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("StreamArn"), KeyType: types.KeyTypeHash},
+					{AttributeName: aws.String("ShardID"), KeyType: types.KeyTypeRange},
+				},
+			}}, nil
+		},
+		createTable: func(context.Context, *dynamodb.CreateTableInput, ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+			return nil, errors.New("CreateTable must not be called when table exists")
+		},
+		updateTable: func(context.Context, *dynamodb.UpdateTableInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+			updateCalled = true
+			return &dynamodb.UpdateTableOutput{}, nil
+		},
+	}
+	_, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "t", StreamArn: "arn:A", CheckpointLimit: 1,
+		GlobalTable: true, Region: "us-east-1", ReplicaRegions: []string{"us-west-2"},
+	}, checkpointTestLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "StreamArn")
+	require.Contains(t, err.Error(), "global_table")
+	require.False(t, updateCalled, "must not reconcile replicas against a schema-mismatched table")
+}
+
+// globalTableKeySchema returns the key schema of a checkpoint table created in
+// global mode (TableId hash + ShardID range), matching what ensureTableExists
+// provisions and what validateGlobalTableSchema requires.
+func globalTableKeySchema() []types.KeySchemaElement {
+	return []types.KeySchemaElement{
+		{AttributeName: aws.String("TableId"), KeyType: types.KeyTypeHash},
+		{AttributeName: aws.String("ShardID"), KeyType: types.KeyTypeRange},
+	}
+}
+
 func globalCheckpointerWithPartition(t *testing.T, currentStreamArn string, items []map[string]types.AttributeValue) *Checkpointer {
 	t.Helper()
 	api := &fakeCheckpointAPI{
 		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
 			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableName:   aws.String("cps"),
 				TableStatus: types.TableStatusActive,
+				KeySchema:   globalTableKeySchema(),
 				Replicas:    []types.ReplicaDescription{{RegionName: aws.String("us-east-1")}, {RegionName: aws.String("us-west-2")}},
 			}}, nil
 		},

--- a/internal/impl/aws/dynamodb/checkpoint_test.go
+++ b/internal/impl/aws/dynamodb/checkpoint_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// fakeCheckpointAPI is a programmable stand-in for the DynamoDB client used by
+// the Checkpointer. Each field is a function the test sets to control behavior;
+// unset functions panic to surface unexpected calls.
+type fakeCheckpointAPI struct {
+	describeTable func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
+	createTable   func(context.Context, *dynamodb.CreateTableInput, ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error)
+	updateTable   func(context.Context, *dynamodb.UpdateTableInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error)
+	getItem       func(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	putItem       func(context.Context, *dynamodb.PutItemInput, ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	query         func(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+func (f *fakeCheckpointAPI) DescribeTable(ctx context.Context, in *dynamodb.DescribeTableInput, o ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+	return f.describeTable(ctx, in, o...)
+}
+
+func (f *fakeCheckpointAPI) CreateTable(ctx context.Context, in *dynamodb.CreateTableInput, o ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+	return f.createTable(ctx, in, o...)
+}
+
+func (f *fakeCheckpointAPI) UpdateTable(ctx context.Context, in *dynamodb.UpdateTableInput, o ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+	return f.updateTable(ctx, in, o...)
+}
+
+func (f *fakeCheckpointAPI) GetItem(ctx context.Context, in *dynamodb.GetItemInput, o ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return f.getItem(ctx, in, o...)
+}
+
+func (f *fakeCheckpointAPI) PutItem(ctx context.Context, in *dynamodb.PutItemInput, o ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	return f.putItem(ctx, in, o...)
+}
+
+func (f *fakeCheckpointAPI) Query(ctx context.Context, in *dynamodb.QueryInput, o ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return f.query(ctx, in, o...)
+}
+
+func checkpointTestLogger() *service.Logger { return service.MockResources().Logger() }
+
+func TestNewCheckpointer_NonGlobalCreatesTable(t *testing.T) {
+	created := false
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			return nil, &types.ResourceNotFoundException{}
+		},
+		createTable: func(_ context.Context, in *dynamodb.CreateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+			created = true
+			require.Nil(t, in.StreamSpecification, "non-global table must not enable streams")
+			require.Equal(t, "StreamArn", aws.ToString(in.KeySchema[0].AttributeName))
+			return &dynamodb.CreateTableOutput{}, nil
+		},
+	}
+	_, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName:       "cps",
+		SourceTable:     "mytable",
+		StreamArn:       "arn:stream:A",
+		CheckpointLimit: 1000,
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+	require.True(t, created)
+}
+
+func TestCheckpointer_GlobalModeSetUsesPortableKey(t *testing.T) {
+	var put *dynamodb.PutItemInput
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableStatus: types.TableStatusActive,
+				Replicas: []types.ReplicaDescription{
+					{RegionName: aws.String("us-east-1")},
+					{RegionName: aws.String("us-west-2")},
+				},
+			}}, nil
+		},
+		putItem: func(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			put = in
+			return &dynamodb.PutItemOutput{}, nil
+		},
+	}
+	c, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "mytable", StreamArn: "arn:A",
+		CheckpointLimit: 1, GlobalTable: true, Region: "us-east-1", ReplicaRegions: []string{"us-west-2"},
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+
+	require.NoError(t, c.Set(context.Background(), "shard-1", "seq-100", "2026-06-16T10:00:00Z"))
+
+	require.Equal(t, "mytable", put.Item["TableId"].(*types.AttributeValueMemberS).Value)
+	require.Equal(t, "shard-1", put.Item["ShardID"].(*types.AttributeValueMemberS).Value)
+	require.Equal(t, "seq-100", put.Item["SequenceNumber"].(*types.AttributeValueMemberS).Value)
+	require.Equal(t, "arn:A", put.Item["StreamArn"].(*types.AttributeValueMemberS).Value)
+	require.Equal(t, "2026-06-16T10:00:00Z", put.Item["ApproximateCreationTime"].(*types.AttributeValueMemberS).Value)
+	_, hasStreamArnHashKey := put.Item["TableId"]
+	require.True(t, hasStreamArnHashKey)
+}
+
+func TestEnsureTable_GlobalCreatesWithStreamsAndAddsReplicas(t *testing.T) {
+	var createIn *dynamodb.CreateTableInput
+	var replicaRegions []string
+	describeCalls := 0
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			describeCalls++
+			if describeCalls == 1 {
+				return nil, &types.ResourceNotFoundException{} // not exists -> create
+			}
+			reps := make([]types.ReplicaDescription, 0, len(replicaRegions))
+			for _, r := range replicaRegions {
+				reps = append(reps, types.ReplicaDescription{RegionName: aws.String(r), ReplicaStatus: types.ReplicaStatusActive})
+			}
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableStatus: types.TableStatusActive,
+				Replicas:    reps,
+			}}, nil
+		},
+		createTable: func(_ context.Context, in *dynamodb.CreateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+			createIn = in
+			return &dynamodb.CreateTableOutput{}, nil
+		},
+		updateTable: func(_ context.Context, in *dynamodb.UpdateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+			for _, u := range in.ReplicaUpdates {
+				if u.Create != nil {
+					replicaRegions = append(replicaRegions, aws.ToString(u.Create.RegionName))
+				}
+			}
+			return &dynamodb.UpdateTableOutput{}, nil
+		},
+	}
+	_, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "t", StreamArn: "arn:A", CheckpointLimit: 1,
+		GlobalTable: true, Region: "us-east-1", ReplicaRegions: []string{"us-west-2"},
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+	require.NotNil(t, createIn.StreamSpecification)
+	require.True(t, aws.ToBool(createIn.StreamSpecification.StreamEnabled))
+	require.Equal(t, types.StreamViewTypeNewAndOldImages, createIn.StreamSpecification.StreamViewType)
+	require.Equal(t, "TableId", aws.ToString(createIn.KeySchema[0].AttributeName))
+	require.Contains(t, replicaRegions, "us-west-2")
+	require.NotContains(t, replicaRegions, "us-east-1", "home region must not be added as a replica")
+}
+
+func TestEnsureTable_GlobalReconcilesMissingReplicaWhenTableExists(t *testing.T) {
+	added := []string{}
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			reps := []types.ReplicaDescription{{RegionName: aws.String("us-east-1"), ReplicaStatus: types.ReplicaStatusActive}}
+			for _, r := range added {
+				reps = append(reps, types.ReplicaDescription{RegionName: aws.String(r), ReplicaStatus: types.ReplicaStatusActive})
+			}
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{TableStatus: types.TableStatusActive, Replicas: reps}}, nil
+		},
+		createTable: func(context.Context, *dynamodb.CreateTableInput, ...func(*dynamodb.Options)) (*dynamodb.CreateTableOutput, error) {
+			return nil, errors.New("CreateTable must not be called when table exists")
+		},
+		updateTable: func(_ context.Context, in *dynamodb.UpdateTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error) {
+			for _, u := range in.ReplicaUpdates {
+				if u.Create != nil {
+					added = append(added, aws.ToString(u.Create.RegionName))
+				}
+			}
+			return &dynamodb.UpdateTableOutput{}, nil
+		},
+	}
+	_, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "t", StreamArn: "arn:A", CheckpointLimit: 1,
+		GlobalTable: true, Region: "us-east-1", ReplicaRegions: []string{"us-west-2"},
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+	require.Equal(t, []string{"us-west-2"}, added)
+}
+
+func globalCheckpointerWithPartition(t *testing.T, currentStreamArn string, items []map[string]types.AttributeValue) *Checkpointer {
+	t.Helper()
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{
+				TableStatus: types.TableStatusActive,
+				Replicas:    []types.ReplicaDescription{{RegionName: aws.String("us-east-1")}, {RegionName: aws.String("us-west-2")}},
+			}}, nil
+		},
+		query: func(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{Items: items}, nil
+		},
+	}
+	c, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "t", StreamArn: currentStreamArn, CheckpointLimit: 1,
+		GlobalTable: true, Region: "us-east-1", ReplicaRegions: []string{"us-west-2"},
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+	return c
+}
+
+func shardRow(streamArn, shardID, seq, ts string) map[string]types.AttributeValue {
+	row := map[string]types.AttributeValue{
+		"TableId":        &types.AttributeValueMemberS{Value: "t"},
+		"ShardID":        &types.AttributeValueMemberS{Value: shardID},
+		"StreamArn":      &types.AttributeValueMemberS{Value: streamArn},
+		"SequenceNumber": &types.AttributeValueMemberS{Value: seq},
+	}
+	if ts != "" {
+		row["ApproximateCreationTime"] = &types.AttributeValueMemberS{Value: ts}
+	}
+	return row
+}
+
+func TestResolveResume_ExactWhenCurrentStreamHasRows(t *testing.T) {
+	c := globalCheckpointerWithPartition(t, "arn:A", []map[string]types.AttributeValue{
+		shardRow("arn:A", "shard-1", "seq-9", "2026-06-16T10:00:00Z"),
+	})
+	d, err := c.ResolveResume(context.Background(), "shard-1")
+	require.NoError(t, err)
+	require.Equal(t, resumeExact, d.Mode)
+	require.Equal(t, "seq-9", d.SequenceNumber)
+}
+
+func TestResolveResume_FailoverUsesMinTimestampOfForeignRows(t *testing.T) {
+	c := globalCheckpointerWithPartition(t, "arn:B", []map[string]types.AttributeValue{
+		shardRow("arn:A", "shard-x", "seq-1", "2026-06-16T10:05:00Z"),
+		shardRow("arn:A", "shard-y", "seq-2", "2026-06-16T10:01:00Z"), // min
+	})
+	d, err := c.ResolveResume(context.Background(), "shard-new")
+	require.NoError(t, err)
+	require.Equal(t, resumeFailover, d.Mode)
+	require.Equal(t, "2026-06-16T10:01:00Z", d.Cutoff.UTC().Format(time.RFC3339))
+}
+
+func TestResolveResume_DefaultWhenPartitionEmpty(t *testing.T) {
+	c := globalCheckpointerWithPartition(t, "arn:A", nil)
+	d, err := c.ResolveResume(context.Background(), "shard-1")
+	require.NoError(t, err)
+	require.Equal(t, resumeDefault, d.Mode)
+}
+
+func TestResolveResume_NonGlobalFallsBackToGet(t *testing.T) {
+	api := &fakeCheckpointAPI{
+		describeTable: func(context.Context, *dynamodb.DescribeTableInput, ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{TableStatus: types.TableStatusActive}}, nil
+		},
+		getItem: func(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+			return &dynamodb.GetItemOutput{Item: map[string]types.AttributeValue{
+				"SequenceNumber": &types.AttributeValueMemberS{Value: "seq-42"},
+			}}, nil
+		},
+	}
+	c, err := NewCheckpointer(context.Background(), api, CheckpointerConfig{
+		TableName: "cps", SourceTable: "t", StreamArn: "arn:A", CheckpointLimit: 1,
+	}, checkpointTestLogger())
+	require.NoError(t, err)
+	d, err := c.ResolveResume(context.Background(), "shard-1")
+	require.NoError(t, err)
+	require.Equal(t, resumeExact, d.Mode)
+	require.Equal(t, "seq-42", d.SequenceNumber)
+}

--- a/internal/impl/aws/dynamodb/checkpoint_test.go
+++ b/internal/impl/aws/dynamodb/checkpoint_test.go
@@ -277,6 +277,18 @@ func shardRow(streamArn, shardID, seq, ts string) map[string]types.AttributeValu
 	return row
 }
 
+func TestCDCCheckpointProbeNeeded(t *testing.T) {
+	// Only an exact, same-region resume can be a stale checkpoint: its sequence
+	// number belongs to this stream, so a failed iterator means trimmed data.
+	require.True(t, cdcCheckpointProbeNeeded(resumeExact))
+	// A failover resume reads from the trim horizon (another region's sequence
+	// number must NOT be probed against this stream) — never stale. This is the
+	// regression guard: probing here re-triggered a full snapshot after failover.
+	require.False(t, cdcCheckpointProbeNeeded(resumeFailover))
+	// No usable checkpoint: nothing to probe.
+	require.False(t, cdcCheckpointProbeNeeded(resumeDefault))
+}
+
 func TestResolveResume_ExactWhenCurrentStreamHasRows(t *testing.T) {
 	c := globalCheckpointerWithPartition(t, "arn:A", []map[string]types.AttributeValue{
 		shardRow("arn:A", "shard-1", "seq-9", "2026-06-16T10:00:00Z"),

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1431,22 +1431,34 @@ func (d *dynamoDBCDCInput) isCDCCheckpointStale(ctx context.Context) (bool, erro
 	for _, shard := range shards {
 		shardID := *shard.ShardId
 
-		// Check if we have a checkpoint for this shard
-		checkpoint, err := d.checkpointer.Get(ctx, shardID)
-		if err != nil || checkpoint == "" {
-			if err != nil {
-				d.log.Warnf("Failed to get checkpoint for shard %s: %v", shardID, err)
-			}
+		// Resolve how this shard would resume, using the same global-table-aware
+		// logic as the real readers. After a regional failover the checkpoint
+		// row holds another region's sequence number, which ResolveResume
+		// classifies as a time-based failover replay (resumeFailover) rather
+		// than an exact resume — so we must NOT probe it with that foreign
+		// sequence number against this region's stream. Doing so previously
+		// errored and was misread as a stale checkpoint, forcing a needless full
+		// re-snapshot on the first restart after failover.
+		decision, err := d.checkpointer.ResolveResume(ctx, shardID)
+		if err != nil {
+			return false, fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
+		}
+
+		// Only an exact (same-region) resume can be stale: its sequence number
+		// belongs to this stream, so a failed iterator means the data has been
+		// trimmed (connector down beyond the retention window). Failover and
+		// default resumes read from the trim horizon, which is always valid.
+		if !cdcCheckpointProbeNeeded(decision.Mode) {
 			continue
 		}
 
-		// Try to get a shard iterator using the checkpointed sequence number
-		// If this fails, the sequence is too old and data has expired
+		// Try to get a shard iterator using the checkpointed sequence number.
+		// If this fails, the sequence is too old and data has expired.
 		_, err = d.streamsClient.GetShardIterator(ctx, &dynamodbstreams.GetShardIteratorInput{
 			StreamArn:         d.streamArn,
 			ShardId:           shard.ShardId,
 			ShardIteratorType: types.ShardIteratorTypeAfterSequenceNumber,
-			SequenceNumber:    &checkpoint,
+			SequenceNumber:    &decision.SequenceNumber,
 		})
 		if err != nil {
 			d.log.Warnf("Shard %s checkpoint is stale: %v", shardID, err)
@@ -1456,6 +1468,14 @@ func (d *dynamoDBCDCInput) isCDCCheckpointStale(ctx context.Context) (bool, erro
 	}
 
 	return false, nil
+}
+
+// cdcCheckpointProbeNeeded reports whether a shard's resume decision warrants
+// probing the stream to detect a stale (trimmed) checkpoint. Only an exact,
+// same-region resume carries a sequence number valid against this stream;
+// failover and default resumes read from the trim horizon and are never stale.
+func cdcCheckpointProbeNeeded(mode resumeMode) bool {
+	return mode == resumeExact
 }
 
 func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -2196,19 +2196,34 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 	}
 }
 
+// shouldSkipFailoverRecord reports whether a record was already processed in the
+// prior region during a global-table failover replay and may be skipped.
+//
+// The cutoff is the minimum ApproximateCreationTime across the prior region's
+// checkpoints. DynamoDB Streams ApproximateCreationDateTime is second-granular,
+// so records can share the cutoff second; on the shard whose checkpoint defines
+// the cutoff, records in that same second that followed the checkpointed
+// position were never processed in the prior region. Skipping only records
+// strictly before the cutoff replays that boundary second (acceptable
+// duplicates) rather than dropping it, preserving at-least-once delivery.
+func shouldSkipFailoverRecord(record types.Record, failoverCutoff time.Time) bool {
+	if failoverCutoff.IsZero() || record.Dynamodb == nil || record.Dynamodb.ApproximateCreationDateTime == nil {
+		return false
+	}
+	return record.Dynamodb.ApproximateCreationDateTime.Before(failoverCutoff)
+}
+
 // convertTableRecordsToBatch converts DynamoDB Stream records to Benthos messages for a specific table
 func convertTableRecordsToBatch(records []types.Record, tableName, shardID string, dedupeBuffer *snapshotSequenceBuffer, failoverCutoff time.Time, failoverSkipped *service.MetricCounter) service.MessageBatch {
 	batch := make(service.MessageBatch, 0, len(records))
 
 	for _, record := range records {
 		// Global-table failover: skip records already processed in the prior region.
-		if !failoverCutoff.IsZero() && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
-			if !record.Dynamodb.ApproximateCreationDateTime.After(failoverCutoff) {
-				if failoverSkipped != nil {
-					failoverSkipped.Incr(1)
-				}
-				continue
+		if shouldSkipFailoverRecord(record, failoverCutoff) {
+			if failoverSkipped != nil {
+				failoverSkipped.Incr(1)
 			}
+			continue
 		}
 
 		// CDC deduplication: skip records already seen in snapshot
@@ -2809,13 +2824,11 @@ func (d *dynamoDBCDCInput) convertRecordsToBatch(records []types.Record, shardID
 
 	for _, record := range records {
 		// Global-table failover: skip records already processed in the prior region.
-		if !failoverCutoff.IsZero() && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
-			if !record.Dynamodb.ApproximateCreationDateTime.After(failoverCutoff) {
-				if d.metrics.failoverSkipped != nil {
-					d.metrics.failoverSkipped.Incr(1)
-				}
-				continue
+		if shouldSkipFailoverRecord(record, failoverCutoff) {
+			if d.metrics.failoverSkipped != nil {
+				d.metrics.failoverSkipped.Incr(1)
 			}
+			continue
 		}
 
 		// CDC deduplication: skip records already seen in snapshot

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -58,6 +58,7 @@ const (
 	metricSnapshotBufferOverflow  = "dynamodb_cdc_snapshot_buffer_overflow"
 	metricCheckpointFailures      = "dynamodb_cdc_checkpoint_failures"
 	metricSnapshotSegmentDuration = "dynamodb_cdc_snapshot_segment_duration"
+	metricFailoverSkipped         = "dynamodb_cdc_failover_skipped"
 
 	// Config field names.
 	dciFieldTables                 = "tables"
@@ -65,6 +66,8 @@ const (
 	dciFieldTableTagFilter         = "table_tag_filter"
 	dciFieldTableDiscoveryInterval = "table_discovery_interval"
 	dciFieldCheckpointTable        = "checkpoint_table"
+	dciFieldGlobalTable            = "global_table"
+	dciFieldGlobalTableReplicas    = "global_table_replicas"
 	dciFieldBatchSize              = "batch_size"
 	dciFieldPollInterval           = "poll_interval"
 	dciFieldStartFrom              = "start_from"
@@ -157,6 +160,7 @@ This input adds the following metadata fields to each message:
 
 - `+"`dynamodb_shard_id`"+` - The shard ID from which the record was read (empty for snapshot records)
 - `+"`dynamodb_sequence_number`"+` - The sequence number of the record in the stream (empty for snapshot records)
+- `+"`dynamodb_approximate_creation_time`"+` - RFC3339 approximate creation time of the stream record (empty for snapshot records)
 - `+"`dynamodb_event_name`"+` - The type of change: INSERT, MODIFY, REMOVE, or READ (for snapshot records)
 - `+"`dynamodb_table`"+` - The name of the DynamoDB table
 
@@ -172,6 +176,13 @@ This input emits the following metrics:
 - `+"`dynamodb_cdc_snapshot_buffer_overflow`"+` - Incremented when the deduplication buffer exceeds its size limit, disabling dedup (counter)
 - `+"`dynamodb_cdc_snapshot_segment_duration`"+` - Time taken by each snapshot scan segment to complete (timer)
 - `+"`dynamodb_cdc_checkpoint_failures`"+` - Number of failed checkpoint writes to the checkpoint table (counter)
+- `+"`dynamodb_cdc_failover_skipped`"+` - Records skipped during global-table failover replay because they predate the resumed cutoff (counter)
+
+### Global Table Checkpoints (multi-region failover)
+
+In active/active or active/passive multi-region deployments, set `+"`global_table: true`"+` and list the other regions in `+"`global_table_replicas`"+` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. This only affects table creation — it is a no-op if the checkpoint table already exists.
+
+When `+"`global_table`"+` is enabled the principal additionally needs `+"`dynamodb:CreateTable`"+`, `+"`dynamodb:UpdateTable`"+`, `+"`dynamodb:DescribeTable`"+`, `+"`dynamodb:DescribeLimits`"+`, `+"`iam:CreateServiceLinkedRole`"+`, and create/describe permissions in each replica region.
 `).
 		Fields(
 			service.NewStringListField(dciFieldTables).
@@ -192,6 +203,14 @@ This input emits the following metrics:
 			service.NewStringField(dciFieldCheckpointTable).
 				Description("DynamoDB table name for storing checkpoints. Will be created if it doesn't exist.").
 				Default("redpanda_dynamodb_checkpoints"),
+			service.NewBoolField(dciFieldGlobalTable).
+				Description("When the checkpoint table is auto-created, provision it as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. No effect if the checkpoint table already exists.").
+				Default(false).
+				Advanced(),
+			service.NewStringListField(dciFieldGlobalTableReplicas).
+				Description("Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Only used when the checkpoint table is created.").
+				Default([]any{}).
+				Advanced(),
 			service.NewIntField(dciFieldBatchSize).
 				Description("Maximum number of records to read per shard in a single request. Valid range: 1-1000.").
 				Default(defaultDynamoDBBatchSize).
@@ -344,6 +363,8 @@ type dynamoDBCDCConfig struct {
 	parsedTagFilter        map[string][]string // Parsed filter for efficient matching
 	tableDiscoveryInterval time.Duration
 	checkpointTable        string
+	globalTable            bool
+	globalTableReplicas    []string
 	batchSize              int
 	pollInterval           time.Duration
 	startFrom              string
@@ -407,6 +428,7 @@ type dynamoDBCDCMetrics struct {
 	snapshotBufferOverflow  *service.MetricCounter // Counts buffer overflow events
 	snapshotSegmentDuration *service.MetricTimer   // Tracks segment scan duration
 	checkpointFailures      *service.MetricCounter // Counts checkpoint write failures
+	failoverSkipped         *service.MetricCounter // Counts records skipped during global-table failover replay
 }
 
 type dynamoDBShardReader struct {
@@ -418,6 +440,7 @@ type dynamoDBShardReader struct {
 	// where reading left off if the current iterator expires (see
 	// refreshExpiredIterator).
 	lastSequenceNumber string
+	failoverCutoff     time.Time // global-table failover: skip records at/under this time
 }
 
 // snapshotState encapsulates all state related to snapshot scanning.
@@ -641,6 +664,10 @@ func validateDynamoDBCDCConfig(conf dynamoDBCDCConfig) error {
 		return errors.New("tables list cannot be empty when table_discovery_mode is 'single' or 'includelist'")
 	}
 
+	if conf.globalTable && len(conf.globalTableReplicas) == 0 {
+		return errors.New("global_table requires at least one replica region in global_table_replicas")
+	}
+
 	// Validate snapshot configuration
 	if conf.snapshot.segments < 1 || conf.snapshot.segments > 10 {
 		return errors.New("snapshot_segments must be between 1 and 10")
@@ -686,6 +713,12 @@ func dynamoCDCInputConfigFromParsed(pConf *service.ParsedConfig) (conf dynamoDBC
 		return
 	}
 	if conf.checkpointTable, err = pConf.FieldString(dciFieldCheckpointTable); err != nil {
+		return
+	}
+	if conf.globalTable, err = pConf.FieldBool(dciFieldGlobalTable); err != nil {
+		return
+	}
+	if conf.globalTableReplicas, err = pConf.FieldStringList(dciFieldGlobalTableReplicas); err != nil {
 		return
 	}
 	if conf.batchSize, err = pConf.FieldInt(dciFieldBatchSize); err != nil {
@@ -742,6 +775,9 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 	if err != nil {
 		return nil, err
 	}
+	if conf.globalTable && awsConf.Region == "" {
+		return nil, errors.New("global_table requires an AWS region to be configured (set `region` or the AWS_REGION environment)")
+	}
 
 	input := &dynamoDBCDCInput{
 		conf:         conf,
@@ -759,6 +795,7 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 			snapshotBufferOverflow:  mgr.Metrics().NewCounter(metricSnapshotBufferOverflow),
 			snapshotSegmentDuration: mgr.Metrics().NewTimer(metricSnapshotSegmentDuration),
 			checkpointFailures:      mgr.Metrics().NewCounter(metricCheckpointFailures),
+			failoverSkipped:         mgr.Metrics().NewCounter(metricFailoverSkipped),
 		},
 	}
 
@@ -948,7 +985,15 @@ func (d *dynamoDBCDCInput) connectSingleTable(ctx context.Context, tableName str
 	d.keySchema = descTable.Table.KeySchema
 
 	// Initialize checkpointer
-	d.checkpointer, err = NewCheckpointer(ctx, d.dynamoClient, d.conf.checkpointTable, *d.streamArn, d.conf.checkpointLimit, d.log)
+	d.checkpointer, err = NewCheckpointer(ctx, d.dynamoClient, CheckpointerConfig{
+		TableName:       d.conf.checkpointTable,
+		SourceTable:     tableName,
+		StreamArn:       *d.streamArn,
+		CheckpointLimit: d.conf.checkpointLimit,
+		GlobalTable:     d.conf.globalTable,
+		Region:          d.awsConf.Region,
+		ReplicaRegions:  d.conf.globalTableReplicas,
+	}, d.log)
 	if err != nil {
 		return fmt.Errorf("creating checkpointer: %w", err)
 	}
@@ -1052,7 +1097,15 @@ func (d *dynamoDBCDCInput) initializeTableStream(ctx context.Context, tableName 
 	streamArn := *descTable.Table.LatestStreamArn
 
 	// Initialize checkpointer for this table
-	checkpointer, err := NewCheckpointer(ctx, d.dynamoClient, d.conf.checkpointTable, streamArn, d.conf.checkpointLimit, d.log)
+	checkpointer, err := NewCheckpointer(ctx, d.dynamoClient, CheckpointerConfig{
+		TableName:       d.conf.checkpointTable,
+		SourceTable:     tableName,
+		StreamArn:       streamArn,
+		CheckpointLimit: d.conf.checkpointLimit,
+		GlobalTable:     d.conf.globalTable,
+		Region:          d.awsConf.Region,
+		ReplicaRegions:  d.conf.globalTableReplicas,
+	}, d.log)
 	if err != nil {
 		return false, fmt.Errorf("creating checkpointer for table %s: %w", tableName, err)
 	}
@@ -1415,6 +1468,7 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 	type shardToAdd struct {
 		shardID  string
 		iterator *string
+		cutoff   time.Time
 	}
 	var newShards []shardToAdd
 
@@ -1430,22 +1484,29 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 			continue
 		}
 
-		// Check checkpoint (I/O operation - do not hold lock)
-		checkpoint, err := d.checkpointer.Get(ctx, shardID)
+		// Decide how to resume this shard (global-table aware).
+		decision, err := d.checkpointer.ResolveResume(ctx, shardID)
 		if err != nil {
-			return fmt.Errorf("getting checkpoint for shard %s: %w", shardID, err)
+			return fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
 		}
 
 		var (
 			iteratorType   types.ShardIteratorType
 			sequenceNumber *string
+			cutoff         time.Time
 		)
 
-		if checkpoint != "" {
+		switch decision.Mode {
+		case resumeExact:
 			iteratorType = types.ShardIteratorTypeAfterSequenceNumber
-			sequenceNumber = &checkpoint
-			d.log.Infof("Resuming shard %s from checkpoint: %s", shardID, checkpoint)
-		} else {
+			seq := decision.SequenceNumber
+			sequenceNumber = &seq
+			d.log.Infof("Resuming shard %s from checkpoint: %s", shardID, seq)
+		case resumeFailover:
+			iteratorType = types.ShardIteratorTypeTrimHorizon
+			cutoff = decision.Cutoff
+			d.log.Infof("Failover resume for shard %s from trim horizon, skipping records at/before %s", shardID, cutoff.Format(time.RFC3339))
+		default:
 			if d.conf.startFrom == "latest" {
 				iteratorType = types.ShardIteratorTypeLatest
 			} else {
@@ -1468,6 +1529,7 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 		newShards = append(newShards, shardToAdd{
 			shardID:  shardID,
 			iterator: iter.ShardIterator,
+			cutoff:   cutoff,
 		})
 	}
 
@@ -1478,9 +1540,10 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 			// Double-check shard wasn't added by another goroutine
 			if _, exists := d.shardReaders[s.shardID]; !exists {
 				d.shardReaders[s.shardID] = &dynamoDBShardReader{
-					shardID:   s.shardID,
-					iterator:  s.iterator,
-					exhausted: false,
+					shardID:        s.shardID,
+					iterator:       s.iterator,
+					exhausted:      false,
+					failoverCutoff: s.cutoff,
 				}
 			}
 		}
@@ -1707,6 +1770,7 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 	type shardToAdd struct {
 		shardID  string
 		iterator *string
+		cutoff   time.Time
 	}
 	var newShards []shardToAdd
 
@@ -1721,22 +1785,29 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 			continue
 		}
 
-		// Check checkpoint
-		checkpoint, err := ts.checkpointer.Get(ctx, shardID)
+		// Decide how to resume this shard (global-table aware).
+		decision, err := ts.checkpointer.ResolveResume(ctx, shardID)
 		if err != nil {
-			return fmt.Errorf("getting checkpoint for shard %s: %w", shardID, err)
+			return fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
 		}
 
 		var (
 			iteratorType   types.ShardIteratorType
 			sequenceNumber *string
+			cutoff         time.Time
 		)
 
-		if checkpoint != "" {
+		switch decision.Mode {
+		case resumeExact:
 			iteratorType = types.ShardIteratorTypeAfterSequenceNumber
-			sequenceNumber = &checkpoint
-			d.log.Infof("Resuming shard %s (table %s) from checkpoint: %s", shardID, tableName, checkpoint)
-		} else {
+			seq := decision.SequenceNumber
+			sequenceNumber = &seq
+			d.log.Infof("Resuming shard %s (table %s) from checkpoint: %s", shardID, tableName, seq)
+		case resumeFailover:
+			iteratorType = types.ShardIteratorTypeTrimHorizon
+			cutoff = decision.Cutoff
+			d.log.Infof("Failover resume for shard %s (table %s) from trim horizon, skipping records at/before %s", shardID, tableName, cutoff.Format(time.RFC3339))
+		default:
 			if d.conf.startFrom == "latest" {
 				iteratorType = types.ShardIteratorTypeLatest
 			} else {
@@ -1759,6 +1830,7 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 		newShards = append(newShards, shardToAdd{
 			shardID:  shardID,
 			iterator: iter.ShardIterator,
+			cutoff:   cutoff,
 		})
 	}
 
@@ -1768,9 +1840,10 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 		for _, s := range newShards {
 			if _, exists := ts.shardReaders[s.shardID]; !exists {
 				ts.shardReaders[s.shardID] = &dynamoDBShardReader{
-					shardID:   s.shardID,
-					iterator:  s.iterator,
-					exhausted: false,
+					shardID:        s.shardID,
+					iterator:       s.iterator,
+					exhausted:      false,
+					failoverCutoff: s.cutoff,
 				}
 			}
 		}
@@ -1867,6 +1940,26 @@ func (d *dynamoDBCDCInput) refreshExpiredIterator(ctx context.Context, cp *Check
 		return nil, fmt.Errorf("getting refreshed iterator for shard %s: %w", shardID, err)
 	}
 	return iter.ShardIterator, nil
+}
+
+// getShardCutoff returns the global-table failover cutoff for a shard (zero if
+// none); records at or before it are skipped during failover replay.
+func (ts *tableStream) getShardCutoff(shardID string) time.Time {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	if reader, ok := ts.shardReaders[shardID]; ok {
+		return reader.failoverCutoff
+	}
+	return time.Time{}
+}
+
+func (d *dynamoDBCDCInput) getShardCutoff(shardID string) time.Time {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if reader, ok := d.shardReaders[shardID]; ok {
+		return reader.failoverCutoff
+	}
+	return time.Time{}
 }
 
 // startTableShardReader reads from a single shard for a specific table
@@ -2031,7 +2124,7 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 		if ts.snapshot != nil {
 			dedupeBuffer = ts.snapshot.seqBuffer
 		}
-		batch := convertTableRecordsToBatch(getRecords.Records, tableName, shardID, dedupeBuffer)
+		batch := convertTableRecordsToBatch(getRecords.Records, tableName, shardID, dedupeBuffer, ts.getShardCutoff(shardID), d.metrics.failoverSkipped)
 		if len(batch) == 0 {
 			continue
 		}
@@ -2084,10 +2177,20 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 }
 
 // convertTableRecordsToBatch converts DynamoDB Stream records to Benthos messages for a specific table
-func convertTableRecordsToBatch(records []types.Record, tableName, shardID string, dedupeBuffer *snapshotSequenceBuffer) service.MessageBatch {
+func convertTableRecordsToBatch(records []types.Record, tableName, shardID string, dedupeBuffer *snapshotSequenceBuffer, failoverCutoff time.Time, failoverSkipped *service.MetricCounter) service.MessageBatch {
 	batch := make(service.MessageBatch, 0, len(records))
 
 	for _, record := range records {
+		// Global-table failover: skip records already processed in the prior region.
+		if !failoverCutoff.IsZero() && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
+			if !record.Dynamodb.ApproximateCreationDateTime.After(failoverCutoff) {
+				if failoverSkipped != nil {
+					failoverSkipped.Incr(1)
+				}
+				continue
+			}
+		}
+
 		// CDC deduplication: skip records already seen in snapshot
 		if dedupeBuffer != nil && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
 			cdcTimestamp := record.Dynamodb.ApproximateCreationDateTime.Format(time.RFC3339Nano)
@@ -2138,6 +2241,9 @@ func convertTableRecordsToBatch(records []types.Record, tableName, shardID strin
 		// Set metadata
 		msg.MetaSetMut("dynamodb_shard_id", shardID)
 		msg.MetaSetMut("dynamodb_sequence_number", sequenceNumber)
+		if record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
+			msg.MetaSetMut("dynamodb_approximate_creation_time", record.Dynamodb.ApproximateCreationDateTime.Format(time.RFC3339Nano))
+		}
 		msg.MetaSetMut("dynamodb_event_name", string(record.EventName))
 		msg.MetaSetMut("dynamodb_table", tableName)
 
@@ -2421,7 +2527,7 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 		}
 
 		// Convert records to messages
-		batch := d.convertRecordsToBatch(getRecords.Records, shardID)
+		batch := d.convertRecordsToBatch(getRecords.Records, shardID, d.getShardCutoff(shardID))
 		if len(batch) == 0 {
 			continue
 		}
@@ -2670,7 +2776,7 @@ func writeStreamAttributeValueString(sb *strings.Builder, attr types.AttributeVa
 }
 
 // convertRecordsToBatch converts DynamoDB Stream records to Benthos messages
-func (d *dynamoDBCDCInput) convertRecordsToBatch(records []types.Record, shardID string) service.MessageBatch {
+func (d *dynamoDBCDCInput) convertRecordsToBatch(records []types.Record, shardID string, failoverCutoff time.Time) service.MessageBatch {
 	batch := make(service.MessageBatch, 0, len(records))
 
 	tableName := d.resolvedTable
@@ -2682,6 +2788,16 @@ func (d *dynamoDBCDCInput) convertRecordsToBatch(records []types.Record, shardID
 	}
 
 	for _, record := range records {
+		// Global-table failover: skip records already processed in the prior region.
+		if !failoverCutoff.IsZero() && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
+			if !record.Dynamodb.ApproximateCreationDateTime.After(failoverCutoff) {
+				if d.metrics.failoverSkipped != nil {
+					d.metrics.failoverSkipped.Incr(1)
+				}
+				continue
+			}
+		}
+
 		// CDC deduplication: skip records already seen in snapshot
 		if dedupeBuffer != nil && record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
 			cdcTimestamp := record.Dynamodb.ApproximateCreationDateTime.Format(time.RFC3339Nano)
@@ -2732,6 +2848,9 @@ func (d *dynamoDBCDCInput) convertRecordsToBatch(records []types.Record, shardID
 		// Set metadata
 		msg.MetaSetMut("dynamodb_shard_id", shardID)
 		msg.MetaSetMut("dynamodb_sequence_number", sequenceNumber)
+		if record.Dynamodb != nil && record.Dynamodb.ApproximateCreationDateTime != nil {
+			msg.MetaSetMut("dynamodb_approximate_creation_time", record.Dynamodb.ApproximateCreationDateTime.Format(time.RFC3339Nano))
+		}
 		msg.MetaSetMut("dynamodb_event_name", string(record.EventName))
 		msg.MetaSetMut("dynamodb_table", tableName)
 

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -776,7 +776,7 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 		return nil, err
 	}
 	if conf.globalTable && awsConf.Region == "" {
-		return nil, errors.New("global_table requires an AWS region to be configured (set `region` or the AWS_REGION environment)")
+		return nil, errors.New("global_table requires an AWS region to be configured (set `region` or the AWS_REGION environmental variable)")
 	}
 
 	input := &dynamoDBCDCInput{

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -180,7 +180,7 @@ This input emits the following metrics:
 
 ### Global Table Checkpoints (multi-region failover)
 
-In active/active or active/passive multi-region deployments, set `+"`global_table: true`"+` and list the other regions in `+"`global_table_replicas`"+` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. This only affects table creation — it is a no-op if the checkpoint table already exists.
+In active/active or active/passive multi-region deployments, set `+"`global_table: true`"+` and list the other regions in `+"`global_table_replicas`"+` so the auto-created checkpoint table is provisioned as a DynamoDB Global Table (v2). Checkpoints then replicate across regions: a failed-over pipeline resumes near the last committed position instead of replaying the whole stream. Because each region's stream has its own sequence numbers, cross-region resume is time-based (at-least-once, replaying from the trim horizon up to the last replicated record time); same-region restarts still resume exactly. If the checkpoint table already exists, enabling `+"`global_table`"+` reconciles it towards the desired configuration: any missing replica regions are added via `+"`UpdateTable`"+`. The existing table must have been created in global mode (it must use a `+"`TableId`"+` hash key); pointing `+"`global_table`"+` at a pre-existing non-global checkpoint table fails fast with a clear error rather than mutating it.
 
 When `+"`global_table`"+` is enabled the principal additionally needs `+"`dynamodb:CreateTable`"+`, `+"`dynamodb:UpdateTable`"+`, `+"`dynamodb:DescribeTable`"+`, `+"`dynamodb:DescribeLimits`"+`, `+"`iam:CreateServiceLinkedRole`"+`, and create/describe permissions in each replica region.
 `).
@@ -204,11 +204,11 @@ When `+"`global_table`"+` is enabled the principal additionally needs `+"`dynamo
 				Description("DynamoDB table name for storing checkpoints. Will be created if it doesn't exist.").
 				Default("redpanda_dynamodb_checkpoints"),
 			service.NewBoolField(dciFieldGlobalTable).
-				Description("When the checkpoint table is auto-created, provision it as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. No effect if the checkpoint table already exists.").
+				Description("Provision the checkpoint table as a DynamoDB Global Table (v2) so checkpoints replicate across regions. Requires `global_table_replicas`. When the table is auto-created it is created as a global table; when it already exists, its replicas are reconciled (missing regions are added via `UpdateTable`). The existing table must have been created in global mode (`TableId` hash key) — enabling this against a pre-existing non-global checkpoint table fails fast with a clear error.").
 				Default(false).
 				Advanced(),
 			service.NewStringListField(dciFieldGlobalTableReplicas).
-				Description("Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Only used when the checkpoint table is created.").
+				Description("Regions other than this pipeline's own region to replicate the checkpoint table to. The pipeline's own region is always included. Required when `global_table` is true. Applied both when the checkpoint table is created and, for an existing global table, when reconciling replicas (missing regions are added; this list is not used to remove regions).").
 				Default([]any{}).
 				Advanced(),
 			service.NewIntField(dciFieldBatchSize).

--- a/internal/impl/aws/dynamodb/input_cdc_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_test.go
@@ -37,6 +37,45 @@ func TestConvertTableRecordsToBatch_FailoverSkipsOldRecords(t *testing.T) {
 	require.Equal(t, "2", seq)
 }
 
+// ApproximateCreationDateTime is second-granular, so records can share the
+// cutoff second. The cutoff is the minimum foreign checkpoint time, so records
+// in that exact second may not have been processed in the prior region; they
+// must be replayed (at-least-once) rather than dropped. Only strictly-older
+// records are skipped.
+func TestConvertTableRecordsToBatch_FailoverKeepsBoundarySecond(t *testing.T) {
+	cutoff := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	before := cutoff.Add(-time.Second)
+	atCutoff := cutoff // same second as the cutoff -> must be kept
+	after := cutoff.Add(time.Second)
+	records := []streamstypes.Record{
+		{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: &before, SequenceNumber: aws.String("1")}},
+		{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: &atCutoff, SequenceNumber: aws.String("2")}},
+		{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: &after, SequenceNumber: aws.String("3")}},
+	}
+	skipped := service.MockResources().Metrics().NewCounter("test_skipped_boundary")
+	batch := convertTableRecordsToBatch(records, "t", "shard-1", nil, cutoff, skipped)
+	require.Len(t, batch, 2)
+	seq0, _ := batch[0].MetaGet("dynamodb_sequence_number")
+	seq1, _ := batch[1].MetaGet("dynamodb_sequence_number")
+	require.Equal(t, "2", seq0)
+	require.Equal(t, "3", seq1)
+}
+
+func TestShouldSkipFailoverRecord(t *testing.T) {
+	cutoff := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	rec := func(ts *time.Time) streamstypes.Record {
+		return streamstypes.Record{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: ts}}
+	}
+	before := cutoff.Add(-time.Second)
+	after := cutoff.Add(time.Second)
+
+	require.True(t, shouldSkipFailoverRecord(rec(&before), cutoff), "strictly older record is skipped")
+	require.False(t, shouldSkipFailoverRecord(rec(&cutoff), cutoff), "boundary-second record is kept (at-least-once)")
+	require.False(t, shouldSkipFailoverRecord(rec(&after), cutoff), "newer record is kept")
+	require.False(t, shouldSkipFailoverRecord(rec(&before), time.Time{}), "no cutoff -> never skip")
+	require.False(t, shouldSkipFailoverRecord(rec(nil), cutoff), "missing timestamp -> never skip")
+}
+
 func TestGlobalTableConfigParsing(t *testing.T) {
 	spec := dynamoDBCDCInputConfig()
 	env := service.NewEnvironment()

--- a/internal/impl/aws/dynamodb/input_cdc_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_test.go
@@ -12,13 +12,65 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	streamstypes "github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
+
+func TestConvertTableRecordsToBatch_FailoverSkipsOldRecords(t *testing.T) {
+	cutoff := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	older := cutoff.Add(-time.Minute)
+	newer := cutoff.Add(time.Minute)
+	records := []streamstypes.Record{
+		{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: &older, SequenceNumber: aws.String("1")}},
+		{Dynamodb: &streamstypes.StreamRecord{ApproximateCreationDateTime: &newer, SequenceNumber: aws.String("2")}},
+	}
+	skipped := service.MockResources().Metrics().NewCounter("test_skipped")
+	batch := convertTableRecordsToBatch(records, "t", "shard-1", nil, cutoff, skipped)
+	require.Len(t, batch, 1)
+	seq, _ := batch[0].MetaGet("dynamodb_sequence_number")
+	require.Equal(t, "2", seq)
+}
+
+func TestGlobalTableConfigParsing(t *testing.T) {
+	spec := dynamoDBCDCInputConfig()
+	env := service.NewEnvironment()
+
+	conf := `
+tables: [mytable]
+checkpoint_table: cps
+global_table: true
+global_table_replicas: [us-west-2, us-east-1]
+region: us-east-1
+`
+	parsed, err := spec.ParseYAML(conf, env)
+	require.NoError(t, err)
+
+	cfg, err := dynamoCDCInputConfigFromParsed(parsed)
+	require.NoError(t, err)
+	require.True(t, cfg.globalTable)
+	require.Equal(t, []string{"us-west-2", "us-east-1"}, cfg.globalTableReplicas)
+}
+
+func TestGlobalTableValidation_EmptyReplicas(t *testing.T) {
+	conf := dynamoDBCDCConfig{
+		tables:              []string{"t"},
+		checkpointTable:     "cps",
+		globalTable:         true,
+		globalTableReplicas: nil,
+		startFrom:           "trim_horizon",
+		batchSize:           100,
+		snapshot:            snapshotConfig{mode: snapshotModeNone, segments: 1, batchSize: 100},
+	}
+	err := validateDynamoDBCDCConfig(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "global_table requires at least one replica region")
+}
 
 func TestConvertAttributeValue(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
aws_dynamodb_cdc: support DynamoDB Global Tables for the checkpoint table

    Add `global_table` / `global_table_replicas` options so the auto-created
    checkpoint table is provisioned as a DynamoDB Global Table (v2), replicating
    shard checkpoints across regions for low-RPO multi-region failover.

    Checkpoints are keyed by a region-portable identifier (the source table name)
    and store the stream ARN and record timestamp. Resume is layered: same-region
    restarts resume exactly via AfterSequenceNumber (unchanged behavior), while a
    failed-over region resumes from the trim horizon, skipping records at or before
    the low-water-mark timestamp of the prior region's checkpoints. Table creation
    enables DynamoDB Streams and provisions/reconciles replica regions; all new
    behavior is gated behind `global_table` and is a no-op when disabled.