### PR TITLE
docs: fix rpcn schema formatting in CDC input descriptions

### DIFF
--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -107,7 +107,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the `rpcn` schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
 		
 
 == Fields

--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -107,7 +107,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the `rpcn` schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
 
 == Performance
 

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -135,7 +135,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the `rpcn` schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
 		
 
 == Fields

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -139,7 +139,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the `rpcn` schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
 
 == Performance
 

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -68,7 +68,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "`rpcn`" + ` schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -70,7 +70,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
+When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "`rpcn`" + ` schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
 
 == Performance
 

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -90,7 +90,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + ociFieldCheckpointCacheTableName + "`" + ` for more information.
+When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "`rpcn`" + ` schema must already exist. Refer to ` + "`" + ociFieldCheckpointCacheTableName + "`" + ` for more information.
 		`).
 	Field(service.NewStringField(ociFieldConnectionString).
 		Description("The connection string of the Oracle database to connect to. Additional connection options can be supplied as URL query parameters, for example: `oracle://user:password@host:1522/service?WALLET=/opt/oracle/wallet&SSL=true`.").

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -95,7 +95,7 @@ This input adds the following metadata fields to each message:
 
 == Permissions
 
-When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + ociFieldCheckpointCacheTableName + "`" + ` for more information.
+When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "`rpcn`" + ` schema must already exist. Refer to ` + "`" + ociFieldCheckpointCacheTableName + "`" + ` for more information.
 
 == Performance
 


### PR DESCRIPTION
## Summary

The `oracledb_cdc` and `microsoft_sql_server_cdc` component descriptions render **"the rpcn  schema"** with a double space and no code formatting (flagged by CodeRabbit while reviewing the generated reference docs in redpanda-data/rp-connect-docs#452).

This formats `rpcn` as code and collapses the double space, matching the existing formatting of `rpcn` in the `checkpoint_cache_table_name` field descriptions in the same files.

Changes:
- `internal/impl/oracledb/input_oracledb_cdc.go`
- `internal/impl/mssqlserver/input_mssqlserver_cdc.go`
- The corresponding generated docs pages under `docs/modules/components/pages/inputs/` (same edit `make docs` would produce; description-string-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)