### PR TITLE
Bump to Go 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/v4
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 

--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/enterprise/v4
 
-go 1.26.4
+go 1.26.5
 
 require github.com/redpanda-data/connect/v4 v4.99.0
 

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/free/v4
 
-go 1.26.4
+go 1.26.5
 
 require github.com/redpanda-data/connect/v4 v4.99.0
 


### PR DESCRIPTION
## What

Bumps the `go` directive from `1.26.4` to `1.26.5` in the root module and the two
distributable bundle modules (`public/bundle/enterprise`, `public/bundle/free`).

## Why

The scheduled `Release` workflow is failing at the **"Scan docker images for
vulnerabilities"** step for both the `connect` and `connect-cloud` images. Trivy flags
two Go `stdlib` vulnerabilities present in Go 1.26.4:

| CVE | Component | Installed | Fixed in |
|-----|-----------|-----------|----------|
| CVE-2026-39822 | stdlib | v1.26.4 | 1.25.12, **1.26.5**, 1.27.0-rc.2 |
| CVE-2026-42505 | stdlib | v1.26.4 | 1.25.12, **1.26.5**, 1.27.0-rc.2 |

The Go version used to build the release images is pinned solely by the `go` directive
in `go.mod` (every workflow uses `actions/setup-go` with `go-version-file: 'go.mod'`,
and the release job runs with `GOTOOLCHAIN: local`). Bumping to 1.26.5 — the first
patch release that fixes both — clears the scan.

## Scope

- `go.mod`, `public/bundle/enterprise/go.mod`, `public/bundle/free/go.mod` bumped to `1.26.5`.
- The `internal/**/testdata` plugin fixture modules are intentionally left untouched;
  they are not part of the shipped binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
