### PR TITLE
oracledb_cdc: make the minimum SCN window size configurable

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -47,6 +47,7 @@ input:
     snapshot_max_batch_size: 1000
     logminer:
       scn_window_size: 20000
+      min_scn_window_size: 1000
       backoff_interval: 5s
       mining_interval: 300ms
       strategy: online_catalog
@@ -87,6 +88,7 @@ input:
     snapshot_max_batch_size: 1000
     logminer:
       scn_window_size: 20000
+      min_scn_window_size: 1000
       backoff_interval: 5s
       mining_interval: 300ms
       strategy: online_catalog
@@ -228,6 +230,15 @@ The SCN range to mine per cycle. Each cycle reads changes between the current SC
 *Type*: `int`
 
 *Default*: `20000`
+
+=== `logminer.min_scn_window_size`
+
+The minimum SCN gap required before starting a new LogMiner session. When the gap between the connector's current position and the database's current SCN is smaller than this value, the mining cycle is skipped and the connector backs off instead. This prevents excessive LogMiner start/stop cycles on low-traffic databases where Oracle background activity advances the SCN without producing relevant events. Set to 0 to disable.
+
+
+*Type*: `int`
+
+*Default*: `1000`
 
 === `logminer.backoff_interval`
 

--- a/internal/impl/oracledb/checkpoint_cache_integration_test.go
+++ b/internal/impl/oracledb/checkpoint_cache_integration_test.go
@@ -79,6 +79,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.MTFOO"]
   batching:

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -51,6 +51,7 @@ const (
 	//-- logminer specific
 	ociFieldLogMiner             = "logminer"
 	ociFieldSCNWindowSize        = "scn_window_size"
+	ociFieldMinSCNWindowSize     = "min_scn_window_size"
 	ociFieldBackoffInterval      = "backoff_interval"
 	ociFieldMiningInterval       = "mining_interval"
 	ociFieldMiningStrategy       = "strategy"
@@ -120,6 +121,9 @@ When using the default Oracle based cache, the Connect user requires permission 
 		service.NewIntField(ociFieldSCNWindowSize).
 			Description("The SCN range to mine per cycle. Each cycle reads changes between the current SCN and current SCN + scn_window_size. Smaller values mean more frequent queries with lower memory usage but higher overhead; larger values reduce query frequency and improve throughput at the cost of higher memory usage per cycle.").
 			Default(logminer.DefaultSCNWindowSize),
+		service.NewIntField(ociFieldMinSCNWindowSize).
+			Description("The minimum SCN gap required before starting a new LogMiner session. When the gap between the connector's current position and the database's current SCN is smaller than this value, the mining cycle is skipped and the connector backs off instead. This prevents excessive LogMiner start/stop cycles on low-traffic databases where Oracle background activity advances the SCN without producing relevant events. Set to 0 to disable.").
+			Default(logminer.DefaultMinSCNWindowSize),
 		service.NewDurationField(ociFieldBackoffInterval).
 			Description("The interval between attempts to check for new changes once all data is processed. For low traffic tables increasing this value can reduce network traffic to the server.").
 			Default(logminer.DefaultMiningBackoffInterval.String()).
@@ -717,6 +721,12 @@ func parseLogMinerConfig(conf *service.ParsedConfig) (*logminer.Config, error) {
 		}
 		if cfg.SCNWindowSize <= 0 {
 			return nil, fmt.Errorf("logminer.%s must be greater than 0, got %d", ociFieldSCNWindowSize, cfg.SCNWindowSize)
+		}
+		if cfg.MinSCNWindowSize, err = lmConf.FieldInt(ociFieldMinSCNWindowSize); err != nil {
+			return nil, err
+		}
+		if cfg.MinSCNWindowSize < 0 {
+			return nil, fmt.Errorf("logminer.%s must be 0 or greater, got %d", ociFieldMinSCNWindowSize, cfg.MinSCNWindowSize)
 		}
 		if cfg.MiningBackoffInterval, err = lmConf.FieldDuration(ociFieldBackoffInterval); err != nil {
 			return nil, err

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -69,6 +69,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.MTFOO", "TESTDB2.MTBAR"]
   batching:
@@ -172,6 +173,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"]
   exclude: ["TESTDB.DOESNOTEXIST"]
@@ -282,6 +284,7 @@ oracledb_cdc:
   max_parallel_snapshot_tables: 3
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"]
   exclude: ["TESTDB.DOESNOTEXIST"]`
@@ -345,6 +348,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.FOO"]
   batching:
@@ -539,6 +543,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"]
   exclude: ["TESTDB.DOESNOTEXIST"]
@@ -646,6 +651,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
     transaction_cache: "foocache"
   include: ["TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"]
@@ -781,6 +787,7 @@ oracledb_cdc:
   stream_snapshot: true
   logminer:
     lob_enabled: false
+    min_scn_window_size: 0
   include: ["TESTDB.LOBDISABLED"]`
 			streamBuilder := service.NewStreamBuilder()
 			require.NoError(t, streamBuilder.AddInputYAML(cfg))
@@ -870,6 +877,7 @@ oracledb_cdc:
   stream_snapshot: true
   logminer:
     lob_enabled: true
+    min_scn_window_size: 0
   include: ["TESTDB.LOBENABLED"]`
 			streamBuilder := service.NewStreamBuilder()
 			require.NoError(t, streamBuilder.AddInputYAML(cfg))
@@ -1070,6 +1078,7 @@ oracledb_cdc:
   logminer:
     lob_enabled: true
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.ALL_DATA_TYPES"]`
 
@@ -1270,6 +1279,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_SNAP"]`
 
@@ -1348,6 +1358,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_INS"]`
 
@@ -1408,6 +1419,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_UPD"]`
 
@@ -1472,6 +1484,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_DEL"]`
 
@@ -1544,6 +1557,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_PHASES"]`
 
@@ -1618,6 +1632,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_DRIFT"]`
 
@@ -1691,6 +1706,7 @@ oracledb_cdc:
   stream_snapshot: false
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_T1", "TESTDB.SCHEMA_T2"]`
 
@@ -1795,6 +1811,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.SCHEMA_TYPES"]`
 
@@ -1948,6 +1965,7 @@ oracledb_cdc:
   logminer:
     lob_enabled: true
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.LOBTRIM"]`
 
@@ -2030,6 +2048,7 @@ oracledb_cdc:
   logminer:
     lob_enabled: true
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.LOBTRIMBASIC"]`
 
@@ -2109,6 +2128,7 @@ oracledb_cdc:
   logminer:
     lob_enabled: true
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.LOBTRIMBASICOOR"]`
 
@@ -2189,6 +2209,7 @@ oracledb_cdc:
   logminer:
     lob_enabled: true
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.LOBFILTER_INCLUDED"]`
 

--- a/internal/impl/oracledb/logminer/config.go
+++ b/internal/impl/oracledb/logminer/config.go
@@ -15,6 +15,9 @@ import (
 var (
 	// DefaultSCNWindowSize sets the window size used between SCNs in LogMiner.
 	DefaultSCNWindowSize = 20000
+	// DefaultMinSCNWindowSize is the minimum SCN gap required before starting a new LogMiner
+	// session.
+	DefaultMinSCNWindowSize = 1000
 	// DefaultMiningBackoffInterval controls the mining cycle backoff interval.
 	DefaultMiningBackoffInterval = 5 * time.Second
 	// DefaultMiningInterval controls the interval between mining cycles during normal operation.
@@ -50,6 +53,7 @@ type TransactionCacheConfig struct {
 // Config holds configuration for LogMiner
 type Config struct {
 	SCNWindowSize          int
+	MinSCNWindowSize       int
 	MiningBackoffInterval  time.Duration
 	MiningInterval         time.Duration
 	MiningStrategy         MiningStrategy
@@ -63,6 +67,7 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		SCNWindowSize:         DefaultSCNWindowSize,
+		MinSCNWindowSize:      DefaultMinSCNWindowSize,
 		MiningBackoffInterval: DefaultMiningBackoffInterval,
 		MiningInterval:        DefaultMiningInterval,
 		MiningStrategy:        MiningStrategy(DefaultMiningStrategy),

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -206,6 +206,10 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 		return true, nil
 	}
 
+	if deferMiningCycle(lm.currentSCN, dbCurrentSCN, lm.cfg.MinSCNWindowSize) {
+		return true, nil
+	}
+
 	endSCN := dbCurrentSCN
 	if maxRange := uint64(lm.cfg.SCNWindowSize); lm.currentSCN+maxRange < dbCurrentSCN {
 		endSCN = lm.currentSCN + maxRange
@@ -1022,4 +1026,12 @@ func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64, com
 	}
 
 	return m
+}
+
+func deferMiningCycle(currentSCN, dbCurrentSCN uint64, minWindowSize int) bool {
+	// check to see if SCN window size is greater than configured value
+	if minWindowSize <= 0 || dbCurrentSCN <= currentSCN {
+		return false
+	}
+	return dbCurrentSCN-currentSCN < uint64(minWindowSize)
 }

--- a/internal/impl/oracledb/logminer/logminer_test.go
+++ b/internal/impl/oracledb/logminer/logminer_test.go
@@ -232,6 +232,58 @@ func TestProcessRedoEventWithConnectCacheResource(t *testing.T) {
 	})
 }
 
+func TestShouldDeferMiningCycle(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentSCN    uint64
+		dbSCN         uint64
+		minWindowSize int
+		shouldDefer   bool
+	}{
+		{
+			name:          "gap smaller than min window defers the cycle",
+			currentSCN:    1000,
+			dbSCN:         1005,
+			minWindowSize: 100,
+			shouldDefer:   true,
+		},
+		{
+			name:          "gap equal to min window does not defer",
+			currentSCN:    1000,
+			dbSCN:         1100,
+			minWindowSize: 100,
+			shouldDefer:   false,
+		},
+		{
+			name:          "gap larger than min window does not defer",
+			currentSCN:    1000,
+			dbSCN:         2000,
+			minWindowSize: 100,
+			shouldDefer:   false,
+		},
+		{
+			name:          "min window of zero disables the guard",
+			currentSCN:    1000,
+			dbSCN:         1001,
+			minWindowSize: 0,
+			shouldDefer:   false,
+		},
+		{
+			name:          "scns equal does not defer (existing guard handles this)",
+			currentSCN:    1000,
+			dbSCN:         1000,
+			minWindowSize: 100,
+			shouldDefer:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deferMiningCycle(tt.currentSCN, tt.dbSCN, tt.minWindowSize)
+			assert.Equal(t, tt.shouldDefer, got)
+		})
+	}
+}
+
 func newLogMiner(pub replication.ChangePublisher, cache TransactionCache) *LogMiner {
 	return &LogMiner{
 		publisher: pub,


### PR DESCRIPTION
This change allows the user to control the minimum SCN window gap. The size of the gap dictates whether or not to to start a LogMiner session. This prevents excessive LogMiner start/stop cycles on low-traffic databases where Oracle background activity advances the SCN without producing relevant events.