### PR TITLE
postgres_cdc: wait for snapshot acks before promoting the replication…

### DIFF
--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -482,10 +482,15 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				flushedBatch, err := batcher.Flush(ctx)
 				if err != nil {
 					p.logger.Debugf("error flushing snapshot completion batch: %s", err)
+					// The sentinel is a one-shot signal; if we bail here without
+					// acking, the barrier's snapshot goroutine blocks on
+					// snapshotAcked forever. Trigger a restart instead of stalling.
+					p.stopSig.TriggerSoftStop()
 					break
 				}
 				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch); err != nil {
 					p.logger.Debugf("failed to flush snapshot completion batch: %s", err)
+					p.stopSig.TriggerSoftStop()
 					break
 				}
 				drained := make(chan struct{})

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -396,6 +397,12 @@ type pgStreamInput struct {
 	replicationLag  *service.MetricGauge
 	stopSig         *shutdown.Signaller
 
+	// snapshotAckWG tracks in-flight snapshot batches: incremented when a
+	// snapshot batch (nil LSN) is enqueued and decremented when it is
+	// acknowledged. The snapshot->stream handoff blocks until it drains so the
+	// replication slot is not promoted before snapshot rows are durable.
+	snapshotAckWG sync.WaitGroup
+
 	// IAM authentication fields
 	iamAuthEnabled bool
 }
@@ -466,6 +473,35 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				break
 			}
 		case batch := <-pgStream.Messages():
+			if len(batch) == 1 && batch[0].Operation == pglogicalstream.SnapshotCompleteOpType {
+				// Snapshot fully emitted. Flush any buffered rows, then block
+				// until every snapshot batch is acknowledged downstream before
+				// signalling the stream to promote the replication slot. Blocks
+				// until acks drain or soft-stop (no timeout, by design).
+				nextTimedBatchChan = nil
+				flushedBatch, err := batcher.Flush(ctx)
+				if err != nil {
+					p.logger.Debugf("error flushing snapshot completion batch: %s", err)
+					break
+				}
+				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch); err != nil {
+					p.logger.Debugf("failed to flush snapshot completion batch: %s", err)
+					break
+				}
+				drained := make(chan struct{})
+				go func() {
+					// May outlive the select below if soft-stop fires while the
+					// downstream is stalled; bounded by process lifetime.
+					p.snapshotAckWG.Wait()
+					close(drained)
+				}()
+				select {
+				case <-drained:
+					pgStream.MarkSnapshotAcknowledged()
+				case <-p.stopSig.SoftStopChan():
+				}
+				break
+			}
 			var (
 				flush bool
 				mb    []byte
@@ -543,7 +579,15 @@ func (p *pgStreamInput) flushBatch(
 		return fmt.Errorf("unable to checkpoint: %w", err)
 	}
 
+	// Snapshot batches carry no LSN. Track them so the snapshot->stream handoff
+	// can block until they are acknowledged downstream (see the sentinel handling
+	// in the read loop).
+	isSnapshot := lsn == nil
+
 	ackFn := func(ctx context.Context, _ error) error {
+		if isSnapshot {
+			defer p.snapshotAckWG.Done()
+		}
 		maxOffset := resolveFn()
 		if maxOffset == nil {
 			return nil
@@ -557,9 +601,15 @@ func (p *pgStreamInput) flushBatch(
 		}
 		return nil
 	}
+	if isSnapshot {
+		p.snapshotAckWG.Add(1)
+	}
 	select {
 	case p.msgChan <- asyncMessage{msg: batch, ackFn: ackFn}:
 	case <-ctx.Done():
+		if isSnapshot {
+			p.snapshotAckWG.Done()
+		}
 		return ctx.Err()
 	}
 	return nil

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -359,10 +359,13 @@ pg_stream:
 	require.Zero(t, permanentSlots, "replication slot must not be promoted before snapshot rows are acknowledged")
 
 	// A real process crash drops the connection, so postgres releases the
-	// temporary snapshot slot. Our in-process cancel does not tear the
-	// replication connection down promptly, so terminate the backend still
-	// holding the temporary slot to faithfully model the crash, and wait for the
-	// slot to be released before restarting.
+	// temporary snapshot slot promptly (the socket close is immediate at the
+	// OS level). Our in-process cancel does not: confirmed empirically, the
+	// slot still reports "active for PID ..." 30+ seconds after run1Ctx is
+	// cancelled, since Go's graceful shutdown path doesn't force-close the
+	// underlying connection that fast. Terminate the backend still holding the
+	// temporary slot to faithfully model the crash's prompt socket teardown,
+	// and wait for the slot to be released before restarting.
 	require.Eventually(t, func() bool {
 		_, _ = db.Exec(`SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = 'test_slot_snapshot_ack_barrier_tmp' AND active_pid IS NOT NULL`)
 		var tmpSlots int
@@ -372,9 +375,16 @@ pg_stream:
 		return tmpSlots == 0
 	}, 30*time.Second, 500*time.Millisecond, "temporary snapshot slot from the crashed run was not released")
 
-	// Run 2: restart against the same slot. Since run 1 never acked the snapshot,
-	// the slot must not have been promoted, so the snapshot re-runs and every row
-	// is delivered again.
+	// Run 2: restart against the same slot. Since run 1 never acked the
+	// snapshot, the slot must not have been promoted, so the snapshot re-runs
+	// and every row is delivered again. The temporary slot is already gone by
+	// this point, so Connect's drop-before-create guard (added for CON-489's
+	// review) takes its "does not exist" path here and proceeds straight to
+	// creating a fresh one - the guard's other path, dropping a slot that
+	// still exists but whose owning session has died without yet being
+	// reaped, isn't reachable from this harness (see comment above: emulating
+	// that state needs the same terminate-then-wait this test already does,
+	// which collapses it into the "does not exist" case by construction).
 	var mu sync.Mutex
 	var reads int
 	run2Builder := service.NewStreamBuilder()

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -275,6 +275,133 @@ pg_stream:
 	require.NoError(t, streamOut.StopWithin(time.Second*10))
 }
 
+// TestIntegrationPostgresSnapshotAckBarrier verifies that a crash during the
+// snapshot->stream handoff (after snapshot rows are emitted but before they are
+// acknowledged) does not lose data: because the replication slot is only
+// promoted once every snapshot message is acked, the snapshot must re-run on
+// restart. See CON-489.
+func TestIntegrationPostgresSnapshotAckBarrier(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	const rowCount = 5
+	for i := range rowCount {
+		f := GetFakeFlightRecord()
+		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
+		require.NoError(t, err)
+	}
+
+	// batching.count == rowCount forces all snapshot rows into a single output
+	// batch, so the run-1 consumer receives them all at once and can then block
+	// without acking - reproducing the "emitted but not yet acked" handoff state.
+	template := fmt.Sprintf(`
+pg_stream:
+    dsn: %s
+    slot_name: test_slot_snapshot_ack_barrier
+    stream_snapshot: true
+    snapshot_batch_size: 1000
+    schema: public
+    tables:
+       - '"FlightsCompositePK"'
+    batching:
+      count: %d
+      period: 1h
+`, databaseURL, rowCount)
+
+	// Run 1: receive the snapshot rows but never acknowledge them, then simulate
+	// a crash by cancelling the run before the slot can be promoted.
+	received := make(chan struct{}, 1)
+	run1Builder := service.NewStreamBuilder()
+	require.NoError(t, run1Builder.SetLoggerYAML(`level: OFF`))
+	require.NoError(t, run1Builder.AddInputYAML(template))
+	require.NoError(t, run1Builder.AddBatchConsumerFunc(func(ctx context.Context, _ service.MessageBatch) error {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		// Block without acking until the simulated crash cancels our context.
+		<-ctx.Done()
+		return ctx.Err()
+	}))
+	run1, err := run1Builder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(run1.Resources())
+
+	run1Ctx, crash := context.WithCancel(context.Background())
+	run1Done := make(chan struct{})
+	go func() {
+		defer close(run1Done)
+		_ = run1.Run(run1Ctx)
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(30 * time.Second):
+		t.Fatal("snapshot rows were never delivered to the run-1 output")
+	}
+	// Give the stream time to reach the ack barrier (and, in the buggy version,
+	// to promote the slot) before we crash.
+	time.Sleep(2 * time.Second)
+	crash()
+	select {
+	case <-run1Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("run 1 did not stop after the simulated crash")
+	}
+
+	// The barrier must have prevented the temporary slot from being promoted to
+	// a permanent one, since the snapshot was never acknowledged. This is the
+	// core guarantee: without it the permanent slot would exist here and the
+	// snapshot would be skipped on restart.
+	var permanentSlots int
+	require.NoError(t, db.QueryRow(`SELECT count(*) FROM pg_replication_slots WHERE slot_name = 'test_slot_snapshot_ack_barrier'`).Scan(&permanentSlots))
+	require.Zero(t, permanentSlots, "replication slot must not be promoted before snapshot rows are acknowledged")
+
+	// A real process crash drops the connection, so postgres releases the
+	// temporary snapshot slot. Our in-process cancel does not tear the
+	// replication connection down promptly, so terminate the backend still
+	// holding the temporary slot to faithfully model the crash, and wait for the
+	// slot to be released before restarting.
+	require.Eventually(t, func() bool {
+		_, _ = db.Exec(`SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = 'test_slot_snapshot_ack_barrier_tmp' AND active_pid IS NOT NULL`)
+		var tmpSlots int
+		if err := db.QueryRow(`SELECT count(*) FROM pg_replication_slots WHERE slot_name = 'test_slot_snapshot_ack_barrier_tmp'`).Scan(&tmpSlots); err != nil {
+			return false
+		}
+		return tmpSlots == 0
+	}, 30*time.Second, 500*time.Millisecond, "temporary snapshot slot from the crashed run was not released")
+
+	// Run 2: restart against the same slot. Since run 1 never acked the snapshot,
+	// the slot must not have been promoted, so the snapshot re-runs and every row
+	// is delivered again.
+	var mu sync.Mutex
+	var reads int
+	run2Builder := service.NewStreamBuilder()
+	require.NoError(t, run2Builder.SetLoggerYAML(`level: OFF`))
+	require.NoError(t, run2Builder.AddInputYAML(template))
+	require.NoError(t, run2Builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+		if op, _ := m.MetaGet("operation"); op == "read" { // ReadOpType: snapshot row
+			mu.Lock()
+			reads++
+			mu.Unlock()
+		}
+		return nil
+	}))
+	run2, err := run2Builder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(run2.Resources())
+	go func() { _ = run2.Run(t.Context()) }()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(c, rowCount, reads, "snapshot should have re-run and re-delivered every row after the crash")
+	}, 30*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, run2.StopWithin(10*time.Second))
+}
+
 func TestIntegrationPgStreamingFromRemoteDB(t *testing.T) {
 	t.Skip("This test requires a remote database to run. Aimed to test remote databases")
 

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -45,6 +45,12 @@ type Stream struct {
 	messages              chan []StreamMessage
 	errors                chan error
 
+	// snapshotAcked is closed (once) by the input layer via
+	// MarkSnapshotAcknowledged once every snapshot message has been acknowledged
+	// downstream, unblocking promotion of the replication slot.
+	snapshotAcked     chan struct{}
+	snapshotAckedOnce sync.Once
+
 	includeTxnMarkers       bool
 	slotName                string
 	tables                  []TableFQN
@@ -112,6 +118,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		pgConn:                dbConn,
 		messages:              make(chan []StreamMessage),
 		errors:                make(chan error, 1),
+		snapshotAcked:         make(chan struct{}),
 		slotName:              config.ReplicationSlotName,
 		snapshotBatchSize:     batchSize,
 		tables:                tables,
@@ -254,12 +261,27 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 			for _, table := range tables {
 				stream.monitor.MarkSnapshotComplete(table)
 			}
-			// TODO: Do we want to ensure all snapshot messages are ack'd before moving
-			// onto the replication stream?
 
-			// Now that the snapshot has been processed, we can copy the replication
-			// slot, represerving the LSN but making it not temporary.
-			// This action also expires the snapshot.
+			// Emit a sentinel so the input layer knows the snapshot is fully
+			// emitted, then block until it confirms every snapshot message has
+			// been acknowledged downstream before promoting the replication
+			// slot. This guarantees a crash during the handoff re-runs the
+			// snapshot on restart instead of losing the un-acked rows: the
+			// permanent slot is only created past this barrier.
+			select {
+			case stream.messages <- []StreamMessage{{Operation: SnapshotCompleteOpType}}:
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case <-stream.snapshotAcked:
+			case <-ctx.Done():
+				return
+			}
+
+			// Now that the snapshot has been processed and durably delivered, we
+			// can copy the replication slot, preserving the LSN but making it not
+			// temporary. This action also expires the snapshot.
 			startLSN, err = CopyReplicationSlot(
 				ctx,
 				stream.pgConn,
@@ -774,6 +796,13 @@ func (s *Stream) scanTableRange(ctx context.Context, snapshotter *snapshotter, t
 // Messages is a channel that can be used to consume messages from the plugin. It will contain LSN nil for snapshot messages.
 func (s *Stream) Messages() chan []StreamMessage {
 	return s.messages
+}
+
+// MarkSnapshotAcknowledged is called by the input layer once every snapshot
+// message has been acknowledged downstream, unblocking promotion of the
+// replication slot. Safe to call multiple times.
+func (s *Stream) MarkSnapshotAcknowledged() {
+	s.snapshotAckedOnce.Do(func() { close(s.snapshotAcked) })
 }
 
 // Errors is a channel that can be used to see if and error has occurred internally and the stream should be restarted.

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -230,6 +231,15 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 
 	var snapshotter *snapshotter
 	if config.StreamOldData {
+		// A crash between snapshot completion and slot promotion leaves <slot>_tmp
+		// behind, owned by the dead session. We only get here when no permanent
+		// slot exists, so any leftover _tmp slot is necessarily stale - drop it
+		// first so CREATE_REPLICATION_SLOT doesn't fail with "already exists" and
+		// crash-loop until the dead session's slot is otherwise reaped.
+		if err := DropReplicationSlot(ctx, stream.pgConn, stream.slotName+"_tmp", DropReplicationSlotOptions{}); err != nil && !strings.Contains(err.Error(), "does not exist") {
+			return nil, fmt.Errorf("dropping stale temporary replication slot: %w", err)
+		}
+
 		var snapshotName string
 		_, snapshotName, err = CreateReplicationSlot(
 			ctx,

--- a/internal/impl/postgresql/pglogicalstream/stream_message.go
+++ b/internal/impl/postgresql/pglogicalstream/stream_message.go
@@ -36,6 +36,11 @@ const (
 	BeginOpType OpType = "begin"
 	// CommitOpType is a database transaction commit
 	CommitOpType OpType = "commit"
+	// SnapshotCompleteOpType is an internal sentinel emitted after all snapshot
+	// rows have been sent. It signals the input layer to block promotion of the
+	// replication slot until every snapshot message has been acknowledged
+	// downstream; it is never forwarded downstream.
+	SnapshotCompleteOpType OpType = "snapshot_complete"
 )
 
 // StreamMessage represents a single change from the database


### PR DESCRIPTION
During the initial snapshot the connector emitted snapshot rows (which carry no LSN and are therefore never tracked for postgres acknowledgement) and then immediately promoted the temporary replication slot to a permanent one and began streaming from startLSN, without waiting for those rows to be acknowledged downstream. A crash in that window left the permanent slot in place, so on restart the snapshot phase was skipped and the un-acked rows were silently lost.

Add an acknowledgement barrier across the stream/input boundary, mirroring the mysql input's snapshot_complete sentinel:

- The stream emits a SnapshotCompleteOpType sentinel after the last snapshot row, then blocks (until acked or shutdown) before CopyReplicationSlot.
- The input tracks in-flight snapshot batches with a WaitGroup and, on the sentinel, flushes and waits for every snapshot batch to be acknowledged before calling Stream.MarkSnapshotAcknowledged to release the barrier.

A crash before the snapshot rows are acked now leaves the temporary slot to expire and the permanent slot uncreated, so the snapshot re-runs on restart with no row loss.

Add an integration test that reproduces the crash-during-handoff: it receives the snapshot rows without acking, cancels the run, asserts the slot was not promoted, then restarts and asserts the snapshot re-runs. Verified to fail without the barrier fix.