### PR TITLE
oracledb_cdc: Add support for `snapshot_only` mode, deprecating `stream_snapshot` config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 *.test.exe
 compile_out.txt
 test_output.txt
+benchmark_results.json

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -190,6 +190,7 @@ Controls snapshot behaviour. `none` (default) skips snapshotting and starts stre
 
 *Type*: `string`
 
+Requires version 4.99.0 or newer
 
 Options:
 `none`

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -42,8 +42,7 @@ input:
     connection_string: oracle://username:password@host:port/service_name # No default (required)
     wallet_path: /opt/oracle/wallet # No default (optional)
     wallet_password: "" # No default (optional)
-    stream_snapshot: false
-    snapshot_mode: none
+    snapshot_mode: "" # No default (optional)
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     logminer:
@@ -85,8 +84,7 @@ input:
     connection_string: oracle://username:password@host:port/service_name # No default (required)
     wallet_path: /opt/oracle/wallet # No default (optional)
     wallet_password: "" # No default (optional)
-    stream_snapshot: false
-    snapshot_mode: none
+    snapshot_mode: "" # No default (optional)
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     logminer:
@@ -185,21 +183,6 @@ This field contains sensitive information that usually shouldn't be added to a c
 *Type*: `string`
 
 
-=== `stream_snapshot`
-
-If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current System Change Number position.
-
-
-*Type*: `bool`
-
-*Default*: `false`
-
-```yml
-# Examples
-
-stream_snapshot: true
-```
-
 === `snapshot_mode`
 
 Controls snapshot behaviour. `none` (default) skips snapshotting and starts streaming from the current SCN. `snapshot_only` performs a full snapshot, persists the SCN checkpoint, then stops without streaming. `snapshot_and_stream` performs a full snapshot then transitions to streaming.
@@ -207,7 +190,6 @@ Controls snapshot behaviour. `none` (default) skips snapshotting and starts stre
 
 *Type*: `string`
 
-*Default*: `"none"`
 
 Options:
 `none`

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -43,6 +43,7 @@ input:
     wallet_path: /opt/oracle/wallet # No default (optional)
     wallet_password: "" # No default (optional)
     stream_snapshot: false
+    snapshot_mode: none
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     logminer:
@@ -85,6 +86,7 @@ input:
     wallet_path: /opt/oracle/wallet # No default (optional)
     wallet_password: "" # No default (optional)
     stream_snapshot: false
+    snapshot_mode: none
     max_parallel_snapshot_tables: 1
     snapshot_max_batch_size: 1000
     logminer:
@@ -197,6 +199,21 @@ If set to true, the connector will query all the existing data as a part of snap
 
 stream_snapshot: true
 ```
+
+=== `snapshot_mode`
+
+Controls snapshot behaviour. `none` (default) skips snapshotting and starts streaming from the current SCN. `snapshot_only` performs a full snapshot, persists the SCN checkpoint, then stops without streaming. `snapshot_and_stream` performs a full snapshot then transitions to streaming.
+
+
+*Type*: `string`
+
+*Default*: `"none"`
+
+Options:
+`none`
+, `snapshot_only`
+, `snapshot_and_stream`
+.
 
 === `max_parallel_snapshot_tables`
 

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -54,12 +54,7 @@ func newBatchPublisher(batcher *service.Batcher, checkpoint *checkpoint.Capped[r
 // loop creates a long-running process that periodically flushes batches by configured interval.
 // lifted from internal/impl/kafka/franz_reader_ordered.go
 func (p *batchPublisher) loop() {
-	defer func() {
-		if p.batcher != nil {
-			p.batcher.Close(context.Background())
-		}
-		p.shutSig.TriggerHasStopped()
-	}()
+	defer p.shutSig.TriggerHasStopped()
 
 	// No need to loop when there's no batcher for async writes.
 	if p.batcher == nil {
@@ -90,7 +85,11 @@ func (p *batchPublisher) loop() {
 		flushBatch = flushBatchTicker.C
 	}
 
-	closeAtLeisureCtx, done := p.shutSig.SoftStopCtx(context.Background())
+	// Use HardStopCtx (not SoftStopCtx) so that a soft-stop signal exits the
+	// select loop without cancelling an in-flight publishBatch send. This lets
+	// FlushRemaining drain the loop before taking over as sole flusher, without
+	// risking an aborted send dropping the last batch.
+	closeAtLeisureCtx, done := p.shutSig.HardStopCtx(context.Background())
 	defer done()
 
 	for {
@@ -275,14 +274,26 @@ func (b *batchPublisher) msgs() <-chan asyncMessage {
 	return b.msgChan
 }
 
-// FlushRemaining flushes any partial batch held in the batcher and blocks until
-// it has been consumed by ReadBatch. Call this after all events have been
-// published and before signalling end-of-input, to avoid dropping the last
-// partial batch.
+// FlushRemaining stops the loop goroutine and then flushes any partial batch
+// still held in the batcher, blocking until it is consumed by ReadBatch.
+//
+// Stopping the loop first is necessary to eliminate the race where loop() wins
+// the batcherMu lock, flushes the residual batch, and blocks on msgChan while
+// we simultaneously see an empty batcher and signal end-of-input — leaving
+// loop()'s pending send racing against the stop channel in ReadBatch's select.
+//
+// Because loop() uses HardStopCtx for its publishBatch calls, triggering a soft
+// stop here exits the select but does not cancel an in-flight send. We wait for
+// HasStoppedChan() before touching the batcher, guaranteeing loop() has fully
+// exited (and any in-flight send has been consumed) before we become the sole
+// flusher.
 func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
 	if b.batcher == nil {
 		return nil
 	}
+	b.shutSig.TriggerSoftStop()
+	<-b.shutSig.HasStoppedChan()
+
 	b.batcherMu.Lock()
 	remaining, err := b.batcher.Flush(ctx)
 	b.batcherMu.Unlock()
@@ -293,7 +304,13 @@ func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
 }
 
 // Close signals the publisher's loop goroutine to stop and waits for it to exit.
+// TriggerHardStop cancels the HardStopCtx used by publishBatch, unblocking any
+// send that is waiting on msgChan when no consumer is left.
 func (b *batchPublisher) Close() {
 	b.shutSig.TriggerSoftStop()
+	b.shutSig.TriggerHardStop()
 	<-b.shutSig.HasStoppedChan()
+	if b.batcher != nil {
+		_ = b.batcher.Close(context.Background())
+	}
 }

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -275,6 +275,23 @@ func (b *batchPublisher) msgs() <-chan asyncMessage {
 	return b.msgChan
 }
 
+// FlushRemaining flushes any partial batch held in the batcher and blocks until
+// it has been consumed by ReadBatch. Call this after all events have been
+// published and before signalling end-of-input, to avoid dropping the last
+// partial batch.
+func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
+	if b.batcher == nil {
+		return nil
+	}
+	b.batcherMu.Lock()
+	remaining, err := b.batcher.Flush(ctx)
+	b.batcherMu.Unlock()
+	if err != nil || len(remaining) == 0 {
+		return err
+	}
+	return b.publishBatch(ctx, remaining)
+}
+
 // Close signals the publisher's loop goroutine to stop and waits for it to exit.
 func (b *batchPublisher) Close() {
 	b.shutSig.TriggerSoftStop()

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -85,11 +85,10 @@ func (p *batchPublisher) loop() {
 		flushBatch = flushBatchTicker.C
 	}
 
-	// Use HardStopCtx (not SoftStopCtx) so that a soft-stop signal exits the
-	// select loop without cancelling an in-flight publishBatch send. This lets
-	// FlushRemaining drain the loop before taking over as sole flusher, without
-	// risking an aborted send dropping the last batch.
-	closeAtLeisureCtx, done := p.shutSig.HardStopCtx(context.Background())
+	// hardStopCtx survives a soft stop so that an in-flight publishBatch send can
+	// complete before the loop exits. Only a hard stop (triggered by Close)
+	// cancels it, which is the forced-shutdown last resort.
+	hardStopCtx, done := p.shutSig.HardStopCtx(context.Background())
 	defer done()
 
 	for {
@@ -111,13 +110,13 @@ func (p *batchPublisher) loop() {
 					return
 				}
 
-				if sendBatch, _ = p.batcher.Flush(closeAtLeisureCtx); len(sendBatch) == 0 {
+				if sendBatch, _ = p.batcher.Flush(hardStopCtx); len(sendBatch) == 0 {
 					return
 				}
 			}()
 
 			if len(sendBatch) > 0 {
-				if err := p.publishBatch(closeAtLeisureCtx, sendBatch); err != nil {
+				if err := p.publishBatch(hardStopCtx, sendBatch); err != nil {
 					return
 				}
 			}
@@ -276,17 +275,6 @@ func (b *batchPublisher) msgs() <-chan asyncMessage {
 
 // FlushRemaining stops the loop goroutine and then flushes any partial batch
 // still held in the batcher, blocking until it is consumed by ReadBatch.
-//
-// Stopping the loop first is necessary to eliminate the race where loop() wins
-// the batcherMu lock, flushes the residual batch, and blocks on msgChan while
-// we simultaneously see an empty batcher and signal end-of-input — leaving
-// loop()'s pending send racing against the stop channel in ReadBatch's select.
-//
-// Because loop() uses HardStopCtx for its publishBatch calls, triggering a soft
-// stop here exits the select but does not cancel an in-flight send. We wait for
-// HasStoppedChan() before touching the batcher, guaranteeing loop() has fully
-// exited (and any in-flight send has been consumed) before we become the sole
-// flusher.
 func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
 	if b.batcher == nil {
 		return nil

--- a/internal/impl/oracledb/bench/benchmark_config.yaml
+++ b/internal/impl/oracledb/bench/benchmark_config.yaml
@@ -6,10 +6,9 @@ input:
     # connection_string: oracle://testdb:testdb123@localhost:1521/TESTPDB
     connection_string: oracle://c%23%23testdb:testdb123@localhost:1521/FREE
     pdb_name: TESTPDB
-    stream_snapshot: false
+    snapshot_mode: snapshot_only
     snapshot_max_batch_size: 160000
     logminer:
-      scn_window_size: 190000
       backoff_interval: 2s
       mining_interval: 0s
       # transaction_cache: testcache
@@ -19,7 +18,6 @@ input:
       - TESTDB.PRODUCTS
       - TESTDB.CART
     batching:
-      count: 140000
       period: 1s
 
 output:

--- a/internal/impl/oracledb/config.go
+++ b/internal/impl/oracledb/config.go
@@ -117,18 +117,16 @@ const (
 
 func parseSnapshotMode(conf *service.ParsedConfig) (SnapshotMode, error) {
 	if conf.Contains(ociFieldSnapshotMode) {
-		raw, err := conf.FieldString(ociFieldSnapshotMode)
-		if err != nil {
+		if raw, err := conf.FieldString(ociFieldSnapshotMode); err != nil {
 			return SnapshotModeNone, err
+		} else {
+			return SnapshotMode(raw), nil
 		}
-		return SnapshotMode(raw), nil
 	}
 	// snapshot_mode not set — apply backward compat
-	streamSnapshot, err := conf.FieldBool(ociFieldStreamSnapshot)
-	if err != nil {
+	if streamSnapshot, err := conf.FieldBool(ociFieldStreamSnapshot); err != nil {
 		return SnapshotModeNone, err
-	}
-	if streamSnapshot {
+	} else if streamSnapshot {
 		return SnapshotModeSnapshotAndStream, nil
 	}
 	return SnapshotModeNone, nil

--- a/internal/impl/oracledb/config.go
+++ b/internal/impl/oracledb/config.go
@@ -115,12 +115,12 @@ const (
 	SnapshotModeSnapshotAndStream SnapshotMode = "snapshot_and_stream"
 )
 
-// IsSnapshotNone returns true of snapshot_mode config is snapshot_only, otherwise returns false.
+// IsSnapshotOnly returns true if the snapshot_mode config is snapshot_only, otherwise false.
 func (s SnapshotMode) IsSnapshotOnly() bool {
 	return s == SnapshotModeSnapshotOnly
 }
 
-// IsSnapshotNone returns true of snapshot_mode config is none, otherwise returns false.
+// IsSnapshotNone returns true if the snapshot_mode config is none, otherwise false.
 func (s SnapshotMode) IsSnapshotNone() bool {
 	return s == SnapshotModeNone
 }

--- a/internal/impl/oracledb/config.go
+++ b/internal/impl/oracledb/config.go
@@ -115,6 +115,16 @@ const (
 	SnapshotModeSnapshotAndStream SnapshotMode = "snapshot_and_stream"
 )
 
+// IsSnapshotNone returns true of snapshot_mode config is snapshot_only, otherwise returns false.
+func (s SnapshotMode) IsSnapshotOnly() bool {
+	return s == SnapshotModeSnapshotOnly
+}
+
+// IsSnapshotNone returns true of snapshot_mode config is none, otherwise returns false.
+func (s SnapshotMode) IsSnapshotNone() bool {
+	return s == SnapshotModeNone
+}
+
 func parseSnapshotMode(conf *service.ParsedConfig) (SnapshotMode, error) {
 	if conf.Contains(ociFieldSnapshotMode) {
 		if raw, err := conf.FieldString(ociFieldSnapshotMode); err != nil {

--- a/internal/impl/oracledb/config.go
+++ b/internal/impl/oracledb/config.go
@@ -102,3 +102,34 @@ func parseWalletConfig(conf *service.ParsedConfig, overrides map[string]string) 
 
 	return nil
 }
+
+// SnapshotMode controls whether and how an initial table snapshot is taken before streaming begins.
+type SnapshotMode string
+
+const (
+	// SnapshotModeNone skips snapshotting and starts streaming from the current SCN.
+	SnapshotModeNone SnapshotMode = "none"
+	// SnapshotModeSnapshotOnly performs a full snapshot, persists the SCN checkpoint, then stops without streaming.
+	SnapshotModeSnapshotOnly SnapshotMode = "snapshot_only"
+	// SnapshotModeSnapshotAndStream performs a full snapshot then transitions to streaming.
+	SnapshotModeSnapshotAndStream SnapshotMode = "snapshot_and_stream"
+)
+
+func parseSnapshotMode(conf *service.ParsedConfig) (SnapshotMode, error) {
+	if conf.Contains(ociFieldSnapshotMode) {
+		raw, err := conf.FieldString(ociFieldSnapshotMode)
+		if err != nil {
+			return SnapshotModeNone, err
+		}
+		return SnapshotMode(raw), nil
+	}
+	// snapshot_mode not set — apply backward compat
+	streamSnapshot, err := conf.FieldBool(ociFieldStreamSnapshot)
+	if err != nil {
+		return SnapshotModeNone, err
+	}
+	if streamSnapshot {
+		return SnapshotModeSnapshotAndStream, nil
+	}
+	return SnapshotModeNone, nil
+}

--- a/internal/impl/oracledb/config_test.go
+++ b/internal/impl/oracledb/config_test.go
@@ -164,3 +164,65 @@ func TestBuildConnectionURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSnapshotMode(t *testing.T) {
+	const minimalOracleCDCYAML = `connection_string: oracle://user:pass@host:1521/svc
+include:
+  - SCHEMA.TABLE
+logminer: {}
+`
+	tests := []struct {
+		name string
+		yaml string
+		want SnapshotMode
+	}{
+		{
+			name: "omitted defaults to none",
+			yaml: minimalOracleCDCYAML,
+			want: SnapshotModeNone,
+		},
+		{
+			name: "explicit none",
+			yaml: minimalOracleCDCYAML + "snapshot_mode: none\n",
+			want: SnapshotModeNone,
+		},
+		{
+			name: "snapshot_only",
+			yaml: minimalOracleCDCYAML + "snapshot_mode: snapshot_only\n",
+			want: SnapshotModeSnapshotOnly,
+		},
+		{
+			name: "snapshot_and_stream",
+			yaml: minimalOracleCDCYAML + "snapshot_mode: snapshot_and_stream\n",
+			want: SnapshotModeSnapshotAndStream,
+		},
+		{
+			// backward compat: stream_snapshot: true with no snapshot_mode set
+			name: "stream_snapshot true upgrades to snapshot_and_stream",
+			yaml: minimalOracleCDCYAML + "stream_snapshot: true\n",
+			want: SnapshotModeSnapshotAndStream,
+		},
+		{
+			// explicit snapshot_mode: none must win over stream_snapshot: true
+			name: "explicit snapshot_mode none overrides stream_snapshot true",
+			yaml: minimalOracleCDCYAML + "snapshot_mode: none\nstream_snapshot: true\n",
+			want: SnapshotModeNone,
+		},
+		{
+			// explicit snapshot_mode wins over stream_snapshot: true
+			name: "explicit snapshot_mode snapshot_only overrides stream_snapshot true",
+			yaml: minimalOracleCDCYAML + "snapshot_mode: snapshot_only\nstream_snapshot: true\n",
+			want: SnapshotModeSnapshotOnly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := oracleDBStreamConfigSpec.ParseYAML(tt.yaml, nil)
+			require.NoError(t, err)
+			got, err := parseSnapshotMode(conf)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -513,7 +513,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 	)
 
 	// no cached SCN means we're not recovering from a restart
-	if o.cfg.SnapshotMode != SnapshotModeNone && cachedSCN == replication.InvalidSCN {
+	if !o.cfg.SnapshotMode.IsSnapshotNone() && cachedSCN == replication.InvalidSCN {
 		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.publisher, o.lmCfg.LOBEnabled, pdbNameForCache, o.log, o.metrics); err != nil {
 			return fmt.Errorf("creating database snapshotter: %w", err)
 		}
@@ -576,7 +576,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			o.log.Infof("Successfully captured SCN following snapshot: %d", startSCN)
 		}
 
-		if o.cfg.SnapshotMode == SnapshotModeSnapshotOnly {
+		if o.cfg.SnapshotMode.IsSnapshotOnly() {
 			o.log.Infof("Snapshot-only mode complete, stopping")
 			o.snapshotOnlyDone.Store(true)
 			o.stopSig.TriggerHasStopped()

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -231,9 +232,10 @@ type oracleDBCDCInput struct {
 	publisher *batchPublisher
 	metrics   *service.Metrics
 
-	stopSig *shutdown.Signaller
-	log     *service.Logger
-	cpCache service.Cache
+	stopSig          *shutdown.Signaller
+	snapshotOnlyDone atomic.Bool
+	log              *service.Logger
+	cpCache          service.Cache
 }
 
 func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resources) (s service.BatchInput, err error) {
@@ -541,8 +543,9 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		o.log.Infof("No cached SCN found, fetched current position from database: %d", cachedSCN)
 	}
 
-	// Reset our stop signal
+	// Reset our stop signal and snapshot-only completion flag
 	o.stopSig = shutdown.NewSignaller()
+	o.snapshotOnlyDone.Store(false)
 
 	go func() {
 		var (
@@ -575,6 +578,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 		if o.cfg.SnapshotMode == SnapshotModeSnapshotOnly {
 			o.log.Infof("Snapshot-only mode complete, stopping")
+			o.snapshotOnlyDone.Store(true)
 			o.stopSig.TriggerHasStopped()
 			return
 		}
@@ -660,6 +664,9 @@ func (o *oracleDBCDCInput) ReadBatch(ctx context.Context) (service.MessageBatch,
 	case m := <-o.publisher.msgs():
 		return m.msg, m.ackFn, nil
 	case <-o.stopSig.HasStoppedChan():
+		if o.snapshotOnlyDone.Load() {
+			return nil, nil, service.ErrEndOfInput
+		}
 		return nil, nil, service.ErrNotConnected
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -63,18 +63,6 @@ const (
 	ociFieldTransactionCacheKey  = "transaction_cache_key"
 )
 
-// SnapshotMode controls whether and how an initial table snapshot is taken before streaming begins.
-type SnapshotMode string
-
-const (
-	// SnapshotModeNone skips snapshotting and starts streaming from the current SCN.
-	SnapshotModeNone SnapshotMode = "none"
-	// SnapshotModeSnapshotOnly performs a full snapshot, persists the SCN checkpoint, then stops without streaming.
-	SnapshotModeSnapshotOnly SnapshotMode = "snapshot_only"
-	// SnapshotModeSnapshotAndStream performs a full snapshot then transitions to streaming.
-	SnapshotModeSnapshotAndStream SnapshotMode = "snapshot_and_stream"
-)
-
 func init() {
 	service.MustRegisterBatchInput("oracledb_cdc", oracleDBStreamConfigSpec, newOracleDBCDCInput)
 }
@@ -122,14 +110,15 @@ When using the default Oracle based cache, the Connect user requires permission 
 		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current System Change Number position.").
 		LintRule(`root = if this == true { ["deprecated: use 'snapshot_mode: snapshot_and_stream' instead of 'stream_snapshot: true'"] }`).
 		Example(true).
-		Default(false),
+		Default(false).
+		Deprecated(),
 	).
 	Field(service.NewStringEnumField(ociFieldSnapshotMode,
 		string(SnapshotModeNone),
 		string(SnapshotModeSnapshotOnly),
 		string(SnapshotModeSnapshotAndStream)).
 		Description("Controls snapshot behaviour. `none` (default) skips snapshotting and starts streaming from the current SCN. `snapshot_only` performs a full snapshot, persists the SCN checkpoint, then stops without streaming. `snapshot_and_stream` performs a full snapshot then transitions to streaming.").
-		Default(string(SnapshotModeNone)),
+		Optional(),
 	).
 	Field(service.NewIntField(ociFieldMaxParallelSnapshotTables).
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").
@@ -271,18 +260,8 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	if connectionString, err = conf.FieldString(ociFieldConnectionString); err != nil {
 		return nil, err
 	}
-	if rawMode, err := conf.FieldString(ociFieldSnapshotMode); err != nil {
+	if snapshotMode, err = parseSnapshotMode(conf); err != nil {
 		return nil, err
-	} else {
-		snapshotMode = SnapshotMode(rawMode)
-	}
-	// backward compat: stream_snapshot: true upgrades to snapshot_and_stream when snapshot_mode is not set
-	if snapshotMode == SnapshotModeNone {
-		if streamSnapshot, err := conf.FieldBool(ociFieldStreamSnapshot); err != nil {
-			return nil, err
-		} else if streamSnapshot {
-			snapshotMode = SnapshotModeSnapshotAndStream
-		}
 	}
 	if snapshotMaxWorkers, err = conf.FieldInt(ociFieldMaxParallelSnapshotTables); err != nil {
 		return nil, err

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -580,7 +580,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			if err = o.publisher.FlushRemaining(softCtx); err != nil {
 				o.log.Errorf("Failed to flush remaining snapshot events: %s", err)
 			}
-			o.log.Infof("Snapshot-only mode complete, stopping")
+			o.log.Infof("Snapshot-only mode complete, stopping at SCN %s", startSCN)
 			o.snapshotOnlyDone.Store(true)
 			o.stopSig.TriggerHasStopped()
 			return

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -117,7 +117,8 @@ When using the default Oracle based cache, the Connect user requires permission 
 		string(SnapshotModeSnapshotOnly),
 		string(SnapshotModeSnapshotAndStream)).
 		Description("Controls snapshot behaviour. `none` (default) skips snapshotting and starts streaming from the current SCN. `snapshot_only` performs a full snapshot, persists the SCN checkpoint, then stops without streaming. `snapshot_and_stream` performs a full snapshot then transitions to streaming.").
-		Optional(),
+		Optional().
+		Version("4.99.0"),
 	).
 	Field(service.NewIntField(ociFieldMaxParallelSnapshotTables).
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -108,7 +108,6 @@ When using the default Oracle based cache, the Connect user requires permission 
 	).
 	Field(service.NewBoolField(ociFieldStreamSnapshot).
 		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current System Change Number position.").
-		LintRule(`root = if this == true { ["deprecated: use 'snapshot_mode: snapshot_and_stream' instead of 'stream_snapshot: true'"] }`).
 		Example(true).
 		Default(false).
 		Deprecated(),

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -45,6 +45,7 @@ const (
 	ociFieldCheckpointCacheTableName  = "checkpoint_cache_table_name"
 	ociFieldBatching                  = "batching"
 	ociFieldPDBName                   = "pdb_name"
+	ociFieldSnapshotMode              = "snapshot_mode"
 
 	shutdownTimeout = 5 * time.Second
 
@@ -60,6 +61,18 @@ const (
 	ociFieldLOBEnabled           = "lob_enabled"
 	ociFieldTransactionCache     = "transaction_cache"
 	ociFieldTransactionCacheKey  = "transaction_cache_key"
+)
+
+// SnapshotMode controls whether and how an initial table snapshot is taken before streaming begins.
+type SnapshotMode string
+
+const (
+	// SnapshotModeNone skips snapshotting and starts streaming from the current SCN.
+	SnapshotModeNone SnapshotMode = "none"
+	// SnapshotModeSnapshotOnly performs a full snapshot, persists the SCN checkpoint, then stops without streaming.
+	SnapshotModeSnapshotOnly SnapshotMode = "snapshot_only"
+	// SnapshotModeSnapshotAndStream performs a full snapshot then transitions to streaming.
+	SnapshotModeSnapshotAndStream SnapshotMode = "snapshot_and_stream"
 )
 
 func init() {
@@ -107,8 +120,16 @@ When using the default Oracle based cache, the Connect user requires permission 
 	).
 	Field(service.NewBoolField(ociFieldStreamSnapshot).
 		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current System Change Number position.").
+		LintRule(`root = if this == true { ["deprecated: use 'snapshot_mode: snapshot_and_stream' instead of 'stream_snapshot: true'"] }`).
 		Example(true).
 		Default(false),
+	).
+	Field(service.NewStringEnumField(ociFieldSnapshotMode,
+		string(SnapshotModeNone),
+		string(SnapshotModeSnapshotOnly),
+		string(SnapshotModeSnapshotAndStream)).
+		Description("Controls snapshot behaviour. `none` (default) skips snapshotting and starts streaming from the current SCN. `snapshot_only` performs a full snapshot, persists the SCN checkpoint, then stops without streaming. `snapshot_and_stream` performs a full snapshot then transitions to streaming.").
+		Default(string(SnapshotModeNone)),
 	).
 	Field(service.NewIntField(ociFieldMaxParallelSnapshotTables).
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").
@@ -202,7 +223,7 @@ type asyncMessage struct {
 // Config is the configuration for a Oracle connector.
 type Config struct {
 	ConnectionString     string
-	StreamSnapshot       bool
+	SnapshotMode         SnapshotMode
 	SnapshotMaxBatchSize int
 	SnapshotMaxWorkers   int
 	TablesFilter         *confx.RegexpFilter
@@ -229,7 +250,7 @@ type oracleDBCDCInput struct {
 func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resources) (s service.BatchInput, err error) {
 	var (
 		connectionString     string
-		streamSnapshot       bool
+		snapshotMode         SnapshotMode
 		snapshotMaxWorkers   int
 		snapshotMaxBatchSize int
 
@@ -250,8 +271,18 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	if connectionString, err = conf.FieldString(ociFieldConnectionString); err != nil {
 		return nil, err
 	}
-	if streamSnapshot, err = conf.FieldBool(ociFieldStreamSnapshot); err != nil {
+	if rawMode, err := conf.FieldString(ociFieldSnapshotMode); err != nil {
 		return nil, err
+	} else {
+		snapshotMode = SnapshotMode(rawMode)
+	}
+	// backward compat: stream_snapshot: true upgrades to snapshot_and_stream when snapshot_mode is not set
+	if snapshotMode == SnapshotModeNone {
+		if streamSnapshot, err := conf.FieldBool(ociFieldStreamSnapshot); err != nil {
+			return nil, err
+		} else if streamSnapshot {
+			snapshotMode = SnapshotModeSnapshotAndStream
+		}
 	}
 	if snapshotMaxWorkers, err = conf.FieldInt(ociFieldMaxParallelSnapshotTables); err != nil {
 		return nil, err
@@ -335,7 +366,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	o := oracleDBCDCInput{
 		cfg: Config{
 			ConnectionString:     connectionString,
-			StreamSnapshot:       streamSnapshot,
+			SnapshotMode:         snapshotMode,
 			SnapshotMaxWorkers:   snapshotMaxWorkers,
 			SnapshotMaxBatchSize: snapshotMaxBatchSize,
 			SCNCache:             scnCache,
@@ -501,7 +532,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 	)
 
 	// no cached SCN means we're not recovering from a restart
-	if o.cfg.StreamSnapshot && cachedSCN == replication.InvalidSCN {
+	if o.cfg.SnapshotMode != SnapshotModeNone && cachedSCN == replication.InvalidSCN {
 		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.publisher, o.lmCfg.LOBEnabled, pdbNameForCache, o.log, o.metrics); err != nil {
 			return fmt.Errorf("creating database snapshotter: %w", err)
 		}
@@ -561,6 +592,12 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			}
 
 			o.log.Infof("Successfully captured SCN following snapshot: %d", startSCN)
+		}
+
+		if o.cfg.SnapshotMode == SnapshotModeSnapshotOnly {
+			o.log.Infof("Snapshot-only mode complete, stopping")
+			o.stopSig.TriggerHasStopped()
+			return
 		}
 
 		// streaming

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -577,6 +577,9 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		}
 
 		if o.cfg.SnapshotMode.IsSnapshotOnly() {
+			if err = o.publisher.FlushRemaining(softCtx); err != nil {
+				o.log.Errorf("Failed to flush remaining snapshot events: %s", err)
+			}
 			o.log.Infof("Snapshot-only mode complete, stopping")
 			o.snapshotOnlyDone.Store(true)
 			o.stopSig.TriggerHasStopped()

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -64,7 +64,7 @@ func TestIntegrationOracleDBCDCSnapshotAndStreaming(t *testing.T) {
 oracledb_cdc:
   connection_string: ` + cdbConnStr + `
   pdb_name: ` + pdbName + `
-  stream_snapshot: true
+  snapshot_mode: snapshot_and_stream
   max_parallel_snapshot_tables: 2
   snapshot_max_batch_size: 10
   logminer:
@@ -279,7 +279,7 @@ func TestIntegrationOracleDBCDCConcurrentSnapshot(t *testing.T) {
 		cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  stream_snapshot: true
+  snapshot_mode: snapshot_and_stream
   snapshot_max_batch_size: 10
   max_parallel_snapshot_tables: 3
   logminer:
@@ -353,7 +353,7 @@ func TestIntegrationOracleDBCDCResumesFromCheckpoint(t *testing.T) {
 	cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  stream_snapshot: false
+  snapshot_mode: none
   logminer:
     scn_window_size: 20000
     min_scn_window_size: 0
@@ -548,7 +548,7 @@ func TestIntegrationOracleDBCDCStreaming(t *testing.T) {
 		cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  stream_snapshot: false
+  snapshot_mode: none
   logminer:
     scn_window_size: 20000
     min_scn_window_size: 0
@@ -656,7 +656,7 @@ oracledb_cdc:
 		cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  stream_snapshot: false
+  snapshot_mode: none
   logminer:
     scn_window_size: 20000
     min_scn_window_size: 0
@@ -792,7 +792,7 @@ func TestIntegrationOracleDBCDCLargeObjectColumnsToggle(t *testing.T) {
 			cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  stream_snapshot: true
+  snapshot_mode: snapshot_and_stream
   logminer:
     lob_enabled: false
     min_scn_window_size: 0
@@ -883,6 +883,7 @@ oracledb_cdc:
 oracledb_cdc:
   connection_string: ` + connStr + `
   stream_snapshot: true
+  snapshot_mode: snapshot_and_stream
   logminer:
     lob_enabled: true
     min_scn_window_size: 0

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -279,7 +279,7 @@ func TestIntegrationOracleDBCDCConcurrentSnapshot(t *testing.T) {
 		cfg := `
 oracledb_cdc:
   connection_string: ` + connStr + `
-  snapshot_mode: snapshot_and_stream
+  snapshot_mode: snapshot_only
   snapshot_max_batch_size: 10
   max_parallel_snapshot_tables: 3
   logminer:


### PR DESCRIPTION
This change deprecates the `stream_snapshot: (true|false)` config in favour for `snapshot_mode` which supports a range of enums, including `snapshot_only` which allows users to launch the connector, perform a snapshot and then shutdown without it automatically switching to streaming. This makes it easier for new tables to be loaded.

`snapshot_mode` now includes:
- `none` (equivalent of `stream_snapshot: false`)
- `snapshot_only` (currently not representable in existing config)
- `snapshot_and_stream` (equivalent of `stream_snapshot: true`