### PR TITLE
snowflake_streaming: verify parquet row counts before upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - general: The CGO-enabled distribution binary now embeds the IANA time zone database via the `timetzdata` build tag, matching the other distributions, so `time.LoadLocation` works in minimal runtimes without system tzdata instead of silently falling back to UTC (which shifts JQL date predicates in the `jira` input). ([@squiidz](https://github.com/squiidz), [#4583](https://github.com/redpanda-data/connect/pull/4583))
+- snowflake_streaming: BDEC parquet files are now verified for internally consistent row counts (footer, row groups, and column chunks) before upload, so an inconsistent file fails the batch instead of being registered with Snowflake. ([@squiidz](https://github.com/squiidz))
 
 ## 4.99.0 - 2026-07-02
 

--- a/internal/impl/snowflake/streaming/parquet.go
+++ b/internal/impl/snowflake/streaming/parquet.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/format"
@@ -247,6 +248,38 @@ func (w *parquetWriter) Close() ([]byte, *format.FileMetaData, error) {
 		return nil, nil, err
 	}
 	return w.b.Bytes(), w.w.File().Metadata(), nil
+}
+
+// verifyRowCounts checks that the parquet footer agrees with the rows that
+// were actually serialized into each row group. It guards against internally
+// inconsistent files produced by the concurrent row group writer being
+// uploaded to Snowflake, mirroring the Java SDK's verifyRowCounts check for
+// the same class of bug (SNOW-1465503). expectedRowsPerGroup holds the number
+// of rows written to each row group in order. The BDEC schema is flat, so
+// every column chunk must record exactly one value (nulls included) per row
+// of its group.
+func verifyRowCounts(expectedRowsPerGroup []int64, md *format.FileMetaData) error {
+	var expectedTotal int64
+	for _, n := range expectedRowsPerGroup {
+		expectedTotal += n
+	}
+	if md.NumRows != expectedTotal {
+		return fmt.Errorf("parquet row count verification failed: footer reports %d rows, expected %d rows; refusing to upload corrupted file", md.NumRows, expectedTotal)
+	}
+	if len(md.RowGroups) != len(expectedRowsPerGroup) {
+		return fmt.Errorf("parquet row count verification failed: footer reports %d row groups, expected %d row groups; refusing to upload corrupted file", len(md.RowGroups), len(expectedRowsPerGroup))
+	}
+	for i, rg := range md.RowGroups {
+		if rg.NumRows != expectedRowsPerGroup[i] {
+			return fmt.Errorf("parquet row count verification failed: row group %d reports %d rows, expected %d rows; refusing to upload corrupted file", i, rg.NumRows, expectedRowsPerGroup[i])
+		}
+		for _, col := range rg.Columns {
+			if col.MetaData.NumValues != rg.NumRows {
+				return fmt.Errorf("parquet row count verification failed: column %q in row group %d reports %d values, expected %d; refusing to upload corrupted file", strings.Join(col.MetaData.PathInSchema, "."), i, col.MetaData.NumValues, rg.NumRows)
+			}
+		}
+	}
+	return nil
 }
 
 func totalUncompressedSize(metadata *format.FileMetaData) int32 {

--- a/internal/impl/snowflake/streaming/parquet_test.go
+++ b/internal/impl/snowflake/streaming/parquet_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/format"
 	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -121,4 +122,78 @@ func readGeneric(r io.ReaderAt, size int64, schema *parquet.Schema) (rows []map[
 	}
 	reader.Close()
 	return rows[:n], err
+}
+
+func TestVerifyRowCounts(t *testing.T) {
+	// Build a real two-row-group file through the same write path as
+	// constructBdecPart so the happy path checks genuine footer metadata.
+	batches := []service.MessageBatch{
+		{msg(`{"a":2}`), msg(`{"a":12353}`), msg(`{"a":7}`)},
+		{msg(`{"a":42}`)},
+	}
+	inputDataSchema := parquet.Group{
+		"A": parquet.Decimal(0, 18, parquet.Int64Type),
+	}
+	transformers := []*dataTransformer{
+		{
+			name: "A",
+			converter: numberConverter{
+				nullable:  true,
+				scale:     0,
+				precision: 38,
+			},
+			column: &columnMetadata{
+				Name:         "A",
+				Ordinal:      1,
+				Type:         "NUMBER(18,0)",
+				LogicalType:  "fixed",
+				PhysicalType: "SB8",
+				Precision:    ptr.Int32(18),
+				Scale:        ptr.Int32(0),
+				Nullable:     true,
+			},
+			bufferFactory: int64TypedBufferFactory,
+		},
+	}
+	schema := parquet.NewSchema("bdec", inputDataSchema)
+	w := newParquetWriter("latest", schema)
+	w.Reset(nil)
+	rowGroups := make([]*parquet.ConcurrentRowGroupWriter, len(batches))
+	for i, batch := range batches {
+		rowGroups[i] = w.BeginRowGroup()
+		_, err := writeRowGroupFromObject(batch, schema, transformers, SchemaModeIgnoreExtra, rowGroups[i])
+		require.NoError(t, err)
+	}
+	for _, rg := range rowGroups {
+		_, err := rg.Commit()
+		require.NoError(t, err)
+	}
+	_, md, err := w.Close()
+	require.NoError(t, err)
+
+	require.NoError(t, verifyRowCounts([]int64{3, 1}, md))
+
+	// Every mismatch between what was serialized and what the footer claims
+	// must be rejected.
+	require.ErrorContains(t, verifyRowCounts([]int64{3}, md), "expected 3")
+	require.ErrorContains(t, verifyRowCounts([]int64{2, 2}, md), "row group 0")
+	require.ErrorContains(t, verifyRowCounts([]int64{3, 2}, md), "expected 5")
+	require.ErrorContains(t, verifyRowCounts([]int64{2, 1, 1}, md), "row groups")
+
+	corrupt := *md
+	corrupt.NumRows = 5
+	require.ErrorContains(t, verifyRowCounts([]int64{3, 1}, &corrupt), "5")
+
+	corrupt = *md
+	corrupt.RowGroups = append([]format.RowGroup{}, md.RowGroups...)
+	corrupt.RowGroups[1].NumRows = 9
+	err = verifyRowCounts([]int64{3, 1}, &corrupt)
+	require.ErrorContains(t, err, "9")
+
+	corrupt = *md
+	corrupt.RowGroups = append([]format.RowGroup{}, md.RowGroups...)
+	corrupt.RowGroups[0].Columns = append([]format.ColumnChunk{}, md.RowGroups[0].Columns...)
+	corrupt.RowGroups[0].Columns[0].MetaData.NumValues = 2
+	err = verifyRowCounts([]int64{3, 1}, &corrupt)
+	require.ErrorContains(t, err, "column")
 }

--- a/internal/impl/snowflake/streaming/streaming.go
+++ b/internal/impl/snowflake/streaming/streaming.go
@@ -394,6 +394,16 @@ func (c *SnowflakeIngestionChannel) constructBdecPart(batch service.MessageBatch
 		return bdecPart{}, err
 	}
 
+	// Guard against uploading an internally inconsistent file: the footer
+	// must agree with the rows we actually serialized into each row group.
+	expectedRows := make([]int64, len(chunks))
+	for i, chunk := range chunks {
+		expectedRows[i] = int64(len(chunk))
+	}
+	if err := verifyRowCounts(expectedRows, fileMetadata); err != nil {
+		return bdecPart{}, err
+	}
+
 	// Merge stats from all row groups
 	combinedStats := make([]*statsBuffer, len(c.schema.Fields()))
 	for i := range combinedStats {


### PR DESCRIPTION
## Summary

Snowflake identified a row-count metadata discrepancy in BDEC parquet files uploaded by the `snowflake_streaming` output — the same class of bug as Snowflake's internal SNOW-1465503, which the Java SDK fixed by adding a `verifyRowCounts` guard before upload ([snowflake-ingest-java#784](https://github.com/snowflakedb/snowflake-ingest-java/pull/784)).

The Go path gained parallel row-group construction in [#3940](https://github.com/redpanda-data/connect/pull/3940) (via parquet-go's `ConcurrentRowGroupWriter`) but has no equivalent guard. Worse, the EP registration metadata (`EPS.Rows`) is derived from the same parquet footer, so an internally inconsistent file self-consistently registers with Snowflake and the corruption is only detected server-side.

## Fix

After closing the parquet writer and before encryption/upload, `constructBdecPart` now verifies the footer against the rows actually serialized:

- footer `NumRows` == total rows written
- number and size of row groups == the chunks we wrote
- every column chunk's `NumValues` == its row group's `NumRows` (the BDEC schema is strictly flat — one leaf value per row per column, nulls included — so this is a hard invariant)

Any mismatch fails the batch with a detailed `refusing to upload corrupted file` error naming the offending row group or column, surfacing through normal output retry semantics instead of corrupting the table.

## Testing

`TestVerifyRowCounts` builds a real two-row-group parquet file through the same write path (`writeRowGroupFromObject` → `Commit` → `Close`) and asserts the happy path plus six mismatch cases: wrong expected totals, wrong row-group count, corrupted footer `NumRows`, corrupted row-group `NumRows`, and a short column chunk. All `./internal/impl/snowflake/...` tests pass.
