### PR TITLE
iceberg: make commit retries idempotent to prevent duplicate data files

### DIFF
--- a/internal/impl/iceberg/committer.go
+++ b/internal/impl/iceberg/committer.go
@@ -121,11 +121,27 @@ func (c *committer) doCommit(ctx context.Context, inputs []CommitInput) ([]struc
 		allFiles = append(allFiles, input.Files...)
 	}
 
-	if err := c.commitLocked(ctx, func(txn *table.Transaction, props iceberg.Properties) error {
+	if err := c.commitLocked(ctx, true, func(txn *table.Transaction, props iceberg.Properties, reloaded bool) error {
+		files := allFiles
+		if reloaded {
+			// A prior attempt can land server-side yet report failure (a lost
+			// or ambiguous response). The reload then already references those
+			// files, so re-adding them with the duplicate check disabled would
+			// register the same path in two snapshots and produce conflicting
+			// sequence numbers for downstream readers. Drop any file the
+			// reloaded table already has; if all are present the previous
+			// attempt succeeded and AddDataFiles + Commit become a no-op.
+			remaining, err := c.dropAlreadyCommitted(ctx, allFiles)
+			if err != nil {
+				return err
+			}
+			files = remaining
+		}
 		// WithoutDuplicateCheck: writer.Write stamps each path with a fresh uuid,
 		// so iceberg-go's default O(snapshot) manifest collision scan is wasted
-		// work on the commit hot path (T6692).
-		return txn.AddDataFiles(ctx, allFiles, props,
+		// work on the commit hot path (T6692). On a reloaded retry we run the
+		// targeted dropAlreadyCommitted check above instead.
+		return txn.AddDataFiles(ctx, files, props,
 			table.WithoutAutoNameMapping(),
 			table.WithoutDuplicateCheck(),
 		)
@@ -147,7 +163,12 @@ func (c *committer) commitRowDelta(ctx context.Context, input CommitInput) error
 	if input.SchemaID != currentSchemaID {
 		return &StaleSchemaError{WriterSchemaID: input.SchemaID, CurrentSchemaID: currentSchemaID}
 	}
-	if err := c.commitLocked(ctx, func(txn *table.Transaction, props iceberg.Properties) error {
+	// retryOnUnknownState is false here: this path does not yet dedupe against a
+	// reloaded snapshot on retry, so retrying a possibly-landed commit could
+	// duplicate it. RowDelta commits carry equality-delete files alongside
+	// inserts, so idempotent replay must reconcile both; that is tracked
+	// separately.
+	if err := c.commitLocked(ctx, false, func(txn *table.Transaction, props iceberg.Properties, _ bool) error {
 		// RowDelta derives the snapshot operation automatically
 		// (append/delete/overwrite).
 		rd := txn.NewRowDelta(props)
@@ -165,8 +186,16 @@ func (c *committer) commitRowDelta(ctx context.Context, input CommitInput) error
 
 // commitLocked stages a transaction via stage and commits it, retrying on
 // concurrent-commit conflicts and reloading table metadata between attempts.
-// Callers must hold c.commitMu.
-func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transaction, iceberg.Properties) error) error {
+// The stage callback's reloaded argument is false on the first attempt and
+// true once the table has been reloaded after a failed attempt, so callers can
+// guard against re-adding files a lost-but-landed attempt already committed.
+//
+// retryOnUnknownState controls whether an ErrCommitStateUnknown result (the
+// commit may have landed server-side, e.g. a 5xx/timeout response) is retried.
+// It is only safe to set when stage is idempotent across a reload — i.e. it
+// drops files the reloaded snapshot already references — otherwise a retry of a
+// commit that actually landed would duplicate it. Callers must hold c.commitMu.
+func (c *committer) commitLocked(ctx context.Context, retryOnUnknownState bool, stage func(txn *table.Transaction, props iceberg.Properties, reloaded bool) error) error {
 	props := iceberg.Properties{
 		table.ManifestMergeEnabledKey: strconv.FormatBool(c.cfg.ManifestMergeEnabled),
 	}
@@ -176,6 +205,7 @@ func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transact
 
 	var commitErr error
 	attempt := 0
+	reloaded := false
 	for range c.cfg.MaxRetries {
 		attempt++
 		txn := c.table.NewTransaction()
@@ -187,15 +217,22 @@ func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transact
 				return fmt.Errorf("upgrading version: %w", err)
 			}
 		}
-		if err := stage(txn, props); err != nil {
+		if err := stage(txn, props, reloaded); err != nil {
 			return err
 		}
 		tbl, err := txn.Commit(ctx)
-		if errors.Is(err, rest.ErrCommitFailed) {
+		// ErrCommitFailed is a clean conflict (our commit did not land), so a
+		// reload-and-retry re-adds our files exactly once. ErrCommitStateUnknown
+		// means the commit may have landed; retrying is only safe when stage
+		// dedupes against the reloaded snapshot (retryOnUnknownState), in which
+		// case a landed attempt becomes a no-op and an unlanded one re-adds once.
+		if errors.Is(err, rest.ErrCommitFailed) ||
+			(retryOnUnknownState && errors.Is(err, rest.ErrCommitStateUnknown)) {
 			commitErr = err
 			c.logger.Warnf("Commit attempt %d/%d failed: %v", attempt, c.cfg.MaxRetries, err)
-			if reloaded, reloadErr := c.reloadTable(ctx); reloadErr == nil {
-				c.table = reloaded
+			if reloadedTbl, reloadErr := c.reloadTable(ctx); reloadErr == nil {
+				c.table = reloadedTbl
+				reloaded = true
 			} else {
 				c.logger.Warnf("Failed to reload table during commit retry: %v", reloadErr)
 			}
@@ -213,6 +250,68 @@ func (c *committer) commitLocked(ctx context.Context, stage func(*table.Transact
 	}
 	c.incrCommitFailure()
 	return fmt.Errorf("committing transaction after %d attempts: %w", attempt, commitErr)
+}
+
+// dropAlreadyCommitted returns the subset of files whose paths are not already
+// referenced by the current snapshot of c.table, which the caller must have just
+// reloaded. It exists because commit retries re-add the same DataFile objects
+// (identical paths) after a reload: if a prior attempt actually landed
+// server-side but reported failure, the reloaded snapshot already contains those
+// files, and re-adding them with AddDataFiles' duplicate check disabled would
+// register the same path in two snapshots (the "conflicting sequence numbers"
+// corruption). The scan is O(current snapshot) but only runs on the rare retry
+// path, keeping the first-attempt hot path free of the duplicate scan.
+func (c *committer) dropAlreadyCommitted(ctx context.Context, files []iceberg.DataFile) ([]iceberg.DataFile, error) {
+	snap := c.table.CurrentSnapshot()
+	if snap == nil {
+		return files, nil
+	}
+	fs, err := c.table.FS(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving table filesystem for duplicate check: %w", err)
+	}
+	manifests, err := snap.Manifests(fs)
+	if err != nil {
+		return nil, fmt.Errorf("loading manifests for duplicate check: %w", err)
+	}
+
+	// Match against our candidate paths only, so the lookup set stays O(files)
+	// regardless of table size.
+	want := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		want[f.FilePath()] = struct{}{}
+	}
+	committed := make(map[string]struct{}, len(files))
+	for _, m := range manifests {
+		if m.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		for entry, err := range m.Entries(fs, true) {
+			if err != nil {
+				return nil, fmt.Errorf("reading manifest entries for duplicate check: %w", err)
+			}
+			path := entry.DataFile().FilePath()
+			if _, ok := want[path]; ok {
+				committed[path] = struct{}{}
+			}
+		}
+		if len(committed) == len(want) {
+			break // every candidate already present; no need to scan further.
+		}
+	}
+
+	if len(committed) == 0 {
+		return files, nil
+	}
+	remaining := make([]iceberg.DataFile, 0, len(files)-len(committed))
+	for _, f := range files {
+		if _, ok := committed[f.FilePath()]; ok {
+			c.logger.Warnf("Skipping re-add of data file already committed by a prior attempt: %s", f.FilePath())
+			continue
+		}
+		remaining = append(remaining, f)
+	}
+	return remaining, nil
 }
 
 func (c *committer) incrCommitFailure() {

--- a/internal/impl/iceberg/committer_test.go
+++ b/internal/impl/iceberg/committer_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog/rest"
 	iceio "github.com/apache/iceberg-go/io"
 	"github.com/apache/iceberg-go/table"
 	"github.com/google/uuid"
@@ -144,6 +145,175 @@ func TestCommitterSkipsDuplicateCheck(t *testing.T) {
 	// Second commit at the same path: only succeeds if the dup check is off.
 	df2 := synthDataFile(t, tbl.Spec(), dupPath)
 	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df2}, SchemaID: c.currentSchemaID()}))
+}
+
+// commitOutcome scripts how scriptedCatalog handles a single CommitTable call.
+type commitOutcome int
+
+const (
+	commitSucceed         commitOutcome = iota // apply the update and report success
+	commitLandThenFail                         // apply the update but report ErrCommitFailed (lost/ambiguous ack)
+	commitConflict                             // do NOT apply the update and report ErrCommitFailed (clean 409)
+	commitLandThenUnknown                      // apply the update but report ErrCommitStateUnknown (landed, ambiguous 5xx)
+	commitUnknownNoLand                        // do NOT apply the update and report ErrCommitStateUnknown (5xx before applying)
+)
+
+// scriptedCatalog drives per-call CommitTable outcomes so tests can model the
+// two ways a commit "fails" from the client's point of view: a genuine conflict
+// where nothing landed, and a lost response where the write actually landed.
+// Calls beyond the scripted outcomes succeed normally.
+type scriptedCatalog struct {
+	*memCatalog
+	outcomes []commitOutcome
+	calls    int
+}
+
+func (c *scriptedCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	outcome := commitSucceed
+	if c.calls < len(c.outcomes) {
+		outcome = c.outcomes[c.calls]
+	}
+	c.calls++
+
+	var applies bool
+	var retErr error
+	switch outcome {
+	case commitSucceed:
+		applies, retErr = true, nil
+	case commitLandThenFail:
+		applies, retErr = true, rest.ErrCommitFailed
+	case commitLandThenUnknown:
+		applies, retErr = true, rest.ErrCommitStateUnknown
+	case commitConflict:
+		applies, retErr = false, rest.ErrCommitFailed
+	case commitUnknownNoLand:
+		applies, retErr = false, rest.ErrCommitStateUnknown
+	}
+
+	if applies {
+		if _, _, err := c.memCatalog.CommitTable(ctx, ident, reqs, updates); err != nil {
+			return nil, "", err
+		}
+	}
+	if retErr != nil {
+		return nil, "", retErr
+	}
+	return c.meta, c.metadataLocation, nil
+}
+
+func (c *scriptedCatalog) snapshot() *table.Table {
+	return table.New(
+		c.ident,
+		c.meta,
+		c.metadataLocation,
+		func(context.Context) (iceio.IO, error) { return iceio.LocalFS{}, nil },
+		c,
+	)
+}
+
+// countDataFileRefs counts how many live data-file entries in the table's
+// current snapshot reference path. A correctly committed file appears exactly
+// once; a duplicate-registration bug shows up as two.
+func countDataFileRefs(tb testing.TB, ctx context.Context, tbl *table.Table, path string) int {
+	tb.Helper()
+	snap := tbl.CurrentSnapshot()
+	if snap == nil {
+		return 0
+	}
+	fs, err := tbl.FS(ctx)
+	require.NoError(tb, err)
+	manifests, err := snap.Manifests(fs)
+	require.NoError(tb, err)
+
+	n := 0
+	for _, m := range manifests {
+		if m.ManifestContent() != iceberg.ManifestContentData {
+			continue
+		}
+		for entry, err := range m.Entries(fs, true) {
+			require.NoError(tb, err)
+			if entry.DataFile().FilePath() == path {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func newScriptedCommitter(tb testing.TB, outcomes ...commitOutcome) (*committer, *scriptedCatalog) {
+	tb.Helper()
+	_, mem := newTestTable(tb)
+	cat := &scriptedCatalog{memCatalog: mem, outcomes: outcomes}
+	logger := service.MockResources().Logger()
+	c, err := NewCommitter(cat.snapshot(), CommitConfig{MaxRetries: 3},
+		func(context.Context) (*table.Table, error) { return cat.snapshot(), nil }, logger)
+	require.NoError(tb, err)
+	tb.Cleanup(c.Close)
+	return c, cat
+}
+
+// TestCommitterRetryDoesNotDuplicateLandedFile is the regression test for the
+// "conflicting sequence numbers" corruption: a commit attempt lands server-side
+// but reports failure (a lost/ambiguous response), and connect's retry reloads
+// the table — which now already references the file — then re-adds it with the
+// duplicate check disabled. The file must end up registered exactly once.
+func TestCommitterRetryDoesNotDuplicateLandedFile(t *testing.T) {
+	ctx := t.Context()
+	c, cat := newScriptedCommitter(t, commitLandThenFail)
+
+	path := fmt.Sprintf("%s/data/landed.parquet", cat.location)
+	df := synthDataFile(t, cat.snapshot().Spec(), path)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}))
+
+	require.Equal(t, 1, countDataFileRefs(t, ctx, cat.snapshot(), path),
+		"a file that landed on the failed attempt must not be re-added by the retry")
+}
+
+// TestCommitterRetryReAddsOnGenuineConflict guards against the idempotency fix
+// over-filtering: on a clean conflict nothing landed, so the retry MUST re-add
+// the file. The file must end up committed exactly once (not dropped).
+func TestCommitterRetryReAddsOnGenuineConflict(t *testing.T) {
+	ctx := t.Context()
+	c, cat := newScriptedCommitter(t, commitConflict)
+
+	path := fmt.Sprintf("%s/data/retried.parquet", cat.location)
+	df := synthDataFile(t, cat.snapshot().Spec(), path)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}))
+
+	require.Equal(t, 1, countDataFileRefs(t, ctx, cat.snapshot(), path),
+		"a file that did not land must be re-added by the retry")
+}
+
+// TestCommitterRetriesUnknownStateAndDedupes covers the landed-but-ambiguous
+// case (5xx/timeout -> ErrCommitStateUnknown): the append path must retry
+// rather than surface an error, and the dedupe must keep the landed file
+// registered exactly once. Before ErrCommitStateUnknown was retried this
+// Commit returned an error and the batch was redelivered under a new path.
+func TestCommitterRetriesUnknownStateAndDedupes(t *testing.T) {
+	ctx := t.Context()
+	c, cat := newScriptedCommitter(t, commitLandThenUnknown)
+
+	path := fmt.Sprintf("%s/data/landed-unknown.parquet", cat.location)
+	df := synthDataFile(t, cat.snapshot().Spec(), path)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}))
+
+	require.Equal(t, 1, countDataFileRefs(t, ctx, cat.snapshot(), path),
+		"a file that landed before an unknown-state response must be registered exactly once")
+}
+
+// TestCommitterRetriesUnknownStateWithoutLanding covers the other unknown-state
+// branch: a 5xx before the write landed. The retry must still commit the file
+// (exactly once), proving the unknown-state retry does not drop legitimate work.
+func TestCommitterRetriesUnknownStateWithoutLanding(t *testing.T) {
+	ctx := t.Context()
+	c, cat := newScriptedCommitter(t, commitUnknownNoLand)
+
+	path := fmt.Sprintf("%s/data/unknown-noland.parquet", cat.location)
+	df := synthDataFile(t, cat.snapshot().Spec(), path)
+	require.NoError(t, c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: c.currentSchemaID()}))
+
+	require.Equal(t, 1, countDataFileRefs(t, ctx, cat.snapshot(), path),
+		"a file that did not land before an unknown-state response must be committed once on retry")
 }
 
 // BenchmarkAddDataFilesDupCheck measures the cost of Transaction.AddDataFiles


### PR DESCRIPTION
## Problem

The iceberg output committer retries a failed commit by reloading the table and re-adding the same data files with the duplicate-path check disabled (an intentional hot-path optimisation, since each written file already carries a fresh unique path).

If a commit attempt lands server-side but the client observes a failure, the retry is no longer safe. Two ways this arises:

- A lost or ambiguous response: the request is transparently resent (e.g. by the HTTP transport replaying a POST on a dropped keep-alive connection, or by an intermediary), the resend fails with a conflict because our own first commit already advanced the table head, and that conflict surfaces as `rest.ErrCommitFailed`.
- A `5xx`/timeout, which the REST catalog maps to `rest.ErrCommitStateUnknown`.

On the conflict path the committer reloads the table — which now already references the just-committed files — and re-adds them with the duplicate check off, registering each path in two consecutive snapshots. Downstream readers (for example Redshift and Athena) then fail with `conflicting sequence numbers`, and the table requires manual manifest repair. This reproduces on a single instance and is silent at write time.

## Fix

- **Idempotent append retries.** On a retry that follows a table reload, drop any file the reloaded snapshot already references before re-adding. When all files are already present the commit collapses to a clean no-op. The first-attempt path is byte-for-byte unchanged, so the duplicate-check optimisation on the hot path is preserved; the reconciling scan runs only on the rare retry path.
- **Handle `ErrCommitStateUnknown` on the append path.** Now that the append path dedupes on reload, a possibly-landed commit can be retried safely: a landed attempt becomes a no-op and an unlanded one is re-added exactly once. Previously this error was surfaced to the pipeline and the batch was redelivered, re-writing the same rows under new paths.

## Scope

The row-delta (upsert/delete) path is intentionally left unchanged: it does not yet dedupe delete files on reload, so it is not made eligible for the unknown-state retry. A follow-up can extend the same guarantee there.

## Testing

Adds regression tests driven by a scripted catalog that models each commit outcome:

- landed-then-failed (the corruption case) — asserts the file is registered exactly once;
- genuine conflict (nothing landed) — asserts the file is still re-added exactly once;
- unknown-state, landed and not-landed — asserts a single registration in both cases.

Each new test was confirmed to fail without its corresponding change. `task fmt`, lint, and the full `internal/impl/iceberg/...` test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)