### PR TITLE
sentry: migrate off removed SetExtras API and bump sentry-go to v0.47.0

### DIFF
--- a/docs/modules/components/pages/processors/sentry_capture.adoc
+++ b/docs/modules/components/pages/processors/sentry_capture.adoc
@@ -89,7 +89,7 @@ context: root = deleted()
 
 === `extras`
 
-A mapping that must evaluate to an object. If this mapping produces a value, then it is set on a sentry event as extras.
+A mapping that must evaluate to an object. If this mapping produces a value, then it is attached to the sentry event as a context named `extras`. (Prior to v4.x this populated the event's deprecated Additional Data section, which the upstream sentry-go SDK removed.)
 
 
 *Type*: `string`

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
 	github.com/elastic/go-elasticsearch/v9 v9.3.1
 	github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a
-	github.com/getsentry/sentry-go v0.44.1
+	github.com/getsentry/sentry-go v0.47.0
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-mysql-org/go-mysql v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -757,8 +757,8 @@ github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9t
 github.com/gdamore/optopia v0.2.0/go.mod h1:YKYEwo5C1Pa617H7NlPcmQXl+vG6YnSSNB44n8dNL0Q=
 github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a h1:J8FuFJ7K+Hiwkla2kT9fVIVix+EZhAlDsZwRlfFI3MA=
 github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a/go.mod h1:ms6iGk40n2YQrbM9Sr6onzwYBD1q5D0T5DQmcaye6uU=
-github.com/getsentry/sentry-go v0.44.1 h1:/cPtrA5qB7uMRrhgSn9TYtcEF36auGP3Y6+ThvD/yaI=
-github.com/getsentry/sentry-go v0.44.1/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
+github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
+github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=

--- a/internal/impl/sentry/processor_capture.go
+++ b/internal/impl/sentry/processor_capture.go
@@ -52,7 +52,7 @@ func newCaptureProcessorConfig() *service.ConfigSpec {
 				Example(`root = deleted()`),
 
 			service.NewBloblangField("extras").
-				Description("A mapping that must evaluate to an object. If this mapping produces a value, then it is set on a sentry event as extras.").
+				Description("A mapping that must evaluate to an object. If this mapping produces a value, then it is attached to the sentry event as a context named `extras`. (Prior to v4.x this populated the event's deprecated Additional Data section, which the upstream sentry-go SDK removed.)").
 				Optional().
 				Example(`root.foo = "bar"`).
 				Example(`root = this.without("password")`),
@@ -274,7 +274,16 @@ func (proc *captureProcessor) Process(_ context.Context, msg *service.Message) (
 	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetContexts(sentryCtx)
 		scope.SetTags(tags)
-		scope.SetExtras(extras) //nolint:staticcheck
+		// sentry-go v0.47.0 removed the deprecated Scope.SetExtras/Event.Extra
+		// API in favour of attributes (which only apply to logs, not to the
+		// error/message events this processor captures). To preserve the
+		// extras data on captured events we attach it as a dedicated context
+		// named "extras" instead. The data now surfaces under the event's
+		// Contexts section in Sentry rather than the legacy Additional Data
+		// section.
+		if len(extras) > 0 {
+			scope.SetContext("extras", extras)
+		}
 
 		hub.CaptureMessage(message)
 	})

--- a/internal/impl/sentry/processor_capture_test.go
+++ b/internal/impl/sentry/processor_capture_test.go
@@ -75,7 +75,7 @@ func TestCaptureProcessor(t *testing.T) {
 	require.Equal(t, "benthos-sentry", event.Release, "event has wrong release")
 	require.Equal(t, map[string]any{"country": "us"}, event.Contexts["profile"])
 	require.Equal(t, map[string]string{"app": "test 0.1.0", "pipeline": "test-pipeline", "benthos": "mock"}, event.Tags)
-	require.Equal(t, map[string]any{"foo": "bar", "version": "v0.1.0"}, event.Extra)
+	require.Equal(t, map[string]any{"foo": "bar", "version": "v0.1.0"}, event.Contexts["extras"])
 }
 
 func TestCaptureProcessor_Sync(t *testing.T) {
@@ -123,7 +123,7 @@ func TestCaptureProcessor_Sync(t *testing.T) {
 	require.Equal(t, "testing", event.Environment, "event has wrong environment")
 	require.Equal(t, "benthos-sentry", event.Release, "event has wrong release")
 	require.Equal(t, sentry.LevelDebug, event.Level, "event has wrong level")
-	require.Equal(t, map[string]any{"name": "jane"}, event.Extra)
+	require.Equal(t, map[string]any{"name": "jane"}, event.Contexts["extras"])
 }
 
 func TestCaptureProcessor_InvalidMessage(t *testing.T) {


### PR DESCRIPTION
## What

Migrate the `sentry_capture` processor off the `Scope.SetExtras` API (removed in `getsentry/sentry-go` v0.47.0) and bump the dependency from v0.44.1 to v0.47.0.

## Why

sentry-go v0.47.0 removes the deprecated `Scope.SetExtras` method and the `Event.Extra` field entirely. Building Redpanda Connect from source against a current Go module graph picks up the removal and fails to compile.

The obvious `Scope.SetAttributes` replacement is **not** a drop-in: attributes only apply to the structured-logging API, never to the error/message events this processor captures (`ApplyToEvent` ignores them), so using it would silently drop the extras data.

## How

Attach the configured extras to the captured event as a context named `extras` (via `Scope.SetContext`). `sentry.Context` is a `map[string]any` alias, so arbitrary extras values are preserved with no type loss.

## ⚠️ Behavioral change

The extras data now surfaces under the event's **Contexts** section in Sentry rather than the legacy **Additional Data** section. All data is preserved — only its location in the Sentry UI (and the event payload shape) changes. Saved searches or alerts that query the `extra.*` path may need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
