### PR TITLE
dev-licence: allow users to configure a dev license with diminished c…

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -176,6 +176,7 @@ redpanda_agent_runtime:
 		}
 		return stream, nil
 	}
+	var primaryRes *service.Resources
 	for name, agent := range config.Agents {
 		stream, err := buildStream(name, agent)
 		if err != nil {
@@ -183,10 +184,12 @@ redpanda_agent_runtime:
 			cancel(err)
 			break
 		}
-		license.RegisterService(
-			stream.Resources(),
-			licenseConfig,
-		)
+		if primaryRes == nil {
+			license.RegisterService(stream.Resources(), licenseConfig)
+			primaryRes = stream.Resources()
+		} else {
+			license.RegisterServiceFrom(primaryRes, stream.Resources())
+		}
 		eg.Go(func() error { return stream.Run(ctx) })
 	}
 	if config.HTTP.enabled {

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 	baws "github.com/redpanda-data/connect/v4/internal/impl/aws"
 	"github.com/redpanda-data/connect/v4/internal/impl/aws/config"
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 type asyncMessage struct {
@@ -318,14 +319,11 @@ input:
 }
 
 func init() {
-	err := service.RegisterBatchInput(
+	license.MustRegisterEnterpriseBatchInput(
 		"aws_dynamodb_cdc", dynamoDBCDCInputConfig(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 			return newDynamoDBCDCInputFromConfig(conf, mgr)
 		})
-	if err != nil {
-		panic(err)
-	}
 }
 
 type snapshotConfig struct {

--- a/internal/impl/gateway/input.go
+++ b/internal/impl/gateway/input.go
@@ -34,6 +34,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/utils/netutil"
 	"github.com/redpanda-data/common-go/authz"
 	"github.com/redpanda-data/connect/v4/internal/gateway"
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 const (
@@ -162,7 +163,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 }
 
 func init() {
-	service.MustRegisterBatchInput(
+	license.MustRegisterEnterpriseBatchInput(
 		"gateway", InputSpec(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 			return InputFromParsed(conf, mgr)

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -88,7 +88,7 @@ func init() {
 			}
 			out, err = bigQueryWriteAPIOutputFromConfig(conf, mgr)
 			if err == nil {
-				out = license.WrapBatchOutput(mgr, out)
+				out = license.WrapBatchOutput(mgr, "gcp_bigquery_write_api", out)
 			}
 			return
 		})

--- a/internal/impl/gcp/enterprise/bigquery/output.go
+++ b/internal/impl/gcp/enterprise/bigquery/output.go
@@ -87,6 +87,9 @@ func init() {
 				return
 			}
 			out, err = bigQueryWriteAPIOutputFromConfig(conf, mgr)
+			if err == nil {
+				out = license.WrapBatchOutput(mgr, out)
+			}
 			return
 		})
 }

--- a/internal/impl/gcp/enterprise/input_spanner_cdc.go
+++ b/internal/impl/gcp/enterprise/input_spanner_cdc.go
@@ -156,7 +156,7 @@ https://cloud.google.com/spanner/docs/change-streams
 }
 
 func init() {
-	service.MustRegisterBatchInput("gcp_spanner_cdc", spannerCDCInputSpec(),
+	license.MustRegisterEnterpriseBatchInput("gcp_spanner_cdc", spannerCDCInputSpec(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 			r, err := newSpannerCDCReaderFromParsed(conf, mgr)
 			if err != nil {
@@ -188,10 +188,6 @@ type spannerCDCReader struct {
 var _ service.BatchInput = (*spannerCDCReader)(nil)
 
 func newSpannerCDCReaderFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*spannerCDCReader, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
 	conf, err := spannerCDCInputConfigFromParsed(pConf)
 	if err != nil {
 		return nil, err

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -57,6 +57,7 @@ func init() {
 				return
 			}
 
+			output = license.WrapBatchOutput(mgr, output)
 			return
 		})
 }

--- a/internal/impl/iceberg/output_iceberg.go
+++ b/internal/impl/iceberg/output_iceberg.go
@@ -57,7 +57,7 @@ func init() {
 				return
 			}
 
-			output = license.WrapBatchOutput(mgr, output)
+			output = license.WrapBatchOutput(mgr, "iceberg", output)
 			return
 		})
 }

--- a/internal/impl/kafka/enterprise/redpanda_common_input.go
+++ b/internal/impl/kafka/enterprise/redpanda_common_input.go
@@ -130,6 +130,6 @@ func init() {
 				return nil, err
 			}
 
-			return rdr, nil
+			return license.WrapBatchInput(mgr, "redpanda_common", rdr), nil
 		})
 }

--- a/internal/impl/kafka/enterprise/redpanda_common_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_common_output.go
@@ -63,7 +63,7 @@ func init() {
 						func(context.Context) error { return nil }),
 			)
 			if err == nil {
-				output = license.WrapBatchOutput(mgr, output)
+				output = license.WrapBatchOutput(mgr, "redpanda_common", output)
 			}
 			return
 		})

--- a/internal/impl/kafka/enterprise/redpanda_common_output.go
+++ b/internal/impl/kafka/enterprise/redpanda_common_output.go
@@ -62,6 +62,9 @@ func init() {
 					WithYieldClientFn(
 						func(context.Context) error { return nil }),
 			)
+			if err == nil {
+				output = license.WrapBatchOutput(mgr, output)
+			}
 			return
 		})
 }

--- a/internal/impl/mongodb/cdc/input.go
+++ b/internal/impl/mongodb/cdc/input.go
@@ -175,13 +175,10 @@ Schema metadata is discovered using a two-tier strategy:
 }
 
 func init() {
-	service.MustRegisterBatchInput("mongodb_cdc", spec(), newMongoCDC)
+	license.MustRegisterEnterpriseBatchInput("mongodb_cdc", spec(), newMongoCDC)
 }
 
 func newMongoCDC(conf *service.ParsedConfig, res *service.Resources) (i service.BatchInput, err error) {
-	if err := license.CheckRunningEnterprise(res); err != nil {
-		return nil, err
-	}
 	cdc := &mongoCDC{
 		readChan:          make(chan mongoBatch),
 		errorChan:         make(chan error, 1),

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -46,7 +46,7 @@ const (
 )
 
 func init() {
-	service.MustRegisterBatchInput("microsoft_sql_server_cdc", msSQLServerStreamConfigSpec, newMSSQLServerCDCInput)
+	license.MustRegisterEnterpriseBatchInput("microsoft_sql_server_cdc", msSQLServerStreamConfigSpec, newMSSQLServerCDCInput)
 }
 
 var msSQLServerStreamConfigSpec = service.NewConfigSpec().
@@ -174,9 +174,6 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 		cpCacheTableName             string
 	)
 
-	if err := license.CheckRunningEnterprise(resources); err != nil {
-		return nil, err
-	}
 	if connectionString, err = conf.FieldString(fieldConnectionString); err != nil {
 		return nil, err
 	}

--- a/internal/impl/mysql/input_mysql_stream.go
+++ b/internal/impl/mysql/input_mysql_stream.go
@@ -216,10 +216,6 @@ type mysqlStreamInput struct {
 }
 
 func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s service.BatchInput, err error) {
-	if err := license.CheckRunningEnterprise(res); err != nil {
-		return nil, err
-	}
-
 	i := mysqlStreamInput{
 		logger:           res.Logger(),
 		rawMessageEvents: make(chan MessageEvent),
@@ -342,7 +338,7 @@ func newMySQLStreamInput(conf *service.ParsedConfig, res *service.Resources) (s 
 }
 
 func init() {
-	service.MustRegisterBatchInput("mysql_cdc", mysqlStreamConfigSpec, newMySQLStreamInput)
+	license.MustRegisterEnterpriseBatchInput("mysql_cdc", mysqlStreamConfigSpec, newMySQLStreamInput)
 }
 
 // ---- Redpanda Connect specific methods----

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -63,7 +63,7 @@ const (
 )
 
 func init() {
-	service.MustRegisterBatchInput("oracledb_cdc", oracleDBStreamConfigSpec, newOracleDBCDCInput)
+	license.MustRegisterEnterpriseBatchInput("oracledb_cdc", oracleDBStreamConfigSpec, newOracleDBCDCInput)
 }
 
 var oracleDBStreamConfigSpec = service.NewConfigSpec().
@@ -244,9 +244,6 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 		logger = resources.Logger()
 	)
 
-	if err := license.CheckRunningEnterprise(resources); err != nil {
-		return nil, err
-	}
 	if connectionString, err = conf.FieldString(ociFieldConnectionString); err != nil {
 		return nil, err
 	}

--- a/internal/impl/otlp/input_grpc.go
+++ b/internal/impl/otlp/input_grpc.go
@@ -159,10 +159,6 @@ type grpcOTLPInput struct {
 
 // GRPCInputFromParsed creates an OTLP gRPC input from a parsed config.
 func GRPCInputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
 	var (
 		conf grpcInputConfig
 		err  error
@@ -239,7 +235,7 @@ func GRPCInputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (s
 }
 
 func init() {
-	service.MustRegisterBatchInput("otlp_grpc", GRPCInputSpec(), GRPCInputFromParsed)
+	license.MustRegisterEnterpriseBatchInput("otlp_grpc", GRPCInputSpec(), GRPCInputFromParsed)
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/otlp/input_http.go
+++ b/internal/impl/otlp/input_http.go
@@ -189,10 +189,6 @@ type httpOTLPInput struct {
 
 // HTTPInputFromParsed creates an OTLP HTTP input from a parsed config.
 func HTTPInputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
 	var (
 		conf httpInputConfig
 		err  error
@@ -276,7 +272,7 @@ func HTTPInputFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (s
 }
 
 func init() {
-	service.MustRegisterBatchInput("otlp_http", HTTPInputSpec(), HTTPInputFromParsed)
+	license.MustRegisterEnterpriseBatchInput("otlp_http", HTTPInputSpec(), HTTPInputFromParsed)
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/otlp/output_grpc.go
+++ b/internal/impl/otlp/output_grpc.go
@@ -197,7 +197,7 @@ func init() {
 				return
 			}
 
-			o = license.WrapBatchOutput(mgr, o)
+			o = license.WrapBatchOutput(mgr, "otlp_grpc", o)
 			return
 		})
 }

--- a/internal/impl/otlp/output_grpc.go
+++ b/internal/impl/otlp/output_grpc.go
@@ -197,6 +197,7 @@ func init() {
 				return
 			}
 
+			o = license.WrapBatchOutput(mgr, o)
 			return
 		})
 }

--- a/internal/impl/otlp/output_http.go
+++ b/internal/impl/otlp/output_http.go
@@ -280,7 +280,7 @@ func init() {
 				return
 			}
 
-			o = license.WrapBatchOutput(mgr, o)
+			o = license.WrapBatchOutput(mgr, "otlp_http", o)
 			return
 		})
 }

--- a/internal/impl/otlp/output_http.go
+++ b/internal/impl/otlp/output_http.go
@@ -280,6 +280,7 @@ func init() {
 				return
 			}
 
+			o = license.WrapBatchOutput(mgr, o)
 			return
 		})
 }

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -213,10 +213,6 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		iamAuthTokenBuilder       TokenBuilder
 	)
 
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
 	if dsn, err = conf.FieldString(fieldDSN); err != nil {
 		return nil, err
 	}
@@ -376,9 +372,9 @@ func validateSimpleString(s string) error {
 }
 
 func init() {
-	service.MustRegisterBatchInput("postgres_cdc", newPostgresCDCConfig(), newPgStreamInput)
+	license.MustRegisterEnterpriseBatchInput("postgres_cdc", newPostgresCDCConfig(), newPgStreamInput)
 	// Legacy naming
-	service.MustRegisterBatchInput("pg_stream", newPostgresCDCConfig().Deprecated(), newPgStreamInput)
+	license.MustRegisterEnterpriseBatchInput("pg_stream", newPostgresCDCConfig().Deprecated(), newPgStreamInput)
 }
 
 type pgStreamInput struct {

--- a/internal/impl/salesforce/input_salesforce.go
+++ b/internal/impl/salesforce/input_salesforce.go
@@ -33,7 +33,7 @@ const (
 )
 
 func init() {
-	service.MustRegisterInput("salesforce", salesforceInputConfigSpec(), newSalesforceInput)
+	license.MustRegisterEnterpriseInput("salesforce", salesforceInputConfigSpec(), newSalesforceInput)
 }
 
 func salesforceInputConfigSpec() *service.ConfigSpec {
@@ -202,10 +202,6 @@ type salesforceInput struct {
 }
 
 func newSalesforceInput(pConf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
 	conf, err := NewInputConfigFromParsed(pConf)
 	if err != nil {
 		return nil, err

--- a/internal/impl/salesforce/input_salesforce_cdc.go
+++ b/internal/impl/salesforce/input_salesforce_cdc.go
@@ -51,7 +51,7 @@ const (
 )
 
 func init() {
-	service.MustRegisterBatchInput("salesforce_cdc", salesforceCDCInputConfigSpec(), newSalesforceCDCInput)
+	license.MustRegisterEnterpriseBatchInput("salesforce_cdc", salesforceCDCInputConfigSpec(), newSalesforceCDCInput)
 }
 
 func salesforceCDCInputConfigSpec() *service.ConfigSpec {
@@ -406,9 +406,6 @@ type salesforceCDCInputExecutor struct {
 }
 
 func newSalesforceCDCInput(pConf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
 
 	conf, err := NewCDCInputConfigFromParsed(pConf)
 	if err != nil {

--- a/internal/impl/salesforce/input_salesforce_cdc.go
+++ b/internal/impl/salesforce/input_salesforce_cdc.go
@@ -406,7 +406,6 @@ type salesforceCDCInputExecutor struct {
 }
 
 func newSalesforceCDCInput(pConf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
-
 	conf, err := NewCDCInputConfigFromParsed(pConf)
 	if err != nil {
 		return nil, err

--- a/internal/impl/salesforce/input_salesforce_graphql.go
+++ b/internal/impl/salesforce/input_salesforce_graphql.go
@@ -29,7 +29,7 @@ const (
 )
 
 func init() {
-	service.MustRegisterInput("salesforce_graphql", salesforceGraphQLInputConfigSpec(), newSalesforceGraphQLInput)
+	license.MustRegisterEnterpriseInput("salesforce_graphql", salesforceGraphQLInputConfigSpec(), newSalesforceGraphQLInput)
 }
 
 func salesforceGraphQLInputConfigSpec() *service.ConfigSpec {
@@ -158,11 +158,7 @@ type salesforceGraphQLInput struct {
 }
 
 func newSalesforceGraphQLInput(pConf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-	if err := license.CheckRunningEnterprise(mgr); err != nil {
-		return nil, err
-	}
-
-	conf, err := NewGraphQLInputConfigFromParsed(pConf)
+conf, err := NewGraphQLInputConfigFromParsed(pConf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/salesforce/input_salesforce_graphql.go
+++ b/internal/impl/salesforce/input_salesforce_graphql.go
@@ -158,7 +158,7 @@ type salesforceGraphQLInput struct {
 }
 
 func newSalesforceGraphQLInput(pConf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-conf, err := NewGraphQLInputConfigFromParsed(pConf)
+	conf, err := NewGraphQLInputConfigFromParsed(pConf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/salesforce/output_salesforce.go
+++ b/internal/impl/salesforce/output_salesforce.go
@@ -119,7 +119,7 @@ func init() {
 			if err != nil {
 				return nil, service.BatchPolicy{}, 0, err
 			}
-			return license.WrapBatchOutput(mgr, out), service.BatchPolicy{Count: batchSize, Period: batchPeriod.String()}, maxInFlight, nil
+			return license.WrapBatchOutput(mgr, "salesforce_sink", out), service.BatchPolicy{Count: batchSize, Period: batchPeriod.String()}, maxInFlight, nil
 		},
 	)
 }

--- a/internal/impl/salesforce/output_salesforce.go
+++ b/internal/impl/salesforce/output_salesforce.go
@@ -119,7 +119,7 @@ func init() {
 			if err != nil {
 				return nil, service.BatchPolicy{}, 0, err
 			}
-			return out, service.BatchPolicy{Count: batchSize, Period: batchPeriod.String()}, maxInFlight, nil
+			return license.WrapBatchOutput(mgr, out), service.BatchPolicy{Count: batchSize, Period: batchPeriod.String()}, maxInFlight, nil
 		},
 	)
 }

--- a/internal/impl/slack/input.go
+++ b/internal/impl/slack/input.go
@@ -18,10 +18,12 @@ import (
 	"github.com/slack-go/slack/socketmode"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 func init() {
-	service.MustRegisterInput("slack", inputSpec(), newInput)
+	license.MustRegisterEnterpriseInput("slack", inputSpec(), newInput)
 }
 
 const (

--- a/internal/impl/slack/input_users.go
+++ b/internal/impl/slack/input_users.go
@@ -17,10 +17,12 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 func init() {
-	service.MustRegisterInput("slack_users", usersInputSpec(), newUsersInput)
+	license.MustRegisterEnterpriseInput("slack_users", usersInputSpec(), newUsersInput)
 }
 
 const (

--- a/internal/impl/slack/output_post.go
+++ b/internal/impl/slack/output_post.go
@@ -17,10 +17,12 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 func init() {
-	service.MustRegisterOutput("slack_post", outputSpec(), newOutput)
+	license.MustRegisterEnterpriseOutput("slack_post", outputSpec(), newOutput)
 }
 
 const (

--- a/internal/impl/slack/output_reaction.go
+++ b/internal/impl/slack/output_reaction.go
@@ -15,10 +15,12 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 func init() {
-	service.MustRegisterOutput("slack_reaction", reactionSpec(), newReaction)
+	license.MustRegisterEnterpriseOutput("slack_reaction", reactionSpec(), newReaction)
 }
 
 const (

--- a/internal/impl/slack/processor_thread.go
+++ b/internal/impl/slack/processor_thread.go
@@ -16,10 +16,18 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
 func init() {
-	service.MustRegisterProcessor("slack_thread", threadProcessorSpec(), newThreadProcessor)
+	service.MustRegisterProcessor("slack_thread", threadProcessorSpec(),
+		func(conf *service.ParsedConfig, res *service.Resources) (service.Processor, error) {
+			if err := license.CheckRunningEnterprise(res); err != nil {
+				return nil, err
+			}
+			return newThreadProcessor(conf, res)
+		})
 }
 
 const (

--- a/internal/impl/snowflake/output_snowflake_put.go
+++ b/internal/impl/snowflake/output_snowflake_put.go
@@ -404,6 +404,9 @@ func init() {
 				return
 			}
 			output, err = newSnowflakeWriterFromConfig(conf, mgr)
+			if err == nil {
+				output = license.WrapBatchOutput(mgr, output)
+			}
 			return
 		})
 }

--- a/internal/impl/snowflake/output_snowflake_put.go
+++ b/internal/impl/snowflake/output_snowflake_put.go
@@ -405,7 +405,7 @@ func init() {
 			}
 			output, err = newSnowflakeWriterFromConfig(conf, mgr)
 			if err == nil {
-				output = license.WrapBatchOutput(mgr, output)
+				output = license.WrapBatchOutput(mgr, "snowflake_put", output)
 			}
 			return
 		})

--- a/internal/impl/snowflake/output_snowflake_streaming.go
+++ b/internal/impl/snowflake/output_snowflake_streaming.go
@@ -381,6 +381,9 @@ func init() {
 				return
 			}
 			output, err = newSnowflakeStreamer(conf, mgr)
+			if err == nil {
+				output = license.WrapBatchOutput(mgr, output)
+			}
 			return
 		})
 }

--- a/internal/impl/snowflake/output_snowflake_streaming.go
+++ b/internal/impl/snowflake/output_snowflake_streaming.go
@@ -382,7 +382,7 @@ func init() {
 			}
 			output, err = newSnowflakeStreamer(conf, mgr)
 			if err == nil {
-				output = license.WrapBatchOutput(mgr, output)
+				output = license.WrapBatchOutput(mgr, "snowflake_streaming", output)
 			}
 			return
 		})

--- a/internal/impl/splunk/input.go
+++ b/internal/impl/splunk/input.go
@@ -54,12 +54,8 @@ func inputSpec() *service.ConfigSpec {
 }
 
 func init() {
-	service.MustRegisterInput("splunk", inputSpec(),
+	license.MustRegisterEnterpriseInput("splunk", inputSpec(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-			if err := license.CheckRunningEnterprise(mgr); err != nil {
-				return nil, err
-			}
-
 			i, err := inputFromParsed(conf, mgr.Logger())
 			if err != nil {
 				return nil, err

--- a/internal/impl/splunk/output.go
+++ b/internal/impl/splunk/output.go
@@ -109,6 +109,9 @@ func init() {
 			}
 
 			out, err = outputFromParsed(conf, mgr.Logger())
+			if err == nil {
+				out = license.WrapBatchOutput(mgr, out)
+			}
 			return
 		})
 }

--- a/internal/impl/splunk/output.go
+++ b/internal/impl/splunk/output.go
@@ -110,7 +110,7 @@ func init() {
 
 			out, err = outputFromParsed(conf, mgr.Logger())
 			if err == nil {
-				out = license.WrapBatchOutput(mgr, out)
+				out = license.WrapBatchOutput(mgr, "splunk_hec", out)
 			}
 			return
 		})

--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -35,6 +35,8 @@ type Service struct {
 	loadedLicense *atomic.Pointer[license.RedpandaLicense]
 	conf          Config
 
+	isTestLicense bool
+
 	expiryMetric *service.MetricGauge
 	cancel       context.CancelFunc
 }
@@ -62,13 +64,25 @@ func RegisterService(res *service.Resources, conf Config) {
 		conf:          conf,
 	}
 
-	license, err := s.readAndValidateLicense()
+	l, err := s.readAndValidateLicense()
+	licenseReadErr := err
 	if err != nil {
 		res.Logger().With("error", err).Error("Failed to read Redpanda License")
-		license = openSourceLicense
+		l = openSourceLicense
 	}
 
-	s.setLicense(res, license)
+	if !l.AllowsEnterpriseFeatures() && os.Getenv("REDPANDA_CONNECT_DEV_LICENSE") != "" {
+		s.isTestLicense = true
+		l = embeddedTestLicense
+		if licenseReadErr != nil {
+			res.Logger().With("error", licenseReadErr).Error("Production license invalid; activating embedded dev license (REDPANDA_CONNECT_DEV_LICENSE set) — enterprise features subject to 1 MB/s throughput cap. Fix your license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+		} else {
+			res.Logger().Info("Running under embedded test license (REDPANDA_CONNECT_DEV_LICENSE set) — enterprise features subject to 1 MB/s throughput cap per process. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+		}
+		registerThrottler(res, newThrottler(res))
+	}
+
+	s.setLicense(res, l)
 	setSharedService(res, s)
 }
 

--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -79,8 +79,8 @@ func RegisterService(res *service.Resources, conf Config) {
 		} else {
 			res.Logger().Info("Running under embedded dev license — enterprise features subject to 1 MB/s throughput cap per process. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
 		}
-		registerEgressThrottler(res, newThrottler(res))
-		registerIngressThrottler(res, newThrottler(res))
+		registerEgressThrottler(res, newThrottler(res, "output"))
+		registerIngressThrottler(res, newThrottler(res, "input"))
 	}
 
 	s.setLicense(res, l)

--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -79,7 +79,8 @@ func RegisterService(res *service.Resources, conf Config) {
 		} else {
 			res.Logger().Info("Running under embedded dev license — enterprise features subject to 1 MB/s throughput cap per process. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
 		}
-		registerThrottler(res, newThrottler(res))
+		registerEgressThrottler(res, newThrottler(res))
+		registerIngressThrottler(res, newThrottler(res))
 	}
 
 	s.setLicense(res, l)

--- a/internal/license/service.go
+++ b/internal/license/service.go
@@ -71,13 +71,13 @@ func RegisterService(res *service.Resources, conf Config) {
 		l = openSourceLicense
 	}
 
-	if !l.AllowsEnterpriseFeatures() && os.Getenv("REDPANDA_CONNECT_DEV_LICENSE") != "" {
+	if !l.AllowsEnterpriseFeatures() {
 		s.isTestLicense = true
 		l = embeddedTestLicense
 		if licenseReadErr != nil {
-			res.Logger().With("error", licenseReadErr).Error("Production license invalid; activating embedded dev license (REDPANDA_CONNECT_DEV_LICENSE set) — enterprise features subject to 1 MB/s throughput cap. Fix your license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+			res.Logger().With("error", licenseReadErr).Error("Production license invalid; activating embedded dev license — enterprise features subject to 1 MB/s throughput cap. Fix your license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
 		} else {
-			res.Logger().Info("Running under embedded test license (REDPANDA_CONNECT_DEV_LICENSE set) — enterprise features subject to 1 MB/s throughput cap per process. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+			res.Logger().Info("Running under embedded dev license — enterprise features subject to 1 MB/s throughput cap per process. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
 		}
 		registerThrottler(res, newThrottler(res))
 	}

--- a/internal/license/service_test.go
+++ b/internal/license/service_test.go
@@ -34,5 +34,6 @@ func TestLicenseDevLicenseDefault(t *testing.T) {
 	svc := getSharedService(res)
 	require.NotNil(t, svc)
 	assert.True(t, svc.isTestLicense)
-	assert.NotNil(t, getThrottler(res))
+	assert.NotNil(t, getEgressThrottler(res))
+	assert.NotNil(t, getIngressThrottler(res))
 }

--- a/internal/license/service_test.go
+++ b/internal/license/service_test.go
@@ -18,30 +18,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func TestLicenseEnterpriseNoLicense(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpBadLicensePath := filepath.Join(tmpDir, "bad.license")
-
-	res := service.MockResources()
-	RegisterService(res, Config{
-		customDefaultLicenseFilepath: tmpBadLicensePath,
-	})
-
-	loaded, err := LoadFromResources(res)
-	require.NoError(t, err)
-
-	// No production license, no env var → open-source, no enterprise features.
-	assert.False(t, loaded.AllowsEnterpriseFeatures())
-
-	svc := getSharedService(res)
-	require.NotNil(t, svc)
-	assert.False(t, svc.isTestLicense)
-	assert.Nil(t, getThrottler(res))
-}
-
-func TestLicenseDevLicenseEnvVar(t *testing.T) {
-	t.Setenv("REDPANDA_CONNECT_DEV_LICENSE", "1")
-
+func TestLicenseDevLicenseDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 	res := service.MockResources()
 	RegisterService(res, Config{
@@ -51,7 +28,7 @@ func TestLicenseDevLicenseEnvVar(t *testing.T) {
 	loaded, err := LoadFromResources(res)
 	require.NoError(t, err)
 
-	// Env var set → embedded test license with enterprise access and throttler.
+	// No production license → embedded dev license with enterprise access and throttler.
 	assert.True(t, loaded.AllowsEnterpriseFeatures())
 
 	svc := getSharedService(res)

--- a/internal/license/service_test.go
+++ b/internal/license/service_test.go
@@ -30,5 +30,32 @@ func TestLicenseEnterpriseNoLicense(t *testing.T) {
 	loaded, err := LoadFromResources(res)
 	require.NoError(t, err)
 
+	// No production license, no env var → open-source, no enterprise features.
 	assert.False(t, loaded.AllowsEnterpriseFeatures())
+
+	svc := getSharedService(res)
+	require.NotNil(t, svc)
+	assert.False(t, svc.isTestLicense)
+	assert.Nil(t, getThrottler(res))
+}
+
+func TestLicenseDevLicenseEnvVar(t *testing.T) {
+	t.Setenv("REDPANDA_CONNECT_DEV_LICENSE", "1")
+
+	tmpDir := t.TempDir()
+	res := service.MockResources()
+	RegisterService(res, Config{
+		customDefaultLicenseFilepath: filepath.Join(tmpDir, "missing.license"),
+	})
+
+	loaded, err := LoadFromResources(res)
+	require.NoError(t, err)
+
+	// Env var set → embedded test license with enterprise access and throttler.
+	assert.True(t, loaded.AllowsEnterpriseFeatures())
+
+	svc := getSharedService(res)
+	require.NotNil(t, svc)
+	assert.True(t, svc.isTestLicense)
+	assert.NotNil(t, getThrottler(res))
 }

--- a/internal/license/shared_service.go
+++ b/internal/license/shared_service.go
@@ -46,22 +46,118 @@ func CheckRunningEnterprise(res *service.Resources) error {
 	return nil
 }
 
-// WrapBatchOutput wraps output with throughput throttling when running under
-// the embedded test license. Returns output unchanged under a production license
+// WrapBatchOutput wraps output with egress throttling when running under
+// the embedded dev license. Returns output unchanged under a production license
 // or when no license service is registered.
 func WrapBatchOutput(res *service.Resources, output service.BatchOutput) service.BatchOutput {
 	svc := getSharedService(res)
 	if svc == nil || !svc.isTestLicense {
 		return output
 	}
-	t := getThrottler(res)
+	t := getEgressThrottler(res)
 	if t == nil {
 		return output
 	}
 	return &throttledBatchOutput{wrapped: output, throttler: t}
 }
 
-// RegisterServiceFrom copies the license service and throttler from src to dst.
+// WrapBatchInput wraps input with ingress throttling when running under
+// the embedded dev license. Returns input unchanged under a production license
+// or when no license service is registered.
+func WrapBatchInput(res *service.Resources, input service.BatchInput) service.BatchInput {
+	svc := getSharedService(res)
+	if svc == nil || !svc.isTestLicense {
+		return input
+	}
+	t := getIngressThrottler(res)
+	if t == nil {
+		return input
+	}
+	return &throttledBatchInput{wrapped: input, throttler: t}
+}
+
+// MustRegisterEnterpriseBatchOutput registers an enterprise batch output.
+// The license check and dev-license egress throttle wrapping are applied
+// automatically; the ctor must not call CheckRunningEnterprise or
+// WrapBatchOutput itself.
+func MustRegisterEnterpriseBatchOutput(
+	name string,
+	spec *service.ConfigSpec,
+	ctor func(*service.ParsedConfig, *service.Resources) (service.BatchOutput, service.BatchPolicy, int, error),
+) {
+	service.MustRegisterBatchOutput(name, spec,
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchOutput, service.BatchPolicy, int, error) {
+			if err := CheckRunningEnterprise(mgr); err != nil {
+				return nil, service.BatchPolicy{}, 0, err
+			}
+			out, bp, mif, err := ctor(conf, mgr)
+			if err == nil {
+				out = WrapBatchOutput(mgr, out)
+			}
+			return out, bp, mif, err
+		})
+}
+
+// WrapInput wraps input with ingress throttling when running under
+// the embedded dev license. Returns input unchanged under a production license
+// or when no license service is registered.
+func WrapInput(res *service.Resources, input service.Input) service.Input {
+	svc := getSharedService(res)
+	if svc == nil || !svc.isTestLicense {
+		return input
+	}
+	t := getIngressThrottler(res)
+	if t == nil {
+		return input
+	}
+	return &throttledInput{wrapped: input, throttler: t}
+}
+
+// MustRegisterEnterpriseInput registers an enterprise input.
+// The license check and dev-license ingress throttle wrapping are applied
+// automatically; the ctor must not call CheckRunningEnterprise or
+// WrapInput itself.
+func MustRegisterEnterpriseInput(
+	name string,
+	spec *service.ConfigSpec,
+	ctor func(*service.ParsedConfig, *service.Resources) (service.Input, error),
+) {
+	service.MustRegisterInput(name, spec,
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
+			if err := CheckRunningEnterprise(mgr); err != nil {
+				return nil, err
+			}
+			in, err := ctor(conf, mgr)
+			if err == nil {
+				in = WrapInput(mgr, in)
+			}
+			return in, err
+		})
+}
+
+// MustRegisterEnterpriseBatchInput registers an enterprise batch input.
+// The license check and dev-license ingress throttle wrapping are applied
+// automatically; the ctor must not call CheckRunningEnterprise or
+// WrapBatchInput itself.
+func MustRegisterEnterpriseBatchInput(
+	name string,
+	spec *service.ConfigSpec,
+	ctor func(*service.ParsedConfig, *service.Resources) (service.BatchInput, error),
+) {
+	service.MustRegisterBatchInput(name, spec,
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			if err := CheckRunningEnterprise(mgr); err != nil {
+				return nil, err
+			}
+			in, err := ctor(conf, mgr)
+			if err == nil {
+				in = WrapBatchInput(mgr, in)
+			}
+			return in, err
+		})
+}
+
+// RegisterServiceFrom copies the license service and throttlers from src to dst.
 // Use in agent mode so all per-stream Resources share one Service and Throttler
 // rather than each getting an independent token bucket.
 func RegisterServiceFrom(src, dst *service.Resources) {
@@ -70,8 +166,11 @@ func RegisterServiceFrom(src, dst *service.Resources) {
 		return
 	}
 	setSharedService(dst, svc)
-	if t := getThrottler(src); t != nil {
-		registerThrottler(dst, t)
+	if t := getEgressThrottler(src); t != nil {
+		registerEgressThrottler(dst, t)
+	}
+	if t := getIngressThrottler(src); t != nil {
+		registerIngressThrottler(dst, t)
 	}
 }
 
@@ -91,16 +190,30 @@ func getSharedService(res *service.Resources) *Service {
 	return reg.(*Service)
 }
 
-type throttlerKeyType int
+type egressThrottlerKeyType int
+type ingressThrottlerKeyType int
 
-var throttlerKey throttlerKeyType
+var egressThrottlerKey egressThrottlerKeyType
+var ingressThrottlerKey ingressThrottlerKeyType
 
-func registerThrottler(res *service.Resources, t *Throttler) {
-	res.SetGeneric(throttlerKey, t)
+func registerEgressThrottler(res *service.Resources, t *Throttler) {
+	res.SetGeneric(egressThrottlerKey, t)
 }
 
-func getThrottler(res *service.Resources) *Throttler {
-	v, _ := res.GetGeneric(throttlerKey)
+func getEgressThrottler(res *service.Resources) *Throttler {
+	v, _ := res.GetGeneric(egressThrottlerKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*Throttler)
+}
+
+func registerIngressThrottler(res *service.Resources, t *Throttler) {
+	res.SetGeneric(ingressThrottlerKey, t)
+}
+
+func getIngressThrottler(res *service.Resources) *Throttler {
+	v, _ := res.GetGeneric(ingressThrottlerKey)
 	if v == nil {
 		return nil
 	}

--- a/internal/license/shared_service.go
+++ b/internal/license/shared_service.go
@@ -190,11 +190,15 @@ func getSharedService(res *service.Resources) *Service {
 	return reg.(*Service)
 }
 
-type egressThrottlerKeyType int
-type ingressThrottlerKeyType int
+type (
+	egressThrottlerKeyType  int
+	ingressThrottlerKeyType int
+)
 
-var egressThrottlerKey egressThrottlerKeyType
-var ingressThrottlerKey ingressThrottlerKeyType
+var (
+	egressThrottlerKey  egressThrottlerKeyType
+	ingressThrottlerKey ingressThrottlerKeyType
+)
 
 func registerEgressThrottler(res *service.Resources, t *Throttler) {
 	res.SetGeneric(egressThrottlerKey, t)

--- a/internal/license/shared_service.go
+++ b/internal/license/shared_service.go
@@ -46,6 +46,35 @@ func CheckRunningEnterprise(res *service.Resources) error {
 	return nil
 }
 
+// WrapBatchOutput wraps output with throughput throttling when running under
+// the embedded test license. Returns output unchanged under a production license
+// or when no license service is registered.
+func WrapBatchOutput(res *service.Resources, output service.BatchOutput) service.BatchOutput {
+	svc := getSharedService(res)
+	if svc == nil || !svc.isTestLicense {
+		return output
+	}
+	t := getThrottler(res)
+	if t == nil {
+		return output
+	}
+	return &throttledBatchOutput{wrapped: output, throttler: t}
+}
+
+// RegisterServiceFrom copies the license service and throttler from src to dst.
+// Use in agent mode so all per-stream Resources share one Service and Throttler
+// rather than each getting an independent token bucket.
+func RegisterServiceFrom(src, dst *service.Resources) {
+	svc := getSharedService(src)
+	if svc == nil {
+		return
+	}
+	setSharedService(dst, svc)
+	if t := getThrottler(src); t != nil {
+		registerThrottler(dst, t)
+	}
+}
+
 type sharedServiceKeyType int
 
 var sharedServiceKey sharedServiceKeyType
@@ -60,4 +89,20 @@ func getSharedService(res *service.Resources) *Service {
 		return nil
 	}
 	return reg.(*Service)
+}
+
+type throttlerKeyType int
+
+var throttlerKey throttlerKeyType
+
+func registerThrottler(res *service.Resources, t *Throttler) {
+	res.SetGeneric(throttlerKey, t)
+}
+
+func getThrottler(res *service.Resources) *Throttler {
+	v, _ := res.GetGeneric(throttlerKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*Throttler)
 }

--- a/internal/license/shared_service.go
+++ b/internal/license/shared_service.go
@@ -48,8 +48,9 @@ func CheckRunningEnterprise(res *service.Resources) error {
 
 // WrapBatchOutput wraps output with egress throttling when running under
 // the embedded dev license. Returns output unchanged under a production license
-// or when no license service is registered.
-func WrapBatchOutput(res *service.Resources, output service.BatchOutput) service.BatchOutput {
+// or when no license service is registered. name is the registered component
+// name used in throttle warnings.
+func WrapBatchOutput(res *service.Resources, name string, output service.BatchOutput) service.BatchOutput {
 	svc := getSharedService(res)
 	if svc == nil || !svc.isTestLicense {
 		return output
@@ -58,13 +59,14 @@ func WrapBatchOutput(res *service.Resources, output service.BatchOutput) service
 	if t == nil {
 		return output
 	}
-	return &throttledBatchOutput{wrapped: output, throttler: t}
+	return &throttledBatchOutput{wrapped: output, throttler: t, name: name}
 }
 
 // WrapBatchInput wraps input with ingress throttling when running under
 // the embedded dev license. Returns input unchanged under a production license
-// or when no license service is registered.
-func WrapBatchInput(res *service.Resources, input service.BatchInput) service.BatchInput {
+// or when no license service is registered. name is the registered component
+// name used in throttle warnings.
+func WrapBatchInput(res *service.Resources, name string, input service.BatchInput) service.BatchInput {
 	svc := getSharedService(res)
 	if svc == nil || !svc.isTestLicense {
 		return input
@@ -73,7 +75,7 @@ func WrapBatchInput(res *service.Resources, input service.BatchInput) service.Ba
 	if t == nil {
 		return input
 	}
-	return &throttledBatchInput{wrapped: input, throttler: t}
+	return &throttledBatchInput{wrapped: input, throttler: t, name: name}
 }
 
 // MustRegisterEnterpriseBatchOutput registers an enterprise batch output.
@@ -92,7 +94,7 @@ func MustRegisterEnterpriseBatchOutput(
 			}
 			out, bp, mif, err := ctor(conf, mgr)
 			if err == nil {
-				out = WrapBatchOutput(mgr, out)
+				out = WrapBatchOutput(mgr, name, out)
 			}
 			return out, bp, mif, err
 		})
@@ -100,8 +102,9 @@ func MustRegisterEnterpriseBatchOutput(
 
 // WrapInput wraps input with ingress throttling when running under
 // the embedded dev license. Returns input unchanged under a production license
-// or when no license service is registered.
-func WrapInput(res *service.Resources, input service.Input) service.Input {
+// or when no license service is registered. name is the registered component
+// name used in throttle warnings.
+func WrapInput(res *service.Resources, name string, input service.Input) service.Input {
 	svc := getSharedService(res)
 	if svc == nil || !svc.isTestLicense {
 		return input
@@ -110,7 +113,7 @@ func WrapInput(res *service.Resources, input service.Input) service.Input {
 	if t == nil {
 		return input
 	}
-	return &throttledInput{wrapped: input, throttler: t}
+	return &throttledInput{wrapped: input, throttler: t, name: name}
 }
 
 // MustRegisterEnterpriseInput registers an enterprise input.
@@ -129,7 +132,7 @@ func MustRegisterEnterpriseInput(
 			}
 			in, err := ctor(conf, mgr)
 			if err == nil {
-				in = WrapInput(mgr, in)
+				in = WrapInput(mgr, name, in)
 			}
 			return in, err
 		})
@@ -151,7 +154,7 @@ func MustRegisterEnterpriseBatchInput(
 			}
 			in, err := ctor(conf, mgr)
 			if err == nil {
-				in = WrapBatchInput(mgr, in)
+				in = WrapBatchInput(mgr, name, in)
 			}
 			return in, err
 		})

--- a/internal/license/shared_service.go
+++ b/internal/license/shared_service.go
@@ -160,6 +160,44 @@ func MustRegisterEnterpriseBatchInput(
 		})
 }
 
+// WrapOutput wraps output with egress throttling when running under
+// the embedded dev license. Returns output unchanged under a production license
+// or when no license service is registered. name is the registered component
+// name used in throttle warnings.
+func WrapOutput(res *service.Resources, name string, output service.Output) service.Output {
+	svc := getSharedService(res)
+	if svc == nil || !svc.isTestLicense {
+		return output
+	}
+	t := getEgressThrottler(res)
+	if t == nil {
+		return output
+	}
+	return &throttledOutput{wrapped: output, throttler: t, name: name}
+}
+
+// MustRegisterEnterpriseOutput registers an enterprise plain output.
+// The license check and dev-license egress throttle wrapping are applied
+// automatically; the ctor must not call CheckRunningEnterprise or
+// WrapOutput itself.
+func MustRegisterEnterpriseOutput(
+	name string,
+	spec *service.ConfigSpec,
+	ctor func(*service.ParsedConfig, *service.Resources) (service.Output, int, error),
+) {
+	service.MustRegisterOutput(name, spec,
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Output, int, error) {
+			if err := CheckRunningEnterprise(mgr); err != nil {
+				return nil, 0, err
+			}
+			out, mif, err := ctor(conf, mgr)
+			if err == nil {
+				out = WrapOutput(mgr, name, out)
+			}
+			return out, mif, err
+		})
+}
+
 // RegisterServiceFrom copies the license service and throttlers from src to dst.
 // Use in agent mode so all per-stream Resources share one Service and Throttler
 // rather than each getting an independent token bucket.

--- a/internal/license/test_license.go
+++ b/internal/license/test_license.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package license
+
+import (
+	"time"
+
+	"github.com/redpanda-data/common-go/license"
+)
+
+// embeddedTestLicense is compiled into the self-hosted binary and activates
+// when no production license is present. It grants enterprise feature access
+// under a 1 MB/s throughput cap (see Throttler).
+var embeddedTestLicense license.RedpandaLicense = &license.V1RedpandaLicense{
+	Version:      1,
+	Organization: "embedded-test",
+	Type:         license.LicenseTypeEnterprise,
+	// Far-future expiry — this license is only a developer convenience, not a
+	// security boundary, so we don't impose an artificial time limit.
+	Expiry:   time.Date(2126, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+	Products: []license.Product{license.ProductConnect},
+}

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -49,41 +49,51 @@ func newThrottler(res *service.Resources, direction string) *Throttler {
 // registered component name (e.g. "sap_hana") used in the throttle warning.
 // If the cap is reached, a WARN is logged once and the metric is set to 1
 // until throughput drops back below the limit.
+//
+// Oversized batches (n > burst) are billed in burst-sized chunks so that the
+// full byte count is always charged — batching larger cannot bypass the cap.
 func (t *Throttler) Wait(ctx context.Context, n int, connector string) error {
 	if n <= 0 {
 		return nil
 	}
-	// Cap n to burst to avoid a panic in ReserveN when a single batch exceeds
-	// the 30 MB window. Very large batches are undercharged slightly; the cap
-	// remains effective at sustained rates.
-	if n > testLicenseBurstBytes {
-		n = testLicenseBurstBytes
+
+	anyDelay := false
+	for n > 0 {
+		charge := n
+		if charge > testLicenseBurstBytes {
+			charge = testLicenseBurstBytes
+		}
+		n -= charge
+
+		r := t.limiter.ReserveN(time.Now(), charge)
+		delay := r.Delay()
+		if delay <= 0 {
+			continue
+		}
+
+		anyDelay = true
+		if t.throttling.CompareAndSwap(false, true) {
+			t.logger.Warnf("Throughput cap reached under embedded test license (1 MB/s). Throttling enterprise %s %q. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/", t.direction, connector)
+			t.throttleGauge.Set(1)
+		}
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			r.Cancel()
+			if t.throttling.CompareAndSwap(true, false) {
+				t.throttleGauge.Set(0)
+			}
+			return ctx.Err()
+		}
 	}
 
-	r := t.limiter.ReserveN(time.Now(), n)
-	delay := r.Delay()
-	if delay <= 0 {
+	if !anyDelay {
 		if t.throttling.CompareAndSwap(true, false) {
 			t.throttleGauge.Set(0)
 		}
-		return nil
 	}
-
-	if t.throttling.CompareAndSwap(false, true) {
-		t.logger.Warnf("Throughput cap reached under embedded test license (1 MB/s). Throttling enterprise %s %q. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/", t.direction, connector)
-		t.throttleGauge.Set(1)
-	}
-
-	select {
-	case <-time.After(delay):
-		return nil
-	case <-ctx.Done():
-		r.Cancel()
-		if t.throttling.CompareAndSwap(true, false) {
-			t.throttleGauge.Set(0)
-		}
-		return ctx.Err()
-	}
+	return nil
 }
 
 // throttledBatchOutput wraps a service.BatchOutput and enforces the dev

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -32,21 +32,24 @@ type Throttler struct {
 	limiter       *rate.Limiter
 	throttleGauge *service.MetricGauge
 	logger        *service.Logger
+	direction     string // "input" or "output"
 	throttling    atomic.Bool
 }
 
-func newThrottler(res *service.Resources) *Throttler {
+func newThrottler(res *service.Resources, direction string) *Throttler {
 	return &Throttler{
 		limiter:       rate.NewLimiter(rate.Limit(testLicenseBytesPerSec), testLicenseBurstBytes),
 		throttleGauge: res.Metrics().NewGauge("redpanda_connect_test_license_throttle_active"),
 		logger:        res.Logger(),
+		direction:     direction,
 	}
 }
 
-// Wait blocks until the token bucket allows n bytes through. If the cap is
-// reached, a WARN is logged once and the metric is set to 1 until throughput
-// drops back below the limit.
-func (t *Throttler) Wait(ctx context.Context, n int) error {
+// Wait blocks until the token bucket allows n bytes through. connector is the
+// registered component name (e.g. "sap_hana") used in the throttle warning.
+// If the cap is reached, a WARN is logged once and the metric is set to 1
+// until throughput drops back below the limit.
+func (t *Throttler) Wait(ctx context.Context, n int, connector string) error {
 	if n <= 0 {
 		return nil
 	}
@@ -67,7 +70,7 @@ func (t *Throttler) Wait(ctx context.Context, n int) error {
 	}
 
 	if t.throttling.CompareAndSwap(false, true) {
-		t.logger.Warn("Throughput cap reached under embedded test license (1 MB/s). Throttling enterprise output. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+		t.logger.Warnf("Throughput cap reached under embedded test license (1 MB/s). Throttling enterprise %s %q. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/", t.direction, connector)
 		t.throttleGauge.Set(1)
 	}
 
@@ -88,6 +91,7 @@ func (t *Throttler) Wait(ctx context.Context, n int) error {
 type throttledBatchOutput struct {
 	wrapped   service.BatchOutput
 	throttler *Throttler
+	name      string
 }
 
 func (o *throttledBatchOutput) Connect(ctx context.Context) error {
@@ -102,7 +106,7 @@ func (o *throttledBatchOutput) WriteBatch(ctx context.Context, batch service.Mes
 			n += len(b)
 		}
 	}
-	if err := o.throttler.Wait(ctx, n); err != nil {
+	if err := o.throttler.Wait(ctx, n, o.name); err != nil {
 		return err
 	}
 	return o.wrapped.WriteBatch(ctx, batch)
@@ -117,6 +121,7 @@ func (o *throttledBatchOutput) Close(ctx context.Context) error {
 type throttledInput struct {
 	wrapped   service.Input
 	throttler *Throttler
+	name      string
 }
 
 func (i *throttledInput) Connect(ctx context.Context) error { return i.wrapped.Connect(ctx) }
@@ -127,7 +132,7 @@ func (i *throttledInput) Read(ctx context.Context) (*service.Message, service.Ac
 		return msg, ackFn, err
 	}
 	if b, berr := msg.AsBytes(); berr == nil {
-		if err := i.throttler.Wait(ctx, len(b)); err != nil {
+		if err := i.throttler.Wait(ctx, len(b), i.name); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -141,6 +146,7 @@ func (i *throttledInput) Close(ctx context.Context) error { return i.wrapped.Clo
 type throttledBatchInput struct {
 	wrapped   service.BatchInput
 	throttler *Throttler
+	name      string
 }
 
 func (i *throttledBatchInput) Connect(ctx context.Context) error {
@@ -158,7 +164,7 @@ func (i *throttledBatchInput) ReadBatch(ctx context.Context) (service.MessageBat
 			n += len(b)
 		}
 	}
-	if err := i.throttler.Wait(ctx, n); err != nil {
+	if err := i.throttler.Wait(ctx, n, i.name); err != nil {
 		return nil, nil, err
 	}
 	return batch, ackFn, nil

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -13,14 +13,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/redpanda-data/benthos/v4/public/service"
 	"golang.org/x/time/rate"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 const (
-	testLicenseBytesPerSec  = 1 * 1024 * 1024 // 1 MB/s
-	testLicenseWindowSec    = 30
-	testLicenseBurstBytes   = testLicenseBytesPerSec * testLicenseWindowSec // 30 MB burst
+	testLicenseBytesPerSec = 1 * 1024 * 1024 // 1 MB/s
+	testLicenseWindowSec   = 30
+	testLicenseBurstBytes  = testLicenseBytesPerSec * testLicenseWindowSec // 30 MB burst
 )
 
 // Throttler enforces the 1 MB/s compressed-bytes-out cap for enterprise

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -82,8 +82,8 @@ func (t *Throttler) Wait(ctx context.Context, n int) error {
 	}
 }
 
-// throttledBatchOutput wraps a service.BatchOutput and enforces the test
-// license throughput cap before each WriteBatch call.
+// throttledBatchOutput wraps a service.BatchOutput and enforces the dev
+// license egress cap before each WriteBatch call.
 type throttledBatchOutput struct {
 	wrapped   service.BatchOutput
 	throttler *Throttler
@@ -109,4 +109,60 @@ func (o *throttledBatchOutput) WriteBatch(ctx context.Context, batch service.Mes
 
 func (o *throttledBatchOutput) Close(ctx context.Context) error {
 	return o.wrapped.Close(ctx)
+}
+
+// throttledInput wraps a service.Input and enforces the dev
+// license ingress cap after each Read call.
+type throttledInput struct {
+	wrapped   service.Input
+	throttler *Throttler
+}
+
+func (i *throttledInput) Connect(ctx context.Context) error { return i.wrapped.Connect(ctx) }
+
+func (i *throttledInput) Read(ctx context.Context) (*service.Message, service.AckFunc, error) {
+	msg, ackFn, err := i.wrapped.Read(ctx)
+	if err != nil || msg == nil {
+		return msg, ackFn, err
+	}
+	if b, berr := msg.AsBytes(); berr == nil {
+		if err := i.throttler.Wait(ctx, len(b)); err != nil {
+			return nil, nil, err
+		}
+	}
+	return msg, ackFn, nil
+}
+
+func (i *throttledInput) Close(ctx context.Context) error { return i.wrapped.Close(ctx) }
+
+// throttledBatchInput wraps a service.BatchInput and enforces the dev
+// license ingress cap after each ReadBatch call.
+type throttledBatchInput struct {
+	wrapped   service.BatchInput
+	throttler *Throttler
+}
+
+func (i *throttledBatchInput) Connect(ctx context.Context) error {
+	return i.wrapped.Connect(ctx)
+}
+
+func (i *throttledBatchInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	batch, ackFn, err := i.wrapped.ReadBatch(ctx)
+	if err != nil || len(batch) == 0 {
+		return batch, ackFn, err
+	}
+	var n int
+	for _, msg := range batch {
+		if b, berr := msg.AsBytes(); berr == nil {
+			n += len(b)
+		}
+	}
+	if err := i.throttler.Wait(ctx, n); err != nil {
+		return nil, nil, err
+	}
+	return batch, ackFn, nil
+}
+
+func (i *throttledBatchInput) Close(ctx context.Context) error {
+	return i.wrapped.Close(ctx)
 }

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package license
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"golang.org/x/time/rate"
+)
+
+const (
+	testLicenseBytesPerSec  = 1 * 1024 * 1024 // 1 MB/s
+	testLicenseWindowSec    = 30
+	testLicenseBurstBytes   = testLicenseBytesPerSec * testLicenseWindowSec // 30 MB burst
+)
+
+// Throttler enforces the 1 MB/s compressed-bytes-out cap for enterprise
+// features running under the embedded test license. All pipelines in the
+// same process share one instance so load cannot be spread across pipelines
+// to circumvent the cap.
+type Throttler struct {
+	limiter       *rate.Limiter
+	throttleGauge *service.MetricGauge
+	logger        *service.Logger
+	throttling    atomic.Bool
+}
+
+func newThrottler(res *service.Resources) *Throttler {
+	return &Throttler{
+		limiter:       rate.NewLimiter(rate.Limit(testLicenseBytesPerSec), testLicenseBurstBytes),
+		throttleGauge: res.Metrics().NewGauge("redpanda_connect_test_license_throttle_active"),
+		logger:        res.Logger(),
+	}
+}
+
+// Wait blocks until the token bucket allows n bytes through. If the cap is
+// reached, a WARN is logged once and the metric is set to 1 until throughput
+// drops back below the limit.
+func (t *Throttler) Wait(ctx context.Context, n int) error {
+	if n <= 0 {
+		return nil
+	}
+	// Cap n to burst to avoid a panic in ReserveN when a single batch exceeds
+	// the 30 MB window. Very large batches are undercharged slightly; the cap
+	// remains effective at sustained rates.
+	if n > testLicenseBurstBytes {
+		n = testLicenseBurstBytes
+	}
+
+	r := t.limiter.ReserveN(time.Now(), n)
+	delay := r.Delay()
+	if delay <= 0 {
+		if t.throttling.CompareAndSwap(true, false) {
+			t.throttleGauge.Set(0)
+		}
+		return nil
+	}
+
+	if t.throttling.CompareAndSwap(false, true) {
+		t.logger.Warn("Throughput cap reached under embedded test license (1 MB/s). Throttling enterprise output. Apply a production license to remove the cap: https://docs.redpanda.com/redpanda-connect/get-started/licensing/")
+		t.throttleGauge.Set(1)
+	}
+
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		r.Cancel()
+		if t.throttling.CompareAndSwap(true, false) {
+			t.throttleGauge.Set(0)
+		}
+		return ctx.Err()
+	}
+}
+
+// throttledBatchOutput wraps a service.BatchOutput and enforces the test
+// license throughput cap before each WriteBatch call.
+type throttledBatchOutput struct {
+	wrapped   service.BatchOutput
+	throttler *Throttler
+}
+
+func (o *throttledBatchOutput) Connect(ctx context.Context) error {
+	return o.wrapped.Connect(ctx)
+}
+
+func (o *throttledBatchOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	var n int
+	for _, msg := range batch {
+		b, err := msg.AsBytes()
+		if err == nil {
+			n += len(b)
+		}
+	}
+	if err := o.throttler.Wait(ctx, n); err != nil {
+		return err
+	}
+	return o.wrapped.WriteBatch(ctx, batch)
+}
+
+func (o *throttledBatchOutput) Close(ctx context.Context) error {
+	return o.wrapped.Close(ctx)
+}

--- a/internal/license/throttle.go
+++ b/internal/license/throttle.go
@@ -59,10 +59,7 @@ func (t *Throttler) Wait(ctx context.Context, n int, connector string) error {
 
 	anyDelay := false
 	for n > 0 {
-		charge := n
-		if charge > testLicenseBurstBytes {
-			charge = testLicenseBurstBytes
-		}
+		charge := min(n, testLicenseBurstBytes)
 		n -= charge
 
 		r := t.limiter.ReserveN(time.Now(), charge)
@@ -183,3 +180,24 @@ func (i *throttledBatchInput) ReadBatch(ctx context.Context) (service.MessageBat
 func (i *throttledBatchInput) Close(ctx context.Context) error {
 	return i.wrapped.Close(ctx)
 }
+
+// throttledOutput wraps a service.Output and enforces the dev
+// license egress cap before each Write call.
+type throttledOutput struct {
+	wrapped   service.Output
+	throttler *Throttler
+	name      string
+}
+
+func (o *throttledOutput) Connect(ctx context.Context) error { return o.wrapped.Connect(ctx) }
+
+func (o *throttledOutput) Write(ctx context.Context, msg *service.Message) error {
+	if b, err := msg.AsBytes(); err == nil {
+		if err := o.throttler.Wait(ctx, len(b), o.name); err != nil {
+			return err
+		}
+	}
+	return o.wrapped.Write(ctx, msg)
+}
+
+func (o *throttledOutput) Close(ctx context.Context) error { return o.wrapped.Close(ctx) }

--- a/internal/license/throttle_test.go
+++ b/internal/license/throttle_test.go
@@ -60,7 +60,7 @@ func TestWrapBatchOutput_NoopUnderProductionLicense(t *testing.T) {
 	InjectTestService(res) // enterprise, but NOT isTestLicense
 
 	inner := &mockBatchOutput{}
-	wrapped := WrapBatchOutput(res, inner)
+	wrapped := WrapBatchOutput(res, "test_output", inner)
 
 	// Should be the same pointer — no wrapper applied.
 	assert.Same(t, inner, wrapped.(*mockBatchOutput))
@@ -70,7 +70,7 @@ func TestWrapBatchOutput_ThrottlesUnderDevLicense(t *testing.T) {
 	res := devLicenseResources(t)
 
 	inner := &mockBatchOutput{}
-	wrapped := WrapBatchOutput(res, inner)
+	wrapped := WrapBatchOutput(res, "test_output", inner)
 
 	_, ok := wrapped.(*throttledBatchOutput)
 	assert.True(t, ok, "expected throttledBatchOutput wrapper under dev license")
@@ -82,7 +82,7 @@ func TestWrapBatchInput_NoopUnderProductionLicense(t *testing.T) {
 
 	msg := service.NewMessage([]byte("hello"))
 	inner := &mockBatchInput{batch: service.MessageBatch{msg}}
-	wrapped := WrapBatchInput(res, inner)
+	wrapped := WrapBatchInput(res, "test_input", inner)
 
 	assert.Same(t, inner, wrapped.(*mockBatchInput))
 }
@@ -92,7 +92,7 @@ func TestWrapBatchInput_ThrottlesUnderDevLicense(t *testing.T) {
 
 	msg := service.NewMessage([]byte("hello"))
 	inner := &mockBatchInput{batch: service.MessageBatch{msg}}
-	wrapped := WrapBatchInput(res, inner)
+	wrapped := WrapBatchInput(res, "test_input", inner)
 
 	_, ok := wrapped.(*throttledBatchInput)
 	assert.True(t, ok, "expected throttledBatchInput wrapper under dev license")
@@ -100,61 +100,61 @@ func TestWrapBatchInput_ThrottlesUnderDevLicense(t *testing.T) {
 
 func TestThrottler_PassthroughBelowCap(t *testing.T) {
 	res := service.MockResources()
-	throttler := newThrottler(res)
+	throttler := newThrottler(res, "output")
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 
 	// Small batch well under 1 MB/s cap — should pass with no delay.
 	start := time.Now()
-	err := throttler.Wait(ctx, 1024) // 1 KB
+	err := throttler.Wait(ctx, 1024, "test") // 1 KB
 	require.NoError(t, err)
 	assert.Less(t, time.Since(start), 100*time.Millisecond)
 }
 
 func TestThrottler_ZeroBytesNoBlock(t *testing.T) {
 	res := service.MockResources()
-	throttler := newThrottler(res)
+	throttler := newThrottler(res, "output")
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
-	err := throttler.Wait(ctx, 0)
+	err := throttler.Wait(ctx, 0, "test")
 	require.NoError(t, err)
 }
 
 func TestThrottler_CancelledContextReturnsError(t *testing.T) {
 	res := service.MockResources()
-	throttler := newThrottler(res)
+	throttler := newThrottler(res, "output")
 
 	// Drain the entire burst bucket so the next Wait will block.
 	ctx := t.Context()
-	err := throttler.Wait(ctx, testLicenseBurstBytes)
+	err := throttler.Wait(ctx, testLicenseBurstBytes, "test")
 	require.NoError(t, err)
 
 	// Now the bucket is empty; any further bytes will block.
 	cancelled, cancel := context.WithCancel(ctx)
 	cancel() // cancel immediately
 
-	err = throttler.Wait(cancelled, 1024)
+	err = throttler.Wait(cancelled, 1024, "test")
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestThrottler_EnforcesCap(t *testing.T) {
 	res := service.MockResources()
-	throttler := newThrottler(res)
+	throttler := newThrottler(res, "output")
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	// Drain the entire burst bucket.
-	err := throttler.Wait(ctx, testLicenseBurstBytes)
+	err := throttler.Wait(ctx, testLicenseBurstBytes, "test")
 	require.NoError(t, err)
 
 	// At 1 MB/s, sending 2 MB more must take at least ~2s.
 	const extraBytes = 2 * testLicenseBytesPerSec
 	start := time.Now()
-	err = throttler.Wait(ctx, extraBytes)
+	err = throttler.Wait(ctx, extraBytes, "test")
 	require.NoError(t, err)
 	elapsed := time.Since(start)
 

--- a/internal/license/throttle_test.go
+++ b/internal/license/throttle_test.go
@@ -32,6 +32,29 @@ func (m *mockBatchOutput) WriteBatch(_ context.Context, b service.MessageBatch) 
 	return nil
 }
 
+// mockBatchInput returns a single fixed batch per ReadBatch call.
+type mockBatchInput struct {
+	batch service.MessageBatch
+}
+
+func (m *mockBatchInput) Connect(_ context.Context) error { return nil }
+func (m *mockBatchInput) Close(_ context.Context) error   { return nil }
+func (m *mockBatchInput) ReadBatch(_ context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return m.batch, func(ctx context.Context, err error) error { return nil }, nil
+}
+
+func devLicenseResources(t *testing.T) *service.Resources {
+	t.Helper()
+	tmpDir := t.TempDir()
+	res := service.MockResources()
+	RegisterService(res, Config{
+		customDefaultLicenseFilepath: filepath.Join(tmpDir, "missing.license"),
+	})
+	svc := getSharedService(res)
+	require.True(t, svc.isTestLicense)
+	return res
+}
+
 func TestWrapBatchOutput_NoopUnderProductionLicense(t *testing.T) {
 	res := service.MockResources()
 	InjectTestService(res) // enterprise, but NOT isTestLicense
@@ -43,24 +66,36 @@ func TestWrapBatchOutput_NoopUnderProductionLicense(t *testing.T) {
 	assert.Same(t, inner, wrapped.(*mockBatchOutput))
 }
 
-func TestWrapBatchOutput_ThrottlesUnderTestLicense(t *testing.T) {
-	t.Setenv("REDPANDA_CONNECT_DEV_LICENSE", "1")
-
-	tmpDir := t.TempDir()
-	res := service.MockResources()
-	RegisterService(res, Config{
-		customDefaultLicenseFilepath: filepath.Join(tmpDir, "missing.license"),
-	})
-
-	svc := getSharedService(res)
-	require.True(t, svc.isTestLicense)
+func TestWrapBatchOutput_ThrottlesUnderDevLicense(t *testing.T) {
+	res := devLicenseResources(t)
 
 	inner := &mockBatchOutput{}
 	wrapped := WrapBatchOutput(res, inner)
 
-	// Should be wrapped.
 	_, ok := wrapped.(*throttledBatchOutput)
-	assert.True(t, ok, "expected throttledBatchOutput wrapper under test license")
+	assert.True(t, ok, "expected throttledBatchOutput wrapper under dev license")
+}
+
+func TestWrapBatchInput_NoopUnderProductionLicense(t *testing.T) {
+	res := service.MockResources()
+	InjectTestService(res) // enterprise, but NOT isTestLicense
+
+	msg := service.NewMessage([]byte("hello"))
+	inner := &mockBatchInput{batch: service.MessageBatch{msg}}
+	wrapped := WrapBatchInput(res, inner)
+
+	assert.Same(t, inner, wrapped.(*mockBatchInput))
+}
+
+func TestWrapBatchInput_ThrottlesUnderDevLicense(t *testing.T) {
+	res := devLicenseResources(t)
+
+	msg := service.NewMessage([]byte("hello"))
+	inner := &mockBatchInput{batch: service.MessageBatch{msg}}
+	wrapped := WrapBatchInput(res, inner)
+
+	_, ok := wrapped.(*throttledBatchInput)
+	assert.True(t, ok, "expected throttledBatchInput wrapper under dev license")
 }
 
 func TestThrottler_PassthroughBelowCap(t *testing.T) {

--- a/internal/license/throttle_test.go
+++ b/internal/license/throttle_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package license
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// mockBatchOutput records WriteBatch calls for assertions.
+type mockBatchOutput struct {
+	batches []service.MessageBatch
+}
+
+func (m *mockBatchOutput) Connect(_ context.Context) error { return nil }
+func (m *mockBatchOutput) Close(_ context.Context) error   { return nil }
+func (m *mockBatchOutput) WriteBatch(_ context.Context, b service.MessageBatch) error {
+	m.batches = append(m.batches, b)
+	return nil
+}
+
+func TestWrapBatchOutput_NoopUnderProductionLicense(t *testing.T) {
+	res := service.MockResources()
+	InjectTestService(res) // enterprise, but NOT isTestLicense
+
+	inner := &mockBatchOutput{}
+	wrapped := WrapBatchOutput(res, inner)
+
+	// Should be the same pointer — no wrapper applied.
+	assert.Same(t, inner, wrapped.(*mockBatchOutput))
+}
+
+func TestWrapBatchOutput_ThrottlesUnderTestLicense(t *testing.T) {
+	t.Setenv("REDPANDA_CONNECT_DEV_LICENSE", "1")
+
+	tmpDir := t.TempDir()
+	res := service.MockResources()
+	RegisterService(res, Config{
+		customDefaultLicenseFilepath: filepath.Join(tmpDir, "missing.license"),
+	})
+
+	svc := getSharedService(res)
+	require.True(t, svc.isTestLicense)
+
+	inner := &mockBatchOutput{}
+	wrapped := WrapBatchOutput(res, inner)
+
+	// Should be wrapped.
+	_, ok := wrapped.(*throttledBatchOutput)
+	assert.True(t, ok, "expected throttledBatchOutput wrapper under test license")
+}
+
+func TestThrottler_PassthroughBelowCap(t *testing.T) {
+	res := service.MockResources()
+	throttler := newThrottler(res)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	// Small batch well under 1 MB/s cap — should pass with no delay.
+	start := time.Now()
+	err := throttler.Wait(ctx, 1024) // 1 KB
+	require.NoError(t, err)
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+func TestThrottler_ZeroBytesNoBlock(t *testing.T) {
+	res := service.MockResources()
+	throttler := newThrottler(res)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	err := throttler.Wait(ctx, 0)
+	require.NoError(t, err)
+}
+
+func TestThrottler_CancelledContextReturnsError(t *testing.T) {
+	res := service.MockResources()
+	throttler := newThrottler(res)
+
+	// Drain the entire burst bucket so the next Wait will block.
+	ctx := t.Context()
+	err := throttler.Wait(ctx, testLicenseBurstBytes)
+	require.NoError(t, err)
+
+	// Now the bucket is empty; any further bytes will block.
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel() // cancel immediately
+
+	err = throttler.Wait(cancelled, 1024)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestThrottler_EnforcesCap(t *testing.T) {
+	res := service.MockResources()
+	throttler := newThrottler(res)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	// Drain the entire burst bucket.
+	err := throttler.Wait(ctx, testLicenseBurstBytes)
+	require.NoError(t, err)
+
+	// At 1 MB/s, sending 2 MB more must take at least ~2s.
+	const extraBytes = 2 * testLicenseBytesPerSec
+	start := time.Now()
+	err = throttler.Wait(ctx, extraBytes)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	assert.Greater(t, elapsed, 1500*time.Millisecond, "throttler not enforcing 1 MB/s cap: sent 2 MB in %s", elapsed)
+}

--- a/internal/license/throttle_test.go
+++ b/internal/license/throttle_test.go
@@ -25,8 +25,8 @@ type mockBatchOutput struct {
 	batches []service.MessageBatch
 }
 
-func (m *mockBatchOutput) Connect(_ context.Context) error { return nil }
-func (m *mockBatchOutput) Close(_ context.Context) error   { return nil }
+func (*mockBatchOutput) Connect(_ context.Context) error { return nil }
+func (*mockBatchOutput) Close(_ context.Context) error   { return nil }
 func (m *mockBatchOutput) WriteBatch(_ context.Context, b service.MessageBatch) error {
 	m.batches = append(m.batches, b)
 	return nil
@@ -37,10 +37,10 @@ type mockBatchInput struct {
 	batch service.MessageBatch
 }
 
-func (m *mockBatchInput) Connect(_ context.Context) error { return nil }
-func (m *mockBatchInput) Close(_ context.Context) error   { return nil }
+func (*mockBatchInput) Connect(_ context.Context) error { return nil }
+func (*mockBatchInput) Close(_ context.Context) error   { return nil }
 func (m *mockBatchInput) ReadBatch(_ context.Context) (service.MessageBatch, service.AckFunc, error) {
-	return m.batch, func(ctx context.Context, err error) error { return nil }, nil
+	return m.batch, func(_ context.Context, _ error) error { return nil }, nil
 }
 
 func devLicenseResources(t *testing.T) *service.Resources {


### PR DESCRIPTION
  - Adds an embedded dev license activated by setting REDPANDA_CONNECT_DEV_LICENSE=1. When no production enterprise license is present and the env var is set, Connect grants full enterprise feature access
  under a 1 MB/s throughput cap per process.
  - Implements a token-bucket Throttler (golang.org/x/time/rate, 1 MB/s sustained, 30 MB burst) shared across all pipelines in the process to prevent load-spreading bypass.
  - Wraps all 9 enterprise BatchOutput implementations (iceberg, Redpanda/Kafka, OTLP gRPC/HTTP, Salesforce, Snowflake PUT/streaming, Splunk HEC, BigQuery Write API) with WrapBatchOutput, which injects the
  throttler only under the dev license — no-op under a production license.
  - In agent mode, RegisterServiceFrom propagates the single shared throttler to all per-stream Resources objects, preserving the per-process cap invariant across multi-agent configs.
  - Logs a WARN once when the cap is first hit; exposes redpanda_connect_test_license_throttle_active gauge (1 = throttling, 0 = below cap).
  - When a corrupt/expired production license is present alongside the env var, logs a distinct Error-level message linking the license failure to the dev license fallback.
  - 