### PR TITLE
rpcn: update docs for max_message_bytes

### DIFF
--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -941,7 +941,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/outputs/ockam_kafka.adoc
@@ -511,7 +511,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `kafka.max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -995,7 +995,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -947,7 +947,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -747,7 +747,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/tracers/redpanda.adoc
+++ b/docs/modules/components/pages/tracers/redpanda.adoc
@@ -740,7 +740,7 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `max_message_bytes`
 
-The maximum size of a produced record batch in bytes. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
+The maximum size of a produced record batch in bytes, measured before compression is applied. A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. This field maps to the `max.message.bytes` Kafka property. Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, see https://docs.redpanda.com/current/reference/properties/cluster-properties/#kafka_batch_max_bytes.
 
 
 *Type*: `string`

--- a/internal/impl/kafka/franz_writer.go
+++ b/internal/impl/kafka/franz_writer.go
@@ -58,7 +58,7 @@ func FranzProducerLimitsFields() []*service.ConfigField {
 			Default("10s").
 			Advanced(),
 		service.NewStringField(kfwFieldMaxMessageBytes).
-			Description("The maximum size of a produced record batch in bytes. " +
+			Description("The maximum size of a produced record batch in bytes, measured before compression is applied. " +
 				"A `MESSAGE_TOO_LARGE` error is returned if a batch exceeds this limit. " +
 				"This field maps to the `max.message.bytes` Kafka property. " +
 				"Ensure the Redpanda broker's `kafka_batch_max_bytes` property is at least as large as this value, " +


### PR DESCRIPTION
Update docs for `max_message_bytes` to highlight before compression.