### PR TITLE
cmd: embed the IANA tz database in distributed binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- The IANA time zone database is now embedded in all distributed binaries, so components that resolve named time zones (such as the `jira` input rendering JQL date predicates in the account timezone) work correctly in the stripped release container images, which carry no system zoneinfo.
+
 ## 4.98.0 - 2026-06-26
 
 ### Added

--- a/cmd/redpanda-connect-ai/main.go
+++ b/cmd/redpanda-connect-ai/main.go
@@ -29,6 +29,10 @@ import (
 	_ "github.com/redpanda-data/connect/v4/public/components/cloud"
 	// Add in extra new AI plugins
 	_ "github.com/redpanda-data/connect/v4/public/components/ollama"
+
+	// Embed the IANA tz database so time.LoadLocation works in the stripped
+	// release image (no system zoneinfo). See internal/tzdata.
+	_ "github.com/redpanda-data/connect/v4/internal/tzdata"
 )
 
 var (

--- a/cmd/redpanda-connect-cloud/main.go
+++ b/cmd/redpanda-connect-cloud/main.go
@@ -27,6 +27,10 @@ import (
 
 	// Only import a subset of components for execution.
 	_ "github.com/redpanda-data/connect/v4/public/components/cloud"
+
+	// Embed the IANA tz database so time.LoadLocation works in the stripped
+	// release image (no system zoneinfo). See internal/tzdata.
+	_ "github.com/redpanda-data/connect/v4/internal/tzdata"
 )
 
 var (

--- a/cmd/redpanda-connect-community/main.go
+++ b/cmd/redpanda-connect-community/main.go
@@ -20,6 +20,10 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	_ "github.com/redpanda-data/connect/public/bundle/free/v4"
+
+	// Embed the IANA tz database so time.LoadLocation works in the stripped
+	// release image (no system zoneinfo). See internal/tzdata.
+	_ "github.com/redpanda-data/connect/v4/internal/tzdata"
 )
 
 var (

--- a/cmd/redpanda-connect/main.go
+++ b/cmd/redpanda-connect/main.go
@@ -19,6 +19,10 @@ import (
 	"github.com/redpanda-data/connect/v4/public/schema"
 
 	_ "github.com/redpanda-data/connect/v4/public/components/all"
+
+	// Embed the IANA tz database so time.LoadLocation works in the stripped
+	// release image (no system zoneinfo). See internal/tzdata.
+	_ "github.com/redpanda-data/connect/v4/internal/tzdata"
 )
 
 var (

--- a/cmd/serverless/connect-lambda/main.go
+++ b/cmd/serverless/connect-lambda/main.go
@@ -19,6 +19,10 @@ import (
 
 	// Import all plugins defined within the repo.
 	_ "github.com/redpanda-data/connect/v4/public/components/all"
+
+	// Embed the IANA tz database so time.LoadLocation works in the stripped
+	// release image (no system zoneinfo). See internal/tzdata.
+	_ "github.com/redpanda-data/connect/v4/internal/tzdata"
 )
 
 func main() {

--- a/internal/tzdata/tzdata.go
+++ b/internal/tzdata/tzdata.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tzdata embeds the IANA Time Zone database into the binary.
+//
+// Components that resolve named locations with time.LoadLocation (for example
+// the jira input, which renders JQL date predicates in the account's timezone)
+// otherwise depend on a system tz database being present at runtime. The
+// release container images are busybox-based and do not ship
+// /usr/share/zoneinfo, so without an embedded copy LoadLocation fails for any
+// non-UTC zone and callers silently fall back to UTC — reintroducing the very
+// data-loss windows those features close.
+//
+// Blank-importing time/tzdata embeds the database (~450 KiB) and registers it
+// as a fallback used only when no system database is found, so hosts that
+// already ship tzdata are unaffected. Distribution entrypoints blank-import
+// this package so the guarantee travels with every shipped binary rather than
+// depending on the runtime image.
+package tzdata
+
+import _ "time/tzdata"

--- a/internal/tzdata/tzdata_test.go
+++ b/internal/tzdata/tzdata_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tzdata_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// shippingEntrypoints are the main packages whose binaries are distributed to
+// users. Each must embed the tz database so time.LoadLocation works in the
+// stripped release container images, which carry no system zoneinfo.
+var shippingEntrypoints = []string{
+	"github.com/redpanda-data/connect/v4/cmd/redpanda-connect",
+	"github.com/redpanda-data/connect/v4/cmd/redpanda-connect-ai",
+	"github.com/redpanda-data/connect/v4/cmd/redpanda-connect-cloud",
+	"github.com/redpanda-data/connect/v4/cmd/redpanda-connect-community",
+	"github.com/redpanda-data/connect/v4/cmd/serverless/connect-lambda",
+}
+
+// TestEntrypointsEmbedTzdata asserts every shipping binary pulls in time/tzdata
+// (transitively, via internal/tzdata). This is the host-independent guard
+// against a stripped image silently regressing LoadLocation to UTC: it fails if
+// a future change drops the embed, rather than relying on the host's tz
+// database (which would mask the regression on developer machines).
+func TestEntrypointsEmbedTzdata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go list dependency scan in -short mode")
+	}
+	for _, pkg := range shippingEntrypoints {
+		t.Run(pkg, func(t *testing.T) {
+			out, err := exec.Command("go", "list", "-deps", pkg).CombinedOutput()
+			if err != nil {
+				t.Fatalf("go list -deps %s: %v\n%s", pkg, err, out)
+			}
+			if !containsLine(string(out), "time/tzdata") {
+				t.Errorf("%s does not embed time/tzdata; blank-import internal/tzdata in its main package", pkg)
+			}
+		})
+	}
+}
+
+func containsLine(out, want string) bool {
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Components that resolve named locations via time.LoadLocation (e.g. the jira input, which renders JQL date predicates in the account's timezone) depend on a tz database being available at runtime. The release container images are busybox-based and ship no /usr/share/zoneinfo, so LoadLocation fails for any non-UTC zone and callers silently fall back to UTC, reintroducing the data-loss windows those features close. It passes in development only because dev machines carry system tzdata.

Add an internal/tzdata package that blank-imports time/tzdata, and import it from every distributed entrypoint (the four distributions plus the Lambda serverless build) so the embedded database (~450 KiB, used only as a fallback when no system database is found) travels with the binary rather than depending on the runtime image.

A host-independent regression test asserts each shipping entrypoint pulls in time/tzdata, so CI catches a future change that drops the embed before a stripped image silently regresses to UTC.