### PR TITLE
try_catch_processor: make available in cloud

### DIFF
--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -312,7 +312,7 @@ timeplus                  ,input     ,timeplus                  ,community  ,n  
 timeplus                  ,output    ,timeplus                  ,community  ,n          ,y     ,y              ,
 to_the_end                ,scanner   ,to_the_end                ,certified  ,n          ,y     ,y              ,
 try                       ,processor ,try                       ,certified  ,n          ,y     ,y              ,
-try_catch                 ,processor ,try_catch                 ,community  ,n          ,n     ,n              ,
+try_catch                 ,processor ,try_catch                 ,community  ,n          ,y     ,y              ,
 ttlru                     ,cache     ,ttlru                     ,community  ,n          ,y     ,y              ,
 twitter_search            ,input     ,twitter_search            ,community  ,n          ,n     ,n              ,not yet certified for cloud
 unarchive                 ,processor ,unarchive                 ,certified  ,n          ,y     ,y              ,


### PR DESCRIPTION
Makes the [new](https://github.com/redpanda-data/benthos/pull/452) try_catch processor available in the cloud.