### PR TITLE
aws_dynamodb_cdc: recover from expired shard iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- aws_dynamodb_cdc: The CDC input now recovers automatically from an expired DynamoDB Streams shard iterator (`ExpiredIteratorException`), which previously caused an affected shard to retry the dead iterator indefinitely and stall until a pod restart. The shard now obtains a fresh iterator and resumes from the last read position without a data gap.
+
 ## 4.97.0 - 2026-06-18
 
 ### Added

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -413,6 +413,11 @@ type dynamoDBShardReader struct {
 	shardID   string
 	iterator  *string
 	exhausted bool
+	// lastSequenceNumber is the sequence number of the most recent record read
+	// from the shard. It is used to obtain a fresh iterator that resumes exactly
+	// where reading left off if the current iterator expires (see
+	// refreshExpiredIterator).
+	lastSequenceNumber string
 }
 
 // snapshotState encapsulates all state related to snapshot scanning.
@@ -1799,6 +1804,72 @@ func (d *dynamoDBCDCInput) getShardIterator(shardID string) *string {
 	return reader.iterator
 }
 
+// lastRecordSequenceNumber returns the sequence number of the final record in a
+// GetRecords response, or "" if the slice is empty or the field is unset.
+// Records are returned in stream order, so this is the furthest position the
+// shard iterator has advanced past and the point to resume from after an
+// iterator refresh.
+func lastRecordSequenceNumber(records []types.Record) string {
+	if len(records) == 0 {
+		return ""
+	}
+	last := records[len(records)-1]
+	if last.Dynamodb != nil && last.Dynamodb.SequenceNumber != nil {
+		return *last.Dynamodb.SequenceNumber
+	}
+	return ""
+}
+
+// resolveResumeIterator decides which iterator type and sequence number to use
+// when re-acquiring an iterator after the previous one expired. It prefers the
+// last sequence number actually read from the shard (resuming exactly where a
+// healthy iterator would be, so no records are skipped or re-read beyond the
+// pipeline's normal at-least-once guarantee), then the persisted checkpoint,
+// and finally the configured start position when nothing has been read yet.
+func resolveResumeIterator(lastSeq, checkpoint, startFrom string) (types.ShardIteratorType, *string) {
+	seq := lastSeq
+	if seq == "" {
+		seq = checkpoint
+	}
+	if seq != "" {
+		return types.ShardIteratorTypeAfterSequenceNumber, &seq
+	}
+	if startFrom == "latest" {
+		return types.ShardIteratorTypeLatest, nil
+	}
+	return types.ShardIteratorTypeTrimHorizon, nil
+}
+
+// refreshExpiredIterator obtains a fresh shard iterator after the previous one
+// expired, resuming from the most precise position available so the pipeline
+// self-recovers without a restart and without a data gap. See
+// isExpiredIteratorError and resolveResumeIterator.
+func (d *dynamoDBCDCInput) refreshExpiredIterator(ctx context.Context, cp *Checkpointer, streamArn, shardID, lastSeq string) (*string, error) {
+	// Only consult the checkpoint store when nothing has been read yet; when we
+	// have a last-read sequence it is the most precise resume point and avoids
+	// failing recovery on a transient checkpoint-read error.
+	var checkpoint string
+	if lastSeq == "" {
+		var err error
+		if checkpoint, err = cp.Get(ctx, shardID); err != nil {
+			return nil, fmt.Errorf("getting checkpoint for shard %s: %w", shardID, err)
+		}
+	}
+
+	iteratorType, sequenceNumber := resolveResumeIterator(lastSeq, checkpoint, d.conf.startFrom)
+
+	iter, err := d.streamsClient.GetShardIterator(ctx, &dynamodbstreams.GetShardIteratorInput{
+		StreamArn:         &streamArn,
+		ShardId:           &shardID,
+		ShardIteratorType: iteratorType,
+		SequenceNumber:    sequenceNumber,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting refreshed iterator for shard %s: %w", shardID, err)
+	}
+	return iter.ShardIterator, nil
+}
+
 // startTableShardReader reads from a single shard for a specific table
 func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName string, ts *tableStream, shardID string) {
 	d.log.Debugf("Starting reader for shard %s (table %s)", shardID, tableName)
@@ -1884,6 +1955,33 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 				}
 				return
 			}
+			if isExpiredIteratorError(err) {
+				d.log.Warnf("Shard %s (table %s) iterator expired, refreshing from last position", shardID, tableName)
+				ts.mu.RLock()
+				var lastSeq string
+				if reader, ok := ts.shardReaders[shardID]; ok {
+					lastSeq = reader.lastSequenceNumber
+				}
+				ts.mu.RUnlock()
+
+				newIter, refreshErr := d.refreshExpiredIterator(ctx, ts.checkpointer, ts.streamArn, shardID, lastSeq)
+				if refreshErr != nil {
+					d.log.Errorf("Failed to refresh expired iterator for shard %s (table %s): %v", shardID, tableName, refreshErr)
+					idleTimer.Reset(d.conf.pollInterval)
+					select {
+					case <-ctx.Done():
+						return
+					case <-idleTimer.C:
+					}
+					continue
+				}
+				ts.mu.Lock()
+				if reader, ok := ts.shardReaders[shardID]; ok {
+					reader.iterator = newIter
+				}
+				ts.mu.Unlock()
+				continue
+			}
 			d.log.Errorf("Failed to get records from shard %s (table %s): %v", shardID, tableName, err)
 			idleTimer.Reset(d.conf.pollInterval)
 			select {
@@ -1906,6 +2004,9 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 				d.log.Infof("Shard %s (table %s) exhausted", shardID, tableName)
 				ts.mu.Unlock()
 				return
+			}
+			if seq := lastRecordSequenceNumber(getRecords.Records); seq != "" {
+				reader.lastSequenceNumber = seq
 			}
 		}
 		ts.mu.Unlock()
@@ -2243,6 +2344,33 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 				}
 				return
 			}
+			if isExpiredIteratorError(err) {
+				d.log.Warnf("Shard %s iterator expired, refreshing from last position", shardID)
+				d.mu.RLock()
+				var lastSeq string
+				if reader, ok := d.shardReaders[shardID]; ok {
+					lastSeq = reader.lastSequenceNumber
+				}
+				d.mu.RUnlock()
+
+				newIter, refreshErr := d.refreshExpiredIterator(ctx, d.checkpointer, aws.ToString(d.streamArn), shardID, lastSeq)
+				if refreshErr != nil {
+					d.log.Errorf("Failed to refresh expired iterator for shard %s: %v", shardID, refreshErr)
+					idleTimer.Reset(d.conf.pollInterval)
+					select {
+					case <-ctx.Done():
+						return
+					case <-idleTimer.C:
+					}
+					continue
+				}
+				d.mu.Lock()
+				if reader, ok := d.shardReaders[shardID]; ok {
+					reader.iterator = newIter
+				}
+				d.mu.Unlock()
+				continue
+			}
 			d.log.Errorf("Failed to get records from shard %s: %v", shardID, err)
 			idleTimer.Reset(d.conf.pollInterval)
 			select {
@@ -2265,6 +2393,9 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 				d.log.Infof("Shard %s exhausted", shardID)
 				d.mu.Unlock()
 				return
+			}
+			if seq := lastRecordSequenceNumber(getRecords.Records); seq != "" {
+				reader.lastSequenceNumber = seq
 			}
 		}
 		d.mu.Unlock()

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1827,17 +1827,16 @@ func lastRecordSequenceNumber(records []types.Record) string {
 // pipeline's normal at-least-once guarantee), then the persisted checkpoint,
 // and finally the configured start position when nothing has been read yet.
 func resolveResumeIterator(lastSeq, checkpoint, startFrom string) (types.ShardIteratorType, *string) {
-	seq := lastSeq
-	if seq == "" {
-		seq = checkpoint
-	}
-	if seq != "" {
-		return types.ShardIteratorTypeAfterSequenceNumber, &seq
-	}
-	if startFrom == "latest" {
+	switch {
+	case lastSeq != "":
+		return types.ShardIteratorTypeAfterSequenceNumber, &lastSeq
+	case checkpoint != "":
+		return types.ShardIteratorTypeAfterSequenceNumber, &checkpoint
+	case startFrom == "latest":
 		return types.ShardIteratorTypeLatest, nil
+	default:
+		return types.ShardIteratorTypeTrimHorizon, nil
 	}
-	return types.ShardIteratorTypeTrimHorizon, nil
 }
 
 // refreshExpiredIterator obtains a fresh shard iterator after the previous one
@@ -1966,7 +1965,12 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 
 				newIter, refreshErr := d.refreshExpiredIterator(ctx, ts.checkpointer, ts.streamArn, shardID, lastSeq)
 				if refreshErr != nil {
-					d.log.Errorf("Failed to refresh expired iterator for shard %s (table %s): %v", shardID, tableName, refreshErr)
+					// Refreshing can fail transiently (e.g. throttling or a
+					// network blip). Wait poll_interval and let the loop retry
+					// the refresh rather than spinning, until it succeeds or the
+					// reader is cancelled. No data is lost: the resume position
+					// is recomputed from the checkpoint on each attempt.
+					d.log.Errorf("Failed to refresh expired iterator for shard %s (table %s), retrying in %v: %v", shardID, tableName, d.conf.pollInterval, refreshErr)
 					idleTimer.Reset(d.conf.pollInterval)
 					select {
 					case <-ctx.Done():
@@ -2355,7 +2359,12 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 
 				newIter, refreshErr := d.refreshExpiredIterator(ctx, d.checkpointer, aws.ToString(d.streamArn), shardID, lastSeq)
 				if refreshErr != nil {
-					d.log.Errorf("Failed to refresh expired iterator for shard %s: %v", shardID, refreshErr)
+					// Refreshing can fail transiently (e.g. throttling or a
+					// network blip). Wait poll_interval and let the loop retry
+					// the refresh rather than spinning, until it succeeds or the
+					// reader is cancelled. No data is lost: the resume position
+					// is recomputed from the checkpoint on each attempt.
+					d.log.Errorf("Failed to refresh expired iterator for shard %s, retrying in %v: %v", shardID, d.conf.pollInterval, refreshErr)
 					idleTimer.Reset(d.conf.pollInterval)
 					select {
 					case <-ctx.Done():

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsExpiredIteratorError(t *testing.T) {
+	assert.False(t, isExpiredIteratorError(nil))
+	assert.False(t, isExpiredIteratorError(errors.New("boom")))
+	assert.False(t, isExpiredIteratorError(&types.TrimmedDataAccessException{}))
+	assert.True(t, isExpiredIteratorError(&types.ExpiredIteratorException{}))
+}
+
+func TestResolveResumeIterator(t *testing.T) {
+	tests := []struct {
+		name       string
+		lastSeq    string
+		checkpoint string
+		startFrom  string
+		wantType   types.ShardIteratorType
+		wantSeq    *string
+	}{
+		{
+			name:       "prefers last read sequence over checkpoint",
+			lastSeq:    "100",
+			checkpoint: "50",
+			startFrom:  "latest",
+			wantType:   types.ShardIteratorTypeAfterSequenceNumber,
+			wantSeq:    aws.String("100"),
+		},
+		{
+			name:       "falls back to checkpoint when nothing read",
+			lastSeq:    "",
+			checkpoint: "50",
+			startFrom:  "latest",
+			wantType:   types.ShardIteratorTypeAfterSequenceNumber,
+			wantSeq:    aws.String("50"),
+		},
+		{
+			name:      "falls back to latest when no sequence available",
+			lastSeq:   "",
+			startFrom: "latest",
+			wantType:  types.ShardIteratorTypeLatest,
+			wantSeq:   nil,
+		},
+		{
+			name:      "falls back to trim horizon when no sequence available",
+			lastSeq:   "",
+			startFrom: "trim_horizon",
+			wantType:  types.ShardIteratorTypeTrimHorizon,
+			wantSeq:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotSeq := resolveResumeIterator(tc.lastSeq, tc.checkpoint, tc.startFrom)
+			assert.Equal(t, tc.wantType, gotType)
+			if tc.wantSeq == nil {
+				assert.Nil(t, gotSeq)
+			} else {
+				assert.Equal(t, *tc.wantSeq, *gotSeq)
+			}
+		})
+	}
+}

--- a/internal/impl/aws/dynamodb/snapshot.go
+++ b/internal/impl/aws/dynamodb/snapshot.go
@@ -295,6 +295,20 @@ func isTrimmedDataAccessError(err error) bool {
 	return ok
 }
 
+// isExpiredIteratorError returns true when a GetRecords call fails because the
+// shard iterator has expired. DynamoDB Streams iterators are only valid for 15
+// minutes, so a shard that is not read within that window (prolonged output
+// backpressure, a long idle period, or a stale iterator obtained just before a
+// restart) expires. The caller should obtain a fresh iterator from the last
+// processed position and retry rather than spinning on the dead iterator.
+func isExpiredIteratorError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := errors.AsType[*streamstypes.ExpiredIteratorException](err)
+	return ok
+}
+
 // SnapshotCheckpoint holds the progress of a snapshot scan.
 type SnapshotCheckpoint struct {
 	Complete        bool


### PR DESCRIPTION
DynamoDB Streams shard iterators are valid for only 15 minutes. When an iterator expired (prolonged output backpressure, a long idle period, or a stale iterator obtained just before a restart), GetRecords returned an ExpiredIteratorException that fell through to the generic error handler: log, wait poll_interval, retry with the same dead iterator. The affected shard looped forever and only recovered on a pod restart, accumulating a data gap in the meantime.

Both shard reader paths now detect ExpiredIteratorException and obtain a fresh iterator, resuming from the most precise position available: the last sequence number actually read from the shard, then the persisted checkpoint, and finally the configured start position. Resuming after the last read sequence reproduces exactly where a healthy iterator would be, so recovery introduces no data gap and no duplicates beyond the pipeline's normal at-least-once guarantee.

Fixes CON-508.