### PR TITLE
ffi: use correct glibc SONAME libc.so.6 in processor example

### DIFF
--- a/docs/modules/components/pages/processors/ffi.adoc
+++ b/docs/modules/components/pages/processors/ffi.adoc
@@ -47,13 +47,13 @@ Call a libc function::
 +
 --
 
-This is an example of loading libc.so and calling a function on linux.
+This is an example of loading libc.so.6 and calling a function on linux.
 
 ```yaml
 pipeline:
   processors:
     - ffi:
-        library_path: libc.6.so
+        library_path: libc.so.6
         function_name: memcmp
         args_mapping: 'root = ["foo", "bar", 3]'
         signature:

--- a/internal/impl/ffi/processor.go
+++ b/internal/impl/ffi/processor.go
@@ -76,12 +76,12 @@ func ffiProcessorConfig() *service.ConfigSpec {
 			).Description("The signature of the function."),
 		).Example(
 		"Call a libc function",
-		"This is an example of loading libc.so and calling a function on linux.",
+		"This is an example of loading libc.so.6 and calling a function on linux.",
 		`
 pipeline:
   processors:
     - ffi:
-        library_path: libc.6.so
+        library_path: libc.so.6
         function_name: memcmp
         args_mapping: 'root = ["foo", "bar", 3]'
         signature:


### PR DESCRIPTION
Fixes #4471.

the FFI processor example used `libc.6.so`, but the glibc SONAME is `libc.so.6`. this updates the example config and summary text, and regenerates the component docs