### PR TITLE
opensearch: support the create action in the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- opensearch: Added support for the `create` action in the opensearch output, required for writing to data streams. ([@highlyavailable](https://github.com/highlyavailable), [#4598](https://github.com/redpanda-data/connect/pull/4598))
+
 ### Fixed
 
 - general: The CGO-enabled distribution binary now embeds the IANA time zone database via the `timetzdata` build tag, matching the other distributions, so `time.LoadLocation` works in minimal runtimes without system tzdata instead of silently falling back to UTC (which shifts JQL date predicates in the `jira` input). ([@squiidz](https://github.com/squiidz), [#4583](https://github.com/redpanda-data/connect/pull/4583))

--- a/docs/modules/components/pages/outputs/opensearch.adoc
+++ b/docs/modules/components/pages/outputs/opensearch.adoc
@@ -169,7 +169,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `action`
 
-The action to take on the document. This field must resolve to one of the following action types: `index`, `update` or `delete`.
+The action to take on the document. This field must resolve to one of the following action types: `index`, `create`, `update` or `delete`. The `create` action fails for documents that already exist and is required when writing to data streams.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 

--- a/internal/impl/opensearch/integration_test.go
+++ b/internal/impl/opensearch/integration_test.go
@@ -133,6 +133,10 @@ func TestIntegrationOpensearch(t *testing.T) {
 		testOpenSearchConnect(urls, client, te)
 	})
 
+	t.Run("TestOpenSearchCreate", func(te *testing.T) {
+		testOpenSearchCreate(urls, client, te)
+	})
+
 	t.Run("TestOpenSearchWriteBatchUnreachable", func(te *testing.T) {
 		testOpenSearchWriteBatchUnreachable(unreachableUrls, te)
 	})
@@ -249,6 +253,39 @@ action: index
 
 		resEqualsJSON(t, get, exp)
 	}
+}
+
+func testOpenSearchCreate(urls []string, client *os.Client, t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), time.Second*30)
+	defer done()
+
+	m := outputFromConf(t, `
+index: test_create_index
+id: 'create-${!json("user")}'
+urls: %v
+action: create
+`, urls)
+
+	require.NoError(t, m.Connect(ctx))
+	defer func() {
+		require.NoError(t, m.Close(ctx))
+	}()
+
+	require.NoError(t, m.WriteBatch(ctx, service.MessageBatch{
+		service.NewMessage([]byte(`{"message":"hello world","user":"1"}`)),
+	}))
+
+	get, err := client.Do(ctx, osapi.DocumentGetReq{
+		Index:      "test_create_index",
+		DocumentID: "create-1",
+	}, nil)
+	require.NoError(t, err)
+	assert.False(t, get.IsError())
+
+	// The create action must reject documents whose ID already exists.
+	require.Error(t, m.WriteBatch(ctx, service.MessageBatch{
+		service.NewMessage([]byte(`{"message":"hello again","user":"1"}`)),
+	}))
 }
 
 func testOpenSearchErrorHandling(urls []string, t *testing.T) {

--- a/internal/impl/opensearch/output.go
+++ b/internal/impl/opensearch/output.go
@@ -160,7 +160,7 @@ Both the `+"`id` and `index`"+` fields can be dynamically set using function int
 			service.NewInterpolatedStringField(esoFieldIndex).
 				Description("The index to place messages."),
 			service.NewInterpolatedStringField(esoFieldAction).
-				Description("The action to take on the document. This field must resolve to one of the following action types: `index`, `update` or `delete`."),
+				Description("The action to take on the document. This field must resolve to one of the following action types: `index`, `create`, `update` or `delete`. The `create` action fails for documents that already exist and is required when writing to data streams."),
 			service.NewInterpolatedStringField(esoFieldID).
 				Description("The ID for indexed messages. Interpolation should be used in order to create a unique ID for each message.").
 				Example(`${!counter()}-${!timestamp_unix()}`),
@@ -388,6 +388,18 @@ func buildBulkableRequest(p *pendingBulkIndex, onError func(err error)) (r *open
 		r = &opensearchutil.BulkIndexerItem{
 			Index:  p.Index,
 			Action: "index",
+			Body:   bytes.NewReader(p.Payload),
+		}
+		if p.ID != "" {
+			r.DocumentID = p.ID
+		}
+		if p.Routing != "" {
+			r.Routing = &p.Routing
+		}
+	case "create":
+		r = &opensearchutil.BulkIndexerItem{
+			Index:  p.Index,
+			Action: "create",
 			Body:   bytes.NewReader(p.Payload),
 		}
 		if p.ID != "" {


### PR DESCRIPTION
Fixes #4515.

the opensearch output rejected `action: create`, which made it impossible to write to data streams (they only accept op_type create)... this PR adds a create case to `buildBulkableRequest`, mirroring the elasticsearch_v8/v9 outputs which already support it, and updates the action field docs.

i have integration tests covering create and the duplicate-ID failure case + ran the full opensearch suite locally against opensearchproject/opensearch:latest.