### PR TITLE
oracledb_cdc: harden SQL_REDO value and LOB parsing against panics and national-charset corruption

### DIFF
--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -2274,3 +2274,74 @@ oracledb_cdc:
 		require.NoError(t, stream.StopWithin(time.Second*10))
 	})
 }
+
+// TestIntegrationOracleDBCDCNationalCharset verifies that non-ASCII data in
+// NVARCHAR2 columns — which Oracle LogMiner emits as UNISTR('...\XXXX...') in
+// SQL_REDO — is decoded to the correct UTF-8 string end-to-end.
+func TestIntegrationOracleDBCDCNationalCharset(t *testing.T) {
+	integration.CheckSkip(t)
+	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+	ctx := t.Context()
+
+	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(ctx, "testdb.natchar",
+		"CREATE TABLE testdb.natchar (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, nv NVARCHAR2(50))"))
+
+	msgChan := make(chan *service.Message, 64)
+	cfg := `
+oracledb_cdc:
+  connection_string: ` + connStr + `
+  snapshot_mode: none
+  logminer:
+    scn_window_size: 20000
+    min_scn_window_size: 0
+    backoff_interval: 1s
+  include: ["TESTDB.NATCHAR"]
+  batching:
+    count: 1`
+
+	streamBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamBuilder.AddInputYAML(cfg))
+	require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
+	require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		for _, msg := range mb {
+			select {
+			case msgChan <- msg:
+			default:
+			}
+		}
+		return nil
+	}))
+	stream, err := streamBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(stream.Resources())
+	go func() { _ = stream.Run(ctx) }()
+
+	time.Sleep(10 * time.Second)
+	// café (BMP) and 😀 (U+1F600, requires a UTF-16 surrogate pair).
+	db.MustExec("INSERT INTO testdb.natchar (nv) VALUES (:1)", "café 😀")
+
+	var got string
+	require.Eventually(t, func() bool {
+		select {
+		case msg := <-msgChan:
+			b, err := msg.AsBytes()
+			if err != nil {
+				return false
+			}
+			var row map[string]any
+			if err := json.Unmarshal(b, &row); err != nil {
+				return false
+			}
+			if v, ok := row["NV"].(string); ok && v != "" {
+				got = v
+				return true
+			}
+			return false
+		default:
+			return false
+		}
+	}, 30*time.Second, 250*time.Millisecond, "did not receive the NVARCHAR2 change event")
+
+	assert.Equal(t, "café 😀", got, "NVARCHAR2 value should be decoded from UNISTR to correct UTF-8")
+	_ = stream.StopWithin(10 * time.Second)
+}

--- a/internal/impl/oracledb/logminer/sqlredo/fuzz_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/fuzz_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package sqlredo
+
+import (
+	"testing"
+	"time"
+)
+
+// FuzzScanSQLCommand asserts that no SQL_REDO input — however malformed — can
+// panic the parser or value converter. The parser only ever returns errors; a
+// panic would crash the whole CDC connector.
+func FuzzScanSQLCommand(f *testing.F) {
+	seeds := []string{
+		`insert into "S"."T"("C1","C2") values ('a','b')`,
+		`update "S"."T" set "C1" = '1' where "C2" = 'old'`,
+		`delete from "S"."T" where "C1" = '1' and ROWID = 'AAAF'`,
+		`insert into "S"."T"("C") values (UNISTR('caf\00e9') || UNISTR('\d83d\de00'))`,
+		`insert into "S"."T"("C") values (HEXTORAW('123'))`,
+		`insert into "S"."T"("C") values (TO_DATE('2020-01-15','YYYY-MM-DD'))`,
+		`update "S"."T" a set a."C" = NULL where a."K" IS NOT NULL`,
+		`delete from "S"."T" where ROWID = ''`,
+		``,
+		`garbage`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	conv := NewOracleValueConverter(time.UTC)
+	f.Fuzz(func(_ *testing.T, sql string) {
+		// Must never panic, regardless of return value.
+		if stmt, err := ParseSQLCommand(sql); err == nil {
+			_, _, _ = ExtractValuesFromAST(stmt, &conv)
+		}
+		_ = conv.ConvertValue(sql)
+	})
+}

--- a/internal/impl/oracledb/logminer/sqlredo/lob.go
+++ b/internal/impl/oracledb/logminer/sqlredo/lob.go
@@ -11,6 +11,7 @@ package sqlredo
 import (
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 
@@ -60,6 +61,20 @@ func (a *LobAccumulator) AddFragment(offset int64, data []byte) {
 	a.Fragments = append(a.Fragments, LobFragment{Offset: offset, Data: data})
 }
 
+// usableOffset reports whether the fragment's 1-based offset can be positioned
+// without indexing negatively (offset < 1) or overflowing int64 when computing its
+// end position. Oracle LOB offsets are 1-based and bounded by the LOB size, so only
+// corrupted redo fails this check.
+//
+// NOTE: this guards the two arithmetic crash paths (negative index, int64 overflow)
+// but does not bound the resulting allocation: a corrupt-but-non-overflowing offset
+// (e.g. 1<<50) still drives Assemble's make([]byte, totalLen) to panic/OOM. Fully
+// closing that requires a maximum-LOB-size policy and is tracked as a follow-up;
+// legitimate Oracle output never produces such an offset.
+func (f LobFragment) usableOffset() bool {
+	return f.Offset >= 1 && f.Offset-1 <= math.MaxInt64-int64(len(f.Data))
+}
+
 // Assemble assembles all fragments into the final column value:
 //   - BLOB → []byte (raw bytes, gaps zero-filled)
 //   - CLOB → string (plain string, gaps space-filled)
@@ -73,6 +88,9 @@ func (a *LobAccumulator) Assemble() any {
 
 	var totalLen int64
 	for _, f := range a.Fragments {
+		if !f.usableOffset() {
+			continue // skip malformed offsets (< 1 or overflowing) rather than crashing
+		}
 		end := (f.Offset - 1) + int64(len(f.Data))
 		if end > totalLen {
 			totalLen = end
@@ -88,6 +106,9 @@ func (a *LobAccumulator) Assemble() any {
 	}
 
 	for _, f := range a.Fragments {
+		if !f.usableOffset() {
+			continue
+		}
 		start := f.Offset - 1 // convert 1-based offset to 0-based
 		copy(result[start:], f.Data)
 	}
@@ -259,7 +280,16 @@ func MergeInlineLOBValues(lobData map[string]any, schema, table string, pkValues
 
 // pkMatches returns true when every key in pkValues is present in data and the
 // string representations are equal.
+//
+// An empty pkValues set returns false rather than vacuously matching: a
+// ROWID-only SELECT_LOB_LOCATOR yields no PK values, and treating that as a match
+// against the first candidate event would merge the LOB into an arbitrary row.
+// Returning false forces callers to fall back to the schema/table disambiguation
+// (see MergeLOBsIntoDMLEvents Pass 3).
 func pkMatches(data map[string]any, pkValues map[string]any) bool {
+	if len(pkValues) == 0 {
+		return false
+	}
 	for k, pkVal := range pkValues {
 		dataVal, ok := data[k]
 		if !ok {

--- a/internal/impl/oracledb/logminer/sqlredo/lob_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/lob_test.go
@@ -9,9 +9,11 @@
 package sqlredo
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeInlineLOBValues(t *testing.T) {
@@ -112,4 +114,101 @@ func TestMergeInlineLOBValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAssembleOffsetValidation(t *testing.T) {
+	t.Run("valid 1-based offsets assemble correctly", func(t *testing.T) {
+		acc := &LobAccumulator{IsBinary: true}
+		acc.AddFragment(1, []byte{0x41, 0x42})
+		acc.AddFragment(3, []byte{0x43})
+		assert.Equal(t, []byte{0x41, 0x42, 0x43}, acc.Assemble())
+	})
+
+	t.Run("offset < 1 is skipped, does not panic", func(t *testing.T) {
+		acc := &LobAccumulator{IsBinary: true}
+		acc.AddFragment(0, []byte{0x41, 0x42}) // invalid: Oracle offsets are 1-based
+		acc.AddFragment(1, []byte{0x58})
+		assert.NotPanics(t, func() {
+			assert.Equal(t, []byte{0x58}, acc.Assemble())
+		})
+	})
+
+	t.Run("overflowing offset is skipped, does not panic", func(t *testing.T) {
+		acc := &LobAccumulator{IsBinary: true}
+		acc.AddFragment(math.MaxInt64, []byte{0x41, 0x42}) // corrupt: (offset-1)+len overflows int64
+		acc.AddFragment(1, []byte{0x58})
+		assert.NotPanics(t, func() {
+			assert.Equal(t, []byte{0x58}, acc.Assemble())
+		})
+	})
+
+	t.Run("CLOB gaps are space-filled", func(t *testing.T) {
+		acc := &LobAccumulator{IsBinary: false}
+		acc.AddFragment(1, []byte("ab"))
+		acc.AddFragment(5, []byte("z"))
+		assert.Equal(t, "ab  z", acc.Assemble())
+	})
+}
+
+func TestPkMatches(t *testing.T) {
+	t.Run("empty pkValues does not vacuously match", func(t *testing.T) {
+		assert.False(t, pkMatches(map[string]any{"ID": "1", "VAL": "x"}, map[string]any{}))
+	})
+	t.Run("subset match", func(t *testing.T) {
+		assert.True(t, pkMatches(map[string]any{"ID": "1", "VAL": "x"}, map[string]any{"ID": "1"}))
+	})
+	t.Run("value mismatch", func(t *testing.T) {
+		assert.False(t, pkMatches(map[string]any{"ID": "2"}, map[string]any{"ID": "1"}))
+	})
+	t.Run("missing key", func(t *testing.T) {
+		assert.False(t, pkMatches(map[string]any{"OTHER": "1"}, map[string]any{"ID": "1"}))
+	})
+}
+
+// TestMergeLOBsEmptyPKNoMisroute verifies that a ROWID-only SELECT_LOB_LOCATOR
+// (which yields an empty PK set) does NOT get merged into an arbitrary INSERT.
+// Previously the empty PK matched the first event vacuously; now, with two
+// candidate rows for the table, the accumulator is left unmerged (Pass 3 cannot
+// disambiguate) so the caller synthesizes a separate event instead of corrupting
+// the wrong row.
+func TestMergeLOBsEmptyPKNoMisroute(t *testing.T) {
+	state := NewTxnLOBState()
+	key := LobKey{Schema: "S", Table: "T", Column: "DOC"}
+	acc := &LobAccumulator{Schema: "S", Table: "T", Column: "DOC", IsBinary: false, PKValues: map[string]any{}}
+	acc.AddFragment(1, []byte("hello"))
+	state.Accumulators[key] = acc
+
+	events := []*DMLEvent{
+		{Operation: OpInsert, Schema: "S", Table: "T", Data: map[string]any{"ID": "1"}},
+		{Operation: OpInsert, Schema: "S", Table: "T", Data: map[string]any{"ID": "2"}},
+	}
+
+	unmerged := MergeLOBsIntoDMLEvents(state, events, nil)
+
+	// Neither INSERT should have had the LOB written into it.
+	for _, ev := range events {
+		_, has := ev.Data["DOC"]
+		assert.Falsef(t, has, "LOB must not be misrouted into row ID=%v", ev.Data["ID"])
+	}
+	// The accumulator is returned as unmerged for the caller to synthesize.
+	require.Len(t, unmerged, 1)
+	assert.Equal(t, "DOC", unmerged[0].Column)
+}
+
+// TestMergeLOBsEmptyPKSingleCandidate confirms the Pass-3 single-candidate path
+// still merges correctly when there is exactly one row for the table.
+func TestMergeLOBsEmptyPKSingleCandidate(t *testing.T) {
+	state := NewTxnLOBState()
+	key := LobKey{Schema: "S", Table: "T", Column: "DOC"}
+	acc := &LobAccumulator{Schema: "S", Table: "T", Column: "DOC", IsBinary: false, PKValues: map[string]any{}}
+	acc.AddFragment(1, []byte("hello"))
+	state.Accumulators[key] = acc
+
+	events := []*DMLEvent{
+		{Operation: OpInsert, Schema: "S", Table: "T", Data: map[string]any{"ID": "1"}},
+	}
+
+	unmerged := MergeLOBsIntoDMLEvents(state, events, nil)
+	assert.Empty(t, unmerged)
+	assert.Equal(t, "hello", events[0].Data["DOC"])
 }

--- a/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
+++ b/internal/impl/oracledb/logminer/sqlredo/valueconverter.go
@@ -9,12 +9,15 @@
 package sqlredo
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf16"
+	"unicode/utf8"
 )
 
 // OracleValueConverter handles conversion of Oracle function calls and special values
@@ -47,6 +50,12 @@ var (
 
 	// EMPTY_CLOB() or EMPTY_BLOB()
 	emptyLobPattern = regexp.MustCompile(`(?i)EMPTY_(CLOB|BLOB)\(\)`)
+
+	// UNISTR('caf\00e9') — national-character literal with \XXXX UTF-16 escapes.
+	uniStrPattern = regexp.MustCompile(`(?i)UNISTR\('((?:[^']|'')*)'\)`)
+	// Whole-value form: one or more UNISTR('...') segments joined by ||. Used to
+	// reject mixed expressions so non-UNISTR text is never silently dropped.
+	uniStrExprPattern = regexp.MustCompile(`(?i)^UNISTR\('(?:[^']|'')*'\)(?:\s*\|\|\s*UNISTR\('(?:[^']|'')*'\))*$`)
 )
 
 // ConvertValue converts an Oracle value (potentially a function call) to its proper Go type.
@@ -72,6 +81,9 @@ func (c *OracleValueConverter) ConvertValue(value any) any {
 	}
 	if emptyLobPattern.MatchString(str) {
 		return c.convertLobValue(str)
+	}
+	if result := c.convertUnistrValue(str); result != nil {
+		return result
 	}
 
 	// Bare numeric literal: try integer first, then floating-point.
@@ -183,18 +195,78 @@ func (*OracleValueConverter) convertRawValue(value string) any {
 		return value
 	}
 
-	hexStr := matches[1]
-	bytes := make([]byte, len(hexStr)/2)
+	decoded, err := hex.DecodeString(matches[1])
+	if err != nil {
+		// Malformed hex (e.g. odd length). Oracle emits even-length hex for
+		// RAW/BLOB, so this is defensive: leave the value untouched rather than
+		// panicking and taking down the whole connector.
+		return value
+	}
+	return decoded
+}
 
-	for i := 0; i < len(hexStr); i += 2 {
-		b, err := strconv.ParseUint(hexStr[i:i+2], 16, 8)
-		if err != nil {
-			return value
-		}
-		bytes[i/2] = byte(b)
+// convertUnistrValue decodes an Oracle UNISTR('...') national-character literal to
+// a Go string. UNISTR encodes characters as \XXXX UTF-16 code units (with \\ for a
+// literal backslash), and LogMiner may concatenate several UNISTR calls with ||.
+// Returns nil when value is not a UNISTR expression so ConvertValue can fall
+// through to its other branches.
+func (*OracleValueConverter) convertUnistrValue(value string) any {
+	// Fast, allocation-free reject for the hot path: only values that begin with
+	// UNISTR( can be UNISTR expressions. EqualFold avoids the strings.ToUpper
+	// allocation on every bare value the converter inspects.
+	const prefix = "UNISTR("
+	v := strings.TrimSpace(value)
+	if len(v) < len(prefix) || !strings.EqualFold(v[:len(prefix)], prefix) {
+		return nil
+	}
+	// Only decode when the WHOLE value is UNISTR('...') segments joined by || .
+	// A mixed expression (e.g. UNISTR('a') || 'plain' || UNISTR('b')) would
+	// otherwise have its non-UNISTR parts silently dropped — safer to leave the
+	// value untouched than to corrupt it. (Genuine LogMiner output never
+	// interleaves plain literals with UNISTR segments.)
+	if !uniStrExprPattern.MatchString(v) {
+		return nil
+	}
+	segments := uniStrPattern.FindAllStringSubmatch(v, -1)
+	if segments == nil {
+		return nil
 	}
 
-	return bytes
+	var units []uint16
+	for _, seg := range segments {
+		inner := strings.ReplaceAll(seg[1], "''", "'")
+		for i := 0; i < len(inner); {
+			if inner[i] == '\\' {
+				// \\ is a literal backslash.
+				if i+1 < len(inner) && inner[i+1] == '\\' {
+					units = append(units, uint16('\\'))
+					i += 2
+					continue
+				}
+				// \XXXX is a single UTF-16 code unit (surrogate halves combine).
+				if i+5 <= len(inner) {
+					if v, err := strconv.ParseUint(inner[i+1:i+5], 16, 16); err == nil {
+						units = append(units, uint16(v))
+						i += 5
+						continue
+					}
+				}
+				// Not a valid escape — treat the backslash literally.
+				units = append(units, uint16('\\'))
+				i++
+				continue
+			}
+			r, size := utf8.DecodeRuneInString(inner[i:])
+			if r == utf8.RuneError && size <= 1 {
+				units = append(units, uint16(inner[i]))
+				i++
+				continue
+			}
+			units = append(units, utf16.Encode([]rune{r})...)
+			i += size
+		}
+	}
+	return string(utf16.Decode(units))
 }
 
 // convertLobValue handles EMPTY_CLOB() and EMPTY_BLOB()

--- a/internal/impl/oracledb/logminer/sqlredo/valueconverter_test.go
+++ b/internal/impl/oracledb/logminer/sqlredo/valueconverter_test.go
@@ -189,6 +189,13 @@ func TestConvertRawValue(t *testing.T) {
 			input:   "48656C6C6F",
 			wantStr: "48656C6C6F",
 		},
+		{
+			// Regression: odd-length hex must not panic (previously sliced out of
+			// range). Malformed input is returned untouched.
+			name:    "HEXTORAW odd-length hex is returned untouched, no panic",
+			input:   "HEXTORAW('123')",
+			wantStr: "HEXTORAW('123')",
+		},
 	}
 
 	for _, tt := range tests {
@@ -199,6 +206,65 @@ func TestConvertRawValue(t *testing.T) {
 			} else {
 				assert.Equal(t, tt.wantStr, result)
 			}
+		})
+	}
+}
+
+func TestConvertUnistrValue(t *testing.T) {
+	converter := NewOracleValueConverter(time.UTC)
+
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name:  "UNISTR with unicode escape",
+			input: `UNISTR('caf\00e9')`,
+			want:  "café",
+		},
+		{
+			name:  "UNISTR pure ASCII",
+			input: `UNISTR('hello')`,
+			want:  "hello",
+		},
+		{
+			name:  "UNISTR concatenation via ||",
+			input: `UNISTR('caf\00e9') || UNISTR(' \2603')`, // é then snowman
+			want:  "café ☃",
+		},
+		{
+			name:  "UNISTR surrogate pair (U+1F600)",
+			input: `UNISTR('\d83d\de00')`,
+			want:  "😀",
+		},
+		{
+			name:  "UNISTR escaped backslash",
+			input: `UNISTR('a\\b')`,
+			want:  `a\b`,
+		},
+		{
+			name:  "not a UNISTR call returns nil",
+			input: "TO_DATE('2020-01-15','YYYY-MM-DD')",
+			want:  nil,
+		},
+		{
+			// A mixed expression is rejected (nil) rather than silently dropping
+			// the plain literal — the caller keeps the raw value untouched.
+			name:  "mixed UNISTR and plain literal returns nil (no silent drop)",
+			input: `UNISTR('a') || 'plain' || UNISTR('b')`,
+			want:  nil,
+		},
+		{
+			name:  "value merely containing UNISTR is not decoded",
+			input: `MYUNISTR('x')`,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, converter.convertUnistrValue(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
## What

Hardens the Oracle CDC (`oracledb_cdc`) LogMiner `SQL_REDO` parser and LOB assembly against a set of panic and data-corruption paths surfaced while investigating a parse failure. Each change turns a former crash or silent corruption into correct-or-safe behaviour; none alters happy-path output.

## Changes

- **`convertRawValue`** now uses `hex.DecodeString` rather than a hand-rolled two-characters-at-a-time loop that sliced out of range and panicked on odd-length `HEXTORAW('...')` input. Malformed hex is now returned untouched, and the behaviour is byte-identical to the previous loop on valid input. This also aligns with the existing usage in `lob_parser.go`.
- **`UNISTR('...')` decoding.** National-character (`NVARCHAR2` / `NCHAR` / `NCLOB`) values are emitted by LogMiner as `UNISTR('...\XXXX...')`; these were previously stored verbatim as the raw SQL text. They are now decoded to the correct UTF-8 string, handling `\XXXX` UTF-16 escapes, surrogate pairs, `\\`, and `||` concatenation. A whole-value guard ensures only pure `UNISTR` expressions are decoded, so any unexpected shape is left untouched rather than silently truncated.
- **`Assemble`** skips LOB fragments whose 1-based offset is unusable — below 1, or large enough that computing the end position would overflow `int64` — instead of indexing out of range.
- **`pkMatches`** returns `false` for an empty PK set instead of matching vacuously. A ROWID-only `SELECT_LOB_LOCATOR` yields no PK values; the previous behaviour merged its LOB into the first candidate event (potentially the wrong row). It now falls through to the schema/table disambiguation as intended.

## Testing

- Unit tests for each fix: odd-length `HEXTORAW`; `UNISTR` incl. surrogate pairs, escaped backslash, concatenation, and mixed-expression rejection; `Assemble` offset validation (negative and overflowing); and empty-PK LOB routing.
- A fuzz target (`FuzzScanSQLCommand`) over the parser and value converter — several million executions with no panics.
- An integration test (`TestIntegrationOracleDBCDCNationalCharset`) that streams a non-ASCII `NVARCHAR2` value end-to-end through a live Oracle container and asserts correct UTF-8 decoding.
- Benchmarks confirm no regression on the per-event hot path; the `UNISTR` fast-reject is allocation-free.

## Follow-ups (not in this PR)

- A configurable maximum assembled-LOB size would fully close a residual, corrupt-input-only allocation crash in `Assemble` (a pathologically large but non-overflowing offset). Legitimate Oracle output cannot produce such an offset.
- Lower-severity items noted during review — concatenation handling for quote-first values, decoding of interval types, and `NCLOB` UTF-16 assembly — are left for separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)