### PR TITLE
metrics/prometheus: rename histogram timings from _ns to _seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - aws_dynamodb_cdc: The CDC input now recovers automatically from an expired DynamoDB Streams shard iterator (`ExpiredIteratorException`), which previously caused an affected shard to retry the dead iterator indefinitely and stall until a pod restart. The shard now obtains a fresh iterator and resumes from the last read position without a data gap.
+- metrics/prometheus: When `use_histogram_timing` is `true`, timing metrics with a `_ns` suffix are now exported as `_seconds` (for example `processor_latency_ns` becomes `processor_latency_seconds`), reflecting that histogram timings are recorded in seconds. This also keeps the histogram series distinct from the summary series emitted when the setting is `false`, preventing Prometheus remote-write "multiple metric kinds" rejections when a fleet mixes the setting.
 
 ## 4.97.0 - 2026-06-18
 

--- a/docs/modules/components/pages/metrics/prometheus.adoc
+++ b/docs/modules/components/pages/metrics/prometheus.adoc
@@ -75,7 +75,7 @@ metrics:
 
 === `use_histogram_timing`
 
-Whether to export timing metrics as a histogram, if `false` a summary is used instead. When exporting histogram timings the delta values are converted from nanoseconds into seconds in order to better fit within bucket definitions. For more information on histograms and summaries refer to: https://prometheus.io/docs/practices/histograms/.
+Whether to export timing metrics as a histogram, if `false` a summary is used instead. When exporting histogram timings the delta values are converted from nanoseconds into seconds in order to better fit within bucket definitions, and a `_ns` metric name suffix is rewritten to `_seconds` to reflect the unit (for example `processor_latency_ns` becomes `processor_latency_seconds`). This also keeps the histogram series distinct from the summary series emitted when this field is `false`, which avoids Prometheus remote-write conflicts when a fleet mixes the setting. For more information on histograms and summaries refer to: https://prometheus.io/docs/practices/histograms/.
 
 
 *Type*: `bool`

--- a/internal/impl/prometheus/metrics_prometheus.go
+++ b/internal/impl/prometheus/metrics_prometheus.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -62,7 +63,7 @@ The Push Gateway is useful for when Redpanda Connect instances are short lived. 
 If the Push Gateway requires HTTP Basic Authentication it can be configured with `+"`push_basic_auth`.").
 		Fields(
 			service.NewBoolField(pmFieldUseHistogramTiming).
-				Description("Whether to export timing metrics as a histogram, if `false` a summary is used instead. When exporting histogram timings the delta values are converted from nanoseconds into seconds in order to better fit within bucket definitions. For more information on histograms and summaries refer to: https://prometheus.io/docs/practices/histograms/.").
+				Description("Whether to export timing metrics as a histogram, if `false` a summary is used instead. When exporting histogram timings the delta values are converted from nanoseconds into seconds in order to better fit within bucket definitions, and a `_ns` metric name suffix is rewritten to `_seconds` to reflect the unit (for example `processor_latency_ns` becomes `processor_latency_seconds`). This also keeps the histogram series distinct from the summary series emitted when this field is `false`, which avoids Prometheus remote-write conflicts when a fleet mixes the setting. For more information on histograms and summaries refer to: https://prometheus.io/docs/practices/histograms/.").
 				Version("3.63.0").
 				Advanced().
 				Default(false),
@@ -450,7 +451,23 @@ func (p *metrics) NewTimerCtor(path string, labelNames ...string) service.Metric
 	}
 }
 
+// histogramTimerName adjusts a timing metric name for histogram mode. Histogram
+// timings are recorded in seconds (see promTimingHistVec), so a `_ns` suffix is
+// rewritten to `_seconds` to reflect the actual unit. This also gives the
+// histogram a distinct series name from the summary variant (`_ns`) emitted by
+// nodes with use_histogram_timing disabled, which prevents remote-write targets
+// (e.g. Vector/Mimir) from rejecting a batch with "multiple metric kinds given"
+// when a fleet mixes the setting. See INC-1095.
+func histogramTimerName(path string) string {
+	if base, ok := strings.CutSuffix(path, "_ns"); ok {
+		return base + "_seconds"
+	}
+	return path
+}
+
 func (p *metrics) getTimerHistVec(path string, labelNames ...string) service.MetricsExporterTimerCtor {
+	path = histogramTimerName(path)
+
 	var pv *promTimingHistVec
 
 	p.mut.Lock()

--- a/internal/impl/prometheus/metrics_prometheus_test.go
+++ b/internal/impl/prometheus/metrics_prometheus_test.go
@@ -192,6 +192,40 @@ use_histogram_timing: true
 	assert.Contains(t, body, "\ntimertwo_sum{label3=\"value4\",label4=\"value5\"} 1.4e-08")
 }
 
+// In histogram mode timings are recorded in seconds, so a `_ns`-suffixed metric
+// is renamed to `_seconds` to reflect the unit. This also ensures the histogram
+// variant uses a distinct series name from the summary variant emitted by nodes
+// with use_histogram_timing disabled, avoiding remote-write metric-kind
+// conflicts in a mixed fleet. See INC-1095.
+func TestPrometheusHistMetricsNanosecondSuffixRenamedToSeconds(t *testing.T) {
+	nm := promFromYAML(t, `
+use_histogram_timing: true
+`)
+
+	tmr := nm.NewTimerCtor("processor_latency_ns")()
+	tmr.Timing(2_000_000_000) // 2s expressed in nanoseconds
+
+	body := getPage(t, nm.HandlerFunc())
+
+	assert.Contains(t, body, "\n# TYPE processor_latency_seconds histogram")
+	assert.Contains(t, body, "\nprocessor_latency_seconds_sum 2")
+	assert.Contains(t, body, "\nprocessor_latency_seconds_count 1")
+	assert.NotContains(t, body, "processor_latency_ns")
+}
+
+func TestPrometheusSummaryMetricsKeepNanosecondSuffix(t *testing.T) {
+	nm := promFromYAML(t, ``) // use_histogram_timing defaults to false
+
+	tmr := nm.NewTimerCtor("processor_latency_ns")()
+	tmr.Timing(2_000_000_000)
+
+	body := getPage(t, nm.HandlerFunc())
+
+	assert.Contains(t, body, "\n# TYPE processor_latency_ns summary")
+	assert.Contains(t, body, "\nprocessor_latency_ns_sum 2e+09")
+	assert.NotContains(t, body, "processor_latency_seconds")
+}
+
 func TestPrometheusWithFileOutputPath(t *testing.T) {
 	fPath := t.TempDir() + "/benthos_metrics.prom"
 


### PR DESCRIPTION
When use_histogram_timing is true, timing metrics are recorded in seconds but were still exported under their _ns name. This both misreported the unit and, in a fleet with mixed use_histogram_timing settings, caused the same metric name to be sent as two Prometheus kinds (summary vs histogram). Remote-write targets such as Vector and Mimir reject the whole batch in that case ("multiple metric kinds given for metric name"), dropping data and adding backpressure.

Rewrite a trailing _ns suffix to _seconds in histogram mode so the histogram series (e.g. processor_latency_seconds) is distinct from the summary series (processor_latency_ns) and the unit suffix is correct.

Fixes INC-1095.