### PR TITLE
postgres_cdc: support "before" data in change events for UPDATE and DELETE events

### DIFF
--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -15,15 +15,24 @@ input:
       count: 1000
       period: 1s
 
+# pipeline:
+#   processors:
+#     - mapping: |
+#         root.payload = this
+#         root.metadata = @
+
 output:
   processors:
     - benchmark:
         interval: 1s
         count_bytes: true
+  # file:
+  #   path: "./benchmark_results.json"
+  #   codec: lines
   drop: {}
 
 logger:
-  level: WARN
+  level: INFO
 
 metrics:
   prometheus:

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS public.users (
     login_count   INT             NOT NULL DEFAULT 0,
     balance       DECIMAL(10,2)   NOT NULL DEFAULT 0.00
 );
+ALTER TABLE public.users REPLICA IDENTITY FULL;
 
 CREATE TABLE IF NOT EXISTS public.products (
     id            SERIAL PRIMARY KEY,
@@ -25,6 +26,7 @@ CREATE TABLE IF NOT EXISTS public.products (
     created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
     is_available  BOOLEAN         NOT NULL DEFAULT TRUE
 );
+ALTER TABLE public.products REPLICA IDENTITY FULL;
 
 CREATE TABLE IF NOT EXISTS public.cart (
     id         SERIAL PRIMARY KEY,
@@ -34,3 +36,4 @@ CREATE TABLE IF NOT EXISTS public.cart (
     price      DECIMAL(10,2) NOT NULL DEFAULT 0.00,
     info       TEXT          NOT NULL
 );
+ALTER TABLE public.cart REPLICA IDENTITY FULL;

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -86,6 +86,7 @@ This input adds the following metadata fields to each message:
 - lsn: the log sequence number in postgres
 - schema: The table schema in benthos common schema format, compatible with processors like parquet_encode
 - commit_ts_ms: The commit timestamp of the transaction as a Unix millisecond timestamp. Not set for snapshot reads.
+- before: The pre-change state of the row for update and delete operations, in benthos common schema format. For updates, availability depends on the table's REPLICA IDENTITY setting - with the default identity only key columns are present, with REPLICA IDENTITY FULL all columns are present.
 		`).
 		Field(service.NewStringField(fieldDSN).
 			Description("The Data Source Name for the PostgreSQL database in the form of `postgres://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]`. Please note that Postgres enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.").
@@ -486,6 +487,9 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				}
 				if msg.ColumnSchema != nil {
 					batchMsg.MetaSetImmut("schema", service.ImmutableAny{V: msg.ColumnSchema})
+				}
+				if msg.BeforeData != nil {
+					batchMsg.MetaSetImmut("before", service.ImmutableAny{V: msg.BeforeData})
 				}
 				if batcher.Add(batchMsg) {
 					flush = true

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -996,6 +996,9 @@ func TestIntegrationPostgresMetadata(t *testing.T) {
 
 	require.NoError(t, err)
 
+	_, err = db.Exec(`ALTER TABLE flights REPLICA IDENTITY FULL`)
+	require.NoError(t, err)
+
 	_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, 1, "delta", "2006-01-02T15:04:05Z07:00")
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ($1, $2);`, "delta", "2006-01-02T15:04:05Z07:00")
@@ -1035,6 +1038,16 @@ postgres_cdc:
 				assert.NoError(t, err, "commit_ts_ms should be a valid integer")
 				assert.Positive(t, ms, "commit_ts_ms should be a positive Unix ms timestamp")
 				d["commit_ts_ms"] = "SET"
+			}
+			if before, ok := d["before"].(map[string]any); ok {
+				op, _ := d["operation"].(string)
+				switch op {
+				case "update":
+					assert.Equal(t, "bravo", before["name"], "update: before.name should be the pre-update value")
+				case "delete":
+					assert.Equal(t, "charlie", before["name"], "delete: before.name should be the post-update, pre-delete value")
+				}
+				d["before"] = "SET"
 			}
 			delete(d, "schema") // Schema metadata tested separately in TestIntegrationPostgresCDCSchemaMetadata
 			outBatches = append(outBatches, data)
@@ -1105,12 +1118,14 @@ postgres_cdc:
 				"table":        "flights",
 				"lsn":          "XXX/XXX",
 				"commit_ts_ms": "SET",
+				"before":       "SET",
 			},
 			map[string]any{
 				"operation":    "delete",
 				"table":        "flights",
 				"lsn":          "XXX/XXX",
 				"commit_ts_ms": "SET",
+				"before":       "SET",
 			},
 		},
 	)

--- a/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
+++ b/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
@@ -133,6 +133,30 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 			}
 		}
 		message.Data = values
+		if logicalMsg.OldTuple != nil {
+			before := map[string]any{}
+			for idx, col := range logicalMsg.OldTuple.Columns {
+				if idx >= len(rel.Columns) {
+					break
+				}
+				colName := rel.Columns[idx].Name
+				switch col.DataType {
+				case 'n': // null
+					before[colName] = nil
+				case 'u': // unchanged toast
+					before[colName] = unchangedToastValue
+				case 't': // text
+					val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
+					if err != nil {
+						return nil, fmt.Errorf("unable to decode before column data: %w", err)
+					}
+					before[colName] = val
+				default:
+					return nil, fmt.Errorf("unable to decode before column data, unknown data type: %d", col.DataType)
+				}
+			}
+			message.BeforeData = before
+		}
 	case *DeleteMessage:
 		rel, ok := relations[logicalMsg.RelationID]
 		if !ok {
@@ -159,6 +183,7 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 			}
 		}
 		message.Data = values
+		message.BeforeData = values
 	case *TruncateMessage:
 	case *TypeMessage:
 	case *OriginMessage:

--- a/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
+++ b/internal/impl/postgresql/pglogicalstream/replication_message_decoders.go
@@ -67,23 +67,9 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 		message.Operation = InsertOpType
 		message.Schema = rel.Namespace
 		message.Table = rel.RelationName
-		values := map[string]any{}
-		for idx, col := range logicalMsg.Tuple.Columns {
-			colName := rel.Columns[idx].Name
-			switch col.DataType {
-			case 'n': // null
-				values[colName] = nil
-			case 'u': // unchanged toast
-				values[colName] = unchangedToastValue
-			case 't': // text
-				val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
-				if err != nil {
-					return nil, fmt.Errorf("unable to decode column data: %w", err)
-				}
-				values[colName] = val
-			default:
-				return nil, fmt.Errorf("unable to decode column data, unknown data type: %d", col.DataType)
-			}
+		values, err := decodeTuple(logicalMsg.Tuple, rel, typeMap, unchangedToastValue, nil)
+		if err != nil {
+			return nil, fmt.Errorf("decoding data for insert message: %w", err)
 		}
 		message.Data = values
 	case *UpdateMessage:
@@ -94,66 +80,21 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 		message.Operation = UpdateOpType
 		message.Schema = rel.Namespace
 		message.Table = rel.RelationName
-		values := map[string]any{}
-		for idx, col := range logicalMsg.NewTuple.Columns {
-			colName := rel.Columns[idx].Name
-			switch col.DataType {
-			case 'n': // null
-				values[colName] = nil
-			case 'u': // unchanged toast
-				values[colName] = unchangedToastValue
-				// In the case of an update of an unchanged toast value and the replica is set to
-				// IDENTITY FULL, we need to look at the old tuple in order to get the data, it's
-				// just marked as unchanged in the new tuple.
-				if logicalMsg.OldTupleType == 'O' && logicalMsg.OldTuple != nil && idx < len(logicalMsg.OldTuple.Columns) {
-					col = logicalMsg.OldTuple.Columns[idx]
-					switch col.DataType {
-					case 'n': // null
-						values[colName] = nil
-					case 'u': // unchanged toast
-						values[colName] = unchangedToastValue
-					case 't':
-						val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
-						if err != nil {
-							return nil, fmt.Errorf("unable to decode column data: %w", err)
-						}
-						values[colName] = val
-					default:
-						return nil, fmt.Errorf("unable to decode column data, unknown data type: %d", col.DataType)
-					}
-				}
-			case 't': // text
-				val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
-				if err != nil {
-					return nil, fmt.Errorf("unable to decode column data: %w", err)
-				}
-				values[colName] = val
-			default:
-				return nil, fmt.Errorf("unable to decode column data, unknown data type: %d", col.DataType)
-			}
+		// When REPLICA IDENTITY FULL is set, unchanged TOAST columns in the new tuple
+		// are resolved against the old tuple which carries the actual pre-update value.
+		var toastFallback *TupleData
+		if logicalMsg.OldTupleType == 'O' {
+			toastFallback = logicalMsg.OldTuple
+		}
+		values, err := decodeTuple(logicalMsg.NewTuple, rel, typeMap, unchangedToastValue, toastFallback)
+		if err != nil {
+			return nil, fmt.Errorf("decoding new data for update message: %w", err)
 		}
 		message.Data = values
 		if logicalMsg.OldTuple != nil {
-			before := map[string]any{}
-			for idx, col := range logicalMsg.OldTuple.Columns {
-				if idx >= len(rel.Columns) {
-					break
-				}
-				colName := rel.Columns[idx].Name
-				switch col.DataType {
-				case 'n': // null
-					before[colName] = nil
-				case 'u': // unchanged toast
-					before[colName] = unchangedToastValue
-				case 't': // text
-					val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
-					if err != nil {
-						return nil, fmt.Errorf("unable to decode before column data: %w", err)
-					}
-					before[colName] = val
-				default:
-					return nil, fmt.Errorf("unable to decode before column data, unknown data type: %d", col.DataType)
-				}
+			before, err := decodeTuple(logicalMsg.OldTuple, rel, typeMap, unchangedToastValue, nil)
+			if err != nil {
+				return nil, fmt.Errorf("decoding before data for update message: %w", err)
 			}
 			message.BeforeData = before
 		}
@@ -165,22 +106,9 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 		message.Operation = DeleteOpType
 		message.Schema = rel.Namespace
 		message.Table = rel.RelationName
-		values := map[string]any{}
-		for idx, col := range logicalMsg.OldTuple.Columns {
-			colName := rel.Columns[idx].Name
-			switch col.DataType {
-			case 'n': // null
-				values[colName] = nil
-			case 'u': // unchanged toast
-				values[colName] = unchangedToastValue
-			case 't': // text
-				val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
-				if err != nil {
-					return nil, fmt.Errorf("unable to decode column data: %w", err)
-				}
-				values[colName] = val
-			default:
-			}
+		values, err := decodeTuple(logicalMsg.OldTuple, rel, typeMap, unchangedToastValue, nil)
+		if err != nil {
+			return nil, fmt.Errorf("decoding data for delete message: %w", err)
 		}
 		message.Data = values
 		message.BeforeData = values
@@ -194,6 +122,48 @@ func toStreamMessage(logicalMsg Message, relations map[uint32]*RelationMessage, 
 	}
 
 	return message, nil
+}
+
+func decodeTuple(tuple *TupleData, rel *RelationMessage, typeMap *pgtype.Map, unchangedToastValue any, toastFallback *TupleData) (map[string]any, error) {
+	values := map[string]any{}
+	for idx, col := range tuple.Columns {
+		if idx >= len(rel.Columns) {
+			break
+		}
+		colName := rel.Columns[idx].Name
+		switch col.DataType {
+		case 'n': // null
+			values[colName] = nil
+		case 'u': // unchanged toast
+			values[colName] = unchangedToastValue
+			if toastFallback != nil && idx < len(toastFallback.Columns) {
+				col = toastFallback.Columns[idx]
+				switch col.DataType {
+				case 'n':
+					values[colName] = nil
+				case 'u':
+					values[colName] = unchangedToastValue
+				case 't':
+					val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
+					if err != nil {
+						return nil, fmt.Errorf("unable to decode column data: %w", err)
+					}
+					values[colName] = val
+				default:
+					return nil, fmt.Errorf("unable to decode column data, unknown data type: %d", col.DataType)
+				}
+			}
+		case 't': // text
+			val, err := decodeTextColumnData(typeMap, col.Data, rel.Columns[idx].DataType, rel.Columns[idx].TypeModifier)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode column data: %w", err)
+			}
+			values[colName] = val
+		default:
+			return nil, fmt.Errorf("unable to decode column data, unknown data type: %d", col.DataType)
+		}
+	}
+	return values, nil
 }
 
 func decodeTextColumnData(mi *pgtype.Map, data []byte, dataType uint32, typeModifier int32) (any, error) {

--- a/internal/impl/postgresql/pglogicalstream/stream_message.go
+++ b/internal/impl/postgresql/pglogicalstream/stream_message.go
@@ -50,4 +50,5 @@ type StreamMessage struct {
 	// It is set as message metadata and excluded from JSON serialization.
 	ColumnSchema any       `json:"-"`
 	CommitTime   time.Time `json:"-"`
+	BeforeData   any       `json:"-"`
 }


### PR DESCRIPTION
This change introduces a new `before` metadata property for update and delete change events which contains the state of the changed row before the commit.

It updates the existing implementation to reuse decoding of PostgreSQL's WAL tuples between new and old values.

Integration tests passing.

### Proof of Work

metadata.before is now on update and delete (but not insert) messages when `REPLICA IDENTITY FULL` is set:

<img width="1463" height="882" alt="image" src="https://github.com/user-attachments/assets/694d0e2b-c796-48bc-8243-e01e9efa8ace" />