### PR TITLE
feat(mongodb): prevent binary fields from being incorrectly saved as base64 strings

### DIFF
--- a/docs/modules/components/pages/outputs/mongodb.adoc
+++ b/docs/modules/components/pages/outputs/mongodb.adoc
@@ -53,6 +53,7 @@ output:
     filter_map: ""
     hint_map: ""
     upsert: false
+    preserve_binary: false
     max_in_flight: 64
     batching:
       count: 0
@@ -86,6 +87,7 @@ output:
     filter_map: ""
     hint_map: ""
     upsert: false
+    preserve_binary: false
     max_in_flight: 64
     batching:
       count: 0
@@ -282,6 +284,15 @@ The upsert setting is optional and only applies for update-one and replace-one o
 
 *Default*: `false`
 Requires version 3.60.0 or newer
+
+=== `preserve_binary`
+
+Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/outputs/mongodb.adoc
+++ b/docs/modules/components/pages/outputs/mongodb.adoc
@@ -53,6 +53,7 @@ output:
     filter_map: ""
     hint_map: ""
     upsert: false
+    preserve_binary: false
     max_in_flight: 64
     batching:
       count: 0
@@ -96,6 +97,7 @@ output:
     filter_map: ""
     hint_map: ""
     upsert: false
+    preserve_binary: false
     max_in_flight: 64
     batching:
       count: 0
@@ -398,6 +400,15 @@ The upsert setting is optional and only applies for update-one and replace-one o
 
 *Default*: `false`
 Requires version 3.60.0 or newer
+
+=== `preserve_binary`
+
+Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/processors/mongodb.adoc
+++ b/docs/modules/components/pages/processors/mongodb.adoc
@@ -52,6 +52,7 @@ mongodb:
   filter_map: ""
   hint_map: ""
   upsert: false
+  preserve_binary: false
 ```
 
 --
@@ -78,6 +79,7 @@ mongodb:
   filter_map: ""
   hint_map: ""
   upsert: false
+  preserve_binary: false
   json_marshal_mode: canonical
 ```
 
@@ -262,6 +264,15 @@ The upsert setting is optional and only applies for update-one and replace-one o
 
 *Default*: `false`
 Requires version 3.60.0 or newer
+
+=== `preserve_binary`
+
+Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `json_marshal_mode`
 

--- a/docs/modules/components/pages/processors/mongodb.adoc
+++ b/docs/modules/components/pages/processors/mongodb.adoc
@@ -52,6 +52,7 @@ mongodb:
   filter_map: ""
   hint_map: ""
   upsert: false
+  preserve_binary: false
 ```
 
 --
@@ -88,6 +89,7 @@ mongodb:
   filter_map: ""
   hint_map: ""
   upsert: false
+  preserve_binary: false
   json_marshal_mode: canonical
 ```
 
@@ -378,6 +380,15 @@ The upsert setting is optional and only applies for update-one and replace-one o
 
 *Default*: `false`
 Requires version 3.60.0 or newer
+
+=== `preserve_binary`
+
+Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `json_marshal_mode`
 

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -459,6 +459,18 @@ func extJSONFromMap(i int, m *service.MessageBatchBloblangExecutor) (any, error)
 	return ejsonVal, nil
 }
 
+func structuredFromMap(i int, m *service.MessageBatchBloblangExecutor) (any, error) {
+	msg, err := m.Query(i)
+	if err != nil {
+		return nil, err
+	}
+	if msg == nil {
+		return nil, nil
+	}
+
+	return msg.AsStructured()
+}
+
 func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	docJSON, filterJSON, hintJSON any, err error,
 ) {
@@ -473,7 +485,7 @@ func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	}
 
 	if documentValWanted && w.documentMap != nil {
-		if docJSON, err = extJSONFromMap(i, w.documentMap); err != nil {
+		if docJSON, err = structuredFromMap(i, w.documentMap); err != nil {
 			err = fmt.Errorf("executing document_map: %v", err)
 			return
 		}

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -71,6 +71,22 @@ func clientFields() []*service.ConfigField {
 	}
 }
 
+//------------------------------------------------------------------------------
+
+const (
+	fieldPreserveBinary = "preserve_binary"
+)
+
+func compatibilityFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewBoolField(fieldPreserveBinary).
+			Description("Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.").
+			Default(false),
+	}
+}
+
+//------------------------------------------------------------------------------
+
 func getClient(parsedConf *service.ParsedConfig) (client *mongo.Client, database *mongo.Database, err error) {
 	var url string
 	if url, err = parsedConf.FieldString(commonFieldClientURL); err != nil {
@@ -358,10 +374,11 @@ func writeMapsFields() []*service.ConfigField {
 }
 
 type writeMaps struct {
-	filterMap   *bloblang.Executor
-	documentMap *bloblang.Executor
-	hintMap     *bloblang.Executor
-	upsert      bool
+	filterMap      *bloblang.Executor
+	documentMap    *bloblang.Executor
+	hintMap        *bloblang.Executor
+	upsert         bool
+	preserveBinary bool
 }
 
 func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps writeMaps, err error) {
@@ -381,6 +398,9 @@ func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps 
 		}
 	}
 	if maps.upsert, err = conf.FieldBool(commonFieldUpsert); err != nil {
+		return
+	}
+	if maps.preserveBinary, err = conf.FieldBool(fieldPreserveBinary); err != nil {
 		return
 	}
 
@@ -418,10 +438,11 @@ func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps 
 }
 
 type writeMapsExec struct {
-	filterMap   *service.MessageBatchBloblangExecutor
-	documentMap *service.MessageBatchBloblangExecutor
-	hintMap     *service.MessageBatchBloblangExecutor
-	upsert      bool
+	filterMap      *service.MessageBatchBloblangExecutor
+	documentMap    *service.MessageBatchBloblangExecutor
+	hintMap        *service.MessageBatchBloblangExecutor
+	upsert         bool
+	preserveBinary bool
 }
 
 func (w writeMaps) exec(b service.MessageBatch) (e writeMapsExec) {
@@ -435,6 +456,7 @@ func (w writeMaps) exec(b service.MessageBatch) (e writeMapsExec) {
 		e.hintMap = b.BloblangExecutor(w.hintMap)
 	}
 	e.upsert = w.upsert
+	e.preserveBinary = w.preserveBinary
 	return
 }
 
@@ -485,7 +507,12 @@ func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	}
 
 	if documentValWanted && w.documentMap != nil {
-		if docJSON, err = structuredFromMap(i, w.documentMap); err != nil {
+		if w.preserveBinary {
+			docJSON, err = structuredFromMap(i, w.documentMap)
+		} else {
+			docJSON, err = extJSONFromMap(i, w.documentMap)
+		}
+		if err != nil {
 			err = fmt.Errorf("executing document_map: %v", err)
 			return
 		}

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -685,6 +685,18 @@ func extJSONFromMap(i int, m *service.MessageBatchBloblangExecutor) (any, error)
 	return ejsonVal, nil
 }
 
+func structuredFromMap(i int, m *service.MessageBatchBloblangExecutor) (any, error) {
+	msg, err := m.Query(i)
+	if err != nil {
+		return nil, err
+	}
+	if msg == nil {
+		return nil, nil
+	}
+
+	return msg.AsStructured()
+}
+
 func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	docJSON, filterJSON, hintJSON any, err error,
 ) {
@@ -699,7 +711,7 @@ func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	}
 
 	if documentValWanted && w.documentMap != nil {
-		if docJSON, err = extJSONFromMap(i, w.documentMap); err != nil {
+		if docJSON, err = structuredFromMap(i, w.documentMap); err != nil {
 			err = fmt.Errorf("executing document_map: %v", err)
 			return
 		}

--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -346,6 +346,20 @@ func clientFields() []*service.ConfigField {
 
 //------------------------------------------------------------------------------
 
+const (
+	fieldPreserveBinary = "preserve_binary"
+)
+
+func compatibilityFields() []*service.ConfigField {
+	return []*service.ConfigField{
+		service.NewBoolField(fieldPreserveBinary).
+			Description("Whether to preserve raw binary fields ([]byte) as native MongoDB BinData. When false, they are encoded as base64 strings.").
+			Default(false),
+	}
+}
+
+//------------------------------------------------------------------------------
+
 // Operation represents the operation that will be performed by MongoDB.
 type Operation string
 
@@ -584,10 +598,11 @@ func writeMapsFields() []*service.ConfigField {
 }
 
 type writeMaps struct {
-	filterMap   *bloblang.Executor
-	documentMap *bloblang.Executor
-	hintMap     *bloblang.Executor
-	upsert      bool
+	filterMap      *bloblang.Executor
+	documentMap    *bloblang.Executor
+	hintMap        *bloblang.Executor
+	upsert         bool
+	preserveBinary bool
 }
 
 func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps writeMaps, err error) {
@@ -607,6 +622,9 @@ func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps 
 		}
 	}
 	if maps.upsert, err = conf.FieldBool(commonFieldUpsert); err != nil {
+		return
+	}
+	if maps.preserveBinary, err = conf.FieldBool(fieldPreserveBinary); err != nil {
 		return
 	}
 
@@ -644,10 +662,11 @@ func writeMapsFromParsed(conf *service.ParsedConfig, operation Operation) (maps 
 }
 
 type writeMapsExec struct {
-	filterMap   *service.MessageBatchBloblangExecutor
-	documentMap *service.MessageBatchBloblangExecutor
-	hintMap     *service.MessageBatchBloblangExecutor
-	upsert      bool
+	filterMap      *service.MessageBatchBloblangExecutor
+	documentMap    *service.MessageBatchBloblangExecutor
+	hintMap        *service.MessageBatchBloblangExecutor
+	upsert         bool
+	preserveBinary bool
 }
 
 func (w writeMaps) exec(b service.MessageBatch) (e writeMapsExec) {
@@ -661,6 +680,7 @@ func (w writeMaps) exec(b service.MessageBatch) (e writeMapsExec) {
 		e.hintMap = b.BloblangExecutor(w.hintMap)
 	}
 	e.upsert = w.upsert
+	e.preserveBinary = w.preserveBinary
 	return
 }
 
@@ -711,7 +731,12 @@ func (w writeMapsExec) extractFromMessage(operation Operation, i int) (
 	}
 
 	if documentValWanted && w.documentMap != nil {
-		if docJSON, err = structuredFromMap(i, w.documentMap); err != nil {
+		if w.preserveBinary {
+			docJSON, err = structuredFromMap(i, w.documentMap)
+		} else {
+			docJSON, err = extJSONFromMap(i, w.documentMap)
+		}
+		if err != nil {
 			err = fmt.Errorf("executing document_map: %v", err)
 			return
 		}

--- a/internal/impl/mongodb/output.go
+++ b/internal/impl/mongodb/output.go
@@ -47,6 +47,7 @@ func outputSpec() *service.ConfigSpec {
 			writeConcernDocs(),
 		).
 		Fields(writeMapsFields()...).
+		Fields(compatibilityFields()...).
 		Fields(
 			service.NewOutputMaxInFlightField(),
 			service.NewBatchPolicyField(moFieldBatching),

--- a/internal/impl/mongodb/output_test.go
+++ b/internal/impl/mongodb/output_test.go
@@ -106,7 +106,7 @@ func generateCollectionName(testID string) string {
 	return regexp.MustCompile("[^a-zA-Z]+").ReplaceAllString(testID, "")
 }
 
-func TestIntegrationMongoDBBinaryOutputField(t *testing.T) {
+func TestIntegrationMongoDBDoesNotPreserveBinaryOutputFieldByDefault(t *testing.T) {
 	integration.CheckSkip(t)
 
 	ctr, err := testcontainers.Run(t.Context(), "mongo:latest",
@@ -153,6 +153,92 @@ username: mongoadmin
 password: secret
 operation: insert-one
 document_map: "root = this"
+`, mp.Port(), collName)
+
+	parsedConf, err := outputSpec().ParseYAML(config, nil)
+	require.NoError(t, err)
+
+	outputWriter, err := newOutputWriter(parsedConf, service.MockResources())
+	require.NoError(t, err)
+
+	err = outputWriter.Connect(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outputWriter.Close(t.Context()) })
+
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{
+		"id":             "bin_test",
+		"binary_payload": rawBytes,
+	})
+	batch := service.MessageBatch{msg}
+
+	err = outputWriter.WriteBatch(t.Context(), batch)
+	require.NoError(t, err)
+
+	filter := bson.M{"id": "bin_test"}
+	var doc bson.M
+	err = collection.FindOne(t.Context(), filter).Decode(&doc)
+	require.NoError(t, err)
+
+	payload, exists := doc["binary_payload"]
+	require.True(t, exists)
+
+	payloadString, isString := payload.(string)
+	require.True(t, isString)
+
+	expectedPayloadString := base64.StdEncoding.EncodeToString(rawBytes)
+	require.Equal(t, expectedPayloadString, payloadString)
+}
+
+func TestIntegrationMongoDBPreserveBinaryOutputField(t *testing.T) {
+	integration.CheckSkip(t)
+
+	ctr, err := testcontainers.Run(t.Context(), "mongo:latest",
+		testcontainers.WithExposedPorts("27017/tcp"),
+		testcontainers.WithEnv(map[string]string{
+			"MONGO_INITDB_ROOT_USERNAME": "mongoadmin",
+			"MONGO_INITDB_ROOT_PASSWORD": "secret",
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("27017/tcp").WithStartupTimeout(time.Minute),
+		),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	mp, err := ctr.MappedPort(t.Context(), "27017/tcp")
+	require.NoError(t, err)
+
+	var mongoClient *mongo.Client
+	require.Eventually(t, func() bool {
+		mongoClient, err = mongo.Connect(options.Client().
+			SetConnectTimeout(10 * time.Second).
+			SetTimeout(30 * time.Second).
+			SetServerSelectionTimeout(30 * time.Second).
+			SetAuth(options.Credential{
+				Username: "mongoadmin",
+				Password: "secret",
+			}).
+			ApplyURI("mongodb://localhost:" + mp.Port()))
+		return err == nil
+	}, time.Minute, time.Second)
+
+	db := mongoClient.Database("TestDB")
+	collName := generateCollectionName(t.Name())
+
+	require.NoError(t, db.CreateCollection(t.Context(), collName))
+	collection := db.Collection(collName)
+
+	config := fmt.Sprintf(`
+url: mongodb://localhost:%v
+database: TestDB
+collection: %v
+username: mongoadmin
+password: secret
+operation: insert-one
+document_map: "root = this"
+preserve_binary: true
 `, mp.Port(), collName)
 
 	parsedConf, err := outputSpec().ParseYAML(config, nil)

--- a/internal/impl/mongodb/output_test.go
+++ b/internal/impl/mongodb/output_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb
+
+import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+)
+
+func TestExtJSONFromMapDontPreserveBinary(t *testing.T) {
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	base64String := base64.StdEncoding.EncodeToString(rawBytes)
+
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{
+		"binary_field": rawBytes,
+	})
+
+	executor, err := bloblang.Parse("root = this")
+	require.NoError(t, err)
+
+	batch := service.MessageBatch{msg}
+	mappingExec := batch.BloblangExecutor(executor)
+
+	result, err := extJSONFromMap(0, mappingExec)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	resultD, ok := result.(bson.D)
+	require.True(t, ok)
+
+	var fieldValue any
+	found := false
+	for _, elem := range resultD {
+		if elem.Key == "binary_field" {
+			fieldValue = elem.Value
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	_, isBytes := fieldValue.([]byte)
+	assert.False(t, isBytes)
+
+	extractedString, isString := fieldValue.(string)
+	assert.True(t, isString)
+	assert.Equal(t, base64String, extractedString)
+}
+
+func TestStructuredFromMapPreservesBinary(t *testing.T) {
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{
+		"binary_field": rawBytes,
+	})
+
+	executor, err := bloblang.Parse("root = this")
+	require.NoError(t, err)
+
+	batch := service.MessageBatch{msg}
+	mappingExec := batch.BloblangExecutor(executor)
+
+	result, err := structuredFromMap(0, mappingExec)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+
+	extractedBytes, isBytes := resultMap["binary_field"].([]byte)
+	assert.True(t, isBytes)
+	assert.Equal(t, rawBytes, extractedBytes)
+}
+
+func generateCollectionName(testID string) string {
+	return regexp.MustCompile("[^a-zA-Z]+").ReplaceAllString(testID, "")
+}
+
+func TestIntegrationMongoDBBinaryOutputField(t *testing.T) {
+	integration.CheckSkip(t)
+
+	ctr, err := testcontainers.Run(t.Context(), "mongo:latest",
+		testcontainers.WithExposedPorts("27017/tcp"),
+		testcontainers.WithEnv(map[string]string{
+			"MONGO_INITDB_ROOT_USERNAME": "mongoadmin",
+			"MONGO_INITDB_ROOT_PASSWORD": "secret",
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("27017/tcp").WithStartupTimeout(time.Minute),
+		),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	mp, err := ctr.MappedPort(t.Context(), "27017/tcp")
+	require.NoError(t, err)
+
+	var mongoClient *mongo.Client
+	require.Eventually(t, func() bool {
+		mongoClient, err = mongo.Connect(options.Client().
+			SetConnectTimeout(10 * time.Second).
+			SetTimeout(30 * time.Second).
+			SetServerSelectionTimeout(30 * time.Second).
+			SetAuth(options.Credential{
+				Username: "mongoadmin",
+				Password: "secret",
+			}).
+			ApplyURI("mongodb://localhost:" + mp.Port()))
+		return err == nil
+	}, time.Minute, time.Second)
+
+	db := mongoClient.Database("TestDB")
+	collName := generateCollectionName(t.Name())
+
+	require.NoError(t, db.CreateCollection(t.Context(), collName))
+	collection := db.Collection(collName)
+
+	config := fmt.Sprintf(`
+url: mongodb://localhost:%v
+database: TestDB
+collection: %v
+username: mongoadmin
+password: secret
+operation: insert-one
+document_map: "root = this"
+`, mp.Port(), collName)
+
+	parsedConf, err := outputSpec().ParseYAML(config, nil)
+	require.NoError(t, err)
+
+	outputWriter, err := newOutputWriter(parsedConf, service.MockResources())
+	require.NoError(t, err)
+
+	err = outputWriter.Connect(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outputWriter.Close(t.Context()) })
+
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{
+		"id":             "bin_test",
+		"binary_payload": rawBytes,
+	})
+	batch := service.MessageBatch{msg}
+
+	err = outputWriter.WriteBatch(t.Context(), batch)
+	require.NoError(t, err)
+
+	filter := bson.M{"id": "bin_test"}
+	var doc bson.M
+	err = collection.FindOne(t.Context(), filter).Decode(&doc)
+	require.NoError(t, err)
+
+	payload, exists := doc["binary_payload"]
+	require.True(t, exists)
+
+	payloadBinary, isBinary := payload.(bson.Binary)
+	require.True(t, isBinary)
+
+	require.Equal(t, rawBytes, payloadBinary.Data)
+}

--- a/internal/impl/mongodb/processor.go
+++ b/internal/impl/mongodb/processor.go
@@ -49,6 +49,7 @@ func ProcessorSpec() *service.ConfigSpec {
 			writeConcernDocs(),
 		).
 		Fields(writeMapsFields()...).
+		Fields(compatibilityFields()...).
 		Field(service.NewStringAnnotatedEnumField(mpFieldJSONMarshalMode, map[string]string{
 			string(JSONMarshalModeCanonical): "A string format that emphasizes type preservation at the expense of readability and interoperability. That is, conversion from canonical to BSON will generally preserve type information except in certain specific cases. ",
 			string(JSONMarshalModeRelaxed):   "A string format that emphasizes readability and interoperability at the expense of type preservation. That is, conversion from relaxed format to BSON can lose type information.",

--- a/internal/impl/mongodb/processor_test.go
+++ b/internal/impl/mongodb/processor_test.go
@@ -15,6 +15,7 @@
 package mongodb_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -100,6 +101,12 @@ func TestProcessorIntegration(t *testing.T) {
 	t.Run("aggregate", func(t *testing.T) {
 		testMongoDBProcessorAggregate(mongoClient, port, t)
 	})
+	t.Run("insert_preserve_binary", func(t *testing.T) {
+		testMongoDBProcessorInsertBinaryPreserve(mongoClient, port, t)
+	})
+	t.Run("insert_without_preserve_binary", func(t *testing.T) {
+		testMongoDBProcessorInsertBinaryDontPreserve(mongoClient, port, t)
+	})
 }
 
 func testMProc(t testing.TB, port, collection, configYAML string) *mongodb.Processor {
@@ -131,6 +138,18 @@ func assertMessagesEqual(t testing.TB, batch service.MessageBatch, to []string) 
 		mBytes, err := batch[i].AsBytes()
 		require.NoError(t, err)
 		assert.Equal(t, exp, string(mBytes))
+	}
+}
+
+func assertStructuredMessagesEqual(t testing.TB, batch service.MessageBatch, to []any) {
+	t.Helper()
+	require.Len(t, batch, len(to))
+
+	for i, exp := range to {
+		actual, err := batch[i].AsStructured()
+		require.NoError(t, err)
+
+		assert.Equal(t, exp, actual)
 	}
 }
 
@@ -572,4 +591,81 @@ document_map: |
 			assert.Equalf(t, jsondiff.FullMatch.String(), diff.String(), "%s: %s", t.Name(), explanation)
 		})
 	}
+}
+
+func testMongoDBProcessorInsertBinaryPreserve(mongoClient *mongo.Client, port string, t *testing.T) {
+	tCtx := t.Context()
+	m := testMProc(t, port, "", `
+write_concern:
+  w: "1"
+  j: false
+  timeout: ""
+operation: "insert-one"
+document_map: |
+  root = this
+preserve_binary: true
+`)
+	collection := mongoClient.Database("TestDB").Collection("TestCollection")
+
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{"binary_field": rawBytes})
+
+	resMsgs, err := m.ProcessBatch(tCtx, service.MessageBatch{msg})
+	require.NoError(t, err)
+	require.Len(t, resMsgs, 1)
+
+	assertStructuredMessagesEqual(t, resMsgs[0], []any{
+		map[string]any{"binary_field": rawBytes},
+	})
+
+	// Validate the record is in the MongoDB
+	result := collection.FindOne(tCtx, bson.M{"binary_field": rawBytes})
+	b, err := result.Raw()
+	assert.NoError(t, err)
+	val := b.Lookup("binary_field")
+
+	subtype, actualBytes, ok := val.BinaryOK()
+	assert.True(t, ok)
+	assert.Equal(t, byte(0), subtype)
+	assert.Equal(t, rawBytes, actualBytes)
+}
+
+func testMongoDBProcessorInsertBinaryDontPreserve(mongoClient *mongo.Client, port string, t *testing.T) {
+	tCtx := t.Context()
+	m := testMProc(t, port, "", `
+write_concern:
+  w: "1"
+  j: false
+  timeout: ""
+operation: "insert-one"
+document_map: |
+  root = this
+`)
+	collection := mongoClient.Database("TestDB").Collection("TestCollection")
+
+	rawBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	encodedString := base64.StdEncoding.EncodeToString(rawBytes)
+
+	msg := service.NewMessage(nil)
+	msg.SetStructured(map[string]any{"binary_field": rawBytes})
+
+	resMsgs, err := m.ProcessBatch(tCtx, service.MessageBatch{msg})
+	require.NoError(t, err)
+	require.Len(t, resMsgs, 1)
+
+	assertStructuredMessagesEqual(t, resMsgs[0], []any{
+		map[string]any{"binary_field": rawBytes},
+	})
+
+	// Validate the record is in the MongoDB
+	result := collection.FindOne(tCtx, bson.M{"binary_field": encodedString})
+	b, err := result.Raw()
+	assert.NoError(t, err)
+	val := b.Lookup("binary_field")
+
+	stringVal, ok := val.StringValueOK()
+	require.True(t, ok)
+	assert.Equal(t, encodedString, stringVal)
 }


### PR DESCRIPTION
Fixed an issue where binary data (`[]byte`) was always serialized as a `base64` string in MongoDB. This occurred because the output plugin was converting the structure to a JSON string and then re-parsing it using the `extJSON` parser, which loses the native binary type.

Replaced `extJSONFromMap` with `structuredFromMap` leveraging `msg.AsStructured()`. This prevents immediate string serialization and preserves native Go slices, enabling the MongoDB driver to properly handle binary payloads.

#### Backward Compatibility
To maintain full backward compatibility and prevent breaking downstream client applications, the old serialization behavior (saving binary fields as base64 strings) is kept by default.

A new configuration option, `preserve_binary` (defaulting to `false`), has been introduced for both MongoDB output and processor components. Users can set this flag to `true` to opt-in to the correct native BSON `BinData` representation.

Some integration and unit tests have been added to verify both the default and new execution paths.