### PR TITLE
goreleaser: embed tz database in the cgo build; guard all distributio…

### DIFF
--- a/.goreleaser/connect-cgo.yaml
+++ b/.goreleaser/connect-cgo.yaml
@@ -11,6 +11,9 @@ builds:
     goarch: [amd64]
     tags:
       - x_benthos_extra
+      # Embed the IANA tz database so time.LoadLocation works in minimal
+      # runtimes without system tzdata (matches the other distributions).
+      - timetzdata
     env:
       - CGO_ENABLED=1
     ldflags: >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- general: The CGO-enabled distribution binary now embeds the IANA time zone database via the `timetzdata` build tag, matching the other distributions, so `time.LoadLocation` works in minimal runtimes without system tzdata instead of silently falling back to UTC (which shifts JQL date predicates in the `jira` input). ([@squiidz](https://github.com/squiidz), [#4583](https://github.com/redpanda-data/connect/pull/4583))
+
 ## 4.99.0 - 2026-07-02
 
 ### Added


### PR DESCRIPTION
Components such as the jira input render JQL date predicates in the account's timezone via time.LoadLocation, which needs an IANA tz database at runtime. The release images are busybox-based with no /usr/share/zoneinfo, so binaries built without the database fall back to time.UTC and silently reintroduce the data-loss window the timezone handling closes.

Every distribution already builds with the `timetzdata` tag except the CGO-enabled build, which was overlooked. Add it there so the embedded database (used only as a fallback, ~405 KiB) travels with that binary too. Verified in busybox: without the tag LoadLocation fails for a non-UTC zone, with it the zone loads.

Add an internal/tzdata package whose host-independent test asserts every goreleaser build carries the tag, so a future config change that drops it fails CI rather than silently shipping a UTC-only image.