### PR TITLE
aws_dynamodb_partiql: support single ExecuteStatement

### DIFF
--- a/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
+++ b/docs/modules/components/pages/processors/aws_dynamodb_partiql.adoc
@@ -53,6 +53,7 @@ label: ""
 aws_dynamodb_partiql:
   query: "" # No default (required)
   unsafe_dynamic_query: false
+  use_batch: true
   args_mapping: ""
   region: "" # No default (optional)
   endpoint: "" # No default (optional)
@@ -102,6 +103,25 @@ pipeline:
 ```
 
 --
+Query a GSI for a single record::
++
+--
+
+The following example looks up a single record from the table footable using the global secondary index index_name, matching on the field bar. BatchExecuteStatement can't query a GSI, so use_batch is disabled:
+
+```yaml
+pipeline:
+  processors:
+    - aws_dynamodb_partiql:
+        query: "SELECT * FROM \"footable\".\"index_name\" WHERE bar = ?"
+        use_batch: false
+        args_mapping: |
+          root = [
+            { "S": this.bar },
+          ]
+```
+
+--
 ======
 
 == Fields
@@ -122,6 +142,15 @@ Whether to enable dynamic queries that support interpolation functions.
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `use_batch`
+
+Whether to execute all messages in a batch as a single `BatchExecuteStatement` call. Set this to `false` to execute one `ExecuteStatement` call per message instead, which is required for PartiQL `SELECT` queries against a global secondary index (GSI) — `BatchExecuteStatement` does not support querying a GSI. Only the first result row is used when a query returns multiple items.
+
+
+*Type*: `bool`
+
+*Default*: `true`
 
 === `args_mapping`
 

--- a/internal/impl/aws/dynamodb/output.go
+++ b/internal/impl/aws/dynamodb/output.go
@@ -187,6 +187,7 @@ type dynamoDBAPI interface {
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
 	BatchWriteItem(ctx context.Context, params *dynamodb.BatchWriteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error)
 	BatchExecuteStatement(ctx context.Context, params *dynamodb.BatchExecuteStatementInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchExecuteStatementOutput, error)
+	ExecuteStatement(ctx context.Context, params *dynamodb.ExecuteStatementInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error)
 	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)

--- a/internal/impl/aws/dynamodb/processor_partiql.go
+++ b/internal/impl/aws/dynamodb/processor_partiql.go
@@ -37,6 +37,10 @@ func init() {
 		Version("3.48.0").
 		Field(service.NewStringField("query").Description("A PartiQL query to execute for each message.")).
 		Field(service.NewBoolField("unsafe_dynamic_query").Description("Whether to enable dynamic queries that support interpolation functions.").Advanced().Default(false)).
+		Field(service.NewBoolField("use_batch").
+			Description("Whether to execute all messages in a batch as a single `BatchExecuteStatement` call. Set this to `false` to execute one `ExecuteStatement` call per message instead, which is required for PartiQL `SELECT` queries against a global secondary index (GSI) — `BatchExecuteStatement` does not support querying a GSI. Only the first result row is used when a query returns multiple items.").
+			Advanced().
+			Default(true)).
 		Field(service.NewBloblangField("args_mapping").
 			Description("A xref:guides:bloblang/about.adoc[Bloblang mapping] that, for each message, creates a list of arguments to use with the query.").Default("")).
 		Example(
@@ -52,6 +56,21 @@ pipeline:
             { "S": this.foo },
             { "S": meta("kafka_topic") },
             { "S": this.document.content },
+          ]
+`,
+		).
+		Example(
+			"Query a GSI for a single record",
+			`The following example looks up a single record from the table footable using the global secondary index index_name, matching on the field bar. BatchExecuteStatement can't query a GSI, so use_batch is disabled:`,
+			`
+pipeline:
+  processors:
+    - aws_dynamodb_partiql:
+        query: "SELECT * FROM \"footable\".\"index_name\" WHERE bar = ?"
+        use_batch: false
+        args_mapping: |
+          root = [
+            { "S": this.bar },
           ]
 `,
 		)
@@ -87,7 +106,11 @@ pipeline:
 					return nil, fmt.Errorf("parsing query: %v", err)
 				}
 			}
-			return newDynamoDBPartiQL(mgr.Logger(), client, query, dynQuery, args), nil
+			useBatch, err := conf.FieldBool("use_batch")
+			if err != nil {
+				return nil, err
+			}
+			return newDynamoDBPartiQL(mgr.Logger(), client, query, dynQuery, args, useBatch), nil
 		})
 }
 
@@ -98,6 +121,7 @@ type dynamoDBPartiQL struct {
 	query    string
 	dynQuery *service.InterpolatedString
 	args     *bloblang.Executor
+	useBatch bool
 }
 
 func newDynamoDBPartiQL(
@@ -106,6 +130,7 @@ func newDynamoDBPartiQL(
 	query string,
 	dynQuery *service.InterpolatedString,
 	args *bloblang.Executor,
+	useBatch bool,
 ) *dynamoDBPartiQL {
 	return &dynamoDBPartiQL{
 		logger:   logger,
@@ -113,48 +138,88 @@ func newDynamoDBPartiQL(
 		query:    query,
 		dynQuery: dynQuery,
 		args:     args,
+		useBatch: useBatch,
 	}
+}
+
+func (d *dynamoDBPartiQL) resolveStatement(batch service.MessageBatch, argsExec *service.MessageBatchBloblangExecutor, i int) (string, []types.AttributeValue, error) {
+	statement := d.query
+	if d.dynQuery != nil {
+		query, err := batch.TryInterpolatedString(i, d.dynQuery)
+		if err != nil {
+			return "", nil, fmt.Errorf("query interpolation error: %w", err)
+		}
+		statement = query
+	}
+
+	argMsg, err := argsExec.Query(i)
+	if err != nil {
+		return "", nil, fmt.Errorf("error evaluating arg mapping at index %d: %v", i, err)
+	}
+
+	argStructured, err := argMsg.AsStructured()
+	if err != nil {
+		return "", nil, fmt.Errorf("error evaluating arg mapping as structured at index %d: %v", i, err)
+	}
+
+	argsSlice, ok := argStructured.([]any)
+	if !ok {
+		return "", nil, fmt.Errorf("arg mapping resulted in non-array value at index %d: %T", i, argStructured)
+	}
+
+	var params []types.AttributeValue
+	for j, a := range argsSlice {
+		tmp, err := objFormToAttributeValue(a)
+		if err != nil {
+			return "", nil, fmt.Errorf("arg mapping index %d mapping to an attribute value: %v", j, err)
+		}
+		params = append(params, tmp)
+	}
+
+	return statement, params, nil
 }
 
 func (d *dynamoDBPartiQL) ProcessBatch(ctx context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
 	argsExec := batch.BloblangExecutor(d.args)
 
+	if !d.useBatch {
+		for i := range batch {
+			statement, params, err := d.resolveStatement(batch, argsExec, i)
+			if err != nil {
+				return nil, err
+			}
+
+			out, err := d.client.ExecuteStatement(ctx, &dynamodb.ExecuteStatementInput{
+				Statement:  &statement,
+				Parameters: params,
+			})
+			if err != nil {
+				batch[i].SetError(fmt.Errorf("executing statement: %w", err))
+				continue
+			}
+
+			if len(out.Items) > 0 {
+				resMap := map[string]any{}
+				for k, v := range out.Items[0] {
+					resMap[k] = attributeValueToObjForm(v)
+				}
+				batch[i].SetStructuredMut(resMap)
+			}
+		}
+
+		return []service.MessageBatch{batch}, nil
+	}
+
 	stmts := []types.BatchStatementRequest{}
 	for i := range batch {
-		req := types.BatchStatementRequest{}
-		req.Statement = &d.query
-		if d.dynQuery != nil {
-			query, err := batch.TryInterpolatedString(i, d.dynQuery)
-			if err != nil {
-				return nil, fmt.Errorf("query interpolation error: %w", err)
-			}
-			req.Statement = &query
-		}
-
-		argMsg, err := argsExec.Query(i)
+		statement, params, err := d.resolveStatement(batch, argsExec, i)
 		if err != nil {
-			return nil, fmt.Errorf("error evaluating arg mapping at index %d: %v", i, err)
+			return nil, err
 		}
-
-		argStructured, err := argMsg.AsStructured()
-		if err != nil {
-			return nil, fmt.Errorf("error evaluating arg mapping as structured at index %d: %v", i, err)
-		}
-
-		argsSlice, ok := argStructured.([]any)
-		if !ok {
-			return nil, fmt.Errorf("arg mapping resulted in non-array value at index %d: %T", i, argStructured)
-		}
-
-		for i, a := range argsSlice {
-			tmp, err := objFormToAttributeValue(a)
-			if err != nil {
-				return nil, fmt.Errorf("arg mapping index %d mapping to an attribute value: %v", i, err)
-			}
-			req.Parameters = append(req.Parameters, tmp)
-		}
-
-		stmts = append(stmts, req)
+		stmts = append(stmts, types.BatchStatementRequest{
+			Statement:  &statement,
+			Parameters: params,
+		})
 	}
 
 	batchResult, err := d.client.BatchExecuteStatement(ctx, &dynamodb.BatchExecuteStatementInput{

--- a/internal/impl/aws/dynamodb/processor_partiql_test.go
+++ b/internal/impl/aws/dynamodb/processor_partiql_test.go
@@ -16,6 +16,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -31,10 +32,15 @@ import (
 type mockProcDynamoDB struct {
 	dynamoDBAPI
 	pbatchFn func(context.Context, *dynamodb.BatchExecuteStatementInput) (*dynamodb.BatchExecuteStatementOutput, error)
+	pexecFn  func(context.Context, *dynamodb.ExecuteStatementInput) (*dynamodb.ExecuteStatementOutput, error)
 }
 
 func (m *mockProcDynamoDB) BatchExecuteStatement(ctx context.Context, params *dynamodb.BatchExecuteStatementInput, _ ...func(*dynamodb.Options)) (*dynamodb.BatchExecuteStatementOutput, error) {
 	return m.pbatchFn(ctx, params)
+}
+
+func (m *mockProcDynamoDB) ExecuteStatement(ctx context.Context, params *dynamodb.ExecuteStatementInput, _ ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error) {
+	return m.pexecFn(ctx, params)
 }
 
 func assertBatchMatches(t *testing.T, exp service.MessageBatch, act []service.MessageBatch) {
@@ -66,7 +72,7 @@ root."-".S = json("content")
 		},
 	}
 
-	db := newDynamoDBPartiQL(nil, client, query, nil, mapping)
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, true)
 
 	reqBatch := service.MessageBatch{
 		service.NewMessage([]byte(`{"content":"foo stuff","id":"foo"}`)),
@@ -128,7 +134,7 @@ root."-".S = json("id")
 		},
 	}
 
-	db := newDynamoDBPartiQL(nil, client, query, nil, mapping)
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, true)
 
 	reqBatch := service.MessageBatch{
 		service.NewMessage([]byte(`{"id":"foo","content":"foo stuff"}`)),
@@ -204,7 +210,7 @@ root."-".S = json("content")
 		},
 	}
 
-	db := newDynamoDBPartiQL(nil, client, query, nil, mapping)
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, true)
 
 	reqBatch := service.MessageBatch{
 		service.NewMessage([]byte(`{"content":"foo stuff","id":"foo"}`)),
@@ -253,4 +259,135 @@ root."-".S = json("content")
 	}
 
 	assert.Equal(t, expected, requests)
+}
+
+func TestDynamoDBPartiqlExecuteStatementRead(t *testing.T) {
+	query := `SELECT * FROM "Orders"."gsi_index" WHERE OrderID = ?`
+	mapping, err := bloblang.Parse(`
+root = []
+root."-".S = json("id")
+`)
+	require.NoError(t, err)
+
+	var requests []*dynamodb.ExecuteStatementInput
+	client := &mockProcDynamoDB{
+		pexecFn: func(_ context.Context, input *dynamodb.ExecuteStatementInput) (*dynamodb.ExecuteStatementOutput, error) {
+			requests = append(requests, input)
+			return &dynamodb.ExecuteStatementOutput{
+				Items: []map[string]types.AttributeValue{
+					{
+						"meow":  &types.AttributeValueMemberS{Value: "meow1"},
+						"meow2": &types.AttributeValueMemberS{Value: "meow2"},
+					},
+				},
+			}, nil
+		},
+	}
+
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, false)
+
+	reqBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{"id":"foo","content":"foo stuff"}`)),
+		service.NewMessage([]byte(`{"id":"bar","content":"bar stuff"}`)),
+	}
+	expBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{"meow":{"S":"meow1"},"meow2":{"S":"meow2"}}`)),
+		service.NewMessage([]byte(`{"meow":{"S":"meow1"},"meow2":{"S":"meow2"}}`)),
+	}
+
+	resBatch, err := db.ProcessBatch(t.Context(), reqBatch)
+	require.NoError(t, err)
+	assertBatchMatches(t, expBatch, resBatch)
+
+	require.Len(t, requests, 2)
+	assert.Equal(t, aws.String(query), requests[0].Statement)
+	assert.Equal(t, []types.AttributeValue{&types.AttributeValueMemberS{Value: "foo"}}, requests[0].Parameters)
+	assert.Equal(t, aws.String(query), requests[1].Statement)
+	assert.Equal(t, []types.AttributeValue{&types.AttributeValueMemberS{Value: "bar"}}, requests[1].Parameters)
+}
+
+func TestDynamoDBPartiqlExecuteStatementWrite(t *testing.T) {
+	query := `INSERT INTO "FooTable" VALUE {'id':'?','content':'?'}`
+	mapping, err := bloblang.Parse(`
+root = []
+root."-".S = json("id")
+root."-".S = json("content")
+`)
+	require.NoError(t, err)
+
+	var requests []*dynamodb.ExecuteStatementInput
+	client := &mockProcDynamoDB{
+		pexecFn: func(_ context.Context, input *dynamodb.ExecuteStatementInput) (*dynamodb.ExecuteStatementOutput, error) {
+			requests = append(requests, input)
+			return &dynamodb.ExecuteStatementOutput{}, nil
+		},
+	}
+
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, false)
+
+	reqBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{"content":"foo stuff","id":"foo"}`)),
+		service.NewMessage([]byte(`{"content":"bar stuff","id":"bar"}`)),
+	}
+
+	resBatch, err := db.ProcessBatch(t.Context(), reqBatch)
+	require.NoError(t, err)
+	assertBatchMatches(t, reqBatch, resBatch)
+
+	require.Len(t, requests, 2)
+	assert.Equal(t, []types.AttributeValue{
+		&types.AttributeValueMemberS{Value: "foo"},
+		&types.AttributeValueMemberS{Value: "foo stuff"},
+	}, requests[0].Parameters)
+	assert.Equal(t, []types.AttributeValue{
+		&types.AttributeValueMemberS{Value: "bar"},
+		&types.AttributeValueMemberS{Value: "bar stuff"},
+	}, requests[1].Parameters)
+}
+
+func TestDynamoDBPartiqlExecuteStatementSadToGood(t *testing.T) {
+	query := `SELECT * FROM "Orders"."gsi_index" WHERE OrderID = ?`
+	mapping, err := bloblang.Parse(`
+root = []
+root."-".S = json("id")
+`)
+	require.NoError(t, err)
+
+	client := &mockProcDynamoDB{
+		pexecFn: func(_ context.Context, input *dynamodb.ExecuteStatementInput) (*dynamodb.ExecuteStatementOutput, error) {
+			if input.Parameters[0].(*types.AttributeValueMemberS).Value == "bar" {
+				return nil, errors.New("it all went wrong")
+			}
+			return &dynamodb.ExecuteStatementOutput{
+				Items: []map[string]types.AttributeValue{
+					{"meow": &types.AttributeValueMemberS{Value: "meow1"}},
+				},
+			}, nil
+		},
+	}
+
+	db := newDynamoDBPartiQL(nil, client, query, nil, mapping, false)
+
+	reqBatch := service.MessageBatch{
+		service.NewMessage([]byte(`{"id":"foo"}`)),
+		service.NewMessage([]byte(`{"id":"bar"}`)),
+		service.NewMessage([]byte(`{"id":"baz"}`)),
+	}
+
+	resBatch, err := db.ProcessBatch(t.Context(), reqBatch)
+	require.NoError(t, err)
+	require.Len(t, resBatch, 1)
+	require.Len(t, resBatch[0], 3)
+
+	assert.NoError(t, resBatch[0][0].GetError())
+	foo, _ := resBatch[0][0].AsBytes()
+	assert.Equal(t, `{"meow":{"S":"meow1"}}`, string(foo))
+
+	err = resBatch[0][1].GetError()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "it all went wrong")
+
+	assert.NoError(t, resBatch[0][2].GetError())
+	baz, _ := resBatch[0][2].AsBytes()
+	assert.Equal(t, `{"meow":{"S":"meow1"}}`, string(baz))
 }


### PR DESCRIPTION
aws_dynamodb_partiql: support single ExecuteStatement calls for GSI queries
BatchExecuteStatement can't query a global secondary index (GSI); only
the single-statement ExecuteStatement API supports it. Add a use_batch
field (default true, no behavior change) — set it to false to issue
one ExecuteStatement call per message instead, enabling GSI point
lookups through this processor.