### PR TITLE
iceberg: tolerate table_location prefixes without a trailing slash

### DIFF
--- a/docs/modules/components/pages/outputs/iceberg.adoc
+++ b/docs/modules/components/pages/outputs/iceberg.adoc
@@ -196,7 +196,7 @@ To use with AWS Glue Data Catalog:
 
 * Set `catalog.url` to `https://glue.<region>.amazonaws.com/iceberg` (the REST client appends the API version automatically).
 * Set `catalog.warehouse` to your AWS account ID (the Glue catalog identifier).
-* Set `schema_evolution.table_location` to an S3 prefix (e.g., `s3://my-bucket/`) since Glue does not automatically assign table locations.
+* Set `schema_evolution.table_location` to an S3 prefix (e.g., `s3://my-bucket/` — a trailing slash is optional) since Glue does not automatically assign table locations.
 * Configure `catalog.auth.aws_sigv4` with the appropriate region and set `service` to `glue`.
 * Configure `storage.aws_s3` with the same bucket and region.
 

--- a/internal/impl/iceberg/config.go
+++ b/internal/impl/iceberg/config.go
@@ -166,7 +166,7 @@ To use with AWS Glue Data Catalog:
 
 * Set `+"`catalog.url`"+` to `+"`https://glue.<region>.amazonaws.com/iceberg`"+` (the REST client appends the API version automatically).
 * Set `+"`catalog.warehouse`"+` to your AWS account ID (the Glue catalog identifier).
-* Set `+"`schema_evolution.table_location`"+` to an S3 prefix (e.g., `+"`s3://my-bucket/`"+`) since Glue does not automatically assign table locations.
+* Set `+"`schema_evolution.table_location`"+` to an S3 prefix (e.g., `+"`s3://my-bucket/`"+` — a trailing slash is optional) since Glue does not automatically assign table locations.
 * Configure `+"`catalog.auth.aws_sigv4`"+` with the appropriate region and set `+"`service`"+` to `+"`glue`"+`.
 * Configure `+"`storage.aws_s3`"+` with the same bucket and region.
 

--- a/internal/impl/iceberg/router.go
+++ b/internal/impl/iceberg/router.go
@@ -271,6 +271,15 @@ func (r *Router) doWrite(ctx context.Context, key tableKey, entry *tableEntry, b
 }
 
 // createNamespace creates the namespace for a table.
+// tableLocationFor joins the configured table-location prefix with a table's
+// namespace path and name, tolerating a prefix with or without a trailing
+// slash. Bare concatenation previously required the trailing slash: a prefix
+// of `s3://bucket` produced `s3://bucketns/table`, which fails table creation
+// against a nonexistent bucket.
+func tableLocationFor(prefix string, nsParts []string, table string) string {
+	return strings.TrimSuffix(prefix, "/") + "/" + strings.Join(nsParts, "/") + "/" + table
+}
+
 func (r *Router) createNamespace(ctx context.Context, key tableKey, entry *tableEntry) error {
 	entry.mu.Lock()
 	defer entry.mu.Unlock()
@@ -369,7 +378,7 @@ func (r *Router) createTable(ctx context.Context, key tableKey, batch service.Me
 		createOpts = append(createOpts, catalog.WithPartitionSpec(partitionSpec))
 	}
 	if r.schemaEvoCfg.TableLocation != "" {
-		location := r.schemaEvoCfg.TableLocation + strings.Join(nsParts, "/") + "/" + key.table
+		location := tableLocationFor(r.schemaEvoCfg.TableLocation, nsParts, key.table)
 		createOpts = append(createOpts, catalog.WithLocation(location))
 	}
 

--- a/internal/impl/iceberg/router_test.go
+++ b/internal/impl/iceberg/router_test.go
@@ -426,3 +426,20 @@ func TestBuildSchemaWithResolverMetadataOnlyFieldOrdering(t *testing.T) {
 	assert.Equal(t, "a", fields[1].Name)
 	assert.Equal(t, "extra", fields[2].Name) // record-only field last
 }
+
+func TestTableLocationFor(t *testing.T) {
+	nsParts := []string{"shop", "cdc"}
+
+	// A prefix works identically with and without a trailing slash. Bare
+	// concatenation used to require the slash: `s3://bucket` yielded
+	// `s3://bucketshop/...` and CreateTable failed on a nonexistent bucket.
+	assert.Equal(t, "s3://bucket/shop/cdc/orders", tableLocationFor("s3://bucket/", nsParts, "orders"))
+	assert.Equal(t, "s3://bucket/shop/cdc/orders", tableLocationFor("s3://bucket", nsParts, "orders"))
+
+	// Deeper warehouse prefixes keep working, slash or not.
+	assert.Equal(t, "s3://bucket/warehouse/shop/cdc/orders", tableLocationFor("s3://bucket/warehouse/", nsParts, "orders"))
+	assert.Equal(t, "s3://bucket/warehouse/shop/cdc/orders", tableLocationFor("s3://bucket/warehouse", nsParts, "orders"))
+
+	// Single-level namespace.
+	assert.Equal(t, "s3://bucket/db/t", tableLocationFor("s3://bucket", []string{"db"}, "t"))
+}


### PR DESCRIPTION
## What

`schema_evolution.table_location` was combined with the table's namespace path by bare string concatenation:

```go
location := r.schemaEvoCfg.TableLocation + strings.Join(nsParts, "/") + "/" + key.table
```

so a prefix of `s3://bucket` (no trailing slash) produced `s3://bucketns/table`, and the first `CreateTable` failed against a nonexistent bucket. Only the exact documented form `s3://bucket/` worked.

This PR extracts the join into `tableLocationFor`, which trims/re-adds the separator so prefixes with and without a trailing slash behave identically (deeper warehouse prefixes included), adds a unit test covering both forms, and notes in the field docs that the trailing slash is optional.

## Why

Hit in a real deployment: an EKS pipeline writing CDC data to Glue-cataloged Iceberg tables failed on first write with a nonexistent-bucket error until the location gained its trailing slash — an easy config trap since nothing validates or normalizes the value.

## Testing

- `go test ./internal/impl/iceberg/` (new `TestTableLocationFor` + existing suite)
- Original failure reproduced and fix behavior verified end to end on EKS (mysql_cdc → iceberg/Glue via SigV4/IRSA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)