### PR TITLE
iceberg: cut per-record shredder allocations and document sink tuning

### DIFF
--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -114,3 +114,90 @@ Both connectors use a 10s commit window and 16 Kafka partitions. The transformat
 - **Kafka Connect with transformation** requires a separate RPCN pre-processing step that writes to an intermediate Kafka topic (`bench-events-transformed`), then Kafka Connect reads from that topic and sinks to Iceberg. The two-stage I/O cuts throughput by more than half.
 - **Redpanda Connect** handles transformation and Iceberg writes in a single pipeline — no intermediate topic, no extra Kafka round-trip.
 - **End-to-end (the realistic scenario):** Redpanda Connect is ~1.3x faster than Kafka Connect (47k vs 37k msg/s).
+
+---
+
+## Tuning Recipes
+
+The single most important factor for `iceberg` throughput is **records per commit**. Each catalog
+commit is a fixed-cost round trip, so the more rows each commit carries, the higher the throughput —
+and the default of small, frequent commits is a throughput trap. The knobs below all work toward one
+goal: make every commit carry a large batch (roughly a commit interval's worth of data).
+
+### Output knobs (apply to any source)
+
+- **`batching`** — accumulate rows before each write/commit. Larger batches mean fewer commits and
+  dramatically higher throughput (see *Write Throughput — CPU & Batch Size Scaling* above: 1-core
+  throughput rises ~7x from `batch=1000` to `batch=10000`). Size the batch to carry ~10s of data.
+- **`max_in_flight`** (default `4`) — the number of concurrent commits. Raising it lets commits
+  proceed in parallel and lets the committer coalesce queued commits into larger ones. This is the
+  most impactful knob once batches are reasonably sized (see *Batch Size & max_in_flight Scaling*:
+  ~4x gain from `max_in_flight=4` to `32`). **Sweet spot in these benchmarks: `batching.count=10000`,
+  `max_in_flight=32`.**
+
+### Recipe A — Order-preserving (memory buffer)
+
+Use when cross-partition ordering must be preserved. A memory buffer decouples the fast input from
+the commit-bound output and accumulates large batches into a single merged stream.
+
+```yaml
+buffer:
+  memory:
+    limit: 524288000        # 500 MiB; size to throughput x commit interval
+    batch_policy:
+      count: 10000
+      period: 10s
+output:
+  iceberg:
+    # ...catalog / storage / table...
+    max_in_flight: 16
+    commit:
+      max_snapshot_age: 24h  # keep snapshot expiry on (see "Avoid over-committing")
+```
+
+Preserves ordering across partitions; throughput plateaus at the single merged stream's ceiling.
+
+### Recipe B — Maximum throughput (input batching, unordered)
+
+Use when the sink does not require cross-partition ordering (usually acceptable for Iceberg). Enable
+per-partition parallel processing on the Redpanda/Kafka input so multiple partition streams feed the
+output concurrently.
+
+```yaml
+input:
+  redpanda:
+    topics: ["your-topic"]
+    unordered_processing:
+      enabled: true
+      checkpoint_limit: 1024
+      batching:
+        count: 10000
+        period: 10s
+output:
+  iceberg:
+    # ...catalog / storage / table...
+    max_in_flight: 32
+```
+
+Gives up cross-partition ordering, but scales higher than the buffer recipe by parallelizing across
+partitions.
+
+### Low-core-count tip: `GOGC`
+
+At 1–2 vCPU the sink is dominated by garbage collection of per-record allocations (JSON decode →
+structured map → shredding). Raising Go's GC threshold trades memory for CPU and recovers throughput
+— in local single-vCPU tests, `GOGC=400` lifted committed throughput by roughly 20–30% with no config
+change:
+
+```sh
+GOGC=400 rpk connect run ./config.yaml
+```
+
+This increases resident memory; validate it against your memory budget before adopting it.
+
+### Avoid over-committing
+
+Beyond the per-commit round trip, very high commit rates also grow table metadata: each commit
+re-reads the full table metadata document, and that cost rises with the number of snapshots. Tiny,
+frequent commits therefore pay a compounding penalty. Prefer larger batches, and keep snapshot expiry
+enabled (`commit.max_snapshot_age`, default `24h`) so metadata stays bounded over long runs.

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -74,6 +74,13 @@ type Sink interface {
 // and definition levels that allow perfect reconstruction.
 type RecordShredder struct {
 	schema *iceberg.Schema
+	// rootFields caches schema.Fields() once. iceberg-go's (*Schema).Fields()
+	// defensively clones the whole NestedField slice on every call, so calling
+	// it per-record in Shred was the single largest allocator on the write path
+	// (a 1-vCPU alloc profile attributed ~6.5% of all bytes to that clone). The
+	// schema is immutable for the shredder's lifetime and shredStruct only reads
+	// the slice, so caching one clone is safe.
+	rootFields []iceberg.NestedField
 	// caseSensitive controls how input record keys are matched against schema
 	// field names. When true (the historical default) names are matched
 	// exactly; when false, matching is case-insensitive — which aligns with
@@ -110,6 +117,7 @@ type RecordShredder struct {
 func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredder {
 	return &RecordShredder{
 		schema:        schema,
+		rootFields:    schema.Fields(),
 		caseSensitive: caseSensitive,
 	}
 }
@@ -133,7 +141,7 @@ func (rs *RecordShredder) SetFieldSchemaMetadata(byID map[int]*schema.Common) {
 // The record should be a map[string]any matching the schema structure.
 // The sink receives each leaf value and notifications of unknown fields.
 func (rs *RecordShredder) Shred(record map[string]any, sink Sink) error {
-	return rs.shredStruct(rs.schema.Fields(), record, nil, 0, 0, 0, sink)
+	return rs.shredStruct(rs.rootFields, record, nil, 0, 0, 0, sink)
 }
 
 // shredStruct processes a struct value.

--- a/internal/impl/iceberg/shredder/shredder_bench_test.go
+++ b/internal/impl/iceberg/shredder/shredder_bench_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package shredder
+
+import (
+	"testing"
+
+	"github.com/apache/iceberg-go"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/icebergx"
+)
+
+// discardSink is a Sink that does no work and no allocation, so a benchmark
+// measures the shredder's own per-record cost rather than the sink's.
+type discardSink struct{}
+
+func (discardSink) EmitValue(ShreddedValue) error         { return nil }
+func (discardSink) OnNewField(icebergx.Path, string, any) {}
+
+// benchSchema is a representative flat event schema (mixed primitive types),
+// mirroring the shape produced by the iceberg benchmark harness.
+func benchSchema() *iceberg.Schema {
+	return iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "event_id", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "category", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 3, Name: "value", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 4, Name: "value_usd", Type: iceberg.PrimitiveTypes.Float64, Required: false},
+		iceberg.NestedField{ID: 5, Name: "value_tier", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 6, Name: "ts", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 7, Name: "ts_ms", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		iceberg.NestedField{ID: 8, Name: "is_high_value", Type: iceberg.PrimitiveTypes.Bool, Required: false},
+	)
+}
+
+func benchRecord() map[string]any {
+	return map[string]any{
+		"event_id":      "1234567890-purchase",
+		"category":      "purchase",
+		"value":         int64(4200),
+		"value_usd":     42.0,
+		"value_tier":    "mid",
+		"ts":            int64(1_700_000_000_000),
+		"ts_ms":         int64(1_700_000_000),
+		"is_high_value": false,
+	}
+}
+
+// BenchmarkShred measures the per-record shred cost. Run with -benchmem; the
+// allocs/op figure is the point of interest — caching Schema.Fields() removes
+// a per-record clone of the field slice.
+func BenchmarkShred(b *testing.B) {
+	rs := NewRecordShredder(benchSchema(), true)
+	record := benchRecord()
+	sink := discardSink{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := rs.Shred(record, sink); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes to the `iceberg` output, from a round of 1-vCPU profiling of the sink:

1. **Shredder: cache the schema's field slice** instead of re-cloning it per record.
2. **Docs: add a Tuning Recipes section** to the Iceberg benchmark-results doc.

## 1. Shredder allocation fix

`RecordShredder.Shred` called `(*iceberg.Schema).Fields()` once per record. That accessor
defensively clones the entire `[]NestedField` slice on every call, which a 1-vCPU allocation profile
identified as the single largest allocator on the write path (~6.5% of all bytes allocated). The
shredder's schema is immutable for its lifetime and `shredStruct` only reads the slice, so the clone
is now taken once at construction and reused.

Benchmark (`BenchmarkShred`, added in this PR; 8-field flat schema, `-benchmem`):

| | ns/op | B/op | allocs/op |
| --- | --- | --- | --- |
| before | ~1088 | 1256 | 20 |
| after | ~895 | 360 | 19 |

−71% bytes/op, −18% ns/op; the saving grows with schema width. Behaviour is unchanged — the shredder
is constructed fresh per batch against an immutable schema, the field slice is read-only during
shredding, and `Shred` is read-only on the receiver, so the cache is safe under schema evolution and
concurrent shredding.

## 2. Tuning recipes docs

`docs/benchmark-results/iceberg.md` gains a Tuning Recipes section. Throughput of the output is
governed by records-per-commit; the default of small, frequent commits is a throughput trap. The
section documents the two config levers the existing benchmarks measured (`batching` and
`max_in_flight`), an order-preserving memory-buffer recipe, a maximum-throughput input-batching
recipe (via `unordered_processing`), a low-core-count `GOGC` tip, and guidance to avoid
over-committing.

## Testing

- `task fmt`, `golangci-lint` (shredder package): clean.
- `go test ./internal/impl/iceberg/...` and `-race` on the shredder + output packages: green.
- New `BenchmarkShred` verifies the allocation reduction; the full shredder suite (nested / list /
  null / schema-evolution) confirms unchanged behaviour.

## Notes

- No functional/behavioural change; the shredder change is a pure allocation optimisation.
- Docs-only change to `docs/benchmark-results/iceberg.md`.
