### PR TITLE
CDC: add include/exclude regex table matching to remaining connectors (CON-498)

### DIFF
--- a/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
@@ -57,6 +57,8 @@ input:
   label: ""
   aws_dynamodb_cdc:
     tables: []
+    include: []
+    exclude: []
     table_discovery_mode: single
     table_tag_filter: ""
     table_discovery_interval: 5m
@@ -292,6 +294,36 @@ List of table names to stream from. For single table mode, provide one table. Fo
 *Type*: `array`
 
 *Default*: `[]`
+
+=== `include`
+
+Regular expressions matched against the table name to further restrict which discovered tables are streamed. Applies to both explicitly listed tables and tables found via `table_discovery_mode: tag`. When set, a table is only streamed if it matches at least one of these patterns.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: orders
+```
+
+=== `exclude`
+
+Regular expressions matched against the table name to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: audit_log
+```
 
 === `table_discovery_mode`
 

--- a/docs/modules/components/pages/inputs/cockroachdb_changefeed.adoc
+++ b/docs/modules/components/pages/inputs/cockroachdb_changefeed.adoc
@@ -46,6 +46,8 @@ input:
   cockroachdb_changefeed:
     dsn: postgres://user:password@example.com:26257/defaultdb?sslmode=require # No default (required)
     tables: [] # No default (required)
+    include: []
+    exclude: []
     cursor_cache: "" # No default (optional)
     auto_replay_nacks: true
 ```
@@ -68,6 +70,8 @@ input:
       root_cas_file: ""
       client_certs: []
     tables: [] # No default (required)
+    include: []
+    exclude: []
     cursor_cache: "" # No default (optional)
     options: [] # No default (optional)
     auto_replay_nacks: true
@@ -261,6 +265,36 @@ CSV of tables to be included in the changefeed
 tables:
   - table1
   - table2
+```
+
+=== `include`
+
+Regular expressions matched against the table name to further restrict which of the configured `tables` are included in the changefeed. When set, a table is only included if it matches at least one of these patterns.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: table1
+```
+
+=== `exclude`
+
+Regular expressions matched against the table name to exclude tables from the changefeed. A table matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: audit_log
 ```
 
 === `cursor_cache`

--- a/docs/modules/components/pages/inputs/gcp_spanner_cdc.adoc
+++ b/docs/modules/components/pages/inputs/gcp_spanner_cdc.adoc
@@ -44,6 +44,8 @@ input:
     instance_id: "" # No default (required)
     database_id: "" # No default (required)
     stream_id: "" # No default (required)
+    include: []
+    exclude: []
     start_timestamp: ""
     end_timestamp: ""
     batching:
@@ -69,6 +71,8 @@ input:
     instance_id: "" # No default (required)
     database_id: "" # No default (required)
     stream_id: "" # No default (required)
+    include: []
+    exclude: []
     start_timestamp: ""
     end_timestamp: ""
     heartbeat_interval: 10s
@@ -143,6 +147,36 @@ The name of the change stream to track, the stream must exist in the database. T
 
 *Type*: `string`
 
+
+=== `include`
+
+Regular expressions matched against the table name of each change record to restrict which of the change stream's tables are emitted. The change stream itself defines the set of watched tables; when this field is set, only records whose table matches at least one of these patterns are emitted.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: Singers
+```
+
+=== `exclude`
+
+Regular expressions matched against the table name of each change record to drop records from emission. A record whose table matches any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: Audit
+```
 
 === `start_timestamp`
 

--- a/docs/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -41,6 +41,8 @@ input:
     username: ""
     password: ""
     collections: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_key: mongodb_cdc_checkpoint
     checkpoint_cache: "" # No default (required)
     checkpoint_interval: 5s
@@ -67,6 +69,8 @@ input:
     username: ""
     password: ""
     collections: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_key: mongodb_cdc_checkpoint
     checkpoint_cache: "" # No default (required)
     checkpoint_interval: 5s
@@ -168,6 +172,36 @@ The collections to stream changes from.
 
 *Type*: `array`
 
+
+=== `include`
+
+Regular expressions matched against the collection name to further restrict which of the configured `collections` are streamed. When set, a collection is only streamed if it matches at least one of these patterns.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: orders
+```
+
+=== `exclude`
+
+Regular expressions matched against the collection name to exclude collections from streaming. A collection matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: audit_log
+```
 
 === `checkpoint_key`
 

--- a/docs/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mysql_cdc.adoc
@@ -42,6 +42,8 @@ input:
     flavor: mysql
     dsn: user:password@tcp(localhost:3306)/database # No default (required)
     tables: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_cache: "" # No default (required)
     checkpoint_key: mysql_binlog_position
     snapshot_max_batch_size: 1000
@@ -69,6 +71,8 @@ input:
     flavor: mysql
     dsn: user:password@tcp(localhost:3306)/database # No default (required)
     tables: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_cache: "" # No default (required)
     checkpoint_key: mysql_binlog_position
     snapshot_max_batch_size: 1000
@@ -163,6 +167,36 @@ A list of tables to stream from the database.
 tables:
   - table1
   - table2
+```
+
+=== `include`
+
+Regular expressions matched against `database.table` to further restrict which of the configured `tables` are streamed. When set, a table is only streamed if it matches at least one of these patterns.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: mydb.products
+```
+
+=== `exclude`
+
+Regular expressions matched against `database.table` to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: mydb.audit_log
 ```
 
 === `checkpoint_cache`

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -45,6 +45,8 @@ input:
     snapshot_batch_size: 1000
     schema: public # No default (required)
     tables: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_limit: 1024
     temporary_slot: false
     slot_name: my_test_slot # No default (required)
@@ -75,6 +77,8 @@ input:
     snapshot_batch_size: 1000
     schema: public # No default (required)
     tables: [] # No default (required)
+    include: []
+    exclude: []
     checkpoint_limit: 1024
     temporary_slot: false
     slot_name: my_test_slot # No default (required)
@@ -198,6 +202,36 @@ A list of table names to include in the logical replication. Each table should b
 tables:
   - my_table_1
   - '"MyCaseSensitiveTableNeedingQuotes"'
+```
+
+=== `include`
+
+Regular expressions matched against `schema.table` to further restrict which of the configured `tables` are streamed. When set, a table is only streamed if it matches at least one of these patterns.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: public.products
+```
+
+=== `exclude`
+
+Regular expressions matched against `schema.table` to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: public.audit_log
 ```
 
 === `checkpoint_limit`

--- a/docs/modules/components/pages/inputs/salesforce_cdc.adoc
+++ b/docs/modules/components/pages/inputs/salesforce_cdc.adoc
@@ -42,6 +42,8 @@ input:
     client_secret: "" # No default (required)
     api_version: v65.0
     topics: [] # No default (required)
+    include: []
+    exclude: []
     stream_snapshot: true
     replay_preset: latest
     snapshot_max_batch_size: 2000
@@ -73,6 +75,8 @@ input:
     client_secret: "" # No default (required)
     api_version: v65.0
     topics: [] # No default (required)
+    include: []
+    exclude: []
     stream_snapshot: true
     replay_preset: latest
     snapshot_max_batch_size: 2000
@@ -370,6 +374,36 @@ topics:
   - Opportunity
   - MyCustom__c
   - /event/Sync_Requested__e
+```
+
+=== `include`
+
+Regular expressions matched against the sObject name to further restrict which of the configured `topics` are subscribed to. When set, an sObject-bearing CDC topic is only kept if its sObject matches at least one of these patterns. The CDC firehose (`/data/ChangeEvents`) and Platform Event (`/event/...`) topics have no single sObject and are not affected by this filter.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+include: Account
+```
+
+=== `exclude`
+
+Regular expressions matched against the sObject name to exclude CDC topics from subscription. An sObject-bearing CDC topic matching any of these patterns is dropped even if it matches an `include` pattern.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+exclude: LoginHistory
 ```
 
 === `stream_snapshot`

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -31,6 +32,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/confx"
 	baws "github.com/redpanda-data/connect/v4/internal/impl/aws"
 	"github.com/redpanda-data/connect/v4/internal/impl/aws/config"
 )
@@ -62,6 +64,8 @@ const (
 
 	// Config field names.
 	dciFieldTables                 = "tables"
+	dciFieldTablesInclude          = "include"
+	dciFieldTablesExclude          = "exclude"
 	dciFieldTableDiscoveryMode     = "table_discovery_mode"
 	dciFieldTableTagFilter         = "table_tag_filter"
 	dciFieldTableDiscoveryInterval = "table_discovery_interval"
@@ -191,6 +195,16 @@ When `+"`global_table`"+` is enabled the principal additionally needs `+"`dynamo
 			service.NewStringListField(dciFieldTables).
 				Description("List of table names to stream from. For single table mode, provide one table. For multi-table mode, provide multiple tables.").
 				Default([]any{}),
+			service.NewStringListField(dciFieldTablesInclude).
+				Description("Regular expressions matched against the table name to further restrict which discovered tables are streamed. Applies to both explicitly listed tables and tables found via `"+dciFieldTableDiscoveryMode+": tag`. When set, a table is only streamed if it matches at least one of these patterns.").
+				Example("orders").
+				Default([]any{}).
+				Advanced(),
+			service.NewStringListField(dciFieldTablesExclude).
+				Description("Regular expressions matched against the table name to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `"+dciFieldTablesInclude+"` pattern.").
+				Example("audit_log").
+				Default([]any{}).
+				Advanced(),
 			service.NewStringEnumField(dciFieldTableDiscoveryMode, "single", "tag", "includelist").
 				Description("Table discovery mode. `single`: stream from tables specified in `tables` list. `tag`: auto-discover tables by tags (ignores `tables` field). `includelist`: stream from tables in `tables` list (alias for `single`, kept for compatibility).").
 				Default("single").
@@ -364,6 +378,7 @@ type snapshotConfig struct {
 
 type dynamoDBCDCConfig struct {
 	tables                 []string
+	tablesFilter           *confx.RegexpFilter // Include/exclude regex filter over table names
 	tableDiscoveryMode     string
 	tableTagFilter         string              // Multi-tag filter: "key1:v1,v2;key2:v3"
 	parsedTagFilter        map[string][]string // Parsed filter for efficient matching
@@ -708,6 +723,18 @@ func dynamoCDCInputConfigFromParsed(pConf *service.ParsedConfig) (conf dynamoDBC
 	if conf.tables, err = pConf.FieldStringList(dciFieldTables); err != nil {
 		return
 	}
+	var tableIncludes, tableExcludes []*regexp.Regexp
+	if includes, err := pConf.FieldStringList(dciFieldTablesInclude); err != nil {
+		return conf, err
+	} else if tableIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return conf, err
+	}
+	if excludes, err := pConf.FieldStringList(dciFieldTablesExclude); err != nil {
+		return conf, err
+	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return conf, err
+	}
+	conf.tablesFilter = &confx.RegexpFilter{Include: tableIncludes, Exclude: tableExcludes}
 	if conf.tableDiscoveryMode, err = pConf.FieldString(dciFieldTableDiscoveryMode); err != nil {
 		return
 	}
@@ -827,22 +854,47 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 
 // discoverTables discovers tables based on the configured discovery mode
 func (d *dynamoDBCDCInput) discoverTables(ctx context.Context) ([]string, error) {
+	var tables []string
 	switch d.conf.tableDiscoveryMode {
 	case discoveryModeSingle, discoveryModeIncludelist:
 		if len(d.conf.tables) == 0 {
 			return nil, errors.New("tables list cannot be empty when table_discovery_mode is single or includelist")
 		}
-		return d.conf.tables, nil
+		tables = d.conf.tables
 
 	case discoveryModeTag:
 		if d.conf.tableTagFilter == "" {
 			return nil, errors.New("table_tag_filter cannot be empty when table_discovery_mode is tag")
 		}
-		return d.discoverTablesByTag(ctx)
+		var err error
+		if tables, err = d.discoverTablesByTag(ctx); err != nil {
+			return nil, err
+		}
 
 	default:
 		return nil, fmt.Errorf("unsupported table_discovery_mode: %s", d.conf.tableDiscoveryMode)
 	}
+
+	filtered := filterDynamoTables(d.conf.tablesFilter, tables)
+	if len(filtered) == 0 && len(tables) > 0 {
+		d.log.Warnf("the configured %s and %s patterns excluded every discovered table", dciFieldTablesInclude, dciFieldTablesExclude)
+	}
+	return filtered, nil
+}
+
+// filterDynamoTables returns the subset of tables that pass the include/exclude
+// regex filter. Each table is matched by its name.
+func filterDynamoTables(filter *confx.RegexpFilter, tables []string) []string {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return tables
+	}
+	kept := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if filter.Matches(table) {
+			kept = append(kept, table)
+		}
+	}
+	return kept
 }
 
 // discoverTablesByTag discovers tables that match the configured tag key/value

--- a/internal/impl/aws/dynamodb/table_filter_test.go
+++ b/internal/impl/aws/dynamodb/table_filter_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterDynamoTables(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	tables := []string{"orders", "order_items", "users", "audit_log"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: tables,
+		},
+		{
+			name:    "include only keeps matching tables",
+			include: re(`^order`),
+			want:    []string{"orders", "order_items"},
+		},
+		{
+			name:    "exclude only drops matching tables",
+			exclude: re(`^audit_`),
+			want:    []string{"orders", "order_items", "users"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^order`),
+			exclude: re(`_items$`),
+			want:    []string{"orders"},
+		},
+		{
+			name:    "include matches nothing",
+			include: re(`^nonexistent$`),
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got := filterDynamoTables(filter, tables)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/cockroachdb/input_changefeed.go
+++ b/internal/impl/cockroachdb/input_changefeed.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -31,6 +32,8 @@ import (
 	"github.com/Jeffail/shutdown"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
 
 	_ "github.com/lib/pq"
 )
@@ -54,6 +57,14 @@ func crdbChangefeedInputConfig() *service.ConfigSpec {
 			service.NewStringListField("tables").
 				Description("CSV of tables to be included in the changefeed").
 				Example([]string{"table1", "table2"}),
+			service.NewStringListField("include").
+				Description("Regular expressions matched against the table name to further restrict which of the configured `tables` are included in the changefeed. When set, a table is only included if it matches at least one of these patterns.").
+				Example("table1").
+				Default([]any{}),
+			service.NewStringListField("exclude").
+				Description("Regular expressions matched against the table name to exclude tables from the changefeed. A table matching any of these patterns is dropped even if it matches an `include` pattern.").
+				Example("audit_log").
+				Default([]any{}),
 			service.NewStringField("cursor_cache").
 				Description("A https://docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current latest cursor that has been successfully delivered, this allows Redpanda Connect to continue from that cursor upon restart, rather than consume the entire state of the table.").
 				Optional(),
@@ -87,6 +98,21 @@ type crdbChangefeedInput struct {
 
 const cursorCacheKey = "crdb_changefeed_cursor"
 
+// filterCRDBTables returns the subset of tables that pass the include/exclude
+// regex filter. Each table is matched by its name as configured.
+func filterCRDBTables(filter *confx.RegexpFilter, tables []string) []string {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return tables
+	}
+	kept := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if filter.Matches(table) {
+			kept = append(kept, table)
+		}
+	}
+	return kept
+}
+
 func newCRDBChangefeedInputFromConfig(conf *service.ParsedConfig, res *service.Resources) (*crdbChangefeedInput, error) {
 	c := &crdbChangefeedInput{
 		cursorCheckpointer: checkpoint.NewCapped[string](1024), // TODO: Configure this?
@@ -114,6 +140,22 @@ func newCRDBChangefeedInputFromConfig(conf *service.ParsedConfig, res *service.R
 	tables, err := conf.FieldStringList("tables")
 	if err != nil {
 		return nil, err
+	}
+
+	var tableIncludes, tableExcludes []*regexp.Regexp
+	if includes, err := conf.FieldStringList("include"); err != nil {
+		return nil, err
+	} else if tableIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return nil, err
+	}
+	if excludes, err := conf.FieldStringList("exclude"); err != nil {
+		return nil, err
+	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return nil, err
+	}
+	tables = filterCRDBTables(&confx.RegexpFilter{Include: tableIncludes, Exclude: tableExcludes}, tables)
+	if len(tables) == 0 {
+		return nil, errors.New("the configured include and exclude patterns excluded every entry in tables")
 	}
 
 	tmpOptions, _ := conf.FieldStringList("options")

--- a/internal/impl/cockroachdb/table_filter_test.go
+++ b/internal/impl/cockroachdb/table_filter_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdb
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterCRDBTables(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	tables := []string{"orders", "order_items", "users", "audit_log"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: tables,
+		},
+		{
+			name:    "include only keeps matching tables",
+			include: re(`^order`),
+			want:    []string{"orders", "order_items"},
+		},
+		{
+			name:    "exclude only drops matching tables",
+			exclude: re(`^audit_`),
+			want:    []string{"orders", "order_items", "users"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^order`),
+			exclude: re(`_items$`),
+			want:    []string{"orders"},
+		},
+		{
+			name:    "include matches nothing",
+			include: re(`^nonexistent$`),
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got := filterCRDBTables(filter, tables)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/gcp/enterprise/input_spanner_cdc.go
+++ b/internal/impl/gcp/enterprise/input_spanner_cdc.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/ack"
+	"github.com/redpanda-data/connect/v4/internal/confx"
 
 	"github.com/redpanda-data/connect/v4/internal/impl/gcp/enterprise/changestreams"
 	"github.com/redpanda-data/connect/v4/internal/license"
@@ -32,6 +34,8 @@ const (
 	siFieldInstanceID           = "instance_id"
 	siFieldDatabaseID           = "database_id"
 	siFieldStreamID             = "stream_id"
+	siFieldTablesInclude        = "include"
+	siFieldTablesExclude        = "exclude"
 	siFieldStartTimestamp       = "start_timestamp"
 	siFieldEndTimestamp         = "end_timestamp"
 	siFieldHeartbeatInterval    = "heartbeat_interval"
@@ -49,6 +53,20 @@ const (
 
 type spannerCDCInputConfig struct {
 	changestreams.Config
+
+	// tablesFilter restricts which tables' change records are emitted. The
+	// change stream itself defines the set of watched tables (in Spanner DDL);
+	// this filter is applied per-record against the record's table name.
+	tablesFilter *confx.RegexpFilter
+}
+
+// includeTable reports whether change records for the given table should be
+// emitted under the configured include/exclude regex filter.
+func (c spannerCDCInputConfig) includeTable(table string) bool {
+	if c.tablesFilter == nil {
+		return true
+	}
+	return c.tablesFilter.Matches(table)
 }
 
 func parseRFC3339Nano(pConf *service.ParsedConfig, key string) (time.Time, error) {
@@ -93,6 +111,18 @@ func spannerCDCInputConfigFromParsed(pConf *service.ParsedConfig) (conf spannerC
 	if conf.StreamID, err = pConf.FieldString(siFieldStreamID); err != nil {
 		return
 	}
+	var tableIncludes, tableExcludes []*regexp.Regexp
+	if includes, err := pConf.FieldStringList(siFieldTablesInclude); err != nil {
+		return conf, err
+	} else if tableIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return conf, err
+	}
+	if excludes, err := pConf.FieldStringList(siFieldTablesExclude); err != nil {
+		return conf, err
+	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return conf, err
+	}
+	conf.tablesFilter = &confx.RegexpFilter{Include: tableIncludes, Exclude: tableExcludes}
 	if conf.StartTimestamp, err = parseRFC3339Nano(pConf, siFieldStartTimestamp); err != nil {
 		return
 	}
@@ -145,6 +175,14 @@ https://cloud.google.com/spanner/docs/change-streams
 		Field(service.NewStringField(siFieldInstanceID).Description("Spanner instance ID")).
 		Field(service.NewStringField(siFieldDatabaseID).Description("Spanner database ID")).
 		Field(service.NewStringField(siFieldStreamID).Description("The name of the change stream to track, the stream must exist in the database. To create a change stream, see https://cloud.google.com/spanner/docs/change-streams/manage.")).
+		Field(service.NewStringListField(siFieldTablesInclude).
+			Description("Regular expressions matched against the table name of each change record to restrict which of the change stream's tables are emitted. The change stream itself defines the set of watched tables; when this field is set, only records whose table matches at least one of these patterns are emitted.").
+			Example("Singers").
+			Default([]any{})).
+		Field(service.NewStringListField(siFieldTablesExclude).
+			Description("Regular expressions matched against the table name of each change record to drop records from emission. A record whose table matches any of these patterns is dropped even if it matches an `" + siFieldTablesInclude + "` pattern.").
+			Example("Audit").
+			Default([]any{})).
 		Field(service.NewStringField(siFieldStartTimestamp).Optional().Description("RFC3339 formatted inclusive timestamp to start reading from the change stream (default: current time)").Example("2022-01-01T00:00:00Z").Default("")).
 		Field(service.NewStringField(siFieldEndTimestamp).Optional().Description("RFC3339 formatted exclusive timestamp to stop reading at (default: no end time)").Example("2022-01-01T00:00:00Z").Default("")).
 		Field(service.NewStringField(siFieldHeartbeatInterval).Advanced().Description("Duration string for heartbeat interval").Default("10s")).
@@ -292,6 +330,12 @@ func (r *spannerCDCReader) onDataChangeRecord(ctx context.Context, partitionToke
 		}
 		batcher.AddAck(ack)
 
+		return nil
+	}
+
+	// Skip records for tables excluded by the include/exclude filter. The
+	// change stream may watch more tables than the pipeline wants to consume.
+	if !r.conf.includeTable(dcr.TableName) {
 		return nil
 	}
 

--- a/internal/impl/gcp/enterprise/input_spanner_cdc_filter_test.go
+++ b/internal/impl/gcp/enterprise/input_spanner_cdc_filter_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package enterprise
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestSpannerIncludeTable(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	tables := []string{"Singers", "Songs", "Albums", "AuditLog"}
+
+	filterFor := func(include, exclude []*regexp.Regexp) spannerCDCInputConfig {
+		return spannerCDCInputConfig{tablesFilter: &confx.RegexpFilter{Include: include, Exclude: exclude}}
+	}
+
+	tests := []struct {
+		name string
+		conf spannerCDCInputConfig
+		want []string
+	}{
+		{
+			name: "nil filter emits all",
+			conf: spannerCDCInputConfig{},
+			want: tables,
+		},
+		{
+			name: "no patterns emits all",
+			conf: filterFor(nil, nil),
+			want: tables,
+		},
+		{
+			name: "include only keeps matching tables",
+			conf: filterFor(re(`^S`), nil),
+			want: []string{"Singers", "Songs"},
+		},
+		{
+			name: "exclude only drops matching tables",
+			conf: filterFor(nil, re(`^Audit`)),
+			want: []string{"Singers", "Songs", "Albums"},
+		},
+		{
+			name: "combined include and exclude (exclude wins)",
+			conf: filterFor(re(`s$`), re(`^Album`)),
+			want: []string{"Singers", "Songs"},
+		},
+		{
+			name: "include matches nothing",
+			conf: filterFor(re(`^Nonexistent$`), nil),
+			want: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make([]string, 0, len(tables))
+			for _, tbl := range tables {
+				if tc.conf.includeTable(tbl) {
+					got = append(got, tbl)
+				}
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/mongodb/cdc/collection_filter_test.go
+++ b/internal/impl/mongodb/cdc/collection_filter_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package cdc
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterMongoCollections(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	collections := []string{"orders", "order_items", "users", "audit_log"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: collections,
+		},
+		{
+			name:    "include only keeps matching collections",
+			include: re(`^order`),
+			want:    []string{"orders", "order_items"},
+		},
+		{
+			name:    "exclude only drops matching collections",
+			exclude: re(`^audit_`),
+			want:    []string{"orders", "order_items", "users"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^order`),
+			exclude: re(`_items$`),
+			want:    []string{"orders"},
+		},
+		{
+			name:    "include matches nothing",
+			include: re(`^nonexistent$`),
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got := filterMongoCollections(filter, collections)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/mongodb/cdc/input.go
+++ b/internal/impl/mongodb/cdc/input.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -32,6 +33,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	"github.com/redpanda-data/connect/v4/internal/confx"
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
@@ -42,6 +44,8 @@ const (
 	fieldClientPassword      = "password"
 	fieldClientAppName       = "app_name"
 	fieldCollections         = "collections"
+	fieldCollectionsInclude  = "include"
+	fieldCollectionsExclude  = "exclude"
 	fieldStreamSnapshot      = "stream_snapshot"
 	fieldSnapshotParallelism = "snapshot_parallelism"
 	fieldBucketSharding      = "snapshot_auto_bucket_sharding"
@@ -104,6 +108,14 @@ Schema metadata is discovered using a two-tier strategy:
 				Secret(),
 			service.NewStringListField(fieldCollections).
 				Description("The collections to stream changes from."),
+			service.NewStringListField(fieldCollectionsInclude).
+				Description("Regular expressions matched against the collection name to further restrict which of the configured `"+fieldCollections+"` are streamed. When set, a collection is only streamed if it matches at least one of these patterns.").
+				Example("orders").
+				Default([]any{}),
+			service.NewStringListField(fieldCollectionsExclude).
+				Description("Regular expressions matched against the collection name to exclude collections from streaming. A collection matching any of these patterns is dropped even if it matches an `"+fieldCollectionsInclude+"` pattern.").
+				Example("audit_log").
+				Default([]any{}),
 			service.NewStringField(fieldCheckpointKey).
 				Description("Checkpoint cache key name.").
 				Default("mongodb_cdc_checkpoint"),
@@ -178,6 +190,21 @@ func init() {
 	service.MustRegisterBatchInput("mongodb_cdc", spec(), newMongoCDC)
 }
 
+// filterMongoCollections returns the subset of collections that pass the
+// include/exclude regex filter. Each collection is matched by its name.
+func filterMongoCollections(filter *confx.RegexpFilter, collections []string) []string {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return collections
+	}
+	kept := make([]string, 0, len(collections))
+	for _, coll := range collections {
+		if filter.Matches(coll) {
+			kept = append(kept, coll)
+		}
+	}
+	return kept
+}
+
 func newMongoCDC(conf *service.ParsedConfig, res *service.Resources) (i service.BatchInput, err error) {
 	if err := license.CheckRunningEnterprise(res); err != nil {
 		return nil, err
@@ -209,6 +236,21 @@ func newMongoCDC(conf *service.ParsedConfig, res *service.Resources) (i service.
 	}
 	if len(cdc.collections) == 0 {
 		return nil, errors.New("at least one collection must be specified")
+	}
+	var collectionIncludes, collectionExcludes []*regexp.Regexp
+	if includes, err := conf.FieldStringList(fieldCollectionsInclude); err != nil {
+		return nil, err
+	} else if collectionIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return nil, err
+	}
+	if excludes, err := conf.FieldStringList(fieldCollectionsExclude); err != nil {
+		return nil, err
+	} else if collectionExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return nil, err
+	}
+	cdc.collections = filterMongoCollections(&confx.RegexpFilter{Include: collectionIncludes, Exclude: collectionExcludes}, cdc.collections)
+	if len(cdc.collections) == 0 {
+		return nil, fmt.Errorf("the configured %s and %s patterns excluded every entry in %s", fieldCollectionsInclude, fieldCollectionsExclude, fieldCollections)
 	}
 	var snapshotEnabled bool
 	if snapshotEnabled, err = conf.FieldBool(fieldStreamSnapshot); err != nil {

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
+	"github.com/redpanda-data/connect/v4/internal/confx"
 	"github.com/redpanda-data/connect/v4/internal/license"
 	"github.com/redpanda-data/connect/v4/internal/sqlutil"
 )
@@ -40,6 +41,8 @@ const (
 	fieldMySQLFlavor               = "flavor"
 	fieldMySQLDSN                  = "dsn"
 	fieldMySQLTables               = "tables"
+	fieldMySQLTablesInclude        = "include"
+	fieldMySQLTablesExclude        = "exclude"
 	fieldStreamSnapshot            = "stream_snapshot"
 	fieldMaxParallelSnapshotTables = "max_parallel_snapshot_tables"
 	fieldSnapshotMaxBatchSize      = "snapshot_max_batch_size"
@@ -97,6 +100,14 @@ This input adds the following metadata fields to each message:
 			Description("A list of tables to stream from the database.").
 			Example([]string{"table1", "table2"}).
 			LintRule("root = if this.length() == 0 { [ \"field 'tables' must contain at least one table\" ] }"),
+		service.NewStringListField(fieldMySQLTablesInclude).
+			Description("Regular expressions matched against `database.table` to further restrict which of the configured `"+fieldMySQLTables+"` are streamed. When set, a table is only streamed if it matches at least one of these patterns.").
+			Example("mydb.products").
+			Default([]any{}),
+		service.NewStringListField(fieldMySQLTablesExclude).
+			Description("Regular expressions matched against `database.table` to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `"+fieldMySQLTablesInclude+"` pattern.").
+			Example("mydb.audit_log").
+			Default([]any{}),
 		service.NewStringField(fieldCheckpointCache).
 			Description("A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current latest BinLog Position that has been successfully delivered, this allows Redpanda Connect to continue from that BinLog Position upon restart, rather than consume the entire state of the table."),
 		service.NewStringField(fieldCheckpointKey).
@@ -215,6 +226,22 @@ type mysqlStreamInput struct {
 	tableSchemasMu sync.RWMutex
 }
 
+// filterMySQLTables returns the subset of tables that pass the include/exclude
+// regex filter. Each table is matched in its fully qualified `database.table`
+// form, consistent with how the canal include regexes are constructed.
+func filterMySQLTables(filter *confx.RegexpFilter, db string, tables []string) []string {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return tables
+	}
+	kept := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if filter.Matches(db + "." + table) {
+			kept = append(kept, table)
+		}
+	}
+	return kept
+}
+
 func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s service.BatchInput, err error) {
 	if err := license.CheckRunningEnterprise(res); err != nil {
 		return nil, err
@@ -278,6 +305,22 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 
 	if i.tables, err = conf.FieldStringList(fieldMySQLTables); err != nil {
 		return nil, err
+	}
+
+	var tableIncludes, tableExcludes []*regexp.Regexp
+	if includes, err := conf.FieldStringList(fieldMySQLTablesInclude); err != nil {
+		return nil, err
+	} else if tableIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return nil, err
+	}
+	if excludes, err := conf.FieldStringList(fieldMySQLTablesExclude); err != nil {
+		return nil, err
+	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return nil, err
+	}
+	i.tables = filterMySQLTables(&confx.RegexpFilter{Include: tableIncludes, Exclude: tableExcludes}, i.mysqlConfig.DBName, i.tables)
+	if len(i.tables) == 0 {
+		return nil, fmt.Errorf("the configured %s and %s patterns excluded every entry in %s", fieldMySQLTablesInclude, fieldMySQLTablesExclude, fieldMySQLTables)
 	}
 
 	if i.streamSnapshot, err = conf.FieldBool(fieldStreamSnapshot); err != nil {

--- a/internal/impl/mysql/table_filter_test.go
+++ b/internal/impl/mysql/table_filter_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package mysql
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterMySQLTables(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	const db = "shop"
+	tables := []string{"orders", "order_items", "users", "audit_log"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: tables,
+		},
+		{
+			name:    "include only keeps matching tables",
+			include: re(`^shop\.order`),
+			want:    []string{"orders", "order_items"},
+		},
+		{
+			name:    "exclude only drops matching tables",
+			exclude: re(`^shop\.audit_`),
+			want:    []string{"orders", "order_items", "users"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^shop\.order`),
+			exclude: re(`_items$`),
+			want:    []string{"orders"},
+		},
+		{
+			name:    "include matches nothing",
+			include: re(`^shop\.nonexistent$`),
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got := filterMySQLTables(filter, db, tables)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	"github.com/redpanda-data/connect/v4/internal/confx"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
@@ -37,6 +39,8 @@ const (
 	fieldSnapshotBatchSize         = "snapshot_batch_size"
 	fieldSchema                    = "schema"
 	fieldTables                    = "tables"
+	fieldTablesInclude             = "include"
+	fieldTablesExclude             = "exclude"
 	fieldCheckpointLimit           = "checkpoint_limit"
 	fieldTemporarySlot             = "temporary_slot"
 	fieldPgStandbyTimeout          = "pg_standby_timeout"
@@ -115,6 +119,14 @@ This input adds the following metadata fields to each message:
 		Field(service.NewStringListField(fieldTables).
 			Description("A list of table names to include in the logical replication. Each table should be specified as a separate item.").
 			Example([]string{"my_table_1", `"MyCaseSensitiveTableNeedingQuotes"`})).
+		Field(service.NewStringListField(fieldTablesInclude).
+			Description("Regular expressions matched against `schema.table` to further restrict which of the configured `" + fieldTables + "` are streamed. When set, a table is only streamed if it matches at least one of these patterns.").
+			Example("public.products").
+			Default([]any{})).
+		Field(service.NewStringListField(fieldTablesExclude).
+			Description("Regular expressions matched against `schema.table` to exclude tables from streaming. A table matching any of these patterns is dropped even if it matches an `" + fieldTablesInclude + "` pattern.").
+			Example("public.audit_log").
+			Default([]any{})).
 		Field(service.NewIntField(fieldCheckpointLimit).
 			Description("The maximum number of messages that can be processed at a given time. Increasing this limit enables parallel processing and batching at the output level. Any given LSN will not be acknowledged unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.").
 			Default(1024)).
@@ -196,6 +208,21 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 		Field(service.NewBatchPolicyField(fieldBatching))
 }
 
+// filterPostgresTables returns the subset of tables that pass the include/exclude
+// regex filter. Each table is matched in its fully qualified `schema.table` form.
+func filterPostgresTables(filter *confx.RegexpFilter, schema string, tables []string) []string {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return tables
+	}
+	kept := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if filter.Matches(schema + "." + table) {
+			kept = append(kept, table)
+		}
+	}
+	return kept
+}
+
 func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s service.BatchInput, err error) {
 	var (
 		dsn                       string
@@ -249,6 +276,22 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 
 	if tables, err = conf.FieldStringList(fieldTables); err != nil {
 		return nil, err
+	}
+
+	var tableIncludes, tableExcludes []*regexp.Regexp
+	if includes, err := conf.FieldStringList(fieldTablesInclude); err != nil {
+		return nil, err
+	} else if tableIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return nil, err
+	}
+	if excludes, err := conf.FieldStringList(fieldTablesExclude); err != nil {
+		return nil, err
+	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return nil, err
+	}
+	tables = filterPostgresTables(&confx.RegexpFilter{Include: tableIncludes, Exclude: tableExcludes}, schema, tables)
+	if len(tables) == 0 {
+		return nil, fmt.Errorf("the configured %s and %s patterns excluded every entry in %s", fieldTablesInclude, fieldTablesExclude, fieldTables)
 	}
 
 	if checkpointLimit, err = conf.FieldInt(fieldCheckpointLimit); err != nil {

--- a/internal/impl/postgresql/table_filter_test.go
+++ b/internal/impl/postgresql/table_filter_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterPostgresTables(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	const schema = "public"
+	tables := []string{"orders", "order_items", "users", "audit_log"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: tables,
+		},
+		{
+			name:    "include only keeps matching tables",
+			include: re(`^public\.order`),
+			want:    []string{"orders", "order_items"},
+		},
+		{
+			name:    "exclude only drops matching tables",
+			exclude: re(`^public\.audit_`),
+			want:    []string{"orders", "order_items", "users"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^public\.order`),
+			exclude: re(`_items$`),
+			want:    []string{"orders"},
+		},
+		{
+			name:    "include matches nothing",
+			include: re(`^public\.nonexistent$`),
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got := filterPostgresTables(filter, schema, tables)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/impl/salesforce/input_salesforce_cdc.go
+++ b/internal/impl/salesforce/input_salesforce_cdc.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
+	"github.com/redpanda-data/connect/v4/internal/confx"
 	"github.com/redpanda-data/connect/v4/internal/httpclient"
 	"github.com/redpanda-data/connect/v4/internal/impl/salesforce/salesforcegrpc"
 	"github.com/redpanda-data/connect/v4/internal/impl/salesforce/salesforcehttp"
@@ -33,9 +35,11 @@ import (
 )
 
 const (
-	sfciFieldTopics         = "topics"
-	sfciFieldStreamSnapshot = "stream_snapshot"
-	sfciFieldReplayPreset   = "replay_preset"
+	sfciFieldTopics          = "topics"
+	sfciFieldSObjectsInclude = "include"
+	sfciFieldSObjectsExclude = "exclude"
+	sfciFieldStreamSnapshot  = "stream_snapshot"
+	sfciFieldReplayPreset    = "replay_preset"
 
 	sfciFieldSnapshotMaxBatchSize    = "snapshot_max_batch_size"
 	sfciFieldStreamBatchSize         = "stream_batch_size"
@@ -114,6 +118,14 @@ Each ` + "`/data/...`" + ` topic requires Change Data Capture to be enabled for 
 			Example([]string{"/data/ChangeEvents"}).
 			Example([]string{"Account", "/event/Order__e"}).
 			Example([]string{"Opportunity", "MyCustom__c", "/event/Sync_Requested__e"})).
+		Field(service.NewStringListField(sfciFieldSObjectsInclude).
+			Description("Regular expressions matched against the sObject name to further restrict which of the configured `" + sfciFieldTopics + "` are subscribed to. When set, an sObject-bearing CDC topic is only kept if its sObject matches at least one of these patterns. The CDC firehose (`/data/ChangeEvents`) and Platform Event (`/event/...`) topics have no single sObject and are not affected by this filter.").
+			Example("Account").
+			Default([]any{})).
+		Field(service.NewStringListField(sfciFieldSObjectsExclude).
+			Description("Regular expressions matched against the sObject name to exclude CDC topics from subscription. An sObject-bearing CDC topic matching any of these patterns is dropped even if it matches an `" + sfciFieldSObjectsInclude + "` pattern.").
+			Example("LoginHistory").
+			Default([]any{})).
 		Field(service.NewBoolField(sfciFieldStreamSnapshot).
 			Description("When true (default), paginate a full REST snapshot of every CDC sObject in `topics` before opening any streaming subscription. When false, skip the snapshot and start streaming immediately. Platform Event topics (`/event/...`) are always skipped — they have no REST equivalent.").
 			Default(true)).
@@ -273,6 +285,28 @@ func parseCDCTopic(entry string) (cdcTopicSpec, error) {
 	}, nil
 }
 
+// filterSalesforceTopics returns the subset of topics that pass the
+// include/exclude regex filter. The filter is matched against the sObject name
+// of each CDC topic that resolves to a concrete sObject. Topics without a single
+// sObject (the CDC firehose and Platform Event topics) are always retained, as
+// there is no sObject name to match against.
+func filterSalesforceTopics(filter *confx.RegexpFilter, topics []string) ([]string, error) {
+	if filter == nil || (len(filter.Include) == 0 && len(filter.Exclude) == 0) {
+		return topics, nil
+	}
+	kept := make([]string, 0, len(topics))
+	for _, t := range topics {
+		spec, err := parseCDCTopic(t)
+		if err != nil {
+			return nil, err
+		}
+		if spec.SObject == "" || filter.Matches(spec.SObject) {
+			kept = append(kept, t)
+		}
+	}
+	return kept, nil
+}
+
 // CDCInputConfig holds the parsed configuration for the salesforce_cdc input.
 type CDCInputConfig struct {
 	Auth       AuthConfig
@@ -321,6 +355,24 @@ func NewCDCInputConfigFromParsed(pConf *service.ParsedConfig) (CDCInputConfig, e
 		if _, err := parseCDCTopic(t); err != nil {
 			return cfg, err
 		}
+	}
+
+	var sObjectIncludes, sObjectExcludes []*regexp.Regexp
+	if includes, err := pConf.FieldStringList(sfciFieldSObjectsInclude); err != nil {
+		return cfg, err
+	} else if sObjectIncludes, err = confx.ParseRegexpPatterns(includes); err != nil {
+		return cfg, err
+	}
+	if excludes, err := pConf.FieldStringList(sfciFieldSObjectsExclude); err != nil {
+		return cfg, err
+	} else if sObjectExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
+		return cfg, err
+	}
+	if cfg.Topics, err = filterSalesforceTopics(&confx.RegexpFilter{Include: sObjectIncludes, Exclude: sObjectExcludes}, cfg.Topics); err != nil {
+		return cfg, err
+	}
+	if len(cfg.Topics) == 0 {
+		return cfg, fmt.Errorf("the configured %s and %s patterns excluded every entry in %s", sfciFieldSObjectsInclude, sfciFieldSObjectsExclude, sfciFieldTopics)
 	}
 
 	if cfg.StreamSnapshot, err = pConf.FieldBool(sfciFieldStreamSnapshot); err != nil {

--- a/internal/impl/salesforce/sobject_filter_test.go
+++ b/internal/impl/salesforce/sobject_filter_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package salesforce
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+)
+
+func TestFilterSalesforceTopics(t *testing.T) {
+	re := func(patterns ...string) []*regexp.Regexp {
+		var out []*regexp.Regexp
+		for _, p := range patterns {
+			out = append(out, regexp.MustCompile(p))
+		}
+		return out
+	}
+
+	// A mix of bare sObjects, an explicit CDC channel, the firehose, and a
+	// Platform Event topic. The firehose and PE topics carry no single sObject.
+	topics := []string{"Account", "Contact", "/data/OrderChangeEvent", "/data/ChangeEvents", "/event/Sync__e"}
+
+	tests := []struct {
+		name    string
+		include []*regexp.Regexp
+		exclude []*regexp.Regexp
+		want    []string
+	}{
+		{
+			name: "no patterns returns all",
+			want: topics,
+		},
+		{
+			name:    "include only keeps matching sObjects plus non-sObject topics",
+			include: re(`^Account$`, `^Order$`),
+			want:    []string{"Account", "/data/OrderChangeEvent", "/data/ChangeEvents", "/event/Sync__e"},
+		},
+		{
+			name:    "exclude only drops matching sObjects",
+			exclude: re(`^Contact$`),
+			want:    []string{"Account", "/data/OrderChangeEvent", "/data/ChangeEvents", "/event/Sync__e"},
+		},
+		{
+			name:    "combined include and exclude (exclude wins)",
+			include: re(`^Account$`, `^Contact$`),
+			exclude: re(`^Contact$`),
+			want:    []string{"Account", "/data/ChangeEvents", "/event/Sync__e"},
+		},
+		{
+			name:    "include matches no sObject keeps only non-sObject topics",
+			include: re(`^Nonexistent$`),
+			want:    []string{"/data/ChangeEvents", "/event/Sync__e"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &confx.RegexpFilter{Include: tc.include, Exclude: tc.exclude}
+			got, err := filterSalesforceTopics(filter, topics)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds include/exclude regex table matching to the CDC connectors that lacked it, per CONTRIBUTING.md §5.5.7 (reference: `oracledb_cdc`). `oracledb_cdc` and `microsoft_sql_server_cdc` already expose this.

Each connector now exposes two new fields — `include` and `exclude` — string lists of regular expressions, wired through the shared `internal/confx.RegexpFilter` (`ParseRegexpPatterns` + `Matches`), exactly as the two reference connectors do.

Connectors added (one commit each):

- `mysql_cdc`
- `postgres_cdc`
- `mongodb_cdc` (collections)
- `aws_dynamodb_cdc`
- `cockroachdb_changefeed`
- `salesforce_cdc` (sObjects)
- `gcp_spanner_cdc`

## Where the filter is applied (per-source)

The two reference connectors auto-discover every table from the source and use include/exclude as the *only* selection mechanism. Most connectors here instead take an **explicit** table/collection list, so the filter is applied at each connector's natural selection point and **narrows** the set rather than replacing existing fields (non-breaking):

| Connector | Matched against | Applied at |
|---|---|---|
| `mysql_cdc` | `database.table` | configured `tables` list, before canal include regexes |
| `postgres_cdc` | `schema.table` | configured `tables` list, before the replication publication |
| `mongodb_cdc` | collection name | configured `collections` list |
| `aws_dynamodb_cdc` | table name | `discoverTables` result (explicit list **and** `table_discovery_mode: tag`) |
| `cockroachdb_changefeed` | table name | configured `tables` list, before the `EXPERIMENTAL CHANGEFEED` statement |
| `salesforce_cdc` | sObject name | configured `topics` list; the firehose (`/data/ChangeEvents`) and Platform Event (`/event/...`) topics have no single sObject and are retained |
| `gcp_spanner_cdc` | change-record table name | per-record in `onDataChangeRecord` — Spanner has no configurable table list; the change stream defines the watched tables |

For the connectors that take an explicit list, a config whose include/exclude patterns exclude every entry is rejected at startup with a clear error.

## Tests

Each connector has a table-driven unit test for its filter helper covering include-only, exclude-only, and combined (exclude-wins) matching, plus the no-pattern and matches-nothing edges. Run scoped (never a broad `go test`):

```
go test -run 'TestFilterMySQLTables|TestFilterPostgresTables|TestFilterMongoCollections|TestFilterDynamoTables|TestFilterCRDBTables|TestFilterSalesforceTopics|TestSpannerIncludeTable' ./internal/impl/{mysql,postgresql,mongodb/cdc,aws/dynamodb,cockroachdb,salesforce,gcp/enterprise}/
```

`task docs` was run and the generated component pages are committed.

## Note for review

The "narrow an explicit list" semantics (vs. the reference connectors' "discover-everything-then-filter") is a deliberate, non-breaking choice for sources that require an explicit table list. Happy to adjust if a different shape is preferred for any specific connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
