### PR TITLE
iceberg: add row-level operations (insert/upsert/delete) to the output

### DIFF
--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -120,6 +120,8 @@ output:
     namespace: analytics.events # No default (required)
     table: user_events # No default (required)
     case_sensitive_columns: true
+    row_operation: insert
+    identifier_fields: []
     storage:
       aws_s3:
         bucket: my-iceberg-data # No default (required)
@@ -219,12 +221,84 @@ array:list
 |===
 
 
+== Row-level operations
+
+By default this output is append-only — every message becomes a new row (`row_operation: insert`), and existing configurations are unaffected. Set `row_operation` to apply a per-message operation, with `identifier_fields` defining the row identity:
+
+* `insert` — append the row. This is an unconditional append: it is *not* keyed or de-duplicated.
+* `upsert` — replace any existing rows matching `identifier_fields`, then append this row (equivalent to Iceberg's Flink UPSERT mode).
+* `delete` — remove rows matching `identifier_fields`.
+
+`row_operation` supports interpolation, so the operation can be driven by the data itself — for example by mapping a change-data-capture stream's operation field — but no CDC-specific format is assumed (see the change-data-capture example below). It is named `row_operation` to distinguish it from Iceberg's snapshot-level operation.
+
+`upsert` and `delete` require `identifier_fields` and use Iceberg merge-on-read equality deletes, which require table format version 2. A version-1 table is automatically upgraded to version 2 on the first `upsert`/`delete`; *this upgrade is irreversible*.
+
+*Identifier fields.* `identifier_fields` must reference existing table columns of a primitive, non-floating-point type. A static `upsert`/`delete` is validated at startup; an interpolated `row_operation` is validated per message at write time, so an empty `identifier_fields` is not caught until the first `upsert`/`delete` message arrives. Identifier columns of a temporal type (`timestamp`, `timestamptz`, `date`, `time`) must arrive as time values, not bare numbers — a numeric epoch is ambiguous as a delete key and is rejected at write time; convert it to a timestamp upstream. If the table is partitioned, every partition source column must be one of the `identifier_fields`, since equality deletes are partition-scoped.
+
+When this output auto-creates a table (via `schema_evolution`), the `identifier_fields` columns are created as *required* and registered as the table's Iceberg identifier-field-ids, so downstream engines and other writers see the primary key. A consequence is that a null or missing value in an identifier column is rejected on write, even for `insert`. Identifier columns must therefore be present at creation — in the first message or declared via `schema_metadata`. Pre-existing tables are never modified.
+
+*Batching and ordering.* Within a single batch the last `upsert`/`delete` per `identifier_fields` key wins. Each batch containing an `upsert`/`delete` is committed as its own snapshot (these commits are never coalesced, which is required for correctness), so a high-throughput mutation workload produces one snapshot per batch. Size batches accordingly and run regular table maintenance (snapshot expiry and compaction) to keep metadata manageable. Pure `insert`-only batches keep the original append fast path, which does coalesce commits.
+
+Ordering only holds *within* a batch. With more than one batch in flight, concurrent batches can commit out of order, so a stale `upsert` may overwrite a newer one for the same key. Set `max_in_flight: 1` for keyed (change-data-capture) workloads to preserve per-key order — this is enforced by config linting whenever `row_operation` is anything other than a static `insert`.
+
+[CAUTION]
+====
+`insert` is an unconditional append and is *not* keyed or de-duplicated. For keyed data (including change-data-capture), map create/read events to `upsert`, never `insert` — mixing `insert` with `upsert`/`delete` on the same key in one batch produces duplicate rows.
+====
+
 
 == Performance
 
 This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
 
 This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. You can find out more xref:configuration:batching.adoc[in this doc].
+
+== Examples
+
+[tabs]
+======
+Change-data-capture upsert/delete::
++
+--
+
+Materialize a change-data-capture stream into an Iceberg table. A mapping derives the row operation from the source's operation field (here Debezium's `op`: `c`reate / `r`ead / `u`pdate map to `upsert`, `d`elete maps to `delete`) and selects the row image, while `identifier_fields` is the primary key. Note that creates map to `upsert`, never `insert`, so re-delivered or snapshot rows do not duplicate.
+
+```yaml
+input:
+  redpanda:
+    seed_brokers: [ localhost:9092 ]
+    topics: [ dbserver.inventory.customers ]
+    consumer_group: iceberg_sink
+
+pipeline:
+  processors:
+    - mapping: |
+        meta op = match this.op {
+          "d" => "delete",
+          _   => "upsert",
+        }
+        # Debezium puts the row image in 'after' (or 'before' for deletes).
+        root = this.after | this.before
+
+output:
+  iceberg:
+    catalog:
+      url: http://localhost:8181/api/catalog
+    namespace: inventory
+    table: customers
+    row_operation: ${! metadata("op") }
+    identifier_fields: [ id ]
+    # Keyed writes must stay ordered: a single batch in flight prevents
+    # concurrent batches from committing a stale update over a newer one.
+    max_in_flight: 1
+    storage:
+      aws_s3:
+        bucket: my-iceberg-data
+        region: us-east-1
+```
+
+--
+======
 
 == Fields
 
@@ -564,6 +638,50 @@ Controls how message field names are matched against table column names, and how
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `row_operation`
+
+The row-level operation to apply for each message: `insert` (append), `upsert` (replace rows matching `identifier_fields`, then append), or `delete` (remove rows matching `identifier_fields`). Supports interpolation so the operation can be driven by the data — e.g. a change-data-capture stream's operation field. Defaults to `insert`, preserving the original append-only behaviour.
+
+See the <<row-level-operations,Row-level operations>> section above for the full semantics, the format-version-2 upgrade, batching behaviour, and important caveats.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `string`
+
+*Default*: `"insert"`
+
+```yml
+# Examples
+
+row_operation: insert
+
+row_operation: ${! metadata("op") }
+
+row_operation: '${! this.op == "d" ? "delete" : "upsert" }'
+```
+
+=== `identifier_fields`
+
+The columns forming the row identity (the Iceberg identifier fields / equality-delete key) used by `upsert` and `delete`. Required when `row_operation` can evaluate to `upsert` or `delete`, and must reference existing table columns of a primitive, non-floating-point type.
+
+See the <<row-level-operations,Row-level operations>> section above for the full constraints, including the temporal-type and partitioning rules and when the requirement is enforced.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+identifier_fields:
+  - id
+
+identifier_fields:
+  - tenant_id
+  - user_id
+```
 
 === `storage`
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/a2aproject/a2a-go v0.3.12
+	github.com/apache/arrow-go/v18 v18.6.0
 	github.com/apache/iceberg-go v0.5.1-0.20260506193454-dfc5851d9367
 	github.com/apache/pulsar-client-go v0.18.0
 	github.com/auth0/go-jwt-middleware/v2 v2.3.1
@@ -230,7 +231,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.15.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/apache/arrow-go/v18 v18.6.0 // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4 // indirect

--- a/internal/impl/iceberg/committer.go
+++ b/internal/impl/iceberg/committer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -29,9 +30,16 @@ import (
 const CurrentIcebergVersion = 2
 
 // CommitInput holds data files and the schema ID they were written with.
+//
+// Files are inserted (appended) data files. DeleteFiles are equality-delete
+// files produced for upsert/delete operations (ContentType EntryContentEqDeletes
+// with EqualityFieldIDs set). When DeleteFiles is empty the commit is a pure
+// append and takes the optimised AddDataFiles fast path; otherwise the changes
+// are applied atomically through a RowDelta.
 type CommitInput struct {
-	Files    []iceberg.DataFile
-	SchemaID int
+	Files       []iceberg.DataFile
+	DeleteFiles []iceberg.DataFile
+	SchemaID    int
 }
 
 // CommitConfig holds configuration for the committer.
@@ -60,7 +68,12 @@ type committer struct {
 	cfg         CommitConfig
 	reloadTable func(ctx context.Context) (*table.Table, error)
 	batcher     *asyncroutine.Batcher[CommitInput, struct{}]
-	logger      *service.Logger
+	// commitMu serializes all commits and guards c.table. The batcher's
+	// doCommit and the direct commitRowDelta path both take it.
+	commitMu        sync.Mutex
+	upgradeWarnOnce sync.Once
+	metrics         *opMetrics
+	logger          *service.Logger
 }
 
 // NewCommitter creates a new committer for a specific table.
@@ -81,28 +94,83 @@ func NewCommitter(tbl *table.Table, cfg CommitConfig, reloadTable func(ctx conte
 	return c, nil
 }
 
-// Commit submits data files for commit and waits for the result.
+// Commit submits files for commit and waits for the result. Pure appends are
+// batched for throughput. Commits that carry equality-delete files are applied
+// as their own snapshot (never coalesced with other commits): merge-on-read
+// equality deletes only remove rows from earlier snapshots, so merging two
+// keyed batches into a single snapshot would leave same-key duplicates.
 func (c *committer) Commit(ctx context.Context, input CommitInput) error {
+	if len(input.DeleteFiles) > 0 {
+		return c.commitRowDelta(ctx, input)
+	}
 	_, err := c.batcher.Submit(ctx, input)
 	return err
 }
 
-// doCommit processes a batch of commit inputs for this table.
+// doCommit processes a batch of append-only commit inputs (the batcher path).
 func (c *committer) doCommit(ctx context.Context, inputs []CommitInput) ([]struct{}, error) {
-	// Validate schema IDs match the current table schema.
-	currentSchemaID := c.currentSchemaID()
-	for _, input := range inputs {
-		if input.SchemaID != currentSchemaID {
-			return nil, &StaleSchemaError{
-				WriterSchemaID:  input.SchemaID,
-				CurrentSchemaID: currentSchemaID,
-			}
-		}
-	}
+	c.commitMu.Lock()
+	defer c.commitMu.Unlock()
 
+	currentSchemaID := c.currentSchemaID()
 	var allFiles []iceberg.DataFile
 	for _, input := range inputs {
+		if input.SchemaID != currentSchemaID {
+			return nil, &StaleSchemaError{WriterSchemaID: input.SchemaID, CurrentSchemaID: currentSchemaID}
+		}
 		allFiles = append(allFiles, input.Files...)
+	}
+
+	if err := c.commitLocked(ctx, func(txn *table.Transaction, props iceberg.Properties) error {
+		// WithoutDuplicateCheck: writer.Write stamps each path with a fresh uuid,
+		// so iceberg-go's default O(snapshot) manifest collision scan is wasted
+		// work on the commit hot path (T6692).
+		return txn.AddDataFiles(ctx, allFiles, props,
+			table.WithoutAutoNameMapping(),
+			table.WithoutDuplicateCheck(),
+		)
+	}); err != nil {
+		return nil, err
+	}
+	c.logger.Debugf("Committed %d data files", len(allFiles))
+	return make([]struct{}, len(inputs)), nil
+}
+
+// commitRowDelta applies a single input's inserts and equality deletes as one
+// atomic snapshot, outside the batcher so it is never coalesced with another
+// keyed commit.
+func (c *committer) commitRowDelta(ctx context.Context, input CommitInput) error {
+	c.commitMu.Lock()
+	defer c.commitMu.Unlock()
+
+	if input.SchemaID != c.currentSchemaID() {
+		return &StaleSchemaError{WriterSchemaID: input.SchemaID, CurrentSchemaID: c.currentSchemaID()}
+	}
+	if err := c.commitLocked(ctx, func(txn *table.Transaction, props iceberg.Properties) error {
+		// RowDelta derives the snapshot operation automatically
+		// (append/delete/overwrite).
+		rd := txn.NewRowDelta(props)
+		if len(input.Files) > 0 {
+			rd.AddRows(input.Files...)
+		}
+		rd.AddDeletes(input.DeleteFiles...)
+		return rd.Commit(ctx)
+	}); err != nil {
+		return err
+	}
+	c.logger.Debugf("Committed row delta: %d data files, %d delete files", len(input.Files), len(input.DeleteFiles))
+	return nil
+}
+
+// commitLocked stages a transaction via stage and commits it, retrying on
+// concurrent-commit conflicts and reloading table metadata between attempts.
+// Callers must hold c.commitMu.
+func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transaction, iceberg.Properties) error) error {
+	props := iceberg.Properties{
+		table.ManifestMergeEnabledKey: strconv.FormatBool(c.cfg.ManifestMergeEnabled),
+	}
+	if c.cfg.MaxSnapshotAge > 0 {
+		props[table.MaxSnapshotAgeMsKey] = strconv.FormatInt(c.cfg.MaxSnapshotAge.Milliseconds(), 10)
 	}
 
 	var commitErr error
@@ -111,30 +179,20 @@ func (c *committer) doCommit(ctx context.Context, inputs []CommitInput) ([]struc
 		attempt++
 		txn := c.table.NewTransaction()
 		if c.table.Metadata().Version() < CurrentIcebergVersion {
+			c.upgradeWarnOnce.Do(func() {
+				c.logger.Warnf("Upgrading iceberg table to format version %d to support row-level deletes; this change is irreversible", CurrentIcebergVersion)
+			})
 			if err := txn.UpgradeFormatVersion(CurrentIcebergVersion); err != nil {
-				return nil, fmt.Errorf("upgrading version: %w", err)
+				return fmt.Errorf("upgrading version: %w", err)
 			}
 		}
-		props := iceberg.Properties{
-			table.ManifestMergeEnabledKey: strconv.FormatBool(c.cfg.ManifestMergeEnabled),
-		}
-		if c.cfg.MaxSnapshotAge > 0 {
-			props[table.MaxSnapshotAgeMsKey] = strconv.FormatInt(c.cfg.MaxSnapshotAge.Milliseconds(), 10)
-		}
-		// WithoutDuplicateCheck: writer.Write stamps each path with a fresh uuid,
-		// so the default O(snapshot) manifest scan iceberg-go runs to detect path
-		// collisions is wasted work on the commit hot path (T6692).
-		if err := txn.AddDataFiles(ctx, allFiles, props,
-			table.WithoutAutoNameMapping(),
-			table.WithoutDuplicateCheck(),
-		); err != nil {
-			return nil, fmt.Errorf("adding files: %w", err)
+		if err := stage(txn, props); err != nil {
+			return err
 		}
 		tbl, err := txn.Commit(ctx)
 		if errors.Is(err, rest.ErrCommitFailed) {
 			commitErr = err
 			c.logger.Warnf("Commit attempt %d/%d failed: %v", attempt, c.cfg.MaxRetries, err)
-			// Reload table to get fresh metadata before retrying.
 			if reloaded, reloadErr := c.reloadTable(ctx); reloadErr == nil {
 				c.table = reloaded
 			} else {
@@ -142,23 +200,24 @@ func (c *committer) doCommit(ctx context.Context, inputs []CommitInput) ([]struc
 			}
 			continue
 		} else if err != nil {
-			// Non-retryable error: reload table so next call uses fresh metadata.
+			// Non-retryable error: reload so the next call uses fresh metadata.
 			if reloaded, reloadErr := c.reloadTable(ctx); reloadErr == nil {
 				c.table = reloaded
 			}
-			commitErr = err
-			break
+			c.incrCommitFailure()
+			return fmt.Errorf("committing transaction: %w", err)
 		}
 		c.table = tbl
-		commitErr = nil
-		break
+		return nil
 	}
-	if commitErr != nil {
-		return nil, fmt.Errorf("committing transaction after %d attempts: %w", attempt, commitErr)
+	c.incrCommitFailure()
+	return fmt.Errorf("committing transaction after %d attempts: %w", attempt, commitErr)
+}
+
+func (c *committer) incrCommitFailure() {
+	if c.metrics != nil {
+		c.metrics.commitFailures.Incr(1)
 	}
-	c.logger.Debugf("Committed %d files", len(allFiles))
-	responses := make([]struct{}, len(inputs))
-	return responses, nil
 }
 
 // currentSchemaID returns the table's current schema ID.

--- a/internal/impl/iceberg/committer.go
+++ b/internal/impl/iceberg/committer.go
@@ -143,8 +143,9 @@ func (c *committer) commitRowDelta(ctx context.Context, input CommitInput) error
 	c.commitMu.Lock()
 	defer c.commitMu.Unlock()
 
-	if input.SchemaID != c.currentSchemaID() {
-		return &StaleSchemaError{WriterSchemaID: input.SchemaID, CurrentSchemaID: c.currentSchemaID()}
+	currentSchemaID := c.currentSchemaID()
+	if input.SchemaID != currentSchemaID {
+		return &StaleSchemaError{WriterSchemaID: input.SchemaID, CurrentSchemaID: currentSchemaID}
 	}
 	if err := c.commitLocked(ctx, func(txn *table.Transaction, props iceberg.Properties) error {
 		// RowDelta derives the snapshot operation automatically
@@ -215,9 +216,7 @@ func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transact
 }
 
 func (c *committer) incrCommitFailure() {
-	if c.metrics != nil {
-		c.metrics.commitFailures.Incr(1)
-	}
+	c.metrics.incrCommitFailure()
 }
 
 // currentSchemaID returns the table's current schema ID.

--- a/internal/impl/iceberg/config.go
+++ b/internal/impl/iceberg/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -36,6 +36,13 @@ const (
 	ioFieldNamespace            = "namespace"
 	ioFieldTable                = "table"
 	ioFieldCaseSensitiveColumns = "case_sensitive_columns"
+
+	// Row-operation fields for row-level mutations (insert / upsert / delete).
+	// `row_operation` is named to avoid colliding with Iceberg's snapshot-level
+	// "operation" (append/replace/overwrite/delete); `identifier_fields` matches
+	// the Iceberg spec's identifier-field-ids (primary-key columns).
+	ioFieldRowOperation     = "row_operation"
+	ioFieldIdentifierFields = "identifier_fields"
 
 	// Storage fields - common
 	ioFieldStorage = "storage"
@@ -91,6 +98,39 @@ const (
 	ioFieldParquet               = "parquet"
 	ioFieldParquetStringEncoding = "string_encoding"
 )
+
+// rowOperationDocs is the long-form documentation for the row-level operation
+// feature. It lives in the component description rather than inline in the
+// `row_operation` / `identifier_fields` field descriptions because the field
+// table on the docs site renders long, multi-paragraph cells poorly; those
+// field descriptions stay short and link here via the `row-level-operations`
+// anchor. Written as a double-quoted string so inline `code` spans can use
+// literal backticks.
+const rowOperationDocs = "\n" +
+	"== Row-level operations\n" +
+	"\n" +
+	"By default this output is append-only — every message becomes a new row (`row_operation: insert`), and existing configurations are unaffected. Set `row_operation` to apply a per-message operation, with `identifier_fields` defining the row identity:\n" +
+	"\n" +
+	"* `insert` — append the row. This is an unconditional append: it is *not* keyed or de-duplicated.\n" +
+	"* `upsert` — replace any existing rows matching `identifier_fields`, then append this row (equivalent to Iceberg's Flink UPSERT mode).\n" +
+	"* `delete` — remove rows matching `identifier_fields`.\n" +
+	"\n" +
+	"`row_operation` supports interpolation, so the operation can be driven by the data itself — for example by mapping a change-data-capture stream's operation field — but no CDC-specific format is assumed (see the change-data-capture example below). It is named `row_operation` to distinguish it from Iceberg's snapshot-level operation.\n" +
+	"\n" +
+	"`upsert` and `delete` require `identifier_fields` and use Iceberg merge-on-read equality deletes, which require table format version 2. A version-1 table is automatically upgraded to version 2 on the first `upsert`/`delete`; *this upgrade is irreversible*.\n" +
+	"\n" +
+	"*Identifier fields.* `identifier_fields` must reference existing table columns of a primitive, non-floating-point type. A static `upsert`/`delete` is validated at startup; an interpolated `row_operation` is validated per message at write time, so an empty `identifier_fields` is not caught until the first `upsert`/`delete` message arrives. Identifier columns of a temporal type (`timestamp`, `timestamptz`, `date`, `time`) must arrive as time values, not bare numbers — a numeric epoch is ambiguous as a delete key and is rejected at write time; convert it to a timestamp upstream. If the table is partitioned, every partition source column must be one of the `identifier_fields`, since equality deletes are partition-scoped.\n" +
+	"\n" +
+	"When this output auto-creates a table (via `schema_evolution`), the `identifier_fields` columns are created as *required* and registered as the table's Iceberg identifier-field-ids, so downstream engines and other writers see the primary key. A consequence is that a null or missing value in an identifier column is rejected on write, even for `insert`. Identifier columns must therefore be present at creation — in the first message or declared via `schema_metadata`. Pre-existing tables are never modified.\n" +
+	"\n" +
+	"*Batching and ordering.* Within a single batch the last `upsert`/`delete` per `identifier_fields` key wins. Each batch containing an `upsert`/`delete` is committed as its own snapshot (these commits are never coalesced, which is required for correctness), so a high-throughput mutation workload produces one snapshot per batch. Size batches accordingly and run regular table maintenance (snapshot expiry and compaction) to keep metadata manageable. Pure `insert`-only batches keep the original append fast path, which does coalesce commits.\n" +
+	"\n" +
+	"Ordering only holds *within* a batch. With more than one batch in flight, concurrent batches can commit out of order, so a stale `upsert` may overwrite a newer one for the same key. Set `max_in_flight: 1` for keyed (change-data-capture) workloads to preserve per-key order — this is enforced by config linting whenever `row_operation` is anything other than a static `insert`.\n" +
+	"\n" +
+	"[CAUTION]\n" +
+	"====\n" +
+	"`insert` is an unconditional append and is *not* keyed or de-duplicated. For keyed data (including change-data-capture), map create/read events to `upsert`, never `insert` — mixing `insert` with `upsert`/`delete` on the same key in one batch produces duplicate rows.\n" +
+	"====\n"
 
 // icebergOutputConfig returns the configuration spec for the Iceberg output.
 func icebergOutputConfig() *service.ConfigSpec {
@@ -150,7 +190,7 @@ object:struct
 array:list
 |===
 
-`+service.OutputPerformanceDocs(true, true)).
+`+rowOperationDocs+service.OutputPerformanceDocs(true, true)).
 		Fields(
 			// Catalog configuration
 			service.NewObjectField(ioFieldCatalog,
@@ -217,6 +257,22 @@ array:list
 			service.NewBoolField(ioFieldCaseSensitiveColumns).
 				Description("Controls how message field names are matched against table column names, and how column references in the partition spec are resolved. When `true` (the default), names must match exactly. When `false`, matching is case-insensitive — set this when your downstream catalog or query engine treats column names as case-insensitive (the iceberg specification's recommended convention) so that, for example, a message keyed `\"COLUMN\"` lands in an existing `column` rather than triggering schema evolution. Ambiguous case-only duplicates in the input are rejected.").
 				Default(true).
+				Advanced(),
+
+			// Row-level operation mapping (insert / upsert / delete).
+			service.NewInterpolatedStringField(ioFieldRowOperation).
+				Description("The row-level operation to apply for each message: `insert` (append), `upsert` (replace rows matching `identifier_fields`, then append), or `delete` (remove rows matching `identifier_fields`). Supports interpolation so the operation can be driven by the data — e.g. a change-data-capture stream's operation field. Defaults to `insert`, preserving the original append-only behaviour.\n\nSee the <<row-level-operations,Row-level operations>> section above for the full semantics, the format-version-2 upgrade, batching behaviour, and important caveats.").
+				Example("insert").
+				Example(`${! metadata("op") }`).
+				Example(`${! this.op == "d" ? "delete" : "upsert" }`).
+				Default("insert").
+				Advanced(),
+
+			service.NewStringListField(ioFieldIdentifierFields).
+				Description("The columns forming the row identity (the Iceberg identifier fields / equality-delete key) used by `upsert` and `delete`. Required when `row_operation` can evaluate to `upsert` or `delete`, and must reference existing table columns of a primitive, non-floating-point type.\n\nSee the <<row-level-operations,Row-level operations>> section above for the full constraints, including the temporal-type and partitioning rules and when the requirement is enforced.").
+				Example([]string{"id"}).
+				Example([]string{"tenant_id", "user_id"}).
+				Default([]string{}).
 				Advanced(),
 
 			// Storage configuration - one of s3, gcs, or azure must be specified
@@ -368,5 +424,51 @@ array:list
 			// Batching
 			service.NewBatchPolicyField(ioFieldBatching),
 			service.NewOutputMaxInFlightField().Default(4),
+		).
+		// Keyed (upsert/delete) writes rely on per-key ordering. With more than
+		// one batch in flight, concurrent batches can commit out of order and
+		// corrupt the last-writer-wins result, so require max_in_flight: 1 for
+		// any non-insert row_operation. A static `insert` (the default) is
+		// append-only and unaffected; an interpolated row_operation is treated
+		// conservatively as potentially mutating.
+		LintRule(`root = if this.row_operation.or("insert") != "insert" && this.max_in_flight.or(4) > 1 {
+  [ "row_operation can resolve to upsert/delete, which rely on per-key write ordering; with max_in_flight > 1 concurrent batches may commit out of order and corrupt the last-writer-wins result. Set max_in_flight: 1 for keyed (change-data-capture) workloads, or use a static row_operation: insert for append-only writes." ]
+}`).
+		Example(
+			"Change-data-capture upsert/delete",
+			"Materialize a change-data-capture stream into an Iceberg table. A mapping derives the row operation from the source's operation field (here Debezium's `op`: `c`reate / `r`ead / `u`pdate map to `upsert`, `d`elete maps to `delete`) and selects the row image, while `identifier_fields` is the primary key. Note that creates map to `upsert`, never `insert`, so re-delivered or snapshot rows do not duplicate.",
+			`
+input:
+  redpanda:
+    seed_brokers: [ localhost:9092 ]
+    topics: [ dbserver.inventory.customers ]
+    consumer_group: iceberg_sink
+
+pipeline:
+  processors:
+    - mapping: |
+        meta op = match this.op {
+          "d" => "delete",
+          _   => "upsert",
+        }
+        # Debezium puts the row image in 'after' (or 'before' for deletes).
+        root = this.after | this.before
+
+output:
+  iceberg:
+    catalog:
+      url: http://localhost:8181/api/catalog
+    namespace: inventory
+    table: customers
+    row_operation: ${! metadata("op") }
+    identifier_fields: [ id ]
+    # Keyed writes must stay ordered: a single batch in flight prevents
+    # concurrent batches from committing a stale update over a newer one.
+    max_in_flight: 1
+    storage:
+      aws_s3:
+        bucket: my-iceberg-data
+        region: us-east-1
+`,
 		)
 }

--- a/internal/impl/iceberg/e2e/glue/e2e_test.go
+++ b/internal/impl/iceberg/e2e/glue/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -77,7 +77,7 @@ func newRouter(t *testing.T, namespace, table string, schemaEvo bool) *icebergim
 		Enabled:       schemaEvo,
 		TableLocation: fmt.Sprintf("s3://%s/", *glueBucket),
 	}
-	router := icebergimpl.NewRouter(catalogConfig(), namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, nil, logger)
+	router := icebergimpl.NewRouter(catalogConfig(), namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, icebergimpl.RowOpConfig{}, nil, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/e2e/polaris-aws/e2e_test.go
+++ b/internal/impl/iceberg/e2e/polaris-aws/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -202,7 +202,7 @@ func newRouter(t *testing.T, catalogCfg catalogx.Config, namespace, tableName st
 	schemaEvoCfg := icebergimpl.SchemaEvolutionConfig{
 		Enabled: schemaEvo,
 	}
-	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, nil, logger)
+	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, icebergimpl.RowOpConfig{}, nil, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/e2e/polaris-azure/e2e_test.go
+++ b/internal/impl/iceberg/e2e/polaris-azure/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -192,7 +192,7 @@ func newRouter(t *testing.T, catalogCfg catalogx.Config, namespace, table string
 	schemaEvoCfg := icebergimpl.SchemaEvolutionConfig{
 		Enabled: schemaEvo,
 	}
-	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, nil, logger)
+	router := icebergimpl.NewRouter(catalogCfg, namespaceStr, tableStr, true, schemaEvoCfg, commitCfg, icebergimpl.RowOpConfig{}, nil, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/integration/row_operation_integration_test.go
+++ b/internal/impl/iceberg/integration/row_operation_integration_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	icebergimpl "github.com/redpanda-data/connect/v4/internal/impl/iceberg"
+)
+
+// opMsg builds a message whose body is the row data and whose `op` metadata
+// drives the row_operation interpolation — mirroring how a CDC source would map
+// its operation field onto the iceberg output.
+func opMsg(t *testing.T, op, body string) *service.Message {
+	t.Helper()
+	m := service.NewMessage([]byte(body))
+	m.MetaSetMut("op", op)
+	return m
+}
+
+// TestRowOperationsIntegration drives inserts, an upsert, and a delete through
+// the iceberg output and asserts the table reflects the correct final state:
+// the upserted row wins (no duplicate) and the deleted row is gone.
+func TestRowOperationsIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+
+	const ns, tbl = "row_ops_ns", "row_ops_test"
+
+	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
+	require.NoError(t, err)
+
+	router := infra.NewRouter(t, ns, tbl,
+		WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}),
+		WithRowOperation(icebergimpl.RowOpConfig{
+			Operation:        operation,
+			IdentifierFields: []string{"id"},
+		}),
+	)
+
+	// Seed three rows. id is a string so the auto-created column is a valid
+	// (non-floating-point) identifier key.
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opMsg(t, "insert", `{"id": "1", "value": "one"}`),
+		opMsg(t, "insert", `{"id": "2", "value": "two"}`),
+		opMsg(t, "insert", `{"id": "3", "value": "three"}`),
+	})
+
+	// Upsert id=2 (replace its value) and delete id=3.
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opMsg(t, "upsert", `{"id": "2", "value": "two-updated"}`),
+	})
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opMsg(t, "delete", `{"id": "3"}`),
+	})
+
+	type row struct {
+		ID    string `json:"id"`
+		Value string `json:"value"`
+	}
+	rows := querySQL[row](t, ctx, infra,
+		`SELECT id, value FROM iceberg_cat."row_ops_ns"."row_ops_test" ORDER BY id;`)
+
+	require.Len(t, rows, 2, "id=3 should be deleted and id=2 should not be duplicated")
+	assert.Equal(t, "1", rows[0].ID)
+	assert.Equal(t, "one", rows[0].Value)
+	assert.Equal(t, "2", rows[1].ID)
+	assert.Equal(t, "two-updated", rows[1].Value, "upsert should replace the prior value for id=2")
+}

--- a/internal/impl/iceberg/integration/row_operation_types_integration_test.go
+++ b/internal/impl/iceberg/integration/row_operation_types_integration_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	icebergimpl "github.com/redpanda-data/connect/v4/internal/impl/iceberg"
+)
+
+// opStructMsg builds a message with a structured body and an `op` metadata value
+// driving the row_operation interpolation.
+func opStructMsg(op string, body map[string]any) *service.Message {
+	m := service.NewMessage(nil)
+	m.SetStructured(body)
+	m.MetaSetMut("op", op)
+	return m
+}
+
+// keyRoundTrip pre-creates a table with a single typed identifier column `k`
+// plus a string `val` column, then exercises insert -> delete -> upsert keyed on
+// `k` and asserts the final state contains exactly the upserted row. A wrong key
+// encoding (delete/upsert silently matching nothing) shows up as a surviving or
+// duplicated row, i.e. count != 1.
+func keyRoundTrip(t *testing.T, infra *testInfrastructure, ns, tbl string, keyType iceberg.Type, k1, k2 any) {
+	t.Helper()
+	ctx := context.Background()
+
+	client := infra.NewCatalogClient(t, ns)
+	_, err := client.CreateTable(ctx, tbl, iceberg.NewSchemaWithIdentifiers(
+		1, []int{1},
+		iceberg.NestedField{ID: 1, Name: "k", Type: keyType, Required: true},
+		iceberg.NestedField{ID: 2, Name: "val", Type: iceberg.StringType{}, Required: false},
+	))
+	require.NoError(t, err)
+
+	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
+	require.NoError(t, err)
+	router := infra.NewRouter(t, ns, tbl,
+		WithRowOperation(icebergimpl.RowOpConfig{
+			Operation:        operation,
+			IdentifierFields: []string{"k"},
+		}))
+
+	// Seed two rows in their own snapshot.
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("insert", map[string]any{"k": k1, "val": "a"}),
+		opStructMsg("insert", map[string]any{"k": k2, "val": "b"}),
+	})
+	// Delete k2 and upsert k1 in a later snapshot — both must match the seeded
+	// rows for the final state to be correct.
+	produceMessages(t, ctx, router, service.MessageBatch{opStructMsg("delete", map[string]any{"k": k2})})
+	produceMessages(t, ctx, router, service.MessageBatch{opStructMsg("upsert", map[string]any{"k": k1, "val": "a2"})})
+
+	type valRow struct {
+		Val string `json:"val"`
+	}
+	// DuckDB requires the equality-delete key column (k) to be in the projection
+	// to apply the deletes, so select it even though we only assert on val.
+	rows := querySQL[valRow](t, ctx, infra,
+		fmt.Sprintf(`SELECT k, val FROM iceberg_cat."%s"."%s" ORDER BY val;`, ns, tbl))
+	require.Lenf(t, rows, 1, "expected exactly one surviving row (delete+upsert both matched); got %d", len(rows))
+	assert.Equal(t, "a2", rows[0].Val, "surviving row must be the upserted value")
+}
+
+func TestRowOperationKeyTypesIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+	const ns = "row_op_keytypes"
+	infra.CreateNamespace(t, ns)
+
+	ts1 := time.UnixMilli(1700000000000).UTC()
+	ts2 := time.UnixMilli(1700000111000).UTC()
+
+	cases := []struct {
+		name    string
+		tbl     string
+		keyType iceberg.Type
+		k1, k2  any
+	}{
+		{"string", "k_string", iceberg.StringType{}, "alpha", "beta"},
+		{"int64-big", "k_int64", iceberg.Int64Type{}, int64(9007199254740993), int64(9007199254740994)},
+		{"uuid", "k_uuid", iceberg.UUIDType{}, "f47ac10b-58cc-4372-a567-0e02b2c3d479", "1b4e28ba-2fa1-11d2-883f-0016d3cca427"},
+		{"decimal-float", "k_decimal_f", iceberg.DecimalTypeOf(12, 2), 123.45, 234.56},
+		{"decimal-string", "k_decimal_s", iceberg.DecimalTypeOf(12, 2), "123.45", "234.56"},
+		{"timestamp-time", "k_ts_time", iceberg.TimestampType{}, ts1, ts2},
+		// Note: a bare numeric timestamp key is deliberately rejected at write
+		// time (its unit is ambiguous and cannot be matched against the insert
+		// path) — covered by the deleteKeyJSONValue unit test, not here.
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyRoundTrip(t, infra, ns, tc.tbl, tc.keyType, tc.k1, tc.k2)
+		})
+	}
+}
+
+// TestRowOperationCompositeKeyIntegration verifies a multi-column identifier.
+func TestRowOperationCompositeKeyIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+	const ns, tbl = "row_op_composite", "ck"
+	infra.CreateNamespace(t, ns)
+
+	client := infra.NewCatalogClient(t, ns)
+	_, err := client.CreateTable(ctx, tbl, iceberg.NewSchemaWithIdentifiers(
+		1, []int{1, 2},
+		iceberg.NestedField{ID: 1, Name: "tenant", Type: iceberg.StringType{}, Required: true},
+		iceberg.NestedField{ID: 2, Name: "id", Type: iceberg.StringType{}, Required: true},
+		iceberg.NestedField{ID: 3, Name: "val", Type: iceberg.StringType{}, Required: false},
+	))
+	require.NoError(t, err)
+
+	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
+	require.NoError(t, err)
+	router := infra.NewRouter(t, ns, tbl,
+		WithRowOperation(icebergimpl.RowOpConfig{
+			Operation:        operation,
+			IdentifierFields: []string{"tenant", "id"},
+		}))
+
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("insert", map[string]any{"tenant": "t1", "id": "x", "val": "a"}),
+		opStructMsg("insert", map[string]any{"tenant": "t1", "id": "y", "val": "b"}),
+		opStructMsg("insert", map[string]any{"tenant": "t2", "id": "x", "val": "c"}),
+	})
+	// Delete only (t1,y); upsert (t2,x). (t1,x) is left untouched. The composite
+	// key must distinguish (t1,x) from (t2,x).
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("delete", map[string]any{"tenant": "t1", "id": "y"}),
+		opStructMsg("upsert", map[string]any{"tenant": "t2", "id": "x", "val": "c2"}),
+	})
+
+	type row struct {
+		Tenant string `json:"tenant"`
+		ID     string `json:"id"`
+		Val    string `json:"val"`
+	}
+	rows := querySQL[row](t, ctx, infra,
+		fmt.Sprintf(`SELECT tenant, id, val FROM iceberg_cat."%s"."%s" ORDER BY tenant, id;`, ns, tbl))
+	require.Len(t, rows, 2)
+	assert.Equal(t, row{"t1", "x", "a"}, rows[0], "(t1,x) must be untouched")
+	assert.Equal(t, row{"t2", "x", "c2"}, rows[1], "(t2,x) must be upserted, not confused with (t1,x)")
+}
+
+// TestRowOperationPartitionedIntegration verifies upsert/delete on a partitioned
+// table: the equality-delete records must carry the partition source column so
+// deletes route to the correct partition and match the intended rows.
+func TestRowOperationPartitionedIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+	const ns, tbl = "row_op_partitioned", "p"
+	infra.CreateNamespace(t, ns)
+
+	client := infra.NewCatalogClient(t, ns)
+	// The partition source (region) must be part of the identifier so equality
+	// deletes route to the correct partition.
+	sc := iceberg.NewSchemaWithIdentifiers(1, []int{1, 2},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.StringType{}, Required: true},
+		iceberg.NestedField{ID: 2, Name: "region", Type: iceberg.StringType{}, Required: true},
+		iceberg.NestedField{ID: 3, Name: "val", Type: iceberg.StringType{}, Required: false},
+	)
+	spec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{2}, FieldID: 1000, Name: "region", Transform: iceberg.IdentityTransform{},
+	})
+	_, err := client.CreateTable(ctx, tbl, sc, catalog.WithPartitionSpec(&spec))
+	require.NoError(t, err)
+
+	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
+	require.NoError(t, err)
+	router := infra.NewRouter(t, ns, tbl,
+		WithRowOperation(icebergimpl.RowOpConfig{
+			Operation:        operation,
+			IdentifierFields: []string{"id", "region"},
+		}))
+
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("insert", map[string]any{"id": "1", "region": "us", "val": "a"}),
+		opStructMsg("insert", map[string]any{"id": "2", "region": "eu", "val": "b"}),
+	})
+	// Delete id=2 (in the eu partition) and upsert id=1 (in the us partition).
+	// The delete/upsert records must include region so they route correctly.
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("delete", map[string]any{"id": "2", "region": "eu"}),
+		opStructMsg("upsert", map[string]any{"id": "1", "region": "us", "val": "a2"}),
+	})
+
+	type row struct {
+		ID  string `json:"id"`
+		Val string `json:"val"`
+	}
+	// DuckDB needs all equality-delete key columns (id, region) in the projection
+	// to apply the deletes.
+	rows := querySQL[row](t, ctx, infra,
+		fmt.Sprintf(`SELECT id, region, val FROM iceberg_cat."%s"."%s" ORDER BY id;`, ns, tbl))
+	require.Len(t, rows, 1, "id=2 (eu) must be deleted and id=1 (us) must not be duplicated")
+	assert.Equal(t, row{"1", "a2"}, rows[0])
+}
+
+// TestRowOperationBatchCollapseIntegration verifies the per-key collapse: two
+// upserts of the same key in one batch must leave a single (latest) row.
+func TestRowOperationBatchCollapseIntegration(t *testing.T) {
+	integration.CheckSkip(t)
+	ctx := context.Background()
+	infra := setupTestInfra(t, ctx)
+	const ns, tbl = "row_op_collapse", "c"
+	infra.CreateNamespace(t, ns)
+
+	client := infra.NewCatalogClient(t, ns)
+	_, err := client.CreateTable(ctx, tbl, iceberg.NewSchemaWithIdentifiers(
+		1, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.StringType{}, Required: true},
+		iceberg.NestedField{ID: 2, Name: "val", Type: iceberg.StringType{}, Required: false},
+	))
+	require.NoError(t, err)
+
+	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
+	require.NoError(t, err)
+	router := infra.NewRouter(t, ns, tbl,
+		WithRowOperation(icebergimpl.RowOpConfig{
+			Operation:        operation,
+			IdentifierFields: []string{"id"},
+		}))
+
+	// Two upserts of "k" plus an upsert-then-delete of "g", all in one batch.
+	produceMessages(t, ctx, router, service.MessageBatch{
+		opStructMsg("upsert", map[string]any{"id": "k", "val": "v1"}),
+		opStructMsg("upsert", map[string]any{"id": "k", "val": "v2"}),
+		opStructMsg("upsert", map[string]any{"id": "g", "val": "g1"}),
+		opStructMsg("delete", map[string]any{"id": "g"}),
+	})
+
+	type row struct {
+		ID  string `json:"id"`
+		Val string `json:"val"`
+	}
+	rows := querySQL[row](t, ctx, infra,
+		fmt.Sprintf(`SELECT id, val FROM iceberg_cat."%s"."%s" ORDER BY id;`, ns, tbl))
+	require.Len(t, rows, 1, "k must appear once (no duplicate from two same-batch upserts); g must be deleted")
+	assert.Equal(t, row{"k", "v2"}, rows[0], "the later upsert of k must win")
+}

--- a/internal/impl/iceberg/integration/test_helpers.go
+++ b/internal/impl/iceberg/integration/test_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -91,12 +91,20 @@ type RouterOption func(*routerOpts)
 type routerOpts struct {
 	caseSensitive bool
 	schemaEvoCfg  icebergimpl.SchemaEvolutionConfig
+	rowOpCfg      icebergimpl.RowOpConfig
 }
 
 // WithSchemaEvolution enables schema evolution on the test router.
 func WithSchemaEvolution(cfg icebergimpl.SchemaEvolutionConfig) RouterOption {
 	return func(o *routerOpts) {
 		o.schemaEvoCfg = cfg
+	}
+}
+
+// WithRowOperation configures per-message row-level operations on the test router.
+func WithRowOperation(cfg icebergimpl.RowOpConfig) RouterOption {
+	return func(o *routerOpts) {
+		o.rowOpCfg = cfg
 	}
 }
 
@@ -138,7 +146,7 @@ func (infra *testInfrastructure) NewRouter(
 		MaxSnapshotAge:       24 * time.Hour,
 		MaxRetries:           3,
 	}
-	router := icebergimpl.NewRouter(infra.CatalogConfig(), namespaceStr, tableStr, o.caseSensitive, o.schemaEvoCfg, commitCfg, nil, logger)
+	router := icebergimpl.NewRouter(infra.CatalogConfig(), namespaceStr, tableStr, o.caseSensitive, o.schemaEvoCfg, commitCfg, o.rowOpCfg, nil, logger)
 	t.Cleanup(func() { router.Close() })
 	return router
 }

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -67,22 +67,45 @@ type icebergOutput struct {
 	logger *service.Logger
 }
 
-// opMetrics holds counters for row-level operations and commit health. Fields
-// are nil in tests that construct writers/committers directly; callers must
-// nil-check the holder before incrementing.
+// opMetrics holds counters for row-level operations and commit health. Row
+// operations share a single counter labelled by operation (insert/upsert/
+// delete), following the Prometheus convention of one metric with a label
+// rather than one metric per verb, so they aggregate cleanly. The holder is nil
+// in tests that construct writers/committers directly; the incr* methods are
+// nil-safe so callers need not check.
 type opMetrics struct {
-	inserted       *service.MetricCounter
-	upserted       *service.MetricCounter
-	deleted        *service.MetricCounter
+	rowOps         *service.MetricCounter // labelled by "operation"
 	commitFailures *service.MetricCounter
 }
 
 func newOpMetrics(m *service.Metrics) *opMetrics {
 	return &opMetrics{
-		inserted:       m.NewCounter("iceberg_rows_inserted"),
-		upserted:       m.NewCounter("iceberg_rows_upserted"),
-		deleted:        m.NewCounter("iceberg_rows_deleted"),
-		commitFailures: m.NewCounter("iceberg_commit_failures"),
+		rowOps:         m.NewCounter("iceberg_row_operations_total", "operation"),
+		commitFailures: m.NewCounter("iceberg_commit_failures_total"),
+	}
+}
+
+func (m *opMetrics) incrInserted(n int64) {
+	if m != nil && n > 0 {
+		m.rowOps.Incr(n, "insert")
+	}
+}
+
+func (m *opMetrics) incrUpserted(n int64) {
+	if m != nil && n > 0 {
+		m.rowOps.Incr(n, "upsert")
+	}
+}
+
+func (m *opMetrics) incrDeleted(n int64) {
+	if m != nil && n > 0 {
+		m.rowOps.Incr(n, "delete")
+	}
+}
+
+func (m *opMetrics) incrCommitFailure() {
+	if m != nil {
+		m.commitFailures.Incr(1)
 	}
 }
 

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -67,6 +67,25 @@ type icebergOutput struct {
 	logger *service.Logger
 }
 
+// opMetrics holds counters for row-level operations and commit health. Fields
+// are nil in tests that construct writers/committers directly; callers must
+// nil-check the holder before incrementing.
+type opMetrics struct {
+	inserted       *service.MetricCounter
+	upserted       *service.MetricCounter
+	deleted        *service.MetricCounter
+	commitFailures *service.MetricCounter
+}
+
+func newOpMetrics(m *service.Metrics) *opMetrics {
+	return &opMetrics{
+		inserted:       m.NewCounter("iceberg_rows_inserted"),
+		upserted:       m.NewCounter("iceberg_rows_upserted"),
+		deleted:        m.NewCounter("iceberg_rows_deleted"),
+		commitFailures: m.NewCounter("iceberg_commit_failures"),
+	}
+}
+
 // newIcebergOutputFromConfig creates a new Iceberg output from parsed configuration.
 func newIcebergOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (*icebergOutput, error) {
 	// Parse catalog configuration
@@ -103,6 +122,24 @@ func newIcebergOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 		return nil, fmt.Errorf("parsing commit config: %w", err)
 	}
 
+	// Parse row-level operation config
+	rowOpCfg, err := parseRowOpConfig(conf)
+	if err != nil {
+		return nil, fmt.Errorf("parsing row operation config: %w", err)
+	}
+
+	// Keyed (upsert/delete) writes rely on per-key ordering, but with more than
+	// one batch in flight concurrent batches can commit out of order, letting a
+	// stale upsert overwrite a newer one. Config linting flags this, but linting
+	// is advisory and easily skipped, so warn at startup too. mutating() is
+	// conservative — an interpolated row_operation is treated as potentially
+	// mutating.
+	if rowOpCfg.mutating() {
+		if maxInFlight, err := conf.FieldInt(ioFieldMaxInFlight); err == nil && maxInFlight > 1 {
+			mgr.Logger().Warnf("row_operation can produce upsert/delete operations but max_in_flight is %d; concurrent batches may commit out of order and corrupt the last-writer-wins result. Set max_in_flight: 1 for keyed (change-data-capture) workloads.", maxInFlight)
+		}
+	}
+
 	// Parse parquet config
 	var writerOpts []parquet.WriterOption
 	if conf.Contains(ioFieldParquet) {
@@ -120,7 +157,8 @@ func newIcebergOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 		}
 	}
 
-	rtr := NewRouter(catalogCfg, namespaceStr, tableStr, caseSensitive, schemaEvoCfg, commitCfg, writerOpts, mgr.Logger())
+	rtr := NewRouter(catalogCfg, namespaceStr, tableStr, caseSensitive, schemaEvoCfg, commitCfg, rowOpCfg, writerOpts, mgr.Logger())
+	rtr.metrics = newOpMetrics(mgr.Metrics())
 	return &icebergOutput{
 		router: rtr,
 		logger: mgr.Logger(),
@@ -492,6 +530,39 @@ func parseSchemaEvolutionConfig(conf *service.ParsedConfig) (SchemaEvolutionConf
 	}
 	if cfg.RequireSchemaMetadata && cfg.SchemaMetadata == "" {
 		return cfg, fmt.Errorf("%s.%s requires %s.%s to be set", ioFieldSchemaEvolution, ioFieldSchemaEvolutionRequireSchemaMetadata, ioFieldSchemaEvolution, ioFieldSchemaEvolutionSchemaMetadata)
+	}
+
+	return cfg, nil
+}
+
+// parseRowOpConfig parses the row-level operation configuration and validates
+// the static case at startup. When row_operation is a static literal it must be
+// a known operation, and a static upsert/delete requires identifier_fields.
+// Dynamic (interpolated) operations cannot be checked here, so they are
+// validated per message at write time (a hard error on an unknown value or a
+// missing identifier_fields key, never a silent insert).
+func parseRowOpConfig(conf *service.ParsedConfig) (RowOpConfig, error) {
+	cfg := RowOpConfig{}
+
+	op, err := conf.FieldInterpolatedString(ioFieldRowOperation)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Operation = op
+
+	cfg.IdentifierFields, err = conf.FieldStringList(ioFieldIdentifierFields)
+	if err != nil {
+		return cfg, err
+	}
+
+	if static, ok := op.Static(); ok {
+		parsed, err := parseRowOperation(static)
+		if err != nil {
+			return cfg, err
+		}
+		if (parsed == rowOpUpsert || parsed == rowOpDelete) && len(cfg.IdentifierFields) == 0 {
+			return cfg, fmt.Errorf("%s %q requires %s to be set", ioFieldRowOperation, parsed, ioFieldIdentifierFields)
+		}
 	}
 
 	return cfg, nil

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -77,10 +77,15 @@ type Router struct {
 	caseSensitive bool
 	schemaEvoCfg  SchemaEvolutionConfig
 	commitCfg     CommitConfig
+	rowOpCfg      RowOpConfig
 	writerOpts    []parquet.WriterOption
 	resolver      *typeResolver
 
 	entries sync.Map // tableKey -> *tableEntry
+
+	// metrics is optional (nil in some tests); set after construction by the
+	// output. Writers and committers inherit it.
+	metrics *opMetrics
 
 	logger *service.Logger
 }
@@ -96,6 +101,7 @@ func NewRouter(
 	caseSensitive bool,
 	schemaEvoCfg SchemaEvolutionConfig,
 	commitCfg CommitConfig,
+	rowOpCfg RowOpConfig,
 	writerOpts []parquet.WriterOption,
 	logger *service.Logger,
 ) *Router {
@@ -106,6 +112,7 @@ func NewRouter(
 		caseSensitive: caseSensitive,
 		schemaEvoCfg:  schemaEvoCfg,
 		commitCfg:     commitCfg,
+		rowOpCfg:      rowOpCfg,
 		writerOpts:    writerOpts,
 		resolver:      newTypeResolver(schemaEvoCfg.SchemaMetadata, schemaEvoCfg.NewColumnTypeMapping, caseSensitive, logger),
 		logger:        logger,
@@ -463,7 +470,54 @@ func (r *Router) buildSchemaWithResolver(record map[string]any, msg *service.Mes
 		})
 	}
 
-	return iceberg.NewSchema(0, fields...), nil
+	return r.schemaWithIdentifierFields(fields)
+}
+
+// schemaWithIdentifierFields builds the create-table schema, registering the
+// configured identifier_fields as the table's Iceberg identifier-field-ids so
+// that downstream engines and other writers see the row's primary key. Iceberg
+// requires identifier fields to be required and of a primitive, non-floating-
+// point type, so the matching columns are marked required here; a null or
+// missing value in an identifier column is consequently rejected on write
+// (consistent with how upsert/delete already reject null keys). A configured
+// identifier column that is absent from the created schema (not present in the
+// first message and not declared in schema_metadata) or of an unsuitable type
+// is a hard error rather than a silently unkeyed table.
+//
+// With no identifier_fields configured the schema is created exactly as before
+// (all columns optional, no identifier-field-ids), so append-only table
+// creation is unchanged.
+func (r *Router) schemaWithIdentifierFields(fields []iceberg.NestedField) (*iceberg.Schema, error) {
+	if len(r.rowOpCfg.IdentifierFields) == 0 {
+		return iceberg.NewSchema(0, fields...), nil
+	}
+
+	identifierIDs := make([]int, 0, len(r.rowOpCfg.IdentifierFields))
+	for _, name := range r.rowOpCfg.IdentifierFields {
+		idx := -1
+		for i := range fields {
+			if fields[i].Name == name || (!r.caseSensitive && strings.EqualFold(fields[i].Name, name)) {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return nil, fmt.Errorf("%s column %q is not present in the table being created; it must appear in the first message or be declared in schema_metadata", ioFieldIdentifierFields, name)
+		}
+		field := fields[idx]
+		if _, ok := field.Type.(iceberg.PrimitiveType); !ok {
+			return nil, fmt.Errorf("%s column %q has non-primitive type %s; identifier fields must be primitive", ioFieldIdentifierFields, field.Name, field.Type)
+		}
+		switch field.Type.(type) {
+		case iceberg.Float32Type, iceberg.Float64Type:
+			return nil, fmt.Errorf("%s column %q has floating-point type %s, which cannot be an identifier field", ioFieldIdentifierFields, field.Name, field.Type)
+		}
+		// Iceberg requires identifier fields to be required (non-null).
+		fields[idx].Required = true
+		identifierIDs = append(identifierIDs, field.ID)
+	}
+
+	return iceberg.NewSchemaWithIdentifiers(0, identifierIDs, fields...), nil
 }
 
 // orderedField pairs the key used to look up a value in the record with the
@@ -667,11 +721,13 @@ func (r *Router) createWriter(ctx context.Context, key tableKey) (*writer, error
 	if err != nil {
 		return nil, fmt.Errorf("creating committer: %w", err)
 	}
+	comm.metrics = r.metrics
 
 	// Create writer with its own table reference and the committer.
 	// The resolver is passed so the writer can use schema metadata to
 	// interpret numeric inputs into time-typed columns at shredding time.
-	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.resolver, r.schemaEvoCfg.RequireSchemaMetadata, r.logger)
+	w := NewWriter(writerTbl, comm, r.caseSensitive, r.writerOpts, r.resolver, r.schemaEvoCfg.RequireSchemaMetadata, r.rowOpCfg, r.logger)
+	w.metrics = r.metrics
 	r.logger.Debugf("Created writer for table %s.%s", key.namespace, key.table)
 
 	return w, nil

--- a/internal/impl/iceberg/row_operation_commit_test.go
+++ b/internal/impl/iceberg/row_operation_commit_test.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog/rest"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// These tests exercise the real equality-delete write path and RowDelta commit
+// against an in-memory catalog backed by the local filesystem (the same harness
+// the committer tests use), so they validate actual file production and commit
+// semantics without needing a containerised catalog.
+
+func newDeleteWriter(t testing.TB, tbl *table.Table) *writer {
+	t.Helper()
+	return &writer{
+		table:         tbl,
+		caseSensitive: true,
+		rowOpCfg:      RowOpConfig{IdentifierFields: []string{"id"}},
+		logger:        service.MockResources().Logger(),
+	}
+}
+
+func reloadFn(cat *memCatalog) func(context.Context) (*table.Table, error) {
+	return func(context.Context) (*table.Table, error) { return cat.snapshot(), nil }
+}
+
+func TestWriteEqualityDeletesProducesDeleteFiles(t *testing.T) {
+	ctx := t.Context()
+	tbl, _ := newTestTable(t)
+	w := newDeleteWriter(t, tbl)
+
+	msgs := service.MessageBatch{
+		structuredMsg(t, map[string]any{"id": 2}),
+		structuredMsg(t, map[string]any{"id": 4}),
+	}
+	deleteFiles, err := w.writeEqualityDeletes(ctx, msgs)
+	require.NoError(t, err)
+	require.Len(t, deleteFiles, 1)
+	assert.Equal(t, iceberg.EntryContentEqDeletes, deleteFiles[0].ContentType())
+	assert.Equal(t, []int{1}, deleteFiles[0].EqualityFieldIDs())
+	assert.EqualValues(t, 2, deleteFiles[0].Count())
+}
+
+func TestWriteEqualityDeletesMissingKeyErrors(t *testing.T) {
+	ctx := t.Context()
+	tbl, _ := newTestTable(t)
+	w := newDeleteWriter(t, tbl)
+
+	// Message has no "id" field — the delete key cannot be resolved.
+	_, err := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"other": 1})})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing or null")
+}
+
+func TestCommitDeleteOnlyProducesDeleteSnapshot(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTable(t)
+	w := newDeleteWriter(t, tbl)
+
+	deleteFiles, err := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"id": 2})})
+	require.NoError(t, err)
+
+	c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), service.MockResources().Logger())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Commit(ctx, CommitInput{DeleteFiles: deleteFiles, SchemaID: c.currentSchemaID()}))
+
+	snap := cat.snapshot().CurrentSnapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.Summary)
+	assert.Equal(t, table.OpDelete, snap.Summary.Operation)
+}
+
+func TestCommitUpsertProducesOverwriteSnapshot(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTable(t)
+	w := newDeleteWriter(t, tbl)
+
+	deleteFiles, err := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"id": 7})})
+	require.NoError(t, err)
+
+	// A data file alongside the deletes turns the RowDelta into an overwrite,
+	// the shape an upsert produces.
+	dataFile := synthDataFile(t, tbl.Spec(), fmt.Sprintf("%s/data/new-%s.parquet", tbl.Location(), uuid.New()))
+
+	c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), service.MockResources().Logger())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.Commit(ctx, CommitInput{
+		Files:       []iceberg.DataFile{dataFile},
+		DeleteFiles: deleteFiles,
+		SchemaID:    c.currentSchemaID(),
+	}))
+
+	snap := cat.snapshot().CurrentSnapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.Summary)
+	assert.Equal(t, table.OpOverwrite, snap.Summary.Operation)
+}
+
+func TestCommitInsertOnlyStaysAppend(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTable(t)
+
+	dataFile := synthDataFile(t, tbl.Spec(), fmt.Sprintf("%s/data/ins-%s.parquet", tbl.Location(), uuid.New()))
+
+	c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), service.MockResources().Logger())
+	require.NoError(t, err)
+	defer c.Close()
+
+	// No delete files: the committer must take the AddDataFiles fast path,
+	// producing an append snapshot (no behavioural change for existing users).
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{dataFile}, SchemaID: c.currentSchemaID()}))
+
+	snap := cat.snapshot().CurrentSnapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.Summary)
+	assert.Equal(t, table.OpAppend, snap.Summary.Operation)
+}
+
+// newTypedKeyTable builds an unpartitioned v2 table whose identifier column has
+// the given type, backed by an in-memory catalog and the local filesystem.
+func newTypedKeyTable(t testing.TB, keyField iceberg.NestedField) *table.Table {
+	t.Helper()
+	location := filepath.ToSlash(t.TempDir())
+	sc := iceberg.NewSchema(0,
+		keyField,
+		iceberg.NestedField{ID: 9, Name: "payload", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	meta, err := table.NewMetadata(sc, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		location, iceberg.Properties{table.PropertyFormatVersion: "2"})
+	require.NoError(t, err)
+	cat := &memCatalog{
+		meta:             meta,
+		metadataLocation: fmt.Sprintf("%s/metadata/v1-%s.metadata.json", location, uuid.New()),
+		ident:            table.Identifier{"default", "typed"},
+		location:         location,
+	}
+	return cat.snapshot()
+}
+
+// TestWriteEqualityDeletesTypedKeys proves the equality-delete writer produces
+// valid delete files for the key types that used to be gated off — uuid,
+// decimal, timestamp, and a >2^53 int64 — by writing real Parquet via the
+// iceberg-go equality-delete writer over the local filesystem.
+func TestWriteEqualityDeletesTypedKeys(t *testing.T) {
+	ctx := t.Context()
+	cases := []struct {
+		name string
+		key  iceberg.NestedField
+		val  any
+	}{
+		{"uuid", iceberg.NestedField{ID: 1, Name: "k", Type: iceberg.PrimitiveTypes.UUID, Required: true}, "f47ac10b-58cc-4372-a567-0e02b2c3d479"},
+		{"decimal", iceberg.NestedField{ID: 1, Name: "k", Type: iceberg.DecimalTypeOf(10, 2), Required: true}, "123.45"},
+		{"timestamp", iceberg.NestedField{ID: 1, Name: "k", Type: iceberg.PrimitiveTypes.Timestamp, Required: true}, time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)},
+		{"int64-big", iceberg.NestedField{ID: 1, Name: "k", Type: iceberg.PrimitiveTypes.Int64, Required: true}, int64(9007199254740993)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := newTypedKeyTable(t, tc.key)
+			w := &writer{
+				table:         tbl,
+				caseSensitive: true,
+				rowOpCfg:      RowOpConfig{IdentifierFields: []string{"k"}},
+				logger:        service.MockResources().Logger(),
+			}
+			df, err := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"k": tc.val})})
+			require.NoError(t, err)
+			require.Len(t, df, 1)
+			assert.Equal(t, iceberg.EntryContentEqDeletes, df[0].ContentType())
+			assert.Equal(t, []int{1}, df[0].EqualityFieldIDs())
+			assert.EqualValues(t, 1, df[0].Count())
+		})
+	}
+}
+
+// TestCommitRowDeltaConcurrentNotCoalesced pins the fix for the cross-batch
+// duplicate bug: delete-bearing commits must each become their own snapshot and
+// never be coalesced with another commit (coalescing would put multiple rows
+// for the same key at one sequence number, where equality deletes can't remove
+// same-commit data). Firing N concurrent delete commits must yield N snapshots.
+func TestCommitRowDeltaConcurrentNotCoalesced(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTable(t)
+	logger := service.MockResources().Logger()
+	c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 5}, reloadFn(cat), logger)
+	require.NoError(t, err)
+	defer c.Close()
+
+	const n = 4
+	deletes := make([][]iceberg.DataFile, n)
+	for i := range deletes {
+		w := newDeleteWriter(t, tbl)
+		df, derr := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"id": i})})
+		require.NoError(t, derr)
+		deletes[i] = df
+	}
+
+	// The schema is stable for this test; capture the ID once (a writer likewise
+	// uses its own table reference, not the committer's, to set SchemaID).
+	schemaID := c.currentSchemaID()
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = c.Commit(ctx, CommitInput{DeleteFiles: deletes[i], SchemaID: schemaID})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoErrorf(t, e, "commit %d", i)
+	}
+	assert.Len(t, cat.snapshot().Metadata().Snapshots(), n,
+		"each delete-bearing commit must produce its own snapshot (no coalescing)")
+}
+
+// newTestTableV1 mirrors newTestTable but creates a format-version-1 table, so
+// the committer's automatic v1→v2 upgrade path can be exercised.
+func newTestTableV1(tb testing.TB) (*table.Table, *memCatalog) {
+	tb.Helper()
+	location := filepath.ToSlash(tb.TempDir())
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	)
+	meta, err := table.NewMetadata(sc, iceberg.UnpartitionedSpec, table.UnsortedSortOrder,
+		location, iceberg.Properties{table.PropertyFormatVersion: "1"})
+	require.NoError(tb, err)
+	cat := &memCatalog{
+		meta:             meta,
+		metadataLocation: fmt.Sprintf("%s/metadata/00001-%s.metadata.json", location, uuid.New()),
+		ident:            table.Identifier{"default", "t"},
+		location:         location,
+	}
+	return cat.snapshot(), cat
+}
+
+// flakyCatalog wraps memCatalog and fails the first failuresLeft CommitTable
+// calls with failErr before delegating to the real catalog. It lets the tests
+// drive the committer's retry/conflict and commit-failure paths deterministically
+// without a containerised catalog. commitCalls counts every CommitTable
+// invocation so a test can assert how many attempts actually occurred.
+type flakyCatalog struct {
+	*memCatalog
+	mu           sync.Mutex
+	failuresLeft int
+	failErr      error
+	commitCalls  int
+}
+
+func (f *flakyCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	f.mu.Lock()
+	f.commitCalls++
+	if f.failuresLeft > 0 {
+		f.failuresLeft--
+		f.mu.Unlock()
+		return nil, "", f.failErr
+	}
+	f.mu.Unlock()
+	return f.memCatalog.CommitTable(ctx, ident, reqs, updates)
+}
+
+func (f *flakyCatalog) snapshot() *table.Table {
+	return table.New(f.ident, f.meta, f.metadataLocation,
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil }, f)
+}
+
+func (f *flakyCatalog) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.commitCalls
+}
+
+func countParquetFiles(tb testing.TB, dir string) int {
+	tb.Helper()
+	n := 0
+	require.NoError(tb, filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(p, ".parquet") {
+			n++
+		}
+		return nil
+	}))
+	return n
+}
+
+// TestCommitUpgradesFormatVersionV1ToV2 pins the automatic format-version upgrade
+// (committer.commitLocked): a commit against a v1 table transparently upgrades it
+// to v2 (required for row-level deletes), and a subsequent commit succeeds without
+// the once-guarded warning interfering.
+func TestCommitUpgradesFormatVersionV1ToV2(t *testing.T) {
+	ctx := t.Context()
+	tbl, cat := newTestTableV1(t)
+	require.EqualValues(t, 1, tbl.Metadata().Version(), "precondition: table starts at v1")
+
+	c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), service.MockResources().Logger())
+	require.NoError(t, err)
+	defer c.Close()
+
+	df1 := synthDataFile(t, tbl.Spec(), fmt.Sprintf("%s/data/up-%s.parquet", tbl.Location(), uuid.New()))
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df1}, SchemaID: c.currentSchemaID()}))
+	assert.EqualValues(t, 2, cat.snapshot().Metadata().Version(), "table must be upgraded to v2 on first commit")
+
+	// Second commit: the table is already v2, so no upgrade occurs and the
+	// once-guarded warning must not have left the committer in a broken state.
+	df2 := synthDataFile(t, tbl.Spec(), fmt.Sprintf("%s/data/up-%s.parquet", tbl.Location(), uuid.New()))
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df2}, SchemaID: c.currentSchemaID()}))
+	assert.EqualValues(t, 2, cat.snapshot().Metadata().Version())
+}
+
+// TestCommitRetriesOnConflict exercises the retry loop in committer.commitLocked:
+// a commit that fails with rest.ErrCommitFailed is retried (reloading table
+// metadata between attempts) and ultimately succeeds, while exhausting the retry
+// budget surfaces an error naming the attempt count.
+func TestCommitRetriesOnConflict(t *testing.T) {
+	ctx := t.Context()
+	logger := service.MockResources().Logger()
+
+	t.Run("succeeds after retries", func(t *testing.T) {
+		_, plain := newTestTable(t)
+		fc := &flakyCatalog{memCatalog: plain, failuresLeft: 2, failErr: rest.ErrCommitFailed}
+		ftbl := fc.snapshot()
+		c, err := NewCommitter(ftbl, CommitConfig{MaxRetries: 5}, func(context.Context) (*table.Table, error) { return fc.snapshot(), nil }, logger)
+		require.NoError(t, err)
+		defer c.Close()
+
+		df := synthDataFile(t, ftbl.Spec(), fmt.Sprintf("%s/data/retry-%s.parquet", ftbl.Location(), uuid.New()))
+		require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}))
+		// 2 conflict failures + 1 success.
+		assert.Equal(t, 3, fc.calls(), "commit must be retried past the conflicts")
+	})
+
+	t.Run("fails after exhausting retries", func(t *testing.T) {
+		_, plain := newTestTable(t)
+		fc := &flakyCatalog{memCatalog: plain, failuresLeft: 1 << 30, failErr: rest.ErrCommitFailed}
+		ftbl := fc.snapshot()
+		c, err := NewCommitter(ftbl, CommitConfig{MaxRetries: 2}, func(context.Context) (*table.Table, error) { return fc.snapshot(), nil }, logger)
+		require.NoError(t, err)
+		defer c.Close()
+
+		df := synthDataFile(t, ftbl.Spec(), fmt.Sprintf("%s/data/retry-%s.parquet", ftbl.Location(), uuid.New()))
+		err = c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "after 2 attempts")
+		assert.Equal(t, 2, fc.calls(), "must attempt exactly MaxRetries times")
+	})
+}
+
+// TestWriteCleansUpFilesOnCommitFailure pins the best-effort cleanup in
+// writer.Write: when the commit fails, the parquet data files already written to
+// storage are removed rather than left orphaned. A control writer with a healthy
+// committer confirms the write path does produce files, so the absence in the
+// failure case is genuinely due to cleanup and not a vacuous pass.
+func TestWriteCleansUpFilesOnCommitFailure(t *testing.T) {
+	ctx := t.Context()
+	logger := service.MockResources().Logger()
+
+	// Control: a healthy committer leaves the written parquet file in place.
+	t.Run("control writes a file", func(t *testing.T) {
+		tbl, cat := newTestTable(t)
+		c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), logger)
+		require.NoError(t, err)
+		defer c.Close()
+		require.NoError(t, os.MkdirAll(filepath.Join(tbl.Location(), "data"), 0o755))
+		w := &writer{table: tbl, committer: c, caseSensitive: true, logger: logger}
+		require.NoError(t, w.Write(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"id": 1})}))
+		assert.Positive(t, countParquetFiles(t, tbl.Location()), "write path should produce a parquet file")
+	})
+
+	t.Run("failed commit cleans up", func(t *testing.T) {
+		_, plain := newTestTable(t)
+		fc := &flakyCatalog{memCatalog: plain, failuresLeft: 1 << 30, failErr: errors.New("storage unavailable")}
+		ftbl := fc.snapshot()
+		c, err := NewCommitter(ftbl, CommitConfig{MaxRetries: 2}, func(context.Context) (*table.Table, error) { return fc.snapshot(), nil }, logger)
+		require.NoError(t, err)
+		defer c.Close()
+
+		require.NoError(t, os.MkdirAll(filepath.Join(ftbl.Location(), "data"), 0o755))
+		w := &writer{table: ftbl, committer: c, caseSensitive: true, logger: logger}
+		err = w.Write(ctx, service.MessageBatch{structuredMsg(t, map[string]any{"id": 1})})
+		require.Error(t, err)
+		assert.Zero(t, countParquetFiles(t, ftbl.Location()), "the uncommitted parquet file must be cleaned up after a failed commit")
+	})
+}
+
+// BenchmarkCommitterAppend measures the append fast path (no delete files),
+// which existing append-only users hit. It is the baseline for confirming the
+// row-operation work did not regress the commit hot path: the only added cost
+// on this path is one branch and a nil-slice append in doCommit.
+func BenchmarkCommitterAppend(b *testing.B) {
+	ctx := b.Context()
+	logger := service.MockResources().Logger()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tbl, cat := newTestTable(b)
+		c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), logger)
+		require.NoError(b, err)
+		df := synthDataFile(b, tbl.Spec(), fmt.Sprintf("%s/data/bench-%d.parquet", tbl.Location(), i))
+		b.StartTimer()
+
+		if err := c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		c.Close()
+	}
+}
+
+// BenchmarkCommitterRowDelta measures the mutation path (one data file plus one
+// equality-delete file committed via RowDelta). Comparing it against
+// BenchmarkCommitterAppend quantifies the cost of the merge-on-read commit
+// relative to a plain append.
+func BenchmarkCommitterRowDelta(b *testing.B) {
+	ctx := b.Context()
+	logger := service.MockResources().Logger()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tbl, cat := newTestTable(b)
+		w := newDeleteWriter(b, tbl)
+		deleteFiles, err := w.writeEqualityDeletes(ctx, service.MessageBatch{structuredMsg(b, map[string]any{"id": i})})
+		require.NoError(b, err)
+		dataFile := synthDataFile(b, tbl.Spec(), fmt.Sprintf("%s/data/bench-%d.parquet", tbl.Location(), i))
+		c, err := NewCommitter(tbl, CommitConfig{MaxRetries: 1}, reloadFn(cat), logger)
+		require.NoError(b, err)
+		b.StartTimer()
+
+		if err := c.Commit(ctx, CommitInput{
+			Files:       []iceberg.DataFile{dataFile},
+			DeleteFiles: deleteFiles,
+			SchemaID:    c.currentSchemaID(),
+		}); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		c.Close()
+	}
+}

--- a/internal/impl/iceberg/row_operation_test.go
+++ b/internal/impl/iceberg/row_operation_test.go
@@ -1,0 +1,520 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestParseRowOperation(t *testing.T) {
+	for _, in := range []string{"insert", "upsert", "delete"} {
+		op, err := parseRowOperation(in)
+		require.NoError(t, err)
+		assert.Equal(t, rowOperation(in), op)
+	}
+	for _, in := range []string{"", "index", "c", "INSERT", "create"} {
+		_, err := parseRowOperation(in)
+		assert.Error(t, err, "expected %q to be rejected", in)
+	}
+}
+
+func mustInterp(t testing.TB, expr string) *service.InterpolatedString {
+	t.Helper()
+	i, err := service.NewInterpolatedString(expr)
+	require.NoError(t, err)
+	return i
+}
+
+func TestRowOpConfigMutating(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  RowOpConfig
+		want bool
+	}{
+		{"nil operation", RowOpConfig{}, false},
+		{"static insert", RowOpConfig{Operation: mustInterp(t, "insert")}, false},
+		{"static empty", RowOpConfig{Operation: mustInterp(t, "")}, false},
+		{"static upsert", RowOpConfig{Operation: mustInterp(t, "upsert")}, true},
+		{"static delete", RowOpConfig{Operation: mustInterp(t, "delete")}, true},
+		{"dynamic", RowOpConfig{Operation: mustInterp(t, `${! json("op") }`)}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.mutating())
+		})
+	}
+}
+
+func parseTestRowOpConfig(t *testing.T, snippet string) (RowOpConfig, error) {
+	t.Helper()
+	yaml := `
+catalog:
+  url: http://localhost:8181/api/catalog
+namespace: ns
+table: t
+storage:
+  aws_s3:
+    bucket: bucket
+` + snippet
+	conf, err := icebergOutputConfig().ParseYAML(yaml, nil)
+	require.NoError(t, err, "config should pass spec validation")
+	return parseRowOpConfig(conf)
+}
+
+func TestParseRowOpConfigValidation(t *testing.T) {
+	t.Run("default is insert and non-mutating", func(t *testing.T) {
+		cfg, err := parseTestRowOpConfig(t, "")
+		require.NoError(t, err)
+		static, ok := cfg.Operation.Static()
+		require.True(t, ok)
+		assert.Equal(t, "insert", static)
+		assert.False(t, cfg.mutating())
+		assert.Empty(t, cfg.IdentifierFields)
+	})
+
+	t.Run("static upsert without identifier_fields errors", func(t *testing.T) {
+		_, err := parseTestRowOpConfig(t, "row_operation: upsert\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ioFieldIdentifierFields)
+	})
+
+	t.Run("static delete with identifier_fields ok", func(t *testing.T) {
+		cfg, err := parseTestRowOpConfig(t, "row_operation: delete\nidentifier_fields: [id]\n")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"id"}, cfg.IdentifierFields)
+		assert.True(t, cfg.mutating())
+	})
+
+	t.Run("static unknown value errors", func(t *testing.T) {
+		_, err := parseTestRowOpConfig(t, "row_operation: frobnicate\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ioFieldRowOperation)
+	})
+
+	t.Run("dynamic operation defers validation to runtime", func(t *testing.T) {
+		// No identifier_fields, but the operation is interpolated so it cannot be
+		// validated at parse time — must not error here.
+		cfg, err := parseTestRowOpConfig(t, "row_operation: '${! json(\"op\") }'\n")
+		require.NoError(t, err)
+		_, ok := cfg.Operation.Static()
+		assert.False(t, ok)
+	})
+}
+
+func structuredMsg(t testing.TB, v map[string]any) *service.Message {
+	t.Helper()
+	msg := service.NewMessage(nil)
+	msg.SetStructuredMut(v)
+	return msg
+}
+
+func TestSplitByOperation(t *testing.T) {
+	w := &writer{
+		caseSensitive: true,
+		rowOpCfg: RowOpConfig{
+			Operation:        mustInterp(t, `${! json("op") }`),
+			IdentifierFields: []string{"id"},
+		},
+	}
+
+	batch := service.MessageBatch{
+		structuredMsg(t, map[string]any{"op": "insert", "id": 1}),
+		structuredMsg(t, map[string]any{"op": "upsert", "id": 2}),
+		structuredMsg(t, map[string]any{"op": "delete", "id": 3}),
+		structuredMsg(t, map[string]any{"op": "", "id": 4}), // empty defaults to insert
+	}
+
+	inserts, deletes, err := w.splitByOperation(batch)
+	require.NoError(t, err)
+	// insert(1) + upsert(2) + default-insert(4) => 3 inserts; upsert(2) + delete(3) => 2 deletes.
+	assert.Len(t, inserts, 3)
+	assert.Len(t, deletes, 2)
+}
+
+func TestSplitByOperationUnknownValueErrors(t *testing.T) {
+	w := &writer{
+		caseSensitive: true,
+		rowOpCfg: RowOpConfig{
+			Operation:        mustInterp(t, `${! json("op") }`),
+			IdentifierFields: []string{"id"},
+		},
+	}
+	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "c", "id": 1})}
+	_, _, err := w.splitByOperation(batch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "c")
+}
+
+func TestSplitByOperationCollapsesPerKey(t *testing.T) {
+	w := &writer{
+		caseSensitive: true,
+		rowOpCfg: RowOpConfig{
+			Operation:        mustInterp(t, `${! json("op") }`),
+			IdentifierFields: []string{"id"},
+		},
+	}
+	batch := service.MessageBatch{
+		structuredMsg(t, map[string]any{"op": "upsert", "id": 1, "v": "a"}),
+		structuredMsg(t, map[string]any{"op": "upsert", "id": 1, "v": "b"}), // same key, later wins
+		structuredMsg(t, map[string]any{"op": "insert", "id": 9, "v": "x"}), // non-keyed append
+		structuredMsg(t, map[string]any{"op": "upsert", "id": 2, "v": "c"}),
+		structuredMsg(t, map[string]any{"op": "delete", "id": 2}), // upsert-then-delete same key: delete wins
+	}
+
+	inserts, deletes, err := w.splitByOperation(batch)
+	require.NoError(t, err)
+
+	// One equality delete per keyed key {1, 2}.
+	require.Len(t, deletes, 2)
+
+	// Data rows: the insert (id=9) and the surviving upsert for key 1 (v="b").
+	// Key 2's final op is delete, so it contributes no data row.
+	got := map[int]string{}
+	for _, m := range inserts {
+		s, err := m.AsStructured()
+		require.NoError(t, err)
+		row := s.(map[string]any)
+		got[row["id"].(int)] = row["v"].(string)
+	}
+	assert.Equal(t, map[int]string{1: "b", 9: "x"}, got)
+}
+
+func TestSplitByOperationMissingKeyErrors(t *testing.T) {
+	w := &writer{
+		caseSensitive: true,
+		rowOpCfg: RowOpConfig{
+			Operation:        mustInterp(t, `${! json("op") }`),
+			IdentifierFields: []string{"id"},
+		},
+	}
+	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "upsert", "other": 1})}
+	_, _, err := w.splitByOperation(batch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing or null")
+}
+
+func TestSplitByOperationUpsertRequiresIdentifierFields(t *testing.T) {
+	w := &writer{
+		caseSensitive: true,
+		rowOpCfg: RowOpConfig{
+			Operation: mustInterp(t, `${! json("op") }`), // dynamic, so reaches the split
+		},
+	}
+	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "upsert", "id": 1})}
+	_, _, err := w.splitByOperation(batch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ioFieldIdentifierFields)
+}
+
+func TestDeleteKeyJSONValue(t *testing.T) {
+	// int64 beyond float64 precision must survive as an exact string.
+	v, err := deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, int64(9007199254740993))
+	require.NoError(t, err)
+	assert.Equal(t, "9007199254740993", v)
+
+	// decimal is emitted as a string to avoid float rounding.
+	v, err = deleteKeyJSONValue(iceberg.DecimalTypeOf(10, 2), 123.45)
+	require.NoError(t, err)
+	assert.Equal(t, "123.45", v)
+
+	// time.Time into a timestamp column becomes RFC3339.
+	tm := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Timestamp, tm)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-24T12:00:00Z", v)
+
+	// strings and other primitives pass through unchanged.
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.String, "abc")
+	require.NoError(t, err)
+	assert.Equal(t, "abc", v)
+
+	// a non-integer value into an integer column is a hard error.
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, 1.5)
+	require.Error(t, err)
+
+	// a bare numeric value into a temporal column is a hard error: its unit is
+	// ambiguous and would silently mismatch the data written by the insert path.
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Timestamp, int64(1700000000000))
+	require.Error(t, err)
+
+	// timestamptz formats identically to timestamp, normalised to UTC.
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.TimestampTz, tm)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-24T12:00:00Z", v)
+
+	// a date column keeps only the calendar date (UTC), dropping any time-of-day.
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Date, time.Date(2026, 6, 24, 18, 30, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-24", v)
+
+	// a time column keeps only the wall-clock time (UTC), to nanosecond precision.
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Time, time.Date(1970, 1, 1, 15, 4, 5, 123456789, time.UTC))
+	require.NoError(t, err)
+	assert.Equal(t, "15:04:05.123456789", v)
+
+	// bare numbers into date/time columns are rejected for the same ambiguity reason.
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Date, int64(20000))
+	require.Error(t, err)
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Time, int64(54_000_000_000))
+	require.Error(t, err)
+}
+
+func TestDeleteRecordFieldsAcceptsPrimitivesRejectsNested(t *testing.T) {
+	sc := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp, Required: true},
+		iceberg.NestedField{ID: 2, Name: "uid", Type: iceberg.PrimitiveTypes.UUID, Required: true},
+		iceberg.NestedField{ID: 3, Name: "amt", Type: iceberg.DecimalTypeOf(10, 2), Required: true},
+		iceberg.NestedField{ID: 4, Name: "tags", Type: &iceberg.ListType{ElementID: 5, Element: iceberg.PrimitiveTypes.String, ElementRequired: false}, Required: false},
+	)
+	unpartitioned := iceberg.UnpartitionedSpec
+
+	// Previously-gated primitive types are now accepted as delete keys.
+	for _, name := range []string{"ts", "uid", "amt"} {
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{name}}}
+		_, _, err := w.deleteRecordFields(sc, unpartitioned)
+		require.NoErrorf(t, err, "%s should be accepted as a delete key", name)
+	}
+
+	// A non-primitive (list) column is rejected — a fundamental Iceberg constraint.
+	w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"tags"}}}
+	_, _, err := w.deleteRecordFields(sc, unpartitioned)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-primitive")
+}
+
+func eqDelTestSchema() *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "region", Type: iceberg.PrimitiveTypes.String},
+		iceberg.NestedField{ID: 3, Name: "ts", Type: iceberg.PrimitiveTypes.Timestamp},
+	)
+}
+
+func identitySpec(name string, sourceID, fieldID int) iceberg.PartitionSpec {
+	return iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{sourceID}, FieldID: fieldID, Name: name, Transform: iceberg.IdentityTransform{},
+	})
+}
+
+func TestDeleteRecordFields(t *testing.T) {
+	sc := eqDelTestSchema()
+	unpartitioned := iceberg.UnpartitionedSpec
+
+	t.Run("unpartitioned identifier only", func(t *testing.T) {
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"id"}}}
+		fields, eq, err := w.deleteRecordFields(sc, unpartitioned)
+		require.NoError(t, err)
+		require.Len(t, fields, 1)
+		assert.Equal(t, "id", fields[0].Name)
+		assert.Equal(t, []int{1}, eq)
+	})
+
+	t.Run("partition source outside identifier_fields is rejected", func(t *testing.T) {
+		// Partitioned by region (field 2) but identifier is only id (field 1):
+		// region can change between insert and delete, so deletes would miss.
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"id"}}}
+		spec := identitySpec("region", 2, 1000)
+		_, _, err := w.deleteRecordFields(sc, &spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ioFieldIdentifierFields)
+	})
+
+	t.Run("partition source that is an identifier field is allowed", func(t *testing.T) {
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"id"}}}
+		spec := identitySpec("id_part", 1, 1000) // partition derived from the id key
+		fields, eq, err := w.deleteRecordFields(sc, &spec)
+		require.NoError(t, err)
+		require.Len(t, fields, 1)
+		assert.Equal(t, []int{1}, eq)
+	})
+
+	t.Run("floating-point identifier is rejected", func(t *testing.T) {
+		floatSc := iceberg.NewSchema(0,
+			iceberg.NestedField{ID: 1, Name: "score", Type: iceberg.PrimitiveTypes.Float64, Required: true},
+		)
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"score"}}}
+		_, _, err := w.deleteRecordFields(floatSc, unpartitioned)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "floating-point")
+	})
+
+	t.Run("missing identifier column errors", func(t *testing.T) {
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"nope"}}}
+		_, _, err := w.deleteRecordFields(sc, unpartitioned)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("case-insensitive resolves, case-sensitive does not", func(t *testing.T) {
+		wCI := &writer{caseSensitive: false, rowOpCfg: RowOpConfig{IdentifierFields: []string{"ID"}}}
+		fields, _, err := wCI.deleteRecordFields(sc, unpartitioned)
+		require.NoError(t, err)
+		require.Len(t, fields, 1)
+		assert.Equal(t, "id", fields[0].Name)
+
+		wCS := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"ID"}}}
+		_, _, err = wCS.deleteRecordFields(sc, unpartitioned)
+		require.Error(t, err)
+	})
+
+	t.Run("multiple identifier fields preserve order", func(t *testing.T) {
+		w := &writer{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"region", "id"}}}
+		fields, eq, err := w.deleteRecordFields(sc, unpartitioned)
+		require.NoError(t, err)
+		require.Len(t, fields, 2)
+		assert.Equal(t, "region", fields[0].Name)
+		assert.Equal(t, "id", fields[1].Name)
+		assert.Equal(t, []int{2, 1}, eq)
+	})
+}
+
+func TestLookupField(t *testing.T) {
+	row := map[string]any{"ID": 7, "name": "x"}
+
+	v, ok := lookupField(row, "ID", true)
+	assert.True(t, ok)
+	assert.Equal(t, 7, v)
+
+	_, ok = lookupField(row, "id", true)
+	assert.False(t, ok, "case-sensitive lookup should not match different case")
+
+	v, ok = lookupField(row, "id", false)
+	assert.True(t, ok, "case-insensitive lookup should match")
+	assert.Equal(t, 7, v)
+
+	_, ok = lookupField(row, "missing", false)
+	assert.False(t, ok)
+}
+
+func TestSchemaWithIdentifierFields(t *testing.T) {
+	strField := func(id int, name string) iceberg.NestedField {
+		return iceberg.NestedField{ID: id, Name: name, Type: iceberg.PrimitiveTypes.String, Required: false}
+	}
+
+	t.Run("no identifier fields leaves schema unchanged", func(t *testing.T) {
+		r := &Router{caseSensitive: true}
+		sc, err := r.schemaWithIdentifierFields([]iceberg.NestedField{strField(1, "id"), strField(2, "v")})
+		require.NoError(t, err)
+		assert.Empty(t, sc.IdentifierFieldIDs)
+		f, ok := sc.FindFieldByName("id")
+		require.True(t, ok)
+		assert.False(t, f.Required, "columns stay optional when no identifier is configured")
+	})
+
+	t.Run("marks identifier required and registers its id", func(t *testing.T) {
+		r := &Router{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"id"}}}
+		sc, err := r.schemaWithIdentifierFields([]iceberg.NestedField{strField(1, "id"), strField(2, "v")})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1}, sc.IdentifierFieldIDs)
+		id, ok := sc.FindFieldByName("id")
+		require.True(t, ok)
+		assert.True(t, id.Required, "identifier column must be required")
+		v, ok := sc.FindFieldByName("v")
+		require.True(t, ok)
+		assert.False(t, v.Required, "non-identifier columns stay optional")
+	})
+
+	t.Run("composite keys register every id", func(t *testing.T) {
+		r := &Router{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"tenant", "id"}}}
+		sc, err := r.schemaWithIdentifierFields([]iceberg.NestedField{strField(1, "tenant"), strField(2, "id"), strField(3, "v")})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []int{1, 2}, sc.IdentifierFieldIDs)
+	})
+
+	t.Run("absent identifier column is a hard error", func(t *testing.T) {
+		r := &Router{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"missing"}}}
+		_, err := r.schemaWithIdentifierFields([]iceberg.NestedField{strField(1, "id")})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not present in the table being created")
+	})
+
+	t.Run("non-primitive identifier is rejected", func(t *testing.T) {
+		structType := &iceberg.StructType{FieldList: []iceberg.NestedField{strField(2, "inner")}}
+		r := &Router{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"obj"}}}
+		_, err := r.schemaWithIdentifierFields([]iceberg.NestedField{{ID: 1, Name: "obj", Type: structType}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-primitive")
+	})
+
+	t.Run("floating-point identifier is rejected", func(t *testing.T) {
+		r := &Router{caseSensitive: true, rowOpCfg: RowOpConfig{IdentifierFields: []string{"amt"}}}
+		_, err := r.schemaWithIdentifierFields([]iceberg.NestedField{{ID: 1, Name: "amt", Type: iceberg.PrimitiveTypes.Float64}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "floating-point")
+	})
+
+	t.Run("case-insensitive identifier match", func(t *testing.T) {
+		r := &Router{caseSensitive: false, rowOpCfg: RowOpConfig{IdentifierFields: []string{"ID"}}}
+		sc, err := r.schemaWithIdentifierFields([]iceberg.NestedField{strField(1, "id")})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1}, sc.IdentifierFieldIDs)
+		f, ok := sc.FindFieldByName("id")
+		require.True(t, ok)
+		assert.True(t, f.Required)
+	})
+}
+
+// TestMaxInFlightOrderingLint pins the cross-field lint rule that protects keyed
+// (upsert/delete) workloads from out-of-order commits: a non-insert row_operation
+// combined with max_in_flight > 1 must produce a lint error, while append-only
+// configs and max_in_flight: 1 must not.
+func TestMaxInFlightOrderingLint(t *testing.T) {
+	linter := service.GlobalEnvironment().NewComponentConfigLinter()
+	base := func(extra string) string {
+		return `
+iceberg:
+  catalog:
+    url: http://localhost:8181/api/catalog
+  namespace: ns
+  table: t
+  storage:
+    aws_s3:
+      bucket: b
+` + extra
+	}
+
+	cases := []struct {
+		name     string
+		extra    string
+		wantLint bool
+	}{
+		{"append-only default", "", false},
+		{"static insert with high in-flight", "  row_operation: insert\n  max_in_flight: 8\n", false},
+		{"static upsert at default in-flight", "  row_operation: upsert\n  identifier_fields: [id]\n", true},
+		{"static upsert with in-flight 1", "  row_operation: upsert\n  identifier_fields: [id]\n  max_in_flight: 1\n", false},
+		{"dynamic operation at default in-flight", "  row_operation: '${! metadata(\"op\") }'\n  identifier_fields: [id]\n", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lints, err := linter.LintOutputYAML([]byte(base(tc.extra)))
+			require.NoError(t, err)
+
+			var ordering []string
+			for _, l := range lints {
+				if strings.Contains(l.Error(), "max_in_flight") {
+					ordering = append(ordering, l.Error())
+				}
+			}
+			if tc.wantLint {
+				assert.NotEmpty(t, ordering, "expected a max_in_flight ordering lint, got lints: %v", lints)
+			} else {
+				assert.Empty(t, ordering, "expected no ordering lint")
+			}
+		})
+	}
+}

--- a/internal/impl/iceberg/row_operation_test.go
+++ b/internal/impl/iceberg/row_operation_test.go
@@ -138,11 +138,12 @@ func TestSplitByOperation(t *testing.T) {
 		structuredMsg(t, map[string]any{"op": "", "id": 4}), // empty defaults to insert
 	}
 
-	inserts, deletes, err := w.splitByOperation(batch)
+	inserts, deletes, counts, err := w.splitByOperation(batch)
 	require.NoError(t, err)
 	// insert(1) + upsert(2) + default-insert(4) => 3 inserts; upsert(2) + delete(3) => 2 deletes.
 	assert.Len(t, inserts, 3)
 	assert.Len(t, deletes, 2)
+	assert.Equal(t, opCounts{inserted: 2, upserted: 1, deleted: 1}, counts)
 }
 
 func TestSplitByOperationUnknownValueErrors(t *testing.T) {
@@ -154,7 +155,7 @@ func TestSplitByOperationUnknownValueErrors(t *testing.T) {
 		},
 	}
 	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "c", "id": 1})}
-	_, _, err := w.splitByOperation(batch)
+	_, _, _, err := w.splitByOperation(batch)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "c")
 }
@@ -175,11 +176,15 @@ func TestSplitByOperationCollapsesPerKey(t *testing.T) {
 		structuredMsg(t, map[string]any{"op": "delete", "id": 2}), // upsert-then-delete same key: delete wins
 	}
 
-	inserts, deletes, err := w.splitByOperation(batch)
+	inserts, deletes, counts, err := w.splitByOperation(batch)
 	require.NoError(t, err)
 
 	// One equality delete per keyed key {1, 2}.
 	require.Len(t, deletes, 2)
+
+	// Counts are post-collapse: the two upserts to key 1 count as one upsert
+	// (not two), key 2 collapses to a single delete, and id=9 is one insert.
+	assert.Equal(t, opCounts{inserted: 1, upserted: 1, deleted: 1}, counts)
 
 	// Data rows: the insert (id=9) and the surviving upsert for key 1 (v="b").
 	// Key 2's final op is delete, so it contributes no data row.
@@ -202,7 +207,7 @@ func TestSplitByOperationMissingKeyErrors(t *testing.T) {
 		},
 	}
 	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "upsert", "other": 1})}
-	_, _, err := w.splitByOperation(batch)
+	_, _, _, err := w.splitByOperation(batch)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing or null")
 }
@@ -215,7 +220,7 @@ func TestSplitByOperationUpsertRequiresIdentifierFields(t *testing.T) {
 		},
 	}
 	batch := service.MessageBatch{structuredMsg(t, map[string]any{"op": "upsert", "id": 1})}
-	_, _, err := w.splitByOperation(batch)
+	_, _, _, err := w.splitByOperation(batch)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ioFieldIdentifierFields)
 }
@@ -244,6 +249,18 @@ func TestDeleteKeyJSONValue(t *testing.T) {
 
 	// a non-integer value into an integer column is a hard error.
 	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, 1.5)
+	require.Error(t, err)
+
+	// an integer-valued float64 within float64's exact-integer range is fine.
+	v, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, float64(1_000_000_000_000_000))
+	require.NoError(t, err)
+	assert.Equal(t, "1000000000000000", v)
+
+	// a float64 at/beyond 2^53 cannot be represented exactly as an integer, so
+	// int64(n) would silently corrupt or overflow the delete key — reject it.
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, float64(uint64(1)<<53))
+	require.Error(t, err)
+	_, err = deleteKeyJSONValue(iceberg.PrimitiveTypes.Int64, 9.3e18) // > 2^63, would overflow int64
 	require.Error(t, err)
 
 	// a bare numeric value into a temporal column is a hard error: its unit is

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -140,32 +140,35 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 	if !w.rowOpCfg.mutating() {
 		files, err := w.writeDataFiles(ctx, batch)
 		if err != nil {
-			return err
+			return fmt.Errorf("writing data files: %w", err)
 		}
 		if err := w.committer.Commit(ctx, CommitInput{Files: files, SchemaID: w.table.Schema().ID}); err != nil {
 			w.cleanupFiles(ctx, files)
 			return fmt.Errorf("committing: %w", err)
 		}
+		// Metrics reflect successfully committed rows, so they are incremented
+		// only after the commit succeeds.
+		w.metrics.incrInserted(int64(len(batch)))
 		return nil
 	}
 
 	// Row-level mutations: split the batch by operation, write inserted rows as
 	// data files and deleted/upserted keys as equality-delete files, then commit
 	// them together so a single snapshot reflects the whole batch.
-	inserts, deletes, err := w.splitByOperation(batch)
+	inserts, deletes, counts, err := w.splitByOperation(batch)
 	if err != nil {
-		return err
+		return fmt.Errorf("splitting batch by row operation: %w", err)
 	}
 
 	var files, deleteFiles []iceberg.DataFile
 	if len(inserts) > 0 {
 		if files, err = w.writeDataFiles(ctx, inserts); err != nil {
-			return err
+			return fmt.Errorf("writing data files: %w", err)
 		}
 	}
 	if len(deletes) > 0 {
 		if deleteFiles, err = w.writeEqualityDeletes(ctx, deletes); err != nil {
-			return err
+			return fmt.Errorf("writing equality deletes: %w", err)
 		}
 	}
 	if len(files) == 0 && len(deleteFiles) == 0 {
@@ -175,6 +178,10 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 		w.cleanupFiles(ctx, files, deleteFiles)
 		return fmt.Errorf("committing: %w", err)
 	}
+	// Increment only after the commit succeeds, using the post-collapse counts.
+	w.metrics.incrInserted(counts.inserted)
+	w.metrics.incrUpserted(counts.upserted)
+	w.metrics.incrDeleted(counts.deleted)
 	return nil
 }
 
@@ -185,6 +192,7 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 func (w *writer) cleanupFiles(ctx context.Context, groups ...[]iceberg.DataFile) {
 	fs, err := w.table.FS(ctx)
 	if err != nil {
+		w.logger.Debugf("Skipping cleanup of uncommitted files: could not obtain table filesystem: %v", err)
 		return
 	}
 	for _, group := range groups {
@@ -303,7 +311,7 @@ func (w *writer) writeDataFiles(ctx context.Context, batch service.MessageBatch)
 // and is deliberately not keyed; mixing it with upsert/delete on the same key
 // within one batch is not de-duplicated (map create events to `upsert`, not
 // `insert`, for keyed data).
-func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBatch, service.MessageBatch, error) {
+func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBatch, service.MessageBatch, opCounts, error) {
 	var inserts service.MessageBatch
 
 	type keyedOp struct {
@@ -313,35 +321,30 @@ func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBa
 	order := make([]string, 0, len(batch))
 	latest := make(map[string]keyedOp, len(batch))
 
-	var nInsert, nUpsert, nDelete int64
+	var nInsert int64
 	for i, msg := range batch {
 		opStr, err := w.rowOpCfg.Operation.TryString(msg)
 		if err != nil {
-			return nil, nil, fmt.Errorf("evaluating %s for message %d: %w", ioFieldRowOperation, i, err)
+			return nil, nil, opCounts{}, fmt.Errorf("evaluating %s for message %d: %w", ioFieldRowOperation, i, err)
 		}
 		if opStr == "" {
 			opStr = string(rowOpInsert)
 		}
 		op, err := parseRowOperation(opStr)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, opCounts{}, err
 		}
 		if op == rowOpInsert {
 			nInsert++
 			inserts = append(inserts, msg)
 			continue
 		}
-		if op == rowOpUpsert {
-			nUpsert++
-		} else {
-			nDelete++
-		}
 		if len(w.rowOpCfg.IdentifierFields) == 0 {
-			return nil, nil, fmt.Errorf("%s %q requires %s to be set", ioFieldRowOperation, op, ioFieldIdentifierFields)
+			return nil, nil, opCounts{}, fmt.Errorf("%s %q requires %s to be set", ioFieldRowOperation, op, ioFieldIdentifierFields)
 		}
 		key, err := w.dedupKey(msg)
 		if err != nil {
-			return nil, nil, fmt.Errorf("message %d: %w", i, err)
+			return nil, nil, opCounts{}, fmt.Errorf("message %d: %w", i, err)
 		}
 		if _, seen := latest[key]; !seen {
 			order = append(order, key)
@@ -349,7 +352,11 @@ func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBa
 		latest[key] = keyedOp{op: op, msg: msg}
 	}
 
+	// Count upsert/delete after collapsing per key, so the metrics reflect the
+	// operations actually committed (one per identifier key) rather than every
+	// message in the batch.
 	deletes := make(service.MessageBatch, 0, len(order))
+	var nUpsert, nDelete int64
 	for _, key := range order {
 		ko := latest[key]
 		// Every keyed operation removes any prior version of the row.
@@ -357,15 +364,22 @@ func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBa
 		// An upsert also (re)writes the row; a delete does not.
 		if ko.op == rowOpUpsert {
 			inserts = append(inserts, ko.msg)
+			nUpsert++
+		} else {
+			nDelete++
 		}
 	}
 
-	if w.metrics != nil {
-		w.metrics.inserted.Incr(nInsert)
-		w.metrics.upserted.Incr(nUpsert)
-		w.metrics.deleted.Incr(nDelete)
-	}
-	return inserts, deletes, nil
+	return inserts, deletes, opCounts{inserted: nInsert, upserted: nUpsert, deleted: nDelete}, nil
+}
+
+// opCounts is the per-operation tally for a batch, counted after per-key
+// collapse so it matches what is committed. Metrics are incremented from it
+// only once the commit succeeds.
+type opCounts struct {
+	inserted int64
+	upserted int64
+	deleted  int64
 }
 
 // dedupKey builds a stable identity string from a message's identifier_fields
@@ -417,6 +431,13 @@ func deleteKeyJSONValue(t iceberg.Type, v any) (any, error) {
 		case float64:
 			if n != math.Trunc(n) {
 				return nil, fmt.Errorf("integer column given non-integer value %v", n)
+			}
+			// A float64 only represents integers exactly up to 2^53; beyond that
+			// int64(n) loses precision or overflows, silently producing a wrong
+			// delete key. Reject rather than corrupt — pass large integers as an
+			// int64/json.Number/string instead.
+			if math.Abs(n) >= 1<<53 {
+				return nil, fmt.Errorf("integer column given value %v outside the range representable exactly as a float64 (provide it as an integer or string)", n)
 			}
 			return strconv.FormatInt(int64(n), 10), nil
 		case string:
@@ -474,9 +495,11 @@ func deleteKeyJSONValue(t iceberg.Type, v any) (any, error) {
 // a partition source appears once). Every contributing column must be a
 // primitive type (a fundamental Iceberg constraint on identifier fields).
 func (w *writer) deleteRecordFields(tableSchema *iceberg.Schema, spec *iceberg.PartitionSpec) ([]iceberg.NestedField, []int, error) {
-	seen := map[int]struct{}{}
-	var fields []iceberg.NestedField
-	eqFieldIDs := make([]int, 0, len(w.rowOpCfg.IdentifierFields))
+	var (
+		fields     []iceberg.NestedField
+		seen       = map[int]struct{}{}
+		eqFieldIDs = make([]int, 0, len(w.rowOpCfg.IdentifierFields))
+	)
 
 	for _, name := range w.rowOpCfg.IdentifierFields {
 		field, ok := tableSchema.FindFieldByName(name)

--- a/internal/impl/iceberg/writer.go
+++ b/internal/impl/iceberg/writer.go
@@ -11,12 +11,19 @@ package iceberg
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"path"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/iceberg-go"
 	icebergio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
@@ -30,6 +37,55 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/shredder"
 )
 
+// rowOperation is the row-level mutation applied to a message when written to
+// the table. It is deliberately distinct from Iceberg's snapshot-level
+// operation (append/replace/overwrite/delete).
+type rowOperation string
+
+const (
+	rowOpInsert rowOperation = "insert"
+	rowOpUpsert rowOperation = "upsert"
+	rowOpDelete rowOperation = "delete"
+)
+
+// parseRowOperation validates s against the supported row operations. Unknown
+// values are a hard error rather than a silent fallback to insert, so that a
+// misconfigured mapping (e.g. an unmapped Debezium "c"/"u"/"d") fails loudly
+// instead of silently appending duplicates.
+func parseRowOperation(s string) (rowOperation, error) {
+	switch op := rowOperation(s); op {
+	case rowOpInsert, rowOpUpsert, rowOpDelete:
+		return op, nil
+	default:
+		return "", fmt.Errorf("invalid %s %q: must be one of %q, %q, or %q", ioFieldRowOperation, s, rowOpInsert, rowOpUpsert, rowOpDelete)
+	}
+}
+
+// RowOpConfig configures per-message row-level operations.
+type RowOpConfig struct {
+	// Operation resolves per message to insert, upsert, or delete. When it
+	// resolves to the empty string the default (insert) is assumed.
+	Operation *service.InterpolatedString
+	// IdentifierFields are the table column names forming the equality-delete
+	// key (the Iceberg identifier fields) used by upsert and delete. Empty for
+	// append-only (insert) workloads.
+	IdentifierFields []string
+}
+
+// mutating reports whether the configuration can ever produce a non-insert
+// operation. A purely static insert (or unset) configuration takes the
+// untouched append-only fast path.
+func (c RowOpConfig) mutating() bool {
+	if c.Operation == nil {
+		return false
+	}
+	if static, ok := c.Operation.Static(); ok {
+		return static != "" && rowOperation(static) != rowOpInsert
+	}
+	// Dynamic: assume it may resolve to a mutation.
+	return true
+}
+
 // writer handles writing batches of messages to a single Iceberg table.
 type writer struct {
 	table                 *table.Table
@@ -38,6 +94,8 @@ type writer struct {
 	writerOpts            []parquet.WriterOption
 	resolver              *typeResolver
 	requireSchemaMetadata bool
+	rowOpCfg              RowOpConfig
+	metrics               *opMetrics
 	logger                *service.Logger
 
 	// coerceLoggedFieldIDs tracks the iceberg field IDs we have already
@@ -56,7 +114,7 @@ type writer struct {
 // to interpret numeric inputs into time-typed columns; pass nil to disable.
 // requireSchemaMetadata enables shredder strict mode — see
 // [shredder.RecordShredder.StrictTemporalMode].
-func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, requireSchemaMetadata bool, logger *service.Logger) *writer {
+func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts []parquet.WriterOption, resolver *typeResolver, requireSchemaMetadata bool, rowOpCfg RowOpConfig, logger *service.Logger) *writer {
 	return &writer{
 		table:                 tbl,
 		committer:             comm,
@@ -64,6 +122,7 @@ func NewWriter(tbl *table.Table, comm *committer, caseSensitive bool, writerOpts
 		writerOpts:            writerOpts,
 		resolver:              resolver,
 		requireSchemaMetadata: requireSchemaMetadata,
+		rowOpCfg:              rowOpCfg,
 		logger:                logger,
 		coerceLoggedFieldIDs:  map[int]struct{}{},
 	}
@@ -75,39 +134,102 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 		return nil
 	}
 
+	// Append-only fast path: when the configuration can never produce a
+	// non-insert operation, write the whole batch as data files exactly as
+	// before, with no per-message operation evaluation.
+	if !w.rowOpCfg.mutating() {
+		files, err := w.writeDataFiles(ctx, batch)
+		if err != nil {
+			return err
+		}
+		if err := w.committer.Commit(ctx, CommitInput{Files: files, SchemaID: w.table.Schema().ID}); err != nil {
+			w.cleanupFiles(ctx, files)
+			return fmt.Errorf("committing: %w", err)
+		}
+		return nil
+	}
+
+	// Row-level mutations: split the batch by operation, write inserted rows as
+	// data files and deleted/upserted keys as equality-delete files, then commit
+	// them together so a single snapshot reflects the whole batch.
+	inserts, deletes, err := w.splitByOperation(batch)
+	if err != nil {
+		return err
+	}
+
+	var files, deleteFiles []iceberg.DataFile
+	if len(inserts) > 0 {
+		if files, err = w.writeDataFiles(ctx, inserts); err != nil {
+			return err
+		}
+	}
+	if len(deletes) > 0 {
+		if deleteFiles, err = w.writeEqualityDeletes(ctx, deletes); err != nil {
+			return err
+		}
+	}
+	if len(files) == 0 && len(deleteFiles) == 0 {
+		return nil
+	}
+	if err := w.committer.Commit(ctx, CommitInput{Files: files, DeleteFiles: deleteFiles, SchemaID: w.table.Schema().ID}); err != nil {
+		w.cleanupFiles(ctx, files, deleteFiles)
+		return fmt.Errorf("committing: %w", err)
+	}
+	return nil
+}
+
+// cleanupFiles best-effort removes written-but-uncommitted parquet files after a
+// failed commit, to limit orphaned objects in storage. Failures are logged at
+// debug and otherwise ignored (table maintenance / remove_orphan_files remains
+// the backstop).
+func (w *writer) cleanupFiles(ctx context.Context, groups ...[]iceberg.DataFile) {
+	fs, err := w.table.FS(ctx)
+	if err != nil {
+		return
+	}
+	for _, group := range groups {
+		for _, f := range group {
+			if rmErr := fs.Remove(f.FilePath()); rmErr != nil {
+				w.logger.Debugf("Failed to clean up uncommitted file %q: %v", f.FilePath(), rmErr)
+			}
+		}
+	}
+}
+
+// writeDataFiles shreds a batch into parquet data files, writes them to table
+// storage and returns the resulting iceberg data files (uncommitted).
+func (w *writer) writeDataFiles(ctx context.Context, batch service.MessageBatch) ([]iceberg.DataFile, error) {
 	// Convert messages to parquet (grouped by partition)
 	parquetFiles, err := w.messagesToParquet(batch)
 	if err != nil {
-		return fmt.Errorf("converting messages to parquet: %w", err)
+		return nil, fmt.Errorf("converting messages to parquet: %w", err)
 	}
 
 	// Get location provider for the table
 	locProvider, err := w.table.LocationProvider()
 	if err != nil {
-		return fmt.Errorf("getting location provider: %w", err)
+		return nil, fmt.Errorf("getting location provider: %w", err)
 	}
 
 	// Write file using table's IO
 	tableIO, err := w.table.FS(ctx)
 	if err != nil {
-		return fmt.Errorf("getting table IO: %w", err)
+		return nil, fmt.Errorf("getting table IO: %w", err)
 	}
 	writeIO, ok := tableIO.(icebergio.WriteFileIO)
 	if !ok {
-		return fmt.Errorf("table IO does not support writing (got %T)", tableIO)
+		return nil, fmt.Errorf("table IO does not support writing (got %T)", tableIO)
 	}
-
-	schemaID := w.table.Schema().ID
 
 	// Build field ID mappings for stats extraction and partition data
 	_, fieldToCol, err := icebergx.BuildParquetSchema(w.table.Schema())
 	if err != nil {
-		return fmt.Errorf("building parquet schema: %w", err)
+		return nil, fmt.Errorf("building parquet schema: %w", err)
 	}
 	colToFieldID := icebergx.ReverseFieldIDMap(fieldToCol)
 	fieldIDToLogicalType, fieldIDToFixedSize := icebergx.PartitionFieldMaps(w.table.Spec(), w.table.Schema())
 
-	// Write each partition file and submit to committer
+	// Write each partition file
 	var files []iceberg.DataFile
 	for _, pf := range parquetFiles {
 		fileName := uuid.New().String() + ".parquet"
@@ -118,13 +240,13 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 		} else {
 			partitionPath, err := icebergx.PartitionKeyToPath(w.table.Spec(), pf.partitionKey)
 			if err != nil {
-				return fmt.Errorf("unable to compute partition key path: %w", err)
+				return nil, fmt.Errorf("unable to compute partition key path: %w", err)
 			}
 			filePath = locProvider.NewDataLocation(path.Join(partitionPath, fileName))
 		}
 
 		if err := writeIO.WriteFile(filePath, pf.result.data); err != nil {
-			return fmt.Errorf("writing parquet file %q: %w", filePath, err)
+			return nil, fmt.Errorf("writing parquet file %q: %w", filePath, err)
 		}
 
 		w.logger.Debugf("Wrote parquet file: %s (%d bytes, %d rows)", filePath, len(pf.result.data), pf.result.footer.NumRows)
@@ -144,13 +266,13 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 			int64(len(pf.result.data)),
 		)
 		if err != nil {
-			return fmt.Errorf("unable to create data file builder: %w", err)
+			return nil, fmt.Errorf("unable to create data file builder: %w", err)
 		}
 
 		// Extract parquet statistics
 		stats, err := icebergx.ExtractParquetStats(pf.result.footer, w.table.Schema(), colToFieldID)
 		if err != nil {
-			return fmt.Errorf("extracting parquet stats: %w", err)
+			return nil, fmt.Errorf("extracting parquet stats: %w", err)
 		}
 		builder = builder.
 			ColumnSizes(stats.ColumnSizes).
@@ -163,12 +285,331 @@ func (w *writer) Write(ctx context.Context, batch service.MessageBatch) error {
 		files = append(files, builder.Build())
 	}
 
-	// Submit all files to committer
-	if err := w.committer.Commit(ctx, CommitInput{Files: files, SchemaID: schemaID}); err != nil {
-		return fmt.Errorf("committing: %w", err)
+	return files, nil
+}
+
+// splitByOperation partitions a batch by its per-message row_operation. Rows to
+// insert go into inserts; messages whose identifier key should be equality-
+// deleted go into deletes. Unknown operations, and upsert/delete without
+// identifier_fields, are hard errors so a misconfiguration fails loudly rather
+// than silently dropping or duplicating rows.
+//
+// Keyed operations (upsert/delete) are collapsed per identifier key to the last
+// one in batch order. This is required for correctness: merge-on-read equality
+// deletes only remove rows from earlier snapshots, never rows added in the same
+// commit, so emitting more than one keyed operation per key in a single commit
+// would otherwise leave duplicates (repeated upserts) or fail to delete (a
+// delete following a same-batch upsert). `insert` is an unconditional append
+// and is deliberately not keyed; mixing it with upsert/delete on the same key
+// within one batch is not de-duplicated (map create events to `upsert`, not
+// `insert`, for keyed data).
+func (w *writer) splitByOperation(batch service.MessageBatch) (service.MessageBatch, service.MessageBatch, error) {
+	var inserts service.MessageBatch
+
+	type keyedOp struct {
+		op  rowOperation
+		msg *service.Message
+	}
+	order := make([]string, 0, len(batch))
+	latest := make(map[string]keyedOp, len(batch))
+
+	var nInsert, nUpsert, nDelete int64
+	for i, msg := range batch {
+		opStr, err := w.rowOpCfg.Operation.TryString(msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("evaluating %s for message %d: %w", ioFieldRowOperation, i, err)
+		}
+		if opStr == "" {
+			opStr = string(rowOpInsert)
+		}
+		op, err := parseRowOperation(opStr)
+		if err != nil {
+			return nil, nil, err
+		}
+		if op == rowOpInsert {
+			nInsert++
+			inserts = append(inserts, msg)
+			continue
+		}
+		if op == rowOpUpsert {
+			nUpsert++
+		} else {
+			nDelete++
+		}
+		if len(w.rowOpCfg.IdentifierFields) == 0 {
+			return nil, nil, fmt.Errorf("%s %q requires %s to be set", ioFieldRowOperation, op, ioFieldIdentifierFields)
+		}
+		key, err := w.dedupKey(msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("message %d: %w", i, err)
+		}
+		if _, seen := latest[key]; !seen {
+			order = append(order, key)
+		}
+		latest[key] = keyedOp{op: op, msg: msg}
 	}
 
-	return nil
+	deletes := make(service.MessageBatch, 0, len(order))
+	for _, key := range order {
+		ko := latest[key]
+		// Every keyed operation removes any prior version of the row.
+		deletes = append(deletes, ko.msg)
+		// An upsert also (re)writes the row; a delete does not.
+		if ko.op == rowOpUpsert {
+			inserts = append(inserts, ko.msg)
+		}
+	}
+
+	if w.metrics != nil {
+		w.metrics.inserted.Incr(nInsert)
+		w.metrics.upserted.Incr(nUpsert)
+		w.metrics.deleted.Incr(nDelete)
+	}
+	return inserts, deletes, nil
+}
+
+// dedupKey builds a stable identity string from a message's identifier_fields
+// values, used to collapse multiple keyed operations on the same row within a
+// batch. A missing or null identifier value is a hard error.
+func (w *writer) dedupKey(msg *service.Message) (string, error) {
+	structured, err := msg.AsStructured()
+	if err != nil {
+		return "", fmt.Errorf("reading structured message for delete key: %w", err)
+	}
+	row, ok := structured.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("message for upsert/delete must be an object, got %T", structured)
+	}
+	values := make([]any, len(w.rowOpCfg.IdentifierFields))
+	for i, name := range w.rowOpCfg.IdentifierFields {
+		v, ok := lookupField(row, name, w.caseSensitive)
+		if !ok || v == nil {
+			return "", fmt.Errorf("%s %q is missing or null", ioFieldIdentifierFields, name)
+		}
+		values[i] = v
+	}
+	b, err := json.Marshal(values)
+	if err != nil {
+		return "", fmt.Errorf("encoding delete key: %w", err)
+	}
+	return string(b), nil
+}
+
+// deleteKeyJSONValue converts a Go identifier value into a JSON-encodable form
+// that array.RecordFromJSON parses losslessly for the column's iceberg type.
+// Integers and decimals are emitted as strings to avoid the float64 precision
+// loss that JSON number parsing would otherwise incur, and temporal time.Time
+// values are formatted to the canonical string forms the Arrow JSON reader
+// accepts. Other primitives (string, bool, float, binary, uuid) pass through
+// json.Marshal unchanged.
+func deleteKeyJSONValue(t iceberg.Type, v any) (any, error) {
+	switch t.(type) {
+	case iceberg.Int32Type, iceberg.Int64Type:
+		switch n := v.(type) {
+		case json.Number:
+			return n.String(), nil
+		case int:
+			return strconv.FormatInt(int64(n), 10), nil
+		case int32:
+			return strconv.FormatInt(int64(n), 10), nil
+		case int64:
+			return strconv.FormatInt(n, 10), nil
+		case float64:
+			if n != math.Trunc(n) {
+				return nil, fmt.Errorf("integer column given non-integer value %v", n)
+			}
+			return strconv.FormatInt(int64(n), 10), nil
+		case string:
+			return n, nil
+		default:
+			return nil, fmt.Errorf("unsupported value type %T for integer column", v)
+		}
+	case iceberg.DecimalType:
+		// Format to the column's exact scale so the encoded key matches the
+		// stored decimal; the shortest float representation would not.
+		scale := t.(iceberg.DecimalType).Scale()
+		switch n := v.(type) {
+		case json.Number:
+			return n.String(), nil
+		case string:
+			return n, nil
+		case float64:
+			return strconv.FormatFloat(n, 'f', scale, 64), nil
+		case int:
+			return strconv.Itoa(n), nil
+		case int64:
+			return strconv.FormatInt(n, 10), nil
+		default:
+			return nil, fmt.Errorf("unsupported value type %T for decimal column", v)
+		}
+	// Temporal keys must arrive as time.Time. A bare number is ambiguous (the
+	// data path interprets it via schema_metadata or a seconds fallback, which
+	// the delete path cannot reproduce), so accepting one would silently fail to
+	// match the intended rows — reject it loudly instead.
+	case iceberg.DateType:
+		if tm, ok := v.(time.Time); ok {
+			return tm.UTC().Format("2006-01-02"), nil
+		}
+		return nil, fmt.Errorf("date identifier column requires a time value, got %T", v)
+	case iceberg.TimeType:
+		if tm, ok := v.(time.Time); ok {
+			return tm.UTC().Format("15:04:05.999999999"), nil
+		}
+		return nil, fmt.Errorf("time identifier column requires a time value, got %T", v)
+	case iceberg.TimestampType, iceberg.TimestampTzType:
+		if tm, ok := v.(time.Time); ok {
+			return tm.UTC().Format(time.RFC3339Nano), nil
+		}
+		return nil, fmt.Errorf("timestamp identifier column requires a time value, got %T (a bare numeric timestamp is ambiguous as a delete key — convert it to a timestamp upstream)", v)
+	default:
+		return v, nil
+	}
+}
+
+// deleteRecordFields returns the schema fields that must appear in an
+// equality-delete record — the identifier fields (the equality key) plus, for
+// partitioned tables, the partition source columns needed to route each delete
+// to its partition — together with the identifier field IDs (the equality key).
+// The field list is ordered and de-duplicated (an identifier field that is also
+// a partition source appears once). Every contributing column must be a
+// primitive type (a fundamental Iceberg constraint on identifier fields).
+func (w *writer) deleteRecordFields(tableSchema *iceberg.Schema, spec *iceberg.PartitionSpec) ([]iceberg.NestedField, []int, error) {
+	seen := map[int]struct{}{}
+	var fields []iceberg.NestedField
+	eqFieldIDs := make([]int, 0, len(w.rowOpCfg.IdentifierFields))
+
+	for _, name := range w.rowOpCfg.IdentifierFields {
+		field, ok := tableSchema.FindFieldByName(name)
+		if !ok && !w.caseSensitive {
+			field, ok = tableSchema.FindFieldByNameCaseInsensitive(name)
+		}
+		if !ok {
+			return nil, nil, fmt.Errorf("%s column %q not found in table schema", ioFieldIdentifierFields, name)
+		}
+		if _, ok := field.Type.(iceberg.PrimitiveType); !ok {
+			return nil, nil, fmt.Errorf("%s column %q has non-primitive type %s; equality-delete keys must be primitive", ioFieldIdentifierFields, field.Name, field.Type)
+		}
+		switch field.Type.(type) {
+		case iceberg.Float32Type, iceberg.Float64Type:
+			// Floating-point equality is unreliable (NaN, -0.0, rounding), so a
+			// float key would intermittently fail to match — Iceberg disallows
+			// floats as identifier fields for the same reason.
+			return nil, nil, fmt.Errorf("%s column %q has floating-point type %s, which is not a valid equality-delete key", ioFieldIdentifierFields, field.Name, field.Type)
+		}
+		eqFieldIDs = append(eqFieldIDs, field.ID)
+		if _, dup := seen[field.ID]; !dup {
+			seen[field.ID] = struct{}{}
+			fields = append(fields, field)
+		}
+	}
+
+	// Equality deletes are partition-scoped: a delete only matches data in the
+	// same partition. If a partition is derived from a column outside
+	// identifier_fields, that column can differ between a row's insert and a
+	// later upsert/delete, routing the delete to the wrong partition and silently
+	// missing the row. Require every partition source column to be an identifier
+	// field (so it is part of the key and cannot vary for a given key). This
+	// matches Iceberg/Flink's rule that partition sources must be a subset of the
+	// equality fields. Identifier partition sources are already in `fields`.
+	for _, pf := range spec.Fields() {
+		for _, srcID := range pf.SourceIDs {
+			if _, ok := seen[srcID]; ok {
+				continue
+			}
+			name, _ := tableSchema.FindColumnName(srcID)
+			return nil, nil, fmt.Errorf("table is partitioned by column %q (field %d), which is not in %s; upsert/delete is only supported when every partition source column is an identifier field (equality deletes are partition-scoped)", name, srcID, ioFieldIdentifierFields)
+		}
+	}
+
+	return fields, eqFieldIDs, nil
+}
+
+// writeEqualityDeletes builds equality-delete files for the given messages,
+// keyed on identifier_fields. The identifier columns are projected into Arrow
+// records and written via the iceberg-go equality-delete writer, which owns the
+// on-disk delete-file format. The returned files are uncommitted.
+func (w *writer) writeEqualityDeletes(ctx context.Context, msgs service.MessageBatch) ([]iceberg.DataFile, error) {
+	tableSchema := w.table.Schema()
+	spec := w.table.Spec()
+
+	delFields, eqFieldIDs, err := w.deleteRecordFields(tableSchema, &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Project each message to its identifier columns, keyed by the canonical
+	// schema field name so the JSON keys line up with the Arrow schema.
+	rows := make([]map[string]any, 0, len(msgs))
+	for i, msg := range msgs {
+		structured, err := msg.AsStructured()
+		if err != nil {
+			return nil, fmt.Errorf("reading structured message %d for delete key: %w", i, err)
+		}
+		row, ok := structured.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("message %d for upsert/delete must be an object, got %T", i, structured)
+		}
+		key := make(map[string]any, len(delFields))
+		for _, field := range delFields {
+			v, ok := lookupField(row, field.Name, w.caseSensitive)
+			if !ok || v == nil {
+				return nil, fmt.Errorf("%s %q is missing or null in message %d", ioFieldIdentifierFields, field.Name, i)
+			}
+			jv, err := deleteKeyJSONValue(field.Type, v)
+			if err != nil {
+				return nil, fmt.Errorf("%s %q in message %d: %w", ioFieldIdentifierFields, field.Name, i, err)
+			}
+			key[field.Name] = jv
+		}
+		rows = append(rows, key)
+	}
+
+	jsonRows, err := json.Marshal(rows)
+	if err != nil {
+		return nil, fmt.Errorf("encoding delete keys: %w", err)
+	}
+
+	delSchema := iceberg.NewSchema(0, delFields...)
+	arrowSc, err := table.SchemaToArrowSchema(delSchema, nil, true, false)
+	if err != nil {
+		return nil, fmt.Errorf("building delete arrow schema: %w", err)
+	}
+
+	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, arrowSc, bytes.NewReader(jsonRows))
+	if err != nil {
+		return nil, fmt.Errorf("building delete records: %w", err)
+	}
+	defer rec.Release()
+
+	records := func(yield func(arrow.RecordBatch, error) bool) {
+		yield(rec, nil)
+	}
+
+	// WriteEqualityDeletes is functionally pure w.r.t. the transaction (it only
+	// reads metadata and writes files), so a throwaway transaction is safe; the
+	// committer commits the returned files via a RowDelta.
+	deleteFiles, err := w.table.NewTransaction().WriteEqualityDeletes(ctx, eqFieldIDs, records)
+	if err != nil {
+		return nil, fmt.Errorf("writing equality deletes: %w", err)
+	}
+	return deleteFiles, nil
+}
+
+// lookupField finds a value in a structured row by column name, honouring case
+// sensitivity the same way the shredder matches message keys to columns.
+func lookupField(row map[string]any, name string, caseSensitive bool) (any, bool) {
+	if v, ok := row[name]; ok {
+		return v, true
+	}
+	if caseSensitive {
+		return nil, false
+	}
+	for k, v := range row {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+	return nil, false
 }
 
 // parquetResult holds the output of parquet conversion for a partition.


### PR DESCRIPTION
## What

Extends the `iceberg` output beyond append-only with per-message row-level operations — `insert`, `upsert`, and `delete` — selected by a new interpolated `row_operation` field. The row identity for upserts/deletes is configured via `identifier_fields` (the equality-delete key, matching Iceberg's `identifier-field-ids`). The mapping is source-agnostic: a change-data-capture `op` field can be mapped to these operations upstream, so no CDC-specific format is assumed.

> Supersedes the previous pull request, which had accumulated stale review noise. The branch, the (now single-commit) history, and the content are otherwise current, and CI is green.

## Behaviour

- **`insert`** (the default) keeps the existing append-only fast path unchanged — existing configurations are unaffected.
- **`upsert`** writes an equality delete on `identifier_fields` plus the new row, committed atomically as a merge-on-read `RowDelta` snapshot (latest row wins).
- **`delete`** writes an equality delete only.
- Within a batch, the last operation per identifier key wins; each delete-bearing batch commits as its own snapshot, so concurrent changes to the same key cannot leave duplicates.
- Any primitive identifier type is supported (integers, decimal, uuid, temporal, …), each encoded so the equality-delete key matches what the insert path writes. Floating-point and bare-numeric temporal keys are rejected as unreliable equality keys.
- Partitioned tables include the partition source columns in delete records and require every partition source to be an identifier field (equality deletes are partition-scoped).
- On auto-created tables, `identifier_fields` are registered as the schema's identifier-field-ids and marked required, so downstream engines see the primary key.
- Version-1 tables are upgraded to version 2 (required for equality deletes) on the first upsert/delete; the upgrade is irreversible and warned once.

### Ordering

Keyed writes rely on per-key ordering, so concurrent in-flight batches could otherwise commit out of order. Both a config lint rule and a startup warning flag a mutating `row_operation` combined with `max_in_flight > 1`; set `max_in_flight: 1` for keyed / change-data-capture workloads.

### Safety

Opt-in, and fails loudly rather than silently mishandling data:

- a static `upsert`/`delete` without `identifier_fields`, or an unknown static `row_operation`, is rejected at startup;
- a dynamic `row_operation` that resolves to an unknown value, or to upsert/delete without `identifier_fields`, errors per message — there is no silent fallback to insert;
- unsupported key types and missing/null identifier values produce clear errors.

### Observability

Adds `iceberg_rows_inserted`, `iceberg_rows_upserted`, `iceberg_rows_deleted`, and `iceberg_commit_failures` metrics, plus best-effort cleanup of written-but-uncommitted files when a commit fails.

## Testing

- **Unit:** config and lint-rule validation, per-message batch split and per-key collapse, equality-delete file production, and commit / format-upgrade / retry / cleanup semantics over a local-filesystem catalog.
- **Integration (real REST catalog + MinIO + DuckDB):** insert → upsert → delete round-trips across key types, composite keys, partitioned tables, and batch collapse — all passing.

## Follow-ups (post-merge)

- Add a CI lane for the iceberg integration tests (currently opt-in and skipped by default).
- Document table-maintenance guidance (snapshot expiry and `rewrite_data_files`) for merge-on-read delete-file accumulation.
- Positional deletes and copy-on-write modes are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
