### PR TITLE
oracledb_cdc: set current scn on snapshot events

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -127,7 +127,7 @@ This input adds the following metadata fields to each message:
 - database_schema: The database schema for the table where the message originates from.
 - table_name: Name of the table that the message originated from.
 - operation: Type of operation that generated the message: "read", "delete", "insert", or "update". "read" is from messages that are read in the initial snapshot phase.
-- scn: the System Change Number in Oracle.
+- scn: The System Change Number in Oracle. Messages published as part of a snapshot will contain Oracle's current SCN captured at time of snapshot.
 - transaction_id: The Oracle transaction ID in `USN.SLOT.SEQ` format, identifying the transaction that produced the change. Not present on snapshot (`read`) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from `V$LOGMNR_CONTENTS.TIMESTAMP` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. Not present on snapshot (`read`) messages.

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -80,7 +80,7 @@ This input adds the following metadata fields to each message:
 - database_schema: The database schema for the table where the message originates from.
 - table_name: Name of the table that the message originated from.
 - operation: Type of operation that generated the message: "read", "delete", "insert", or "update". "read" is from messages that are read in the initial snapshot phase.
-- scn: the System Change Number in Oracle.
+- scn: The System Change Number in Oracle. Messages published as part of a snapshot will contain Oracle's current SCN captured at time of snapshot.
 - transaction_id: The Oracle transaction ID in ` + "`USN.SLOT.SEQ`" + ` format, identifying the transaction that produced the change. Not present on snapshot (` + "`read`" + `) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from ` + "`V$LOGMNR_CONTENTS.TIMESTAMP`" + ` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. Not present on snapshot (` + "`read`" + `) messages.

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -269,7 +269,7 @@ func TestIntegrationOracleDBCDCConcurrentSnapshot(t *testing.T) {
 	}
 
 	var (
-		outBatches   []string
+		outBatches   []*service.Message
 		outBatchesMu sync.Mutex
 		stream       *service.Stream
 		err          error
@@ -291,15 +291,13 @@ oracledb_cdc:
 
 		streamBuilder := service.NewStreamBuilder()
 		require.NoError(t, streamBuilder.AddInputYAML(cfg))
-		require.NoError(t, streamBuilder.SetLoggerYAML(`level: DEBUG`))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
 
 		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 			outBatchesMu.Lock()
 			defer outBatchesMu.Unlock()
 			for _, msg := range mb {
-				msgBytes, err := msg.AsBytes()
-				assert.NoError(t, err)
-				outBatches = append(outBatches, string(msgBytes))
+				outBatches = append(outBatches, msg)
 			}
 			return nil
 		}))
@@ -325,6 +323,16 @@ oracledb_cdc:
 			return got >= want
 		}, time.Minute*5, time.Second*1)
 		assert.Truef(t, (got == want), "Wanted %d snapshot messages but got %d", want, got)
+		outBatchesMu.Lock()
+
+		expectedSCN, _ := outBatches[0].MetaGetMut("scn")
+		for i, msg := range outBatches {
+			scn, ok := msg.MetaGet("scn")
+			assert.Truef(t, ok, "Expected snapshot message[%d] to have scn metadata", i)
+			assert.NotEmptyf(t, scn, "Expected snapshot message[%d] scn metadata to be non-empty", i)
+			assert.Equal(t, expectedSCN, scn, "Expected snapshot scn to be identical for all messages but was not")
+		}
+		outBatchesMu.Unlock()
 	}
 
 	require.NoError(t, stream.StopWithin(time.Second*10))

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -36,6 +36,7 @@ type Snapshot struct {
 	snapshotRowsTotalMetric *service.MetricCounter
 	lobEnabled              bool
 	pdbName                 string
+	scn                     SCN // published as part of snapshot read metadata
 }
 
 // NewSnapshot creates a new instance of Snapshot capable of snapshotting provided tables.
@@ -69,6 +70,7 @@ func NewSnapshot(ctx context.Context,
 		snapshotStatusMetric:    metrics.NewGauge("oracledb_cdc_snapshot_status", "table"),
 		snapshotRowsTotalMetric: metrics.NewCounter("oracledb_cdc_snapshot_rows_total", "table"),
 		log:                     logger,
+		scn:                     InvalidSCN,
 	}
 	return s, nil
 }
@@ -81,13 +83,15 @@ func (s *Snapshot) Prepare(ctx context.Context) (SCN, error) {
 	}
 
 	var currentSCN SCN
-	sql := `SELECT CURRENT_SCN FROM V$DATABASE`
-	if err := s.dbPool.QueryRowContext(ctx, sql).Scan(&currentSCN); err != nil {
+	if err := s.dbPool.QueryRowContext(ctx, `SELECT CURRENT_SCN FROM V$DATABASE`).Scan(&currentSCN); err != nil {
 		return InvalidSCN, fmt.Errorf("getting current SCN for snapshot: %w", err)
 	}
 
-	s.log.Infof("Captured SCN before snapshot at SCN: %s", currentSCN)
-	return currentSCN, nil
+	// capture to include on snapshot metadata
+	s.scn = currentSCN
+
+	s.log.Infof("Captured SCN before snapshot at SCN: %s", s.scn)
+	return s.scn, nil
 }
 
 // Read launches N go routines (based on maxWorkers) and starts the process of
@@ -278,9 +282,12 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 			Schema:     table.Schema,
 			Data:       row,
 			Operation:  MessageOperationRead,
-			SCN:        0,
 			ColumnMeta: colMeta,
 		}
+		if s.scn != InvalidSCN {
+			m.SCN = s.scn
+		}
+
 		if err = s.publisher.Publish(ctx, &m); err != nil {
 			return 0, fmt.Errorf("handling snapshot table row: %w", err)
 		}

--- a/internal/impl/oracledb/replication/snapshot_test.go
+++ b/internal/impl/oracledb/replication/snapshot_test.go
@@ -83,6 +83,9 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equalf(t, totalRows, publisher.count(), "Expected all %d rows to be captured during snapshot", totalRows)
+		for i, msg := range publisher.messages {
+			assert.Equalf(t, scn, msg.SCN, "Expected snapshot message[%d] to carry the captured SCN", i)
+		}
 	})
 
 	t.Run("TwoColumnCompositeKey_WithPagination", func(t *testing.T) {
@@ -112,6 +115,9 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equalf(t, totalRows, publisher.count(), "Expected all %d rows to be captured during snapshot", totalRows)
+		for i, msg := range publisher.messages {
+			assert.Equalf(t, scn, msg.SCN, "Expected snapshot message[%d] to carry the captured SCN", i)
+		}
 	})
 
 	t.Run("ThreeColumnCompositeKey_WithPagination", func(t *testing.T) {
@@ -143,6 +149,9 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equalf(t, totalRows, publisher.count(), "Expected all %d rows to be captured during snapshot", totalRows)
+		for i, msg := range publisher.messages {
+			assert.Equalf(t, scn, msg.SCN, "Expected snapshot message[%d] to carry the captured SCN", i)
+		}
 	})
 }
 


### PR DESCRIPTION
This change publishes the SCN captured at snapshot time as the SCN on snapshot messages.