### PR TITLE
postgres_cdc: Add "commit_ts_ms" to insert, update and delete event metadata

### DIFF
--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -84,6 +85,7 @@ This input adds the following metadata fields to each message:
 - operation: Type of operation that generated the message: "read", "insert", "update", or "delete". "read" is from messages that are read in the initial snapshot phase. This will also be "begin" and "commit" if ` + "`" + fieldIncludeTxnMarkers + "`" + ` is enabled
 - lsn: the log sequence number in postgres
 - schema: The table schema in benthos common schema format, compatible with processors like parquet_encode
+- commit_ts_ms: The commit timestamp of the transaction as a Unix millisecond timestamp. Not set for snapshot reads.
 		`).
 		Field(service.NewStringField(fieldDSN).
 			Description("The Data Source Name for the PostgreSQL database in the form of `postgres://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]`. Please note that Postgres enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.").
@@ -478,6 +480,9 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				batchMsg.MetaSet("operation", string(msg.Operation))
 				if msg.LSN != nil {
 					batchMsg.MetaSet("lsn", *msg.LSN)
+				}
+				if !msg.CommitTime.IsZero() {
+					batchMsg.MetaSet("commit_ts_ms", strconv.FormatInt(msg.CommitTime.UnixMilli(), 10))
 				}
 				if msg.ColumnSchema != nil {
 					batchMsg.MetaSetImmut("schema", service.ImmutableAny{V: msg.ColumnSchema})

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -1059,13 +1059,21 @@ postgres_cdc:
 
 	_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, 2, "bravo", "2006-01-02T15:04:05Z07:00")
 	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ($1, $2);`, "bravo", "2006-01-02T15:04:05Z07:00")
+
+	var flightsID int
+	err = db.QueryRow(`INSERT INTO flights (name, created_at) VALUES ($1, $2) RETURNING id;`, "bravo", "2006-01-02T15:04:05Z07:00").Scan(&flightsID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`UPDATE flights SET name = $1 WHERE id = $2;`, "charlie", flightsID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`DELETE FROM flights WHERE id = $1;`, flightsID)
 	require.NoError(t, err)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		outBatchMut.Lock()
 		defer outBatchMut.Unlock()
-		assert.Len(c, outBatches, 4, "got: %#v", outBatches)
+		assert.Len(c, outBatches, 6, "got: %#v", outBatches)
 	}, time.Second*25, time.Millisecond*100)
 
 	require.ElementsMatch(
@@ -1082,13 +1090,25 @@ postgres_cdc:
 			},
 			map[string]any{
 				"operation":    "insert",
-				"table":        "flights",
+				"table":        "FlightsCompositePK",
 				"lsn":          "XXX/XXX",
 				"commit_ts_ms": "SET",
 			},
 			map[string]any{
 				"operation":    "insert",
-				"table":        "FlightsCompositePK",
+				"table":        "flights",
+				"lsn":          "XXX/XXX",
+				"commit_ts_ms": "SET",
+			},
+			map[string]any{
+				"operation":    "update",
+				"table":        "flights",
+				"lsn":          "XXX/XXX",
+				"commit_ts_ms": "SET",
+			},
+			map[string]any{
+				"operation":    "delete",
+				"table":        "flights",
 				"lsn":          "XXX/XXX",
 				"commit_ts_ms": "SET",
 			},

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1029,6 +1030,12 @@ postgres_cdc:
 			if _, ok := d["lsn"]; ok {
 				d["lsn"] = "XXX/XXX" // Consistent LSN for assertions below
 			}
+			if ct, ok := d["commit_ts_ms"].(string); ok {
+				ms, err := strconv.ParseInt(ct, 10, 64)
+				assert.NoError(t, err, "commit_ts_ms should be a valid integer")
+				assert.Positive(t, ms, "commit_ts_ms should be a positive Unix ms timestamp")
+				d["commit_ts_ms"] = "SET"
+			}
 			delete(d, "schema") // Schema metadata tested separately in TestIntegrationPostgresCDCSchemaMetadata
 			outBatches = append(outBatches, data)
 		}
@@ -1074,14 +1081,16 @@ postgres_cdc:
 				"table":     "flights",
 			},
 			map[string]any{
-				"operation": "insert",
-				"table":     "flights",
-				"lsn":       "XXX/XXX",
+				"operation":    "insert",
+				"table":        "flights",
+				"lsn":          "XXX/XXX",
+				"commit_ts_ms": "SET",
 			},
 			map[string]any{
-				"operation": "insert",
-				"table":     "FlightsCompositePK",
-				"lsn":       "XXX/XXX",
+				"operation":    "insert",
+				"table":        "FlightsCompositePK",
+				"lsn":          "XXX/XXX",
+				"commit_ts_ms": "SET",
 			},
 		},
 	)

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -375,17 +375,20 @@ func (s *Stream) commitAckedLSN(ctx context.Context, lsn LSN) error {
 }
 
 func (s *Stream) streamMessages(currentLSN LSN) error {
-	relations := map[uint32]*RelationMessage{}
-	typeMap := pgtype.NewMap()
-	// schemaCache maps relation ID to its serialized schema. It is keyed by relation ID
-	// and invalidated whenever a RelationMessage for that ID is received (which PostgreSQL
-	// sends before any DML when the table definition changes).
-	schemaCache := map[uint32]any{}
-	// If we don't stream commit messages we could not ack them, which means postgres will replay the whole transaction
-	// so if we're at the end of a stream and we get an ack for the last message in a txn, we need to ack the txn not the
-	// last message.
-	lastEmittedLSN := currentLSN
-	lastEmittedCommitLSN := currentLSN
+	var (
+		relations = map[uint32]*RelationMessage{}
+		typeMap   = pgtype.NewMap()
+		// schemaCache maps relation ID to its serialized schema. It is keyed by relation ID
+		// and invalidated whenever a RelationMessage for that ID is received (which PostgreSQL
+		// sends before any DML when the table definition changes).
+		schemaCache = map[uint32]any{}
+		// If we don't stream commit messages we could not ack them, which means postgres will replay the whole transaction
+		// so if we're at the end of a stream and we get an ack for the last message in a txn, we need to ack the txn not the
+		// last message.
+		lastEmittedLSN       = currentLSN
+		lastEmittedCommitLSN = currentLSN
+		currentTxnCommitTime time.Time
+	)
 
 	commitLSN := func(force bool) (committed bool, err error) {
 		ctx, done := s.shutSig.HardStopCtx(context.Background())
@@ -462,7 +465,7 @@ func (s *Stream) streamMessages(currentLSN LSN) error {
 				return fmt.Errorf("parsing XLogData: %w", err)
 			}
 			msgLSN := xld.WALStart + LSN(len(xld.WALData))
-			result, err := s.processChange(ctx, msgLSN, xld, relations, typeMap, schemaCache)
+			result, err := s.processChange(ctx, msgLSN, xld, relations, typeMap, schemaCache, &currentTxnCommitTime)
 			if err != nil {
 				return fmt.Errorf("decoding postgres changes failed: %w", err)
 			}
@@ -493,7 +496,7 @@ const (
 )
 
 // Handle handles the pgoutput output.
-func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, schemaCache map[uint32]any) (processChangeResult, error) {
+func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, schemaCache map[uint32]any, currentTxnCommitTime *time.Time) (processChangeResult, error) {
 	logicalMsg, err := Parse(xld.WALData)
 	if err != nil {
 		return changeResultNoMessage, err
@@ -504,6 +507,13 @@ func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, re
 	// picks up the updated column definitions.
 	if rel, ok := logicalMsg.(*RelationMessage); ok {
 		delete(schemaCache, rel.RelationID)
+	}
+
+	// capture transaction commit time for insert, update and delete events
+	if begin, ok := logicalMsg.(*BeginMessage); ok {
+		*currentTxnCommitTime = begin.CommitTime
+	} else if _, ok := logicalMsg.(*CommitMessage); ok {
+		*currentTxnCommitTime = time.Time{}
 	}
 
 	// parse changes inside the transaction
@@ -551,6 +561,7 @@ func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, re
 		}
 	}
 
+	message.CommitTime = *currentTxnCommitTime
 	lsn := msgLSN.String()
 	message.LSN = &lsn
 	select {

--- a/internal/impl/postgresql/pglogicalstream/stream_message.go
+++ b/internal/impl/postgresql/pglogicalstream/stream_message.go
@@ -8,6 +8,8 @@
 
 package pglogicalstream
 
+import "time"
+
 // StreamMode represents the mode of the stream at the time of the message
 type StreamMode string
 
@@ -46,5 +48,6 @@ type StreamMessage struct {
 	Data any `json:"data"`
 	// ColumnSchema contains the table's column schema in benthos common schema format.
 	// It is set as message metadata and excluded from JSON serialization.
-	ColumnSchema any `json:"-"`
+	ColumnSchema any       `json:"-"`
+	CommitTime   time.Time `json:"-"`
 }


### PR DESCRIPTION
This change adds a new `commit_ts_ms` timestamp to change event metadata for insert, update and delete operations. It also addresses a testing gap in the integration test where we're not verifying update and delete operations.

<img width="1446" height="557" alt="image" src="https://github.com/user-attachments/assets/0c86457b-509b-4420-92ae-573f0e5fcbc9" />
