### PR TITLE
 oracledb_cdc: Add new time to first row metric to visualise SQL timings

### DIFF
--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -539,7 +539,8 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			err      error
 			startSCN = cachedSCN
 		)
-		softCtx, _ := o.stopSig.SoftStopCtx(context.Background())
+		softCtx, cancel := o.stopSig.SoftStopCtx(context.Background())
+		defer cancel()
 
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -28,6 +28,8 @@ import (
 var (
 	// captures the time between DB commit and publish
 	publishLatencyMetric = "oracledb_cdc_publish_lag_ns"
+	// captures the time from query execution to the first row being returned by LogMiner
+	timeToFirstRowMetric = "oracledb_cdc_logminer_time_to_first_row_ns"
 	// https://docs.oracle.com/en/error-help/db/ora-01291/
 	errCodeMissingLogFile = 1291
 	// https://docs.oracle.com/en/error-help/db/ora-01368/
@@ -60,8 +62,9 @@ type LogMiner struct {
 	// suppresses repeated "caught up" log lines within a single idle stretch
 	caughtUpLogged bool
 
-	publishLagMetric *service.MetricTimer
-	log              *service.Logger
+	publishLagMetric     *service.MetricTimer
+	timeToFirstRowMetric *service.MetricTimer
+	log                  *service.Logger
 }
 
 // NewMiner creates a new instance of LogMiner responsible for paging through change events based on the tables param.
@@ -109,12 +112,13 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 	`, buf.String())
 
 	lm := &LogMiner{
-		cfg:              cfg,
-		db:               db,
-		tables:           userTables,
-		publisher:        publisher,
-		publishLagMetric: metrics.NewTimer(publishLatencyMetric),
-		log:              logger,
+		cfg:                  cfg,
+		db:                   db,
+		tables:               userTables,
+		publisher:            publisher,
+		publishLagMetric:     metrics.NewTimer(publishLatencyMetric),
+		timeToFirstRowMetric: metrics.NewTimer(timeToFirstRowMetric),
+		log:                  logger,
 
 		// logminer specific
 		logMinerQuery: logMinerQuery,
@@ -776,14 +780,22 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 	}
 
 	// Use the pre-built query from initialization
+	queryStart := time.Now()
 	rows, err := conn.QueryContext(ctx, lm.logMinerQuery, startSCN, endSCN)
 	if err != nil {
 		return fmt.Errorf("querying logminer: %w", err)
 	}
 	defer rows.Close()
 
-	var pending *sqlredo.RedoEvent // accumulates CSF continuation fragments
+	var (
+		pending  *sqlredo.RedoEvent // accumulates CSF continuation fragments
+		firstRow = true
+	)
 	for rows.Next() {
+		if firstRow {
+			lm.timeToFirstRowMetric.Timing(time.Since(queryStart).Nanoseconds())
+			firstRow = false
+		}
 		event := &sqlredo.RedoEvent{}
 		var (
 			commitSCN sql.NullInt64 // COMMIT_SCN can be NULL for uncommitted transactions


### PR DESCRIPTION
This change:

- Adds a new `oracledb_cdc_logminer_time_to_first_row_ns ` metric that helps visualise how long LogMiner takes querying relevant change data.
-  Clean up leaked context go routine upon reconnect

<img width="2680" height="1115" alt="image" src="https://github.com/user-attachments/assets/db237068-cb82-49ee-9f12-6e5c9832503f" />
