### PR TITLE
kafka: surface broker connectivity failures at WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- kafka: Broker connectivity failures (connection, read, and write errors such as `i/o timeout`) from the franz-go client are now logged at WARN instead of only at debug level, so they can be alerted on without enabling debug logging. Emissions are throttled per broker. Affects all franz-based connectors (`kafka_franz`, `redpanda`, `redpanda_migrator`, ...).
+
 ## 4.98.0 - 2026-06-26
 
 ### Added

--- a/internal/impl/kafka/franz_client.go
+++ b/internal/impl/kafka/franz_client.go
@@ -158,6 +158,7 @@ func (d *FranzConnectionDetails) IsConfigured() bool {
 func (d *FranzConnectionDetails) FranzOpts() []kgo.Opt {
 	opts := []kgo.Opt{
 		kgo.WithLogger(&KGoLogger{d.Logger}),
+		kgo.WithHooks(newConnHooks(d.Logger)),
 		kgo.SeedBrokers(d.SeedBrokers...),
 		kgo.SASL(d.SASL...),
 		kgo.ClientID(d.ClientID),

--- a/internal/impl/kafka/hooks.go
+++ b/internal/impl/kafka/hooks.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// brokerThrottle rate-limits log emissions per broker and event type. The first
+// occurrence for a key is allowed immediately; further occurrences within the
+// interval are suppressed and counted; the next occurrence after the interval
+// is allowed and reports the suppressed count.
+type brokerThrottle struct {
+	interval time.Duration
+	now      func() time.Time
+
+	mu    sync.Mutex
+	state map[throttleKey]*throttleEntry
+}
+
+type throttleKey struct {
+	broker int32
+	event  string
+}
+
+type throttleEntry struct {
+	last       time.Time
+	suppressed int
+}
+
+func newBrokerThrottle(interval time.Duration) *brokerThrottle {
+	return &brokerThrottle{
+		interval: interval,
+		now:      time.Now,
+		state:    map[throttleKey]*throttleEntry{},
+	}
+}
+
+// allow reports whether an emission for the given broker+event should happen
+// now. When ok is true, suppressed is the number of occurrences dropped since
+// the previous emission.
+func (t *brokerThrottle) allow(broker int32, event string) (suppressed int, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	k := throttleKey{broker: broker, event: event}
+	now := t.now()
+	e, exists := t.state[k]
+	if !exists {
+		t.state[k] = &throttleEntry{last: now}
+		return 0, true
+	}
+	if now.Sub(e.last) >= t.interval {
+		suppressed = e.suppressed
+		e.last = now
+		e.suppressed = 0
+		return suppressed, true
+	}
+	e.suppressed++
+	return 0, false
+}
+
+// connHookThrottleInterval bounds how often a given broker+event connectivity
+// failure is logged during a sustained outage.
+const connHookThrottleInterval = 10 * time.Second
+
+// connHooks surfaces franz-go broker connectivity failures (connect, write, and
+// read errors) at WARN so they are visible at the default log level for
+// alerting, without enabling debug logging. Emissions are throttled per broker
+// and event type to bound log volume during sustained outages.
+type connHooks struct {
+	log      *service.Logger
+	throttle *brokerThrottle
+}
+
+var (
+	_ kgo.HookBrokerConnect = (*connHooks)(nil)
+	_ kgo.HookBrokerWrite   = (*connHooks)(nil)
+	_ kgo.HookBrokerRead    = (*connHooks)(nil)
+)
+
+func newConnHooks(log *service.Logger) *connHooks {
+	return &connHooks{log: log, throttle: newBrokerThrottle(connHookThrottleInterval)}
+}
+
+// OnBrokerConnect logs a WARN when a connection attempt to a broker fails (dial,
+// TLS handshake, or connect timeout).
+func (h *connHooks) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
+	h.emit("connect", "Kafka broker connection failed", meta, -1, err)
+}
+
+// OnBrokerWrite logs a WARN when writing a request to a broker fails.
+func (h *connHooks) OnBrokerWrite(meta kgo.BrokerMetadata, key int16, _ int, _, _ time.Duration, err error) {
+	h.emit("write", "Kafka broker write failed", meta, key, err)
+}
+
+// OnBrokerRead logs a WARN when reading a response from a broker fails.
+func (h *connHooks) OnBrokerRead(meta kgo.BrokerMetadata, key int16, _ int, _, _ time.Duration, err error) {
+	h.emit("read", "Kafka broker read failed", meta, key, err)
+}
+
+// emit logs a throttled WARN for a connectivity failure. A key < 0 means the
+// event has no associated Kafka request (connect).
+func (h *connHooks) emit(event, msg string, meta kgo.BrokerMetadata, key int16, err error) {
+	if err == nil {
+		return
+	}
+	suppressed, ok := h.throttle.allow(meta.NodeID, event)
+	if !ok {
+		return
+	}
+	l := h.log.With(
+		"broker", meta.NodeID,
+		"addr", net.JoinHostPort(meta.Host, strconv.Itoa(int(meta.Port))),
+		"err", err.Error(),
+	)
+	if key >= 0 {
+		l = l.With("request", kmsg.NameForKey(key))
+	}
+	if suppressed > 0 {
+		l = l.With("suppressed", suppressed)
+	}
+	l.Warn(msg)
+}

--- a/internal/impl/kafka/hooks_test.go
+++ b/internal/impl/kafka/hooks_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestBrokerThrottleAllowsFirstThenSuppresses(t *testing.T) {
+	now := time.Unix(0, 0)
+	thr := newBrokerThrottle(10 * time.Second)
+	thr.now = func() time.Time { return now }
+
+	// First occurrence emits immediately.
+	suppressed, ok := thr.allow(1, "read")
+	require.True(t, ok)
+	require.Equal(t, 0, suppressed)
+
+	// Within the window: suppressed.
+	_, ok = thr.allow(1, "read")
+	require.False(t, ok)
+	_, ok = thr.allow(1, "read")
+	require.False(t, ok)
+
+	// After the window: emits and reports the 2 suppressed occurrences.
+	now = now.Add(10 * time.Second)
+	suppressed, ok = thr.allow(1, "read")
+	require.True(t, ok)
+	require.Equal(t, 2, suppressed)
+
+	// Counter resets after an emission.
+	now = now.Add(10 * time.Second)
+	suppressed, ok = thr.allow(1, "read")
+	require.True(t, ok)
+	require.Equal(t, 0, suppressed)
+}
+
+func TestBrokerThrottleIndependentKeys(t *testing.T) {
+	now := time.Unix(0, 0)
+	thr := newBrokerThrottle(10 * time.Second)
+	thr.now = func() time.Time { return now }
+
+	_, ok := thr.allow(1, "read")
+	require.True(t, ok)
+	// Different event for same broker is independent.
+	_, ok = thr.allow(1, "write")
+	require.True(t, ok)
+	// Different broker is independent.
+	_, ok = thr.allow(2, "read")
+	require.True(t, ok)
+}
+
+func captureLogger() (*service.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return service.NewLoggerFromSlog(slog.New(h)), &buf
+}
+
+func TestConnHooksIgnoresNilError(t *testing.T) {
+	logger, buf := captureLogger()
+	h := newConnHooks(logger)
+
+	meta := kgo.BrokerMetadata{NodeID: 1, Host: "broker-1", Port: 9092}
+	h.OnBrokerConnect(meta, 0, nil, nil)
+	h.OnBrokerWrite(meta, 0, 0, 0, 0, nil)
+	h.OnBrokerRead(meta, 1, 0, 0, 0, nil)
+
+	require.Empty(t, h.throttle.state, "nil errors must not touch the throttle")
+	require.Empty(t, buf.String(), "nil errors must not log")
+}
+
+func TestConnHooksLogsConnectError(t *testing.T) {
+	logger, buf := captureLogger()
+	h := newConnHooks(logger)
+
+	meta := kgo.BrokerMetadata{NodeID: 3, Host: "broker-3", Port: 9092}
+	h.OnBrokerConnect(meta, 0, nil, errors.New("dial tcp: i/o timeout"))
+
+	out := buf.String()
+	require.Contains(t, out, "Kafka broker connection failed")
+	require.Contains(t, out, "i/o timeout")
+	require.Contains(t, out, "broker-3:9092")
+	require.NotContains(t, out, "request", "connect has no request key")
+	_, exists := h.throttle.state[throttleKey{broker: 3, event: "connect"}]
+	require.True(t, exists)
+}
+
+func TestConnHooksLogsReadErrorWithRequestName(t *testing.T) {
+	logger, buf := captureLogger()
+	h := newConnHooks(logger)
+
+	meta := kgo.BrokerMetadata{NodeID: 2, Host: "broker-2", Port: 9092}
+	// key 1 == Fetch in the Kafka protocol.
+	h.OnBrokerRead(meta, 1, 0, 0, 0, errors.New("read tcp: i/o timeout"))
+
+	out := buf.String()
+	require.Contains(t, out, "Kafka broker read failed")
+	require.Contains(t, out, "Fetch")
+}
+
+func TestConnHooksThrottlesRepeatErrors(t *testing.T) {
+	logger, buf := captureLogger()
+	h := newConnHooks(logger)
+	now := time.Unix(0, 0)
+	h.throttle.now = func() time.Time { return now }
+
+	meta := kgo.BrokerMetadata{NodeID: 5, Host: "broker-5", Port: 9092}
+	for range 4 {
+		h.OnBrokerRead(meta, 1, 0, 0, 0, errors.New("i/o timeout"))
+	}
+	require.Equal(t, 1, strings.Count(buf.String(), "Kafka broker read failed"),
+		"only the first error within the window should log")
+
+	now = now.Add(10 * time.Second)
+	h.OnBrokerRead(meta, 1, 0, 0, 0, errors.New("i/o timeout"))
+	require.Equal(t, 2, strings.Count(buf.String(), "Kafka broker read failed"))
+	require.Contains(t, buf.String(), "suppressed")
+}


### PR DESCRIPTION
franz-go logs broker connectivity failures (connection, read, and write errors such as `i/o timeout`) at its info/debug levels, which the shared KGoLogger adapter downgrades to Connect debug/trace — so these signals were only visible with debug logging enabled, delaying detection of serverless connector connectivity issues (INC-2868).

Add a connHooks type implementing franz-go's broker connect/read/write hooks that logs these failures at WARN with structured fields (broker, addr, err, request), throttled per broker and event type to bound log volume during a sustained outage. Register it once in FranzConnectionDetails.FranzOpts(), the shared builder every franz-based connector (kafka_franz, redpanda, redpanda_migrator) routes through; kgo.WithHooks is additive, so single registration avoids double-logging.