### PR TITLE
CDC tracing: emit snapshot/stream/checkpoint spans across all CDC inputs

### DIFF
--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -14,6 +14,9 @@ import (
 	"sync"
 
 	"github.com/Jeffail/checkpoint"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -40,6 +43,10 @@ type RecordBatcher struct {
 	maxTrackedShards   int
 	maxTrackedMessages int
 	log                *service.Logger
+	// tracer wraps the live checkpoint-commit path (CONTRIBUTING.md §5.4.4).
+	// Defaults to a no-op tracer; the input installs the real tracer after
+	// construction.
+	tracer trace.Tracer
 
 	mu sync.Mutex
 
@@ -101,6 +108,7 @@ func NewRecordBatcher(maxTrackedShards, checkpointLimit int, log *service.Logger
 		maxTrackedShards:   maxTrackedShards,
 		maxTrackedMessages: maxTrackedMessages,
 		log:                log,
+		tracer:             noop.NewTracerProvider().Tracer("aws_dynamodb_cdc"),
 		batches:            make(map[*service.Message]*trackedBatch),
 		shards:             make(map[string]*shardAckTracker),
 	}
@@ -228,7 +236,7 @@ func (b *RecordBatcher) AckMessages(
 	// the last persisted position. A pinned frontier (nacked batch ahead of
 	// us in stream order) accumulates pending acks without persisting.
 	if st.pending >= cp.CheckpointLimit() && st.frontier != "" && st.frontier != st.persisted {
-		if err := cp.Set(ctx, tb.shardID, st.frontier, st.frontierTime); err != nil {
+		if err := b.commitCheckpoint(ctx, cp, tb.shardID, st.frontier, st.frontierTime); err != nil {
 			return err
 		}
 		st.persisted = st.frontier
@@ -236,6 +244,21 @@ func (b *RecordBatcher) AckMessages(
 		b.log.Debugf("Checkpointed shard %s at sequence %s", tb.shardID, st.frontier)
 	}
 
+	return nil
+}
+
+// commitCheckpoint persists a shard's checkpoint within an
+// aws_dynamodb_cdc.checkpoint_commit tracing span (CONTRIBUTING.md §5.4.4).
+// This is the live commit path exercised during normal streaming; the flush
+// on close is traced separately in flushCheckpoint.
+func (b *RecordBatcher) commitCheckpoint(ctx context.Context, cp checkpointer, shardID, sequenceNumber, approxCreationTime string) error {
+	ctx, span := b.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+	if err := cp.Set(ctx, shardID, sequenceNumber, approxCreationTime); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
 	return nil
 }
 

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1031,6 +1031,7 @@ func (d *dynamoDBCDCInput) connectSingleTable(ctx context.Context, tableName str
 
 	// Initialize record batcher
 	d.recordBatcher = NewRecordBatcher(d.conf.maxTrackedShards, d.conf.checkpointLimit, d.log)
+	d.recordBatcher.tracer = d.tracer
 
 	d.log.Infof("Connected to DynamoDB stream: %s", *d.streamArn)
 
@@ -1146,6 +1147,7 @@ func (d *dynamoDBCDCInput) initializeTableStream(ctx context.Context, tableName 
 
 	// Initialize record batcher for this table
 	recordBatcher := NewRecordBatcher(d.conf.maxTrackedShards, d.conf.checkpointLimit, d.log)
+	recordBatcher.tracer = d.tracer
 
 	// Re-check under write lock before inserting (another goroutine may have
 	// initialized this table concurrently during periodic discovery).

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -29,6 +29,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
 	smithytime "github.com/aws/smithy-go/time"
 	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	baws "github.com/redpanda-data/connect/v4/internal/impl/aws"
@@ -398,12 +400,22 @@ type tableStream struct {
 //
 // Lock hierarchy: always acquire d.mu before ts.mu to prevent deadlocks.
 // Never hold ts.mu when acquiring d.mu.
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "aws_dynamodb_cdc.snapshot"
+	traceStream           = "aws_dynamodb_cdc.stream"
+	traceCheckpointCommit = "aws_dynamodb_cdc.checkpoint_commit"
+)
+
 type dynamoDBCDCInput struct {
 	conf          dynamoDBCDCConfig
 	awsConf       aws.Config
 	dynamoClient  *dynamodb.Client
 	streamsClient *dynamodbstreams.Client
 	log           *service.Logger
+	tracer        trace.Tracer
 	metrics       dynamoDBCDCMetrics
 
 	mu           sync.RWMutex            // Level 1 lock - acquire before tableStream.mu (protects tableStreams map only)
@@ -800,6 +812,7 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 		tableStreams: make(map[string]*tableStream),
 		shutSig:      shutdown.NewSignaller(),
 		log:          mgr.Logger(),
+		tracer:       mgr.OtelTracer().Tracer("aws_dynamodb_cdc"),
 		metrics: dynamoDBCDCMetrics{
 			shardsTracked:           mgr.Metrics().NewGauge(metricShardsTracked),
 			shardsActive:            mgr.Metrics().NewGauge(metricShardsActive),
@@ -971,8 +984,11 @@ func (d *dynamoDBCDCInput) Connect(ctx context.Context) error {
 		return d.connectSingleTable(ctx, tables[0])
 	}
 
-	// Multi-table mode (includelist with >1 table, or tag discovery)
-	return d.connectMultipleTables(ctx, tables)
+	// Multi-table mode (includelist with >1 table, or tag discovery). Snapshot
+	// is not supported here (validated at config time), so this is the stream path.
+	return d.spanned(ctx, traceStream, func(ctx context.Context) error {
+		return d.connectMultipleTables(ctx, tables)
+	})
 }
 
 // connectSingleTable handles the single table mode (legacy behavior)
@@ -1020,11 +1036,13 @@ func (d *dynamoDBCDCInput) connectSingleTable(ctx context.Context, tableName str
 
 	// Handle snapshot mode
 	if d.conf.snapshot.mode != snapshotModeNone {
-		return d.connectWithSnapshot(ctx, tableName)
+		return d.spanned(ctx, traceSnapshot, func(ctx context.Context) error {
+			return d.connectWithSnapshot(ctx, tableName)
+		})
 	}
 
 	// CDC-only mode (existing behavior)
-	return d.connectCDCOnly(ctx)
+	return d.spanned(ctx, traceStream, d.connectCDCOnly)
 }
 
 // connectMultipleTables handles streaming from multiple tables simultaneously
@@ -2304,6 +2322,20 @@ func convertTableRecordsToBatch(records []types.Record, tableName, shardID strin
 	return batch
 }
 
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (d *dynamoDBCDCInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := d.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
 // flushCheckpoint flushes pending checkpoints for a given checkpointer/batcher pair.
 // Returns true if any error occurred during flush.
 func (d *dynamoDBCDCInput) flushCheckpoint(ctx context.Context, cp *Checkpointer, batcher *RecordBatcher, label string) bool {
@@ -2316,8 +2348,13 @@ func (d *dynamoDBCDCInput) flushCheckpoint(ctx context.Context, cp *Checkpointer
 		return false
 	}
 
+	ctx, span := d.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	d.log.Infof("Flushing %d pending checkpoints for %s on close", len(pending), label)
 	if err := cp.FlushCheckpoints(ctx, pending); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		d.log.Errorf("Failed to flush checkpoints for %s: %v", label, err)
 		d.metrics.checkpointFailures.Incr(1)
 		return true

--- a/internal/impl/aws/dynamodb/input_cdc_tracing_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_tracing_test.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 // TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
@@ -72,4 +74,32 @@ func TestCDCTracingSpans(t *testing.T) {
 		require.Len(t, spans[0].Events, 1)
 		assert.Equal(t, "exception", spans[0].Events[0].Name)
 	})
+}
+
+// TestCDCTracingLiveCheckpointCommitSpan verifies that the live checkpoint
+// commit during normal streaming (RecordBatcher.AckMessages, not just the flush
+// on close) emits an aws_dynamodb_cdc.checkpoint_commit span.
+func TestCDCTracingLiveCheckpointCommitSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	batcher := NewRecordBatcher(10000, 1000, service.MockResources().Logger())
+	batcher.tracer = tp.Tracer("aws_dynamodb_cdc")
+
+	checkpointer := &mockCheckpointer{checkpointLimit: 5}
+
+	// Ack enough contiguous messages to cross the checkpoint limit, which
+	// triggers the live commit path.
+	batch1 := createTestMessages(3, "shard-001", 0)
+	batch2 := createTestMessages(3, "shard-001", 3)
+	batcher.AddMessages(batch1, "shard-001")
+	batcher.AddMessages(batch2, "shard-001")
+	require.NoError(t, batcher.AckMessages(context.Background(), checkpointer, batch1))
+	require.NoError(t, batcher.AckMessages(context.Background(), checkpointer, batch2))
+	require.Equal(t, 1, checkpointer.calls(), "expected one live checkpoint commit")
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, traceCheckpointCommit, spans[0].Name)
 }

--- a/internal/impl/aws/dynamodb/input_cdc_tracing_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	d := &dynamoDBCDCInput{tracer: tp.Tracer("aws_dynamodb_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := d.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := d.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := d.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/cockroachdb/input_changefeed.go
+++ b/internal/impl/cockroachdb/input_changefeed.go
@@ -25,6 +25,8 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/Jeffail/checkpoint"
 
@@ -82,7 +84,31 @@ type crdbChangefeedInput struct {
 
 	res     *service.Resources
 	logger  *service.Logger
+	tracer  trace.Tracer
 	shutSig *shutdown.Signaller
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4. A CockroachDB
+// changefeed has no distinct snapshot phase (the initial backfill is part of
+// the change stream), so only the stream and checkpoint-commit paths are
+// instrumented.
+const (
+	traceStream           = "cockroachdb_changefeed.stream"
+	traceCheckpointCommit = "cockroachdb_changefeed.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the stream path
+// (CONTRIBUTING.md §5.4.4).
+func (c *crdbChangefeedInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := c.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 const cursorCacheKey = "crdb_changefeed_cursor"
@@ -92,6 +118,7 @@ func newCRDBChangefeedInputFromConfig(conf *service.ParsedConfig, res *service.R
 		cursorCheckpointer: checkpoint.NewCapped[string](1024), // TODO: Configure this?
 		res:                res,
 		logger:             res.Logger(),
+		tracer:             res.OtelTracer().Tracer("cockroachdb_changefeed"),
 		shutSig:            shutdown.NewSignaller(),
 	}
 
@@ -204,7 +231,11 @@ func (c *crdbChangefeedInput) Connect(ctx context.Context) (err error) {
 	queryCtx, queryCancel := c.shutSig.SoftStopCtx(context.Background())
 	c.queryCancel = queryCancel
 
-	c.rows, err = c.pgPool.Query(queryCtx, c.statement)
+	err = c.spanned(queryCtx, traceStream, func(context.Context) error {
+		var qErr error
+		c.rows, qErr = c.pgPool.Query(queryCtx, c.statement)
+		return qErr
+	})
 	if err != nil {
 		queryCancel()
 		c.queryCancel = nil
@@ -301,10 +332,18 @@ func (c *crdbChangefeedInput) Read(ctx context.Context) (*service.Message, servi
 		if cursorTimestamp == nil {
 			return nil
 		}
+		ctx, span := c.tracer.Start(ctx, traceCheckpointCommit)
+		defer span.End()
 		if err := c.res.AccessCache(ctx, c.cursorCache, func(c service.Cache) {
 			cErr = c.Set(ctx, cursorCacheKey, []byte(*cursorTimestamp), nil)
 		}); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return err
+		}
+		if cErr != nil {
+			span.RecordError(cErr)
+			span.SetStatus(codes.Error, cErr.Error())
 		}
 		return
 	}, nil

--- a/internal/impl/cockroachdb/input_changefeed_tracing_test.go
+++ b/internal/impl/cockroachdb/input_changefeed_tracing_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the stream phase emits a tracing span via
+// the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an in-memory
+// recording tracer. A CockroachDB changefeed has no distinct snapshot phase.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	c := &crdbChangefeedInput{tracer: tp.Tracer("cockroachdb_changefeed")}
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := c.spanned(context.Background(), traceStream, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped stream work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := c.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/gcp/enterprise/input_spanner_cdc.go
+++ b/internal/impl/gcp/enterprise/input_spanner_cdc.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/Jeffail/shutdown"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -176,6 +178,7 @@ type asyncMessage struct {
 type spannerCDCReader struct {
 	conf    spannerCDCInputConfig
 	log     *service.Logger
+	tracer  trace.Tracer
 	metrics *changestreams.Metrics
 
 	batching   service.BatchPolicy
@@ -211,12 +214,35 @@ func newSpannerCDCReader(conf spannerCDCInputConfig, batching service.BatchPolic
 	return &spannerCDCReader{
 		conf:     conf,
 		log:      mgr.Logger(),
+		tracer:   mgr.OtelTracer().Tracer("gcp_spanner_cdc"),
 		metrics:  changestreams.NewMetrics(mgr.Metrics(), conf.StreamID),
 		batching: batching,
 		batcher:  newSpannerPartitionBatcherFactory(batching, mgr),
 		resCh:    make(chan asyncMessage),
 		stopSig:  shutdown.NewSignaller(),
 	}
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4. A Spanner change
+// stream has no distinct snapshot phase (initial state arrives as change
+// records), so only the stream and checkpoint-commit paths are instrumented.
+const (
+	traceStream           = "gcp_spanner_cdc.stream"
+	traceCheckpointCommit = "gcp_spanner_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the stream path
+// (CONTRIBUTING.md §5.4.4).
+func (r *spannerCDCReader) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := r.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func (r *spannerCDCReader) emit(
@@ -229,9 +255,13 @@ func (r *spannerCDCReader) emit(
 		return nil, nil
 	}
 	ackOnce := ack.NewOnce(func(ctx context.Context) error {
+		ctx, span := r.tracer.Start(ctx, traceCheckpointCommit)
+		defer span.End()
 		// If we processed the message and failed to update the watermark, we
 		// would try to update it on the next message, no need to return an error here.
 		if err := r.subscriber.UpdatePartitionWatermark(ctx, partitionToken, commitTimestamp); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			r.log.Errorf("%s: failed to update watermark: %v", partitionToken, err)
 		}
 		return nil
@@ -340,7 +370,7 @@ func (r *spannerCDCReader) Connect(ctx context.Context) error {
 
 	go func() {
 		defer cancel()
-		if err := r.subscriber.Run(ctx); err != nil {
+		if err := r.spanned(ctx, traceStream, r.subscriber.Run); err != nil {
 			r.log.Errorf("Spanner change stream reader error: %v", err)
 		}
 		r.subscriber.Close()

--- a/internal/impl/gcp/enterprise/input_spanner_cdc_tracing_test.go
+++ b/internal/impl/gcp/enterprise/input_spanner_cdc_tracing_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package enterprise
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the stream phase emits a tracing span via
+// the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an in-memory
+// recording tracer. A Spanner change stream has no distinct snapshot phase.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	r := &spannerCDCReader{tracer: tp.Tracer("gcp_spanner_cdc")}
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := r.spanned(context.Background(), traceStream, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped stream work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := r.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/mongodb/cdc/checkpoint_cache.go
+++ b/internal/impl/mongodb/cdc/checkpoint_cache.go
@@ -12,6 +12,7 @@ import (
 	"context"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -23,8 +24,13 @@ type checkpointCache struct {
 }
 
 func (c *checkpointCache) Store(ctx context.Context, resumeToken bson.Raw) error {
+	ctx, span := c.resources.OtelTracer().Tracer("mongodb_cdc").Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	b, err := bson.MarshalExtJSON(resumeToken, true, false)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	var cErr error
@@ -33,6 +39,10 @@ func (c *checkpointCache) Store(ctx context.Context, resumeToken bson.Raw) error
 	})
 	if err == nil {
 		err = cErr
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
 	return err
 }

--- a/internal/impl/mongodb/cdc/input.go
+++ b/internal/impl/mongodb/cdc/input.go
@@ -25,6 +25,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -186,6 +188,7 @@ func newMongoCDC(conf *service.ParsedConfig, res *service.Resources) (i service.
 		readChan:          make(chan mongoBatch),
 		errorChan:         make(chan error, 1),
 		logger:            res.Logger(),
+		tracer:            res.OtelTracer().Tracer("mongodb_cdc"),
 		collectionSchemas: make(map[string]*cachedSchema),
 	}
 	var url, username, password, dbName, appName string
@@ -337,6 +340,7 @@ type mongoCDC struct {
 	db          *mongo.Database
 	collections []string
 	logger      *service.Logger
+	tracer      trace.Tracer
 
 	shutsig   *shutdown.Signaller
 	readChan  chan mongoBatch
@@ -365,6 +369,28 @@ type mongoCDC struct {
 type cachedSchema struct {
 	schema any      // serialised Common Schema (from ToAny())
 	keys   []string // sorted top-level field names for key-set fingerprinting
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "mongodb_cdc.snapshot"
+	traceStream           = "mongodb_cdc.stream"
+	traceCheckpointCommit = "mongodb_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (m *mongoCDC) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := m.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func (m *mongoCDC) Connect(ctx context.Context) error {
@@ -494,12 +520,14 @@ func (m *mongoCDC) Connect(ctx context.Context) error {
 		}()
 		cp := checkpoint.NewCapped[bson.Raw](int64(m.checkpointLimit))
 		if m.resumeToken == nil {
-			g, gctx := errgroup.WithContext(ctx)
-			for _, name := range m.collections {
-				coll := m.db.Collection(name)
-				g.Go(func() error { return m.readSnapshot(gctx, coll, ts, cp) })
-			}
-			if err := g.Wait(); err != nil {
+			if err := m.spanned(ctx, traceSnapshot, func(ctx context.Context) error {
+				g, gctx := errgroup.WithContext(ctx)
+				for _, name := range m.collections {
+					coll := m.db.Collection(name)
+					g.Go(func() error { return m.readSnapshot(gctx, coll, ts, cp) })
+				}
+				return g.Wait()
+			}); err != nil {
 				select {
 				case m.errorChan <- fmt.Errorf("error reading MongoDB snapshot: %w", err):
 				default:
@@ -507,7 +535,9 @@ func (m *mongoCDC) Connect(ctx context.Context) error {
 				return
 			}
 		}
-		if err := m.readFromStream(ctx, cp, opts); err != nil {
+		if err := m.spanned(ctx, traceStream, func(ctx context.Context) error {
+			return m.readFromStream(ctx, cp, opts)
+		}); err != nil {
 			select {
 			case m.errorChan <- fmt.Errorf("error watching MongoDB change stream: %w", err):
 			default:

--- a/internal/impl/mongodb/cdc/input_tracing_test.go
+++ b/internal/impl/mongodb/cdc/input_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package cdc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	m := &mongoCDC{tracer: tp.Tracer("mongodb_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := m.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := m.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := m.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/Jeffail/checkpoint"
 	"github.com/Jeffail/shutdown"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -156,7 +158,30 @@ type sqlServerCDCInput struct {
 	connMu  sync.Mutex
 	stopSig *shutdown.Signaller
 	log     *service.Logger
+	tracer  trace.Tracer
 	cpCache service.Cache
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "microsoft_sql_server_cdc.snapshot"
+	traceStream           = "microsoft_sql_server_cdc.stream"
+	traceCheckpointCommit = "microsoft_sql_server_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (i *sqlServerCDCInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := i.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resources) (s service.BatchInput, err error) {
@@ -264,6 +289,7 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 			},
 		},
 		res:       resources,
+		tracer:    resources.OtelTracer().Tracer("microsoft_sql_server_cdc"),
 		log:       logger,
 		metrics:   resources.Metrics(),
 		stopSig:   shutdown.NewSignaller(),
@@ -354,7 +380,11 @@ func (i *sqlServerCDCInput) Connect(ctx context.Context) error {
 
 		// snapshot if no LSN exists then store checkpoint once complete
 		if snapshotter != nil {
-			if maxLSN, err = i.processSnapshot(softCtx, snapshotter); err != nil {
+			if err = i.spanned(softCtx, traceSnapshot, func(ctx context.Context) error {
+				var serr error
+				maxLSN, serr = i.processSnapshot(ctx, snapshotter)
+				return serr
+			}); err != nil {
 				if i.stopSig.IsHardStopSignalled() {
 					i.log.Errorf("Shutting down snapshotting process: %s", err)
 				} else {
@@ -378,10 +408,12 @@ func (i *sqlServerCDCInput) Connect(ctx context.Context) error {
 		// streaming
 		wg, ctx := errgroup.WithContext(softCtx)
 		wg.Go(func() error {
-			if err := streaming.ReadChangeTables(ctx, i.db, maxLSN); err != nil {
-				return fmt.Errorf("streaming from change tables: %w", err)
-			}
-			return nil
+			return i.spanned(ctx, traceStream, func(ctx context.Context) error {
+				if err := streaming.ReadChangeTables(ctx, i.db, maxLSN); err != nil {
+					return fmt.Errorf("streaming from change tables: %w", err)
+				}
+				return nil
+			})
 		})
 		if err := wg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 			i.log.Errorf("Error during Microsoft SQL Server CDC Component: %s", err)
@@ -426,6 +458,9 @@ func (i *sqlServerCDCInput) cacheLSN(ctx context.Context, lsn replication.LSN) e
 		return errors.New("LSN for caching is empty")
 	}
 
+	ctx, span := i.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	var cErr error
 	if i.cpCache != nil {
 		cErr = i.cpCache.Set(ctx, i.cfg.lsnCacheKey, lsn, nil)
@@ -438,6 +473,8 @@ func (i *sqlServerCDCInput) cacheLSN(ctx context.Context, lsn replication.LSN) e
 	}
 
 	if cErr != nil {
+		span.RecordError(cErr)
+		span.SetStatus(codes.Error, cErr.Error())
 		return fmt.Errorf("unable persist checkpoint to cache: %w", cErr)
 	}
 	return nil

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc_tracing_test.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package mssqlserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	i := &sqlServerCDCInput{tracer: tp.Tracer("microsoft_sql_server_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := i.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := i.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := i.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -28,6 +28,8 @@ import (
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/go-mysql-org/go-mysql/schema"
 	"github.com/go-sql-driver/mysql"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -195,6 +197,7 @@ type mysqlStreamInput struct {
 
 	logger                     *service.Logger
 	res                        *service.Resources
+	tracer                     trace.Tracer
 	snapshotRowsProcessedTotal *service.MetricCounter
 
 	rawMessageEvents chan MessageEvent
@@ -225,6 +228,7 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 		rawMessageEvents: make(chan MessageEvent),
 		msgChan:          make(chan asyncMessage),
 		res:              res,
+		tracer:           res.OtelTracer().Tracer("mysql_cdc"),
 		tableSchemas:     make(map[string]any),
 	}
 
@@ -346,6 +350,28 @@ func init() {
 }
 
 // ---- Redpanda Connect specific methods----
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "mysql_cdc.snapshot"
+	traceStream           = "mysql_cdc.stream"
+	traceCheckpointCommit = "mysql_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (i *mysqlStreamInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := i.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
 
 func (i *mysqlStreamInput) Connect(ctx context.Context) error {
 	// If IAM authentication is enabled, generate a new token
@@ -476,7 +502,9 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 			_ = snapshot.close()
 			return fmt.Errorf("unable to prepare snapshot: %w", err)
 		}
-		if err = i.readSnapshot(ctx, snapshot); err != nil {
+		if err = i.spanned(ctx, traceSnapshot, func(ctx context.Context) error {
+			return i.readSnapshot(ctx, snapshot)
+		}); err != nil {
 			_ = snapshot.close()
 			return fmt.Errorf("failed reading snapshot: %w", err)
 		}
@@ -511,7 +539,9 @@ func (i *mysqlStreamInput) startMySQLSync(ctx context.Context, pos *position, sn
 	i.logger.Infof("starting MySQL CDC stream from binlog %s at offset %d", pos.Name, pos.Pos)
 	i.currentBinlogName = pos.Name
 	i.canal.SetEventHandler(i)
-	if err := i.canal.RunFrom(*pos); err != nil {
+	if err := i.spanned(ctx, traceStream, func(context.Context) error {
+		return i.canal.RunFrom(*pos)
+	}); err != nil {
 		return fmt.Errorf("starting streaming: %w", err)
 	}
 	return nil
@@ -961,6 +991,9 @@ func (i *mysqlStreamInput) getCachedBinlogPosition(ctx context.Context) (*positi
 }
 
 func (i *mysqlStreamInput) setCachedBinlogPosition(ctx context.Context, binLogPos position) error {
+	ctx, span := i.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	var cErr error
 	if err := i.res.AccessCache(ctx, i.binLogCache, func(c service.Cache) {
 		cErr = c.Set(
@@ -973,6 +1006,8 @@ func (i *mysqlStreamInput) setCachedBinlogPosition(ctx context.Context, binLogPo
 		return fmt.Errorf("unable to access cache for writing: %w", err)
 	}
 	if cErr != nil {
+		span.RecordError(cErr)
+		span.SetStatus(codes.Error, cErr.Error())
 		return fmt.Errorf("unable persist checkpoint to cache: %w", cErr)
 	}
 	return nil

--- a/internal/impl/mysql/input_mysql_stream_tracing_test.go
+++ b/internal/impl/mysql/input_mysql_stream_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	i := &mysqlStreamInput{tracer: tp.Tracer("mysql_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := i.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := i.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := i.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Jeffail/checkpoint"
 	"github.com/Jeffail/shutdown"
 	_ "github.com/sijms/go-ora/v2"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -249,7 +251,30 @@ type oracleDBCDCInput struct {
 	stopSig          *shutdown.Signaller
 	snapshotOnlyDone atomic.Bool
 	log              *service.Logger
+	tracer           trace.Tracer
 	cpCache          service.Cache
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "oracledb_cdc.snapshot"
+	traceStream           = "oracledb_cdc.stream"
+	traceCheckpointCommit = "oracledb_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (o *oracleDBCDCInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := o.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resources) (s service.BatchInput, err error) {
@@ -391,6 +416,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 		lmCfg:     lmCfg,
 		res:       resources,
 		log:       logger,
+		tracer:    resources.OtelTracer().Tracer("oracledb_cdc"),
 		metrics:   resources.Metrics(),
 		stopSig:   shutdown.NewSignaller(),
 		publisher: newBatchPublisher(batcher, cp, logger),
@@ -592,7 +618,11 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {
-			if startSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
+			if err = o.spanned(softCtx, traceSnapshot, func(ctx context.Context) error {
+				var serr error
+				startSCN, serr = o.processSnapshot(ctx, snapshotter)
+				return serr
+			}); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					o.log.Infof("Snapshotting stopped: %s", err)
 				} else {
@@ -624,10 +654,12 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		// streaming
 		wg, _ := errgroup.WithContext(softCtx)
 		wg.Go(func() error {
-			if err := streaming.ReadChanges(softCtx, startSCN); err != nil {
-				return fmt.Errorf("streaming from logminer: %w", err)
-			}
-			return nil
+			return o.spanned(softCtx, traceStream, func(ctx context.Context) error {
+				if err := streaming.ReadChanges(ctx, startSCN); err != nil {
+					return fmt.Errorf("streaming from logminer: %w", err)
+				}
+				return nil
+			})
 		})
 		if err := wg.Wait(); err != nil && softCtx.Err() == nil && !errors.Is(err, context.Canceled) {
 			o.log.Errorf("Error during Oracle CDC Component: %s", err)
@@ -678,6 +710,9 @@ func (o *oracleDBCDCInput) cacheSCN(ctx context.Context, scn replication.SCN) er
 		return errors.New("SCN for caching is empty")
 	}
 
+	ctx, span := o.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	// Use internal Oracle-based cache if set (when no external cache configured),
 	// otherwise use external cache resource
 	var cErr error
@@ -692,6 +727,8 @@ func (o *oracleDBCDCInput) cacheSCN(ctx context.Context, scn replication.SCN) er
 	}
 
 	if cErr != nil {
+		span.RecordError(cErr)
+		span.SetStatus(codes.Error, cErr.Error())
 		return fmt.Errorf("persisting checkpoint to cache: %w", cErr)
 	}
 	return nil

--- a/internal/impl/oracledb/input_oracledb_cdc_tracing_test.go
+++ b/internal/impl/oracledb/input_oracledb_cdc_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package oracledb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	o := &oracleDBCDCInput{tracer: tp.Tracer("oracledb_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := o.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := o.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := o.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -338,6 +338,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 			WalMonitorInterval:       walMonitorInterval,
 			MaxSnapshotWorkers:       maxParallelSnapshotTables,
 			Logger:                   logger,
+			Tracer:                   mgr.OtelTracer().Tracer("postgres_cdc"),
 			UnchangedToastValue:      unchangedToastValue,
 			HeartbeatInterval:        heartbeatInterval,
 		},

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -42,6 +43,10 @@ type Config struct {
 	IncludeTxnMarkers bool
 
 	Logger *service.Logger
+	// Tracer is used to emit CDC tracing spans around the snapshot, stream,
+	// and checkpoint-commit paths (CONTRIBUTING.md §5.4.4). May be nil, in
+	// which case a no-op tracer is used.
+	Tracer trace.Tracer
 
 	PgStandbyTimeout   time.Duration
 	WalMonitorInterval time.Duration

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -21,6 +21,9 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/jackc/pgx/v5/pgtype"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -30,6 +33,14 @@ import (
 )
 
 const decodingPlugin = "pgoutput"
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "postgres_cdc.snapshot"
+	traceStream           = "postgres_cdc.stream"
+	traceCheckpointCommit = "postgres_cdc.checkpoint_commit"
+)
 
 // Stream is a structure that represents a logical replication stream
 // It includes the connection to the database, the context for the stream, and snapshotting functionality
@@ -58,6 +69,7 @@ type Stream struct {
 	snapshotBatchSize       int
 	decodingPluginArguments []string
 	logger                  *service.Logger
+	tracer                  trace.Tracer
 	monitor                 *Monitor
 	heartbeat               *heartbeat
 	maxSnapshotWorkers      int
@@ -115,6 +127,10 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	if config.BatchSize > 0 {
 		batchSize = config.BatchSize
 	}
+	tracer := config.Tracer
+	if tracer == nil {
+		tracer = noop.NewTracerProvider().Tracer("postgres_cdc")
+	}
 	stream := &Stream{
 		pgConn:                dbConn,
 		messages:              make(chan []StreamMessage),
@@ -125,6 +141,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		tables:                tables,
 		maxSnapshotWorkers:    config.MaxSnapshotWorkers,
 		logger:                config.Logger,
+		tracer:                tracer,
 		shutSig:               shutdown.NewSignaller(),
 		includeTxnMarkers:     config.IncludeTxnMarkers,
 		standbyMessageTimeout: config.PgStandbyTimeout,
@@ -221,7 +238,9 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		}
 		go func() {
 			defer stream.shutSig.TriggerHasStopped()
-			if err := stream.streamMessages(confirmedLSNFromDB); err != nil {
+			if err := stream.spanned(ctx, traceStream, func(context.Context) error {
+				return stream.streamMessages(confirmedLSNFromDB)
+			}); err != nil {
 				stream.errors <- fmt.Errorf("logical replication stream error: %w", err)
 			}
 		}()
@@ -264,7 +283,9 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		defer done()
 		var startLSN LSN
 		if snapshotter != nil {
-			if err = stream.processSnapshot(ctx, snapshotter); err != nil {
+			if err = stream.spanned(ctx, traceSnapshot, func(ctx context.Context) error {
+				return stream.processSnapshot(ctx, snapshotter)
+			}); err != nil {
 				stream.errors <- fmt.Errorf("processing snapshot: %w", err)
 				return
 			}
@@ -335,7 +356,9 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 			stream.errors <- fmt.Errorf("starting logical replication: %w", err)
 			return
 		}
-		if err := stream.streamMessages(startLSN); err != nil {
+		if err := stream.spanned(ctx, traceStream, func(context.Context) error {
+			return stream.streamMessages(startLSN)
+		}); err != nil {
 			stream.errors <- fmt.Errorf("logical replication stream error: %w", err)
 		}
 	}()
@@ -349,6 +372,20 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 // including the % of snapshot messages processed and the WAL lag in bytes.
 func (s *Stream) GetProgress() *Report {
 	return s.monitor.Report()
+}
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (s *Stream) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := s.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func (s *Stream) startLr(ctx context.Context, lsnStart LSN) error {
@@ -392,6 +429,9 @@ func (s *Stream) getAckedLSN() LSN {
 }
 
 func (s *Stream) commitAckedLSN(ctx context.Context, lsn LSN) error {
+	ctx, span := s.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	err := SendStandbyStatusUpdate(
 		ctx,
 		s.pgConn,
@@ -401,6 +441,8 @@ func (s *Stream) commitAckedLSN(ctx context.Context, lsn LSN) error {
 		},
 	)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("sending standby status message at LSN %s: %w", lsn, err)
 	}
 	return nil

--- a/internal/impl/postgresql/pglogicalstream/logical_stream_tracing_test.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the stream's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	s := &Stream{tracer: tp.Tracer("postgres_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := s.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := s.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := s.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}

--- a/internal/impl/salesforce/input_salesforce_cdc.go
+++ b/internal/impl/salesforce/input_salesforce_cdc.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/Jeffail/checkpoint"
 	"github.com/Jeffail/shutdown"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -384,8 +386,31 @@ type salesforceCDCInput struct {
 	batching   service.BatchPolicy
 	mgr        *service.Resources
 	logger     *service.Logger
+	tracer     trace.Tracer
 
 	executor atomic.Pointer[salesforceCDCInputExecutor]
+}
+
+// CDC tracing span names, emitted per CONTRIBUTING.md §5.4.4 around the
+// snapshot, stream, and checkpoint-commit paths.
+const (
+	traceSnapshot         = "salesforce_cdc.snapshot"
+	traceStream           = "salesforce_cdc.stream"
+	traceCheckpointCommit = "salesforce_cdc.checkpoint_commit"
+)
+
+// spanned runs fn within a tracing span named for a CDC phase, recording any
+// error onto the span. It is the seam used to instrument the snapshot and
+// stream paths (CONTRIBUTING.md §5.4.4).
+func (s *salesforceCDCInput) spanned(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := s.tracer.Start(ctx, name)
+	defer span.End()
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 // salesforceCDCInputExecutor hosts everything Connect builds: the gRPC and
@@ -438,6 +463,7 @@ func newSalesforceCDCInput(pConf *service.ParsedConfig, mgr *service.Resources) 
 		batching:   batching,
 		mgr:        mgr,
 		logger:     mgr.Logger(),
+		tracer:     mgr.OtelTracer().Tracer("salesforce_cdc"),
 	}
 	return service.AutoRetryNacksBatchedToggled(pConf, in)
 }
@@ -555,7 +581,7 @@ func (e *salesforceCDCInputExecutor) run() {
 		len(e.topicSpecs), cdcCount, peCount, firehose, e.conf.StreamSnapshot, e.conf.ReplayPreset,
 	)
 
-	if err := e.runSnapshotIfNeeded(ctx); err != nil {
+	if err := e.spanned(ctx, traceSnapshot, e.runSnapshotIfNeeded); err != nil {
 		if ctx.Err() == nil {
 			e.logger.Errorf("snapshot phase failed: %v", err)
 		}
@@ -570,7 +596,9 @@ func (e *salesforceCDCInputExecutor) run() {
 	for _, spec := range e.topicSpecs {
 		go func(spec cdcTopicSpec) {
 			defer wg.Done()
-			if err := e.runTopic(ctx, spec); err != nil {
+			if err := e.spanned(ctx, traceStream, func(ctx context.Context) error {
+				return e.runTopic(ctx, spec)
+			}); err != nil {
 				if ctx.Err() == nil {
 					e.logger.Errorf("topic %s: %v", spec.Path, err)
 				}
@@ -1003,8 +1031,13 @@ func (e *salesforceCDCInputExecutor) loadState(ctx context.Context) error {
 // serialized bytes are unchanged it skips the cache round-trip. Callers must
 // hold e.mu.
 func (e *salesforceCDCInputExecutor) saveStateLocked(ctx context.Context) error {
+	ctx, span := e.tracer.Start(ctx, traceCheckpointCommit)
+	defer span.End()
+
 	b, err := json.Marshal(e.state)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, err.Error())
 		return fmt.Errorf("marshal checkpoint state: %w", err)
 	}
 
@@ -1012,9 +1045,13 @@ func (e *salesforceCDCInputExecutor) saveStateLocked(ctx context.Context) error 
 	if err := e.mgr.AccessCache(ctx, e.conf.Checkpoint.Cache, func(cache service.Cache) {
 		setErr = cache.Set(ctx, e.conf.Checkpoint.CacheKey, b, nil)
 	}); err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, err.Error())
 		return fmt.Errorf("access cache %q: %w", e.conf.Checkpoint.Cache, err)
 	}
 	if setErr != nil {
+		span.RecordError(setErr)
+		span.SetStatus(otelcodes.Error, setErr.Error())
 		return fmt.Errorf("set cache key %q: %w", e.conf.Checkpoint.CacheKey, setErr)
 	}
 

--- a/internal/impl/salesforce/input_salesforce_cdc_tracing_test.go
+++ b/internal/impl/salesforce/input_salesforce_cdc_tracing_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package salesforce
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCDCTracingSpans verifies that the snapshot and stream phases emit tracing
+// spans via the connector's tracing seam (CONTRIBUTING.md §5.4.4), using an
+// in-memory recording tracer.
+func TestCDCTracingSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	s := &salesforceCDCInput{tracer: tp.Tracer("salesforce_cdc")}
+
+	t.Run("snapshot phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		called := false
+		err := s.spanned(context.Background(), traceSnapshot, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, called, "wrapped snapshot work should run")
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceSnapshot, spans[0].Name)
+		assert.Equal(t, codes.Unset, spans[0].Status.Code)
+	})
+
+	t.Run("stream phase emits a span", func(t *testing.T) {
+		exporter.Reset()
+		err := s.spanned(context.Background(), traceStream, func(context.Context) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, traceStream, spans[0].Name)
+	})
+
+	t.Run("phase error is recorded on the span", func(t *testing.T) {
+		exporter.Reset()
+		boom := errors.New("boom")
+		err := s.spanned(context.Background(), traceStream, func(context.Context) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(t, codes.Error, spans[0].Status.Code)
+		require.Len(t, spans[0].Events, 1)
+		assert.Equal(t, "exception", spans[0].Events[0].Name)
+	})
+}


### PR DESCRIPTION
## What

Adds OpenTelemetry tracing spans around the **snapshot**, **stream**, and **checkpoint-commit** paths of every CDC input, per CONTRIBUTING.md §5.4.4.

Before this change, an audit confirmed **none** of the nine CDC inputs emitted tracing spans (verified in code — including the SQL CDC connectors, not assumed). Each connector now acquires a tracer via the established repo pattern `mgr.OtelTracer().Tracer("<connector>")` (the same API used by `internal/agent` and `internal/mcp`) and wraps each phase in a span. Errors are recorded on the span with an error status.

## Connectors

| Connector | snapshot | stream | checkpoint-commit |
|---|---|---|---|
| `aws_dynamodb_cdc` | ✅ | ✅ | ✅ |
| `oracledb_cdc` | ✅ | ✅ | ✅ |
| `mysql_cdc` | ✅ | ✅ | ✅ |
| `microsoft_sql_server_cdc` | ✅ | ✅ | ✅ |
| `postgres_cdc` | ✅ | ✅ | ✅ |
| `mongodb_cdc` | ✅ | ✅ | ✅ |
| `salesforce_cdc` | ✅ | ✅ | ✅ |
| `cockroachdb_changefeed` | n/a¹ | ✅ | ✅ |
| `gcp_spanner_cdc` | n/a¹ | ✅ | ✅ |

¹ Changefeed / change-stream connectors have no distinct snapshot phase — the initial backfill arrives as part of the change stream. This is called out in code comments and in the per-connector commit.

Span names are connector-scoped, e.g. `postgres_cdc.snapshot`, `postgres_cdc.stream`, `postgres_cdc.checkpoint_commit`.

## Notes

- One commit per connector.
- For `postgres_cdc`, the actual phases live in the `pglogicalstream` subpackage, so instrumentation is applied there (tracer threaded through the stream `Config`, defaulting to a no-op tracer when unset).
- For `salesforce_cdc`, the OTel `codes` package is aliased to `otelcodes` to avoid colliding with the existing `google.golang.org/grpc/codes` import.
- License headers match each connector's distribution (RCL, except the Apache-2.0 `cockroachdb_changefeed`).

## Tests

Each connector has a `TestCDCTracingSpans` unit test that drives the connector's tracing seam with an in-memory recording tracer (`tracetest.NewInMemoryExporter` + `sdktrace`) and asserts that correctly-named spans are emitted for the snapshot and stream phases, and that phase errors are recorded on the span with an error status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)