### PR TITLE
jira: register integration test package in packages.json

### DIFF
--- a/cmd/tools/integration/packages.json
+++ b/cmd/tools/integration/packages.json
@@ -27,6 +27,7 @@
   {"path":"./internal/impl/hdfs"},
   {"path":"./internal/impl/iceberg/integration"},
   {"path":"./internal/impl/influxdb"},
+  {"path":"./internal/impl/jira"},
   {"path":"./internal/impl/kafka","timeout":"10m"},
   {"path":"./internal/impl/kafka/enterprise"},
   {"path":"./internal/impl/memcached"},


### PR DESCRIPTION
The jira input (#4484) added integration tests under `internal/impl/jira` without regenerating `cmd/tools/integration/packages.json`, so `task test:integration:verify` currently fails on every branch cut from main.

One-line fix generated via `task test:integration:generate`; `task test:integration:verify` passes with it.