### PR TITLE
oracledb_cdc: LogMiner session handling improvements and SCN windowing

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -48,6 +48,7 @@ input:
     logminer:
       scn_window_size: 20000
       min_scn_window_size: 1000
+      max_scn_window_size: 100000
       backoff_interval: 5s
       mining_interval: 300ms
       strategy: online_catalog
@@ -89,6 +90,7 @@ input:
     logminer:
       scn_window_size: 20000
       min_scn_window_size: 1000
+      max_scn_window_size: 100000
       backoff_interval: 5s
       mining_interval: 300ms
       strategy: online_catalog
@@ -239,6 +241,15 @@ The minimum SCN gap required before starting a new LogMiner session. When the ga
 *Type*: `int`
 
 *Default*: `1000`
+
+=== `logminer.max_scn_window_size`
+
+The maximum SCN range that can be mined in a single cycle. The window starts at scn_window_size and grows by scn_window_size each cycle that ends at the cap (backlog present), up to this limit. It shrinks by the same step each cycle that catches up to the database. This allows the connector to automatically mine larger windows during heavy backlog and smaller windows during steady state.
+
+
+*Type*: `int`
+
+*Default*: `100000`
 
 === `logminer.backoff_interval`
 

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -151,6 +151,14 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 		if m.Operation != replication.MessageOperationRead && typeInfo != nil {
 			if dataMap, ok := m.Data.(map[string]any); ok {
 				coerceStreamingValues(dataMap, typeInfo, b.log)
+				// Oracle LogMiner omits NULL-valued columns from SQL_REDO, so
+				// restore them explicitly to keep streaming records consistent
+				// with snapshot records (which always include every column).
+				for colName := range typeInfo.colTypes {
+					if _, exists := dataMap[colName]; !exists {
+						dataMap[colName] = nil
+					}
+				}
 			}
 		}
 	}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -52,6 +52,7 @@ const (
 	ociFieldLogMiner             = "logminer"
 	ociFieldSCNWindowSize        = "scn_window_size"
 	ociFieldMinSCNWindowSize     = "min_scn_window_size"
+	ociFieldMaxSCNWindowSize     = "max_scn_window_size"
 	ociFieldBackoffInterval      = "backoff_interval"
 	ociFieldMiningInterval       = "mining_interval"
 	ociFieldMiningStrategy       = "strategy"
@@ -119,11 +120,14 @@ When using the default Oracle based cache, the Connect user requires permission 
 	// logminer config
 	Field(service.NewObjectField(ociFieldLogMiner,
 		service.NewIntField(ociFieldSCNWindowSize).
-			Description("The SCN range to mine per cycle. Each cycle reads changes between the current SCN and current SCN + scn_window_size. Smaller values mean more frequent queries with lower memory usage but higher overhead; larger values reduce query frequency and improve throughput at the cost of higher memory usage per cycle.").
+			Description(`The SCN range to mine per cycle. Each cycle reads changes between the current SCN and current SCN + `+ociFieldSCNWindowSize+`. Smaller values mean more frequent queries with lower memory usage but higher overhead; larger values reduce query frequency and improve throughput at the cost of higher memory usage per cycle.`).
 			Default(logminer.DefaultSCNWindowSize),
 		service.NewIntField(ociFieldMinSCNWindowSize).
 			Description("The minimum SCN gap required before starting a new LogMiner session. When the gap between the connector's current position and the database's current SCN is smaller than this value, the mining cycle is skipped and the connector backs off instead. This prevents excessive LogMiner start/stop cycles on low-traffic databases where Oracle background activity advances the SCN without producing relevant events. Set to 0 to disable.").
 			Default(logminer.DefaultMinSCNWindowSize),
+		service.NewIntField(ociFieldMaxSCNWindowSize).
+			Description(`The maximum SCN range that can be mined in a single cycle. The window starts at `+ociFieldSCNWindowSize+` and grows by `+ociFieldSCNWindowSize+` each cycle that ends at the cap (backlog present), up to this limit. It shrinks by the same step each cycle that catches up to the database. This allows the connector to automatically mine larger windows during heavy backlog and smaller windows during steady state.`).
+			Default(logminer.DefaultMaxSCNWindowSize),
 		service.NewDurationField(ociFieldBackoffInterval).
 			Description("The interval between attempts to check for new changes once all data is processed. For low traffic tables increasing this value can reduce network traffic to the server.").
 			Default(logminer.DefaultMiningBackoffInterval.String()).
@@ -727,6 +731,12 @@ func parseLogMinerConfig(conf *service.ParsedConfig) (*logminer.Config, error) {
 		}
 		if cfg.MinSCNWindowSize < 0 {
 			return nil, fmt.Errorf("logminer.%s must be 0 or greater, got %d", ociFieldMinSCNWindowSize, cfg.MinSCNWindowSize)
+		}
+		if cfg.MaxSCNWindowSize, err = lmConf.FieldInt(ociFieldMaxSCNWindowSize); err != nil {
+			return nil, err
+		}
+		if cfg.MaxSCNWindowSize < cfg.SCNWindowSize {
+			return nil, fmt.Errorf("logminer.%s (%d) must be greater than or equal to logminer.%s (%d)", ociFieldMaxSCNWindowSize, cfg.MaxSCNWindowSize, ociFieldSCNWindowSize, cfg.SCNWindowSize)
 		}
 		if cfg.MiningBackoffInterval, err = lmConf.FieldDuration(ociFieldBackoffInterval); err != nil {
 			return nil, err

--- a/internal/impl/oracledb/integration_datatypes_test.go
+++ b/internal/impl/oracledb/integration_datatypes_test.go
@@ -174,6 +174,7 @@ oracledb_cdc:
   snapshot_max_batch_size: 10
   logminer:
     scn_window_size: 20000
+    min_scn_window_size: 0
     backoff_interval: 1s
   include: ["TESTDB.ALL_TYPES"]`
 

--- a/internal/impl/oracledb/logminer/config.go
+++ b/internal/impl/oracledb/logminer/config.go
@@ -18,6 +18,9 @@ var (
 	// DefaultMinSCNWindowSize is the minimum SCN gap required before starting a new LogMiner
 	// session.
 	DefaultMinSCNWindowSize = 1000
+	// DefaultMaxSCNWindowSize is the maximum SCN range that can be mined in a single cycle.
+	// The adaptive window grows toward this ceiling during backlog and shrinks during steady state.
+	DefaultMaxSCNWindowSize = 100000
 	// DefaultMiningBackoffInterval controls the mining cycle backoff interval.
 	DefaultMiningBackoffInterval = 5 * time.Second
 	// DefaultMiningInterval controls the interval between mining cycles during normal operation.
@@ -54,6 +57,7 @@ type TransactionCacheConfig struct {
 type Config struct {
 	SCNWindowSize          int
 	MinSCNWindowSize       int
+	MaxSCNWindowSize       int
 	MiningBackoffInterval  time.Duration
 	MiningInterval         time.Duration
 	MiningStrategy         MiningStrategy
@@ -68,6 +72,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		SCNWindowSize:         DefaultSCNWindowSize,
 		MinSCNWindowSize:      DefaultMinSCNWindowSize,
+		MaxSCNWindowSize:      DefaultMaxSCNWindowSize,
 		MiningBackoffInterval: DefaultMiningBackoffInterval,
 		MiningInterval:        DefaultMiningInterval,
 		MiningStrategy:        MiningStrategy(DefaultMiningStrategy),

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -42,6 +42,7 @@ type LogMiner struct {
 	publisher     replication.ChangePublisher
 	logCollector  *LogFileCollector
 	currentSCN    uint64
+	windowSize    int
 	sessionMgr    *SessionManager
 	db            *sql.DB
 	SleepDuration time.Duration
@@ -107,20 +108,21 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 	`, buf.String())
 
 	lm := &LogMiner{
-		cfg:       cfg,
-		db:        db,
-		tables:    userTables,
-		publisher: publisher,
-		log:       logger,
+		cfg:              cfg,
+		db:               db,
+		tables:           userTables,
+		publisher:        publisher,
+		publishLagMetric: metrics.NewTimer(publishLatencyMetric),
+		log:              logger,
 
 		// logminer specific
-		logMinerQuery:    logMinerQuery,
-		logCollector:     NewLogFileCollector(),
-		sessionMgr:       NewSessionManager(cfg, logger),
-		txnCache:         txnCache,
-		dmlParser:        sqlredo.NewParser(),
-		lobStates:        make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
-		publishLagMetric: metrics.NewTimer(publishLatencyMetric),
+		logMinerQuery: logMinerQuery,
+		logCollector:  NewLogFileCollector(),
+		sessionMgr:    NewSessionManager(cfg, logger),
+		txnCache:      txnCache,
+		dmlParser:     sqlredo.NewParser(),
+		lobStates:     make(map[sqlredo.TransactionID]*sqlredo.TxnLOBState),
+		windowSize:    cfg.SCNWindowSize,
 	}
 	if lm.txnCache == nil {
 		lm.txnCache = NewInMemoryCache(cfg.MaxTransactionEvents, metrics, logger)
@@ -211,8 +213,10 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 	}
 
 	endSCN := dbCurrentSCN
-	if maxRange := uint64(lm.cfg.SCNWindowSize); lm.currentSCN+maxRange < dbCurrentSCN {
+	hitCap := false
+	if maxRange := uint64(lm.windowSize); lm.currentSCN+maxRange < dbCurrentSCN {
 		endSCN = lm.currentSCN + maxRange
+		hitCap = true
 	}
 
 	// Restart the session on every cycle with explicit SCN bounds. Oracle's START_LOGMNR
@@ -256,6 +260,7 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 		return false, fmt.Errorf("querying logminer contents between %d and %d: %w", lm.currentSCN, endSCN, err)
 	}
 
+	lm.windowSize = adaptWindowSize(lm.windowSize, hitCap, lm.cfg.MinSCNWindowSize, lm.cfg.MaxSCNWindowSize, lm.cfg.SCNWindowSize)
 	lm.currentSCN = endSCN
 	return endSCN >= dbCurrentSCN, nil
 }
@@ -859,8 +864,8 @@ func NewLogFileCollector() *LogFileCollector {
 	return &LogFileCollector{}
 }
 
-// GetLogs collects log files whose SCN range overlaps [startSCN, endSCN].
-func (*LogFileCollector) GetLogs(ctx context.Context, conn *sql.Conn, startSCN, endSCN uint64) ([]*LogFile, error) {
+// GetLogsBySCNRange collects log files whose SCN range overlaps [startSCN, endSCN].
+func (*LogFileCollector) GetLogsBySCNRange(ctx context.Context, conn *sql.Conn, startSCN, endSCN uint64) ([]*LogFile, error) {
 	query := `
 		SELECT FILE_NAME, FIRST_CHANGE, NEXT_CHANGE, SEQ, TYPE, THREAD
 		FROM (
@@ -955,16 +960,11 @@ func deduplicateLogs(archived, online []*LogFile) []*LogFile {
 }
 
 // prepareLogsAndStartSession collects redo/archive logs for the given SCN range and
-// starts (or restarts) a LogMiner session with explicit SCN bounds.
-//
-// Log files are only reloaded via ADD_LOGFILE when the required set changes — i.e.
-// on the first call or when a log switch occurs. Oracle supports recalling
-// START_LOGMNR on an already-active session with new bounds, so the session is kept
-// open across consecutive windows that cover the same log files. Passing ENDSCN=0 to
-// START_LOGMNR would freeze the session's view at session-start time; an explicit
-// endSCN ensures all events in [startSCN, endSCN] are visible.
+// starts (or restarts) a LogMiner session with explicit SCN bounds. Files are only reloaded
+// (via ADD_LOGFILE) when the required set of logs that contain SCN range changes - so the session is kept
+// open across consecutive windows that cover the same log files.
 func (lm *LogMiner) prepareLogsAndStartSession(ctx context.Context, conn *sql.Conn, startSCN, endSCN uint64) error {
-	logFiles, err := lm.logCollector.GetLogs(ctx, conn, startSCN, endSCN)
+	logFiles, err := lm.logCollector.GetLogsBySCNRange(ctx, conn, startSCN, endSCN)
 	if err != nil {
 		return fmt.Errorf("collecting redo logs for logminer: %w", err)
 	}
@@ -1035,4 +1035,11 @@ func deferMiningCycle(currentSCN, dbCurrentSCN uint64, minWindowSize int) bool {
 		return false
 	}
 	return dbCurrentSCN-currentSCN < uint64(minWindowSize)
+}
+
+func adaptWindowSize(currentSize int, hitCap bool, minSize, maxSize, increment int) int {
+	if hitCap {
+		return min(currentSize+increment, maxSize)
+	}
+	return max(currentSize-increment, minSize)
 }

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -37,16 +37,15 @@ var (
 // LogMiner tracks and streams all change events from the configured change
 // tables tracked in tables.
 type LogMiner struct {
-	cfg           *Config
-	tables        []replication.UserTable
-	publisher     replication.ChangePublisher
-	logCollector  *LogFileCollector
-	currentSCN    uint64
-	windowSize    int
-	sessionMgr    *SessionManager
-	db            *sql.DB
-	SleepDuration time.Duration
-	dmlParser     *sqlredo.Parser
+	cfg          *Config
+	tables       []replication.UserTable
+	publisher    replication.ChangePublisher
+	logCollector *LogFileCollector
+	currentSCN   uint64
+	windowSize   int
+	sessionMgr   *SessionManager
+	db           *sql.DB
+	dmlParser    *sqlredo.Parser
 
 	// Pre-built query string for LogMiner contents
 	logMinerQuery string
@@ -58,6 +57,8 @@ type LogMiner struct {
 	// lob types are split between redo log lines, we use lobStates to track them
 	// until we have all data to merge into published INSERT or UPDATE event.
 	lobStates map[sqlredo.TransactionID]*sqlredo.TxnLOBState
+	// suppresses repeated "caught up" log lines within a single idle stretch
+	caughtUpLogged bool
 
 	publishLagMetric *service.MetricTimer
 	log              *service.Logger
@@ -175,9 +176,13 @@ func (lm *LogMiner) ReadChanges(ctx context.Context, startPos replication.SCN) (
 			if caughtUp, err := lm.miningCycle(ctx, conn); err != nil {
 				return fmt.Errorf("mining logs: %w", err)
 			} else if caughtUp {
-				lm.log.Debugf("Caught up with redo logs, backing off...")
+				if !lm.caughtUpLogged {
+					lm.log.Debugf("Caught up with redo logs, backing off for %s...", lm.cfg.MiningBackoffInterval)
+					lm.caughtUpLogged = true
+				}
 				time.Sleep(lm.cfg.MiningBackoffInterval)
 			} else {
+				lm.caughtUpLogged = false
 				time.Sleep(lm.cfg.MiningInterval)
 			}
 		}

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -239,7 +239,7 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 				lm.currentSCN, err, lm.cfg.SCNWindowSize, lm.cfg.MiningBackoffInterval)
 		}
 		if errors.As(err, &oraErr) && oraErr.ErrCode == errCodeRedoLogHeaderMismatch {
-			lm.log.Warnf("ORA-01368: redo log sequence recycled before session could start (SCN range %d–%d); the log will be available as an archived log on next cycle", lm.currentSCN, endSCN)
+			lm.log.Debugf("ORA-01368: redo log sequence recycled before session could start (SCN range %d–%d); the log will be available as an archived log on next cycle", lm.currentSCN, endSCN)
 			return false, nil
 		}
 		return false, fmt.Errorf("preparing logs and starting session at position %d: %w", lm.currentSCN, err)
@@ -250,7 +250,7 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 	if err := lm.queryLogMinerContents(ctx, conn, lm.currentSCN, endSCN, lm.processRedoEvent); err != nil {
 		var oraErr *goora.OracleError
 		if errors.As(err, &oraErr) && oraErr.ErrCode == errCodeRedoLogHeaderMismatch {
-			lm.log.Warnf("ORA-01368: redo log sequence recycled mid-query (SCN range %d–%d); retrying — archived log will be used on next cycle", lm.currentSCN, endSCN)
+			lm.log.Debugf("ORA-01368: redo log sequence recycled mid-query (SCN range %d–%d); retrying — archived log will be used on next cycle", lm.currentSCN, endSCN)
 			return false, nil
 		}
 		return false, fmt.Errorf("querying logminer contents between %d and %d: %w", lm.currentSCN, endSCN, err)

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -954,33 +954,34 @@ func deduplicateLogs(archived, online []*LogFile) []*LogFile {
 	return out
 }
 
-// prepareLogsAndStartSession collects redo/archive logs for the given SCN range,
-// loads them into LogMiner, and starts a new mining session.
-// It is called on every mining cycle with explicit bounds. Passing ENDSCN=0 to
-// START_LOGMNR would freeze the session's view at session-start time, making events
-// written after that point invisible. An explicit endSCN ensures all events in
-// [startSCN, endSCN] are accessible.
+// prepareLogsAndStartSession collects redo/archive logs for the given SCN range and
+// starts (or restarts) a LogMiner session with explicit SCN bounds.
+//
+// Log files are only reloaded via ADD_LOGFILE when the required set changes — i.e.
+// on the first call or when a log switch occurs. Oracle supports recalling
+// START_LOGMNR on an already-active session with new bounds, so the session is kept
+// open across consecutive windows that cover the same log files. Passing ENDSCN=0 to
+// START_LOGMNR would freeze the session's view at session-start time; an explicit
+// endSCN ensures all events in [startSCN, endSCN] are visible.
 func (lm *LogMiner) prepareLogsAndStartSession(ctx context.Context, conn *sql.Conn, startSCN, endSCN uint64) error {
-	// End existing session if active
-	if lm.sessionMgr.IsActive() {
-		if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
-			lm.log.Errorf("Failed to end existing LogMiner session: %v", err)
-		}
-	}
-
-	// Collect log files that contain changes from current SCN
-	var (
-		logFiles []*LogFile
-		err      error
-	)
-	if logFiles, err = lm.logCollector.GetLogs(ctx, conn, startSCN, endSCN); err != nil {
+	logFiles, err := lm.logCollector.GetLogs(ctx, conn, startSCN, endSCN)
+	if err != nil {
 		return fmt.Errorf("collecting redo logs for logminer: %w", err)
 	}
 	lm.log.Debugf("Collected %d redo log file(s) for LogMiner", len(logFiles))
 
-	if err := lm.sessionMgr.AddLogFile(ctx, conn, logFiles); err != nil {
-		return fmt.Errorf("loading %d log files into logminer: %w", len(logFiles), err)
+	if lm.sessionMgr.logFilesChanged(logFiles) {
+		// Log files have changed (first start or log switch) — full reload required.
+		if lm.sessionMgr.IsActive() {
+			if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
+				lm.log.Errorf("Failed to end existing LogMiner session: %v", err)
+			}
+		}
+		if err := lm.sessionMgr.AddLogFile(ctx, conn, logFiles); err != nil {
+			return fmt.Errorf("loading %d log files into logminer: %w", len(logFiles), err)
+		}
 	}
+
 	if err := lm.sessionMgr.StartSession(ctx, conn, startSCN, endSCN, false); err != nil {
 		return fmt.Errorf("starting logminer session: %w", err)
 	}

--- a/internal/impl/oracledb/logminer/logminer_test.go
+++ b/internal/impl/oracledb/logminer/logminer_test.go
@@ -240,7 +240,7 @@ func TestSessionManagerFilesChanged(t *testing.T) {
 		wantChanged bool
 	}{
 		{
-			name:        "no files loaded yet reports changed",
+			name:        "no files loaded yet",
 			loaded:      nil,
 			incoming:    []*LogFile{{FileName: "redo01.log"}},
 			wantChanged: true,
@@ -252,19 +252,19 @@ func TestSessionManagerFilesChanged(t *testing.T) {
 			wantChanged: false,
 		},
 		{
-			name:        "more files incoming than loaded reports changed",
+			name:        "more files incoming than loaded",
 			loaded:      []*LogFile{{FileName: "redo01.log"}},
 			incoming:    []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
 			wantChanged: true,
 		},
 		{
-			name:        "fewer files incoming than loaded reports changed",
+			name:        "fewer files incoming than loaded",
 			loaded:      []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
 			incoming:    []*LogFile{{FileName: "redo01.log"}},
 			wantChanged: true,
 		},
 		{
-			name:        "same count but different filename reports changed",
+			name:        "same count but different filename",
 			loaded:      []*LogFile{{FileName: "redo01.log"}},
 			incoming:    []*LogFile{{FileName: "redo02.log"}},
 			wantChanged: true,

--- a/internal/impl/oracledb/logminer/logminer_test.go
+++ b/internal/impl/oracledb/logminer/logminer_test.go
@@ -232,6 +232,52 @@ func TestProcessRedoEventWithConnectCacheResource(t *testing.T) {
 	})
 }
 
+func TestSessionManagerFilesChanged(t *testing.T) {
+	tests := []struct {
+		name        string
+		loaded      []*LogFile
+		incoming    []*LogFile
+		wantChanged bool
+	}{
+		{
+			name:        "no files loaded yet reports changed",
+			loaded:      nil,
+			incoming:    []*LogFile{{FileName: "redo01.log"}},
+			wantChanged: true,
+		},
+		{
+			name:        "same files in same order reports unchanged",
+			loaded:      []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
+			incoming:    []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
+			wantChanged: false,
+		},
+		{
+			name:        "more files incoming than loaded reports changed",
+			loaded:      []*LogFile{{FileName: "redo01.log"}},
+			incoming:    []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
+			wantChanged: true,
+		},
+		{
+			name:        "fewer files incoming than loaded reports changed",
+			loaded:      []*LogFile{{FileName: "redo01.log"}, {FileName: "redo02.log"}},
+			incoming:    []*LogFile{{FileName: "redo01.log"}},
+			wantChanged: true,
+		},
+		{
+			name:        "same count but different filename reports changed",
+			loaded:      []*LogFile{{FileName: "redo01.log"}},
+			incoming:    []*LogFile{{FileName: "redo02.log"}},
+			wantChanged: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := &SessionManager{loadedFiles: tt.loaded}
+			assert.Equal(t, tt.wantChanged, sm.logFilesChanged(tt.incoming))
+		})
+	}
+}
+
 func TestShouldDeferMiningCycle(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/impl/oracledb/logminer/session.go
+++ b/internal/impl/oracledb/logminer/session.go
@@ -20,10 +20,11 @@ import (
 // SessionManager manages LogMiner sessions, such as loading
 // logs into LogMiner then starting/ending mining sessions.
 type SessionManager struct {
-	cfg    *Config
-	opts   []string
-	active bool
-	log    *service.Logger
+	cfg         *Config
+	opts        []string
+	active      bool
+	loadedFiles []*LogFile
+	log         *service.Logger
 }
 
 // NewSessionManager creates a new SessionManager with the specified configuration.
@@ -47,6 +48,20 @@ func NewSessionManager(cfg *Config, logger *service.Logger) *SessionManager {
 	}
 }
 
+// logFilesChanged performance a filename check on whether newFiles differs from the currently loaded log files.
+// If they're considered the same ADD_LOGFILE can be skipped.
+func (sm *SessionManager) logFilesChanged(newFiles []*LogFile) bool {
+	if len(sm.loadedFiles) != len(newFiles) {
+		return true
+	}
+	for i, f := range sm.loadedFiles {
+		if f.FileName != newFiles[i].FileName {
+			return true
+		}
+	}
+	return false
+}
+
 // AddLogFile adds one or more redo log files to the LogMiner session for mining, clearing
 // previously loaded files before adding new files to the list of files to be mined.
 func (sm *SessionManager) AddLogFile(ctx context.Context, conn *sql.Conn, files []*LogFile) error {
@@ -64,6 +79,7 @@ func (sm *SessionManager) AddLogFile(ctx context.Context, conn *sql.Conn, files 
 		sm.log.Debugf("Loaded redo log file '%s' into LogMiner", f.FileName)
 	}
 
+	sm.loadedFiles = files
 	return nil
 }
 
@@ -94,6 +110,7 @@ func (sm *SessionManager) EndSession(ctx context.Context, conn *sql.Conn) error 
 	}
 
 	sm.active = false
+	sm.loadedFiles = nil
 	return nil
 }
 


### PR DESCRIPTION
This change:

- Improves efficiency of LogMiner session handling by checking to see if the logs returned by the SCN window are the same as the currently loaded LogMiner logs, if so it will reuse the session as opposed to start and stop it.
- Adds adaptive SCN windowing, scaling the number of changes it fetches based on the gaps between the min and max SCN. If there is a larger gap it will increase the window to fetch more data, if there's fewer entries it will shrink the window - ultimately reducing the number of queries it needs to make for changes. An upper bound can be configured via the new `max_scn_window_size` config.
- Lowers the `ORA-01368` to a debug. It's a recoverable error that shouldn't be a warning.