### PR TITLE
oracledb_cdc: handle row id based predicates

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -301,6 +301,8 @@ func (lm *LogMiner) processRedoEvent(ctx context.Context, redoEvent *sqlredo.Red
 		// Parse sql insert/update/delete sql statements into key/value object
 		event, err := lm.dmlParser.RedoEventToDMLEvent(redoEvent)
 		if err != nil {
+			lm.log.Debugf("failed to parse SQL_REDO (scn=%d, op=%s, table=%s.%s, txn=%s): %s",
+				redoEvent.SCN, redoEvent.Operation, redoEvent.SchemaName.String, redoEvent.TableName.String, redoEvent.TransactionID, redoEvent.SQLRedo.String)
 			return fmt.Errorf("parsing sql redo event into dml event: %w", err)
 		}
 

--- a/internal/impl/oracledb/logminer/sqlredo/parser_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser_test.go
@@ -135,6 +135,25 @@ func TestParseTest(t *testing.T) {
 				"COL2": "2",
 			},
 		},
+		// Oracle LogMiner emits ROWID-based WHERE clauses for tables without a primary key
+		// or without supplemental logging enabled.
+		{
+			name: "DELETE with ROWID in WHERE clause",
+			sql:  `delete from "CMMSAPP"."FWEQPEQUIPMENT" where ROWID = 'AAABCDefgHIJKLM'`,
+			wantOldValues: map[string]any{
+				"ROWID": "AAABCDefgHIJKLM",
+			},
+		},
+		{
+			name: "UPDATE with ROWID in WHERE clause",
+			sql:  `update "CMMSAPP"."FWEQPEQUIPMENT" set "STATUS" = 'ACTIVE' where ROWID = 'AAABCDefgHIJKLM'`,
+			wantNewValues: map[string]any{
+				"STATUS": "ACTIVE",
+			},
+			wantOldValues: map[string]any{
+				"ROWID": "AAABCDefgHIJKLM",
+			},
+		},
 		// IS NULL / IS NOT NULL predicates in WHERE must be excluded from the result map
 		{
 			name: "IS NULL and IS NOT NULL in WHERE clause excluded from result",

--- a/internal/impl/oracledb/logminer/sqlredo/scanner.go
+++ b/internal/impl/oracledb/logminer/sqlredo/scanner.go
@@ -100,22 +100,38 @@ loop:
 	sc.ws()
 }
 
-// readIdent reads a double-quoted identifier and returns its content without the quotes.
-// It skips an optional alias prefix such as `a.` in `a."COL1"`.
+// readIdent reads a column identifier and returns its name.
+// It handles three forms:
+//   - double-quoted: "COL1"
+//   - alias-prefixed: a."COL1"  (the alias is discarded)
+//   - bare (unquoted): ROWID  (produced by LogMiner for tables without supplemental logging)
 func (sc *redoScanner) readIdent() (string, error) {
 	sc.ws()
-	// skip optional table-alias prefix (e.g. `a.` in `a."COL1"`)
-	if !sc.done() && sc.s[sc.i] != '"' {
-		for !sc.done() && sc.s[sc.i] != '"' {
-			sc.i++
-		}
+	if sc.done() {
+		return "", errors.New("expected identifier, got end of input")
 	}
-	if sc.done() || sc.s[sc.i] != '"' {
-		snippet := sc.s[sc.i:]
-		if len(snippet) > 20 {
-			snippet = snippet[:20]
+	if sc.s[sc.i] != '"' {
+		// Peek ahead: if a '"' appears before any whitespace or '=', the leading
+		// text is a table-alias prefix (e.g. `a.`) — skip it and fall through to
+		// the quoted read. Otherwise it's a bare identifier (e.g. ROWID) — return it.
+		j := sc.i
+		for j < len(sc.s) && sc.s[j] != '"' && !isSpaceByte(sc.s[j]) && sc.s[j] != '=' && sc.s[j] != ',' && sc.s[j] != ')' {
+			j++
 		}
-		return "", fmt.Errorf("expected quoted identifier, got %.20q", snippet)
+		if j < len(sc.s) && sc.s[j] == '"' {
+			sc.i = j // skip alias prefix, fall through to quoted read below
+		} else {
+			if j == sc.i {
+				snippet := sc.s[sc.i:]
+				if len(snippet) > 20 {
+					snippet = snippet[:20]
+				}
+				return "", fmt.Errorf("expected identifier, got %.20q", snippet)
+			}
+			name := sc.s[sc.i:j]
+			sc.i = j
+			return name, nil
+		}
 	}
 	sc.i++ // skip opening "
 	start := sc.i


### PR DESCRIPTION
In Oracle, a ROWID is Oracle's internal physical address for a row - it's not a column in the table; it's a pseudo-column Oracle maintains internally and under some circumstances it's possible that OracleDB will fall back to using it to locate rows (tables without primary keys, LOB based operations).

So this change handles such scenario, publishing the change as an event and logging the SQL via the `DEBUG` flag (it's possible it could contain sensitive information so should be an opt-in behaviour).