### PR TITLE
oracledb_cdc: support snapshot filtering

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -56,6 +56,8 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
+    snapshot:
+      filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
     checkpoint_cache: "" # No default (optional)
@@ -98,6 +100,8 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
+    snapshot:
+      filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
     checkpoint_cache: "" # No default (optional)
@@ -332,6 +336,30 @@ The key prefix used when storing transactions in `transaction_cache`. An alterna
 *Type*: `string`
 
 *Default*: `"oracledb_cdc"`
+
+=== `snapshot`
+
+Snapshot configuration settings.
+
+
+*Type*: `object`
+
+
+=== `snapshot.filters`
+
+A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
+
+
+*Type*: `object`
+
+
+```yml
+# Examples
+
+filters:
+  TESTDB.PRODUCTS: SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000
+  TESTDB.USERS: SELECT * FROM TESTDB.USERS
+```
 
 === `include`
 

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -339,7 +339,7 @@ The key prefix used when storing transactions in `transaction_cache`. An alterna
 
 A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
 
-Each query must project every column of the table's primary key, if the table has a composite primary key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.
+Each query must project every column of the table's primary key - all of them, for a composite key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.
 
 
 *Type*: `object`

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -349,6 +349,8 @@ Snapshot configuration settings.
 
 A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
 
+Each query must project every column of the table's primary key, if the table has a composite primary key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.
+
 
 *Type*: `object`
 

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -56,8 +56,7 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
-    snapshot:
-      filters: {} # No default (optional)
+    snapshot_filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
     checkpoint_cache: "" # No default (optional)
@@ -100,8 +99,7 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
-    snapshot:
-      filters: {} # No default (optional)
+    snapshot_filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
     checkpoint_cache: "" # No default (optional)
@@ -337,15 +335,7 @@ The key prefix used when storing transactions in `transaction_cache`. An alterna
 
 *Default*: `"oracledb_cdc"`
 
-=== `snapshot`
-
-Snapshot configuration settings.
-
-
-*Type*: `object`
-
-
-=== `snapshot.filters`
+=== `snapshot_filters`
 
 A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
 
@@ -358,7 +348,7 @@ Each query must project every column of the table's primary key, if the table ha
 ```yml
 # Examples
 
-filters:
+snapshot_filters:
   TESTDB.PRODUCTS: SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000
   TESTDB.USERS: SELECT * FROM TESTDB.USERS
 ```

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -62,6 +62,10 @@ const (
 	ociFieldLOBEnabled           = "lob_enabled"
 	ociFieldTransactionCache     = "transaction_cache"
 	ociFieldTransactionCacheKey  = "transaction_cache_key"
+
+	//-- snapshot specific
+	ociFieldSnapshot        = "snapshot"
+	ociFieldSnapshotFilters = "filters"
 )
 
 func init() {
@@ -169,6 +173,18 @@ This cache is designed for low-latency stores with cheap per-operation cost. Red
 			Optional(),
 	).Description("LogMiner configuration settings."),
 	).
+	// snapshot config
+	Field(service.NewObjectField(ociFieldSnapshot,
+		service.NewStringMapField(ociFieldSnapshotFilters).
+			Description("A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.").
+			Example(map[string]any{
+				"TESTDB.USERS":    "SELECT * FROM TESTDB.USERS",
+				"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000",
+			}).
+			Optional(),
+	).Description("Snapshot configuration settings.").
+		Optional(),
+	).
 	Field(service.NewStringListField(ociFieldTablesInclude).
 		Description("Regular expressions for tables to include.").
 		Example("SCHEMA.PRODUCTS"),
@@ -216,6 +232,7 @@ type Config struct {
 	SnapshotMode         SnapshotMode
 	SnapshotMaxBatchSize int
 	SnapshotMaxWorkers   int
+	SnapshotFilters      map[string]string
 	TablesFilter         *confx.RegexpFilter
 	SCNCache             string
 	SCNCacheKey          string
@@ -273,6 +290,20 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	}
 	if lmCfg, err = parseLogMinerConfig(conf); err != nil {
 		return nil, err
+	}
+
+	// snapshot filters
+	var snapshotFilters map[string]string
+	if conf.Contains(ociFieldSnapshot) {
+		snapshotConf := conf.Namespace(ociFieldSnapshot)
+		if snapshotConf.Contains(ociFieldSnapshotFilters) {
+			if snapshotFilters, err = snapshotConf.FieldStringMap(ociFieldSnapshotFilters); err != nil {
+				return nil, err
+			}
+			if err := replication.ValidateSnapshotFilters(snapshotFilters); err != nil {
+				return nil, fmt.Errorf("validating snapshot filters: %w", err)
+			}
+		}
 	}
 
 	// tables
@@ -350,6 +381,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 			SnapshotMode:         snapshotMode,
 			SnapshotMaxWorkers:   snapshotMaxWorkers,
 			SnapshotMaxBatchSize: snapshotMaxBatchSize,
+			SnapshotFilters:      snapshotFilters,
 			SCNCache:             scnCache,
 			SCNCacheKey:          scnCacheKey,
 			CpCacheTableName:     cpCacheTableName,
@@ -458,6 +490,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			if userTables, err = replication.VerifyUserTables(ctx, conn, o.cfg.TablesFilter, o.log); err != nil {
 				return fmt.Errorf("verifying user defined tables: %w", err)
 			}
+
 			return nil
 		}(); err != nil {
 			return err
@@ -466,6 +499,11 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		if userTables, err = replication.VerifyUserTables(ctx, o.db, o.cfg.TablesFilter, o.log); err != nil {
 			return fmt.Errorf("verifying user defined tables: %w", err)
 		}
+	}
+
+	// Validate that every table named in snapshot filters is actually being monitored.
+	if err = replication.SnapshotFilterTablesExist(userTables, o.cfg.SnapshotFilters); err != nil {
+		return fmt.Errorf("verifying snapshot filters: %w", err)
 	}
 
 	// Pre-fetch schemas for all monitored tables. A fresh cache is created on every Connect()
@@ -514,7 +552,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 	// no cached SCN means we're not recovering from a restart
 	if !o.cfg.SnapshotMode.IsSnapshotNone() && cachedSCN == replication.InvalidSCN {
-		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.publisher, o.lmCfg.LOBEnabled, pdbNameForCache, o.log, o.metrics); err != nil {
+		if snapshotter, err = replication.NewSnapshot(ctx, o.cfg.ConnectionString, userTables, o.cfg.SnapshotFilters, o.publisher, o.lmCfg.LOBEnabled, pdbNameForCache, o.log, o.metrics); err != nil {
 			return fmt.Errorf("creating database snapshotter: %w", err)
 		}
 		defer func() {

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -302,6 +302,9 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 			if snapshotFilters, err = snapshotConf.FieldStringMap(ociFieldSnapshotFilters); err != nil {
 				return nil, err
 			}
+			if snapshotFilters, err = replication.NormalizeSnapshotFilterKeys(snapshotFilters); err != nil {
+				return nil, fmt.Errorf("validating snapshot filters: %w", err)
+			}
 			if err := replication.ValidateSnapshotFilters(snapshotFilters); err != nil {
 				return nil, fmt.Errorf("validating snapshot filters: %w", err)
 			}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -64,8 +64,7 @@ const (
 	ociFieldTransactionCacheKey  = "transaction_cache_key"
 
 	//-- snapshot specific
-	ociFieldSnapshot        = "snapshot"
-	ociFieldSnapshotFilters = "filters"
+	ociFieldSnapshotFilters = "snapshot_filters"
 )
 
 func init() {
@@ -173,18 +172,14 @@ This cache is designed for low-latency stores with cheap per-operation cost. Red
 			Optional(),
 	).Description("LogMiner configuration settings."),
 	).
-	// snapshot config
-	Field(service.NewObjectField(ociFieldSnapshot,
-		service.NewStringMapField(ociFieldSnapshotFilters).
-			Description(`A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
+	Field(service.NewStringMapField(ociFieldSnapshotFilters).
+		Description(`A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
 
 Each query must project every column of the table's primary key, if the table has a composite primary key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.`).
-			Example(map[string]any{
-				"TESTDB.USERS":    "SELECT * FROM TESTDB.USERS",
-				"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000",
-			}).
-			Optional(),
-	).Description("Snapshot configuration settings.").
+		Example(map[string]any{
+			"TESTDB.USERS":    "SELECT * FROM TESTDB.USERS",
+			"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000",
+		}).
 		Optional(),
 	).
 	Field(service.NewStringListField(ociFieldTablesInclude).
@@ -296,18 +291,15 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 
 	// snapshot filters
 	var snapshotFilters map[string]string
-	if conf.Contains(ociFieldSnapshot) {
-		snapshotConf := conf.Namespace(ociFieldSnapshot)
-		if snapshotConf.Contains(ociFieldSnapshotFilters) {
-			if snapshotFilters, err = snapshotConf.FieldStringMap(ociFieldSnapshotFilters); err != nil {
-				return nil, err
-			}
-			if snapshotFilters, err = replication.NormalizeSnapshotFilterKeys(snapshotFilters); err != nil {
-				return nil, fmt.Errorf("validating snapshot filters: %w", err)
-			}
-			if err := replication.ValidateSnapshotFilters(snapshotFilters); err != nil {
-				return nil, fmt.Errorf("validating snapshot filters: %w", err)
-			}
+	if conf.Contains(ociFieldSnapshotFilters) {
+		if snapshotFilters, err = conf.FieldStringMap(ociFieldSnapshotFilters); err != nil {
+			return nil, err
+		}
+		if snapshotFilters, err = replication.NormalizeSnapshotFilterKeys(snapshotFilters); err != nil {
+			return nil, fmt.Errorf("validating snapshot filters: %w", err)
+		}
+		if err := replication.ValidateSnapshotFilters(snapshotFilters); err != nil {
+			return nil, fmt.Errorf("validating snapshot filters: %w", err)
 		}
 	}
 

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -175,7 +175,7 @@ This cache is designed for low-latency stores with cheap per-operation cost. Red
 	Field(service.NewStringMapField(ociFieldSnapshotFilters).
 		Description(`A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
 
-Each query must project every column of the table's primary key, if the table has a composite primary key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.`).
+Each query must project every column of the table's primary key - all of them, for a composite key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.`).
 		Example(map[string]any{
 			"TESTDB.USERS":    "SELECT * FROM TESTDB.USERS",
 			"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000",

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -176,7 +176,9 @@ This cache is designed for low-latency stores with cheap per-operation cost. Red
 	// snapshot config
 	Field(service.NewObjectField(ociFieldSnapshot,
 		service.NewStringMapField(ociFieldSnapshotFilters).
-			Description("A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.").
+			Description(`A map of fully-qualified table names (e.g. SCHEMA.TABLE) to SQL SELECT queries, used to override the default snapshot query per table.
+
+Each query must project every column of the table's primary key, if the table has a composite primary key - even if it otherwise selects only a subset of columns. Snapshotting pages through a table's rows by filtering and sorting on its full primary key, against the query's own result set - if any primary key column isn't projected, this fails part-way through the snapshot, once the first batch of rows has been read.`).
 			Example(map[string]any{
 				"TESTDB.USERS":    "SELECT * FROM TESTDB.USERS",
 				"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000",

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -344,6 +344,96 @@ oracledb_cdc:
 	require.NoError(t, stream.StopWithin(time.Second*10))
 }
 
+func TestIntegrationOracleDBCDCSnapshotFilters(t *testing.T) {
+	integration.CheckSkip(t)
+
+	// Create tables
+	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo", "CREATE TABLE testdb.foo (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name VARCHAR2(100), excluded_col VARCHAR2(100))"))
+	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.foo2", "CREATE TABLE testdb.foo2 (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, name VARCHAR2(100), excluded_col VARCHAR2(100))"))
+
+	// Insert 2000 rows across tables for initial snapshot streaming
+	want := 1000
+	for range 1000 {
+		db.MustExec("INSERT INTO testdb.foo (id, name, excluded_col) VALUES (DEFAULT, 'foo_name', 'should_not_appear')")
+		db.MustExec("INSERT INTO testdb.foo2 (id, name, excluded_col) VALUES (DEFAULT, 'foo2_name', 'should_not_appear')")
+	}
+
+	// wait for changes to propagate to redo logs
+	time.Sleep(5 * time.Second)
+
+	var (
+		outBatches   []string
+		outBatchesMu sync.Mutex
+		stream       *service.Stream
+		err          error
+	)
+	t.Log("Launching component...")
+	{
+		cfg := `
+oracledb_cdc:
+  connection_string: %s
+  stream_snapshot: true
+  snapshot:
+    filters:
+      TESTDB.FOO: "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"
+      TESTDB.FOO2: "SELECT ID, NAME FROM TESTDB.FOO2 WHERE ID > 500"
+  snapshot_max_batch_size: 10
+  max_parallel_snapshot_tables: 3
+  logminer:
+    scn_window_size: 20000
+    backoff_interval: 1s
+  include: ["TESTDB.FOO", "TESTDB.FOO2"]
+  exclude: ["TESTDB.DOESNOTEXIST"]`
+
+		streamBuilder := service.NewStreamBuilder()
+		require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
+		require.NoError(t, streamBuilder.SetLoggerYAML(`level: DEBUG`))
+
+		require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+			outBatchesMu.Lock()
+			defer outBatchesMu.Unlock()
+			for _, msg := range mb {
+				msgBytes, err := msg.AsBytes()
+				assert.NoError(t, err)
+				outBatches = append(outBatches, string(msgBytes))
+			}
+			return nil
+		}))
+
+		stream, err = streamBuilder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		go func() {
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		t.Log("Verifying snapshot changes...")
+		var got int
+		assert.Eventually(t, func() bool {
+			outBatchesMu.Lock()
+			defer outBatchesMu.Unlock()
+			got = len(outBatches)
+			return got >= want
+		}, time.Minute*5, time.Second*1)
+		assert.Truef(t, (got == want), "Wanted %d snapshot messages but got %d", want, got)
+
+		outBatchesMu.Lock()
+		for _, msg := range outBatches {
+			var row map[string]any
+			require.NoError(t, json.Unmarshal([]byte(msg), &row))
+			assert.Contains(t, row, "NAME", "expected NAME column in snapshot row")
+			assert.NotContains(t, row, "EXCLUDED_COL", "expected EXCLUDED_COL to be absent from snapshot row")
+		}
+		outBatchesMu.Unlock()
+	}
+
+	require.NoError(t, stream.StopWithin(time.Second*10))
+}
+
 func TestIntegrationOracleDBCDCResumesFromCheckpoint(t *testing.T) {
 	integration.CheckSkip(t)
 

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -376,7 +376,7 @@ oracledb_cdc:
   stream_snapshot: true
   snapshot:
     filters:
-      TESTDB.FOO: "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"
+      testdb.foo: "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"
       TESTDB.FOO2: "SELECT ID, NAME FROM TESTDB.FOO2 WHERE ID > 500"
   snapshot_max_batch_size: 10
   max_parallel_snapshot_tables: 3

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -374,10 +374,9 @@ func TestIntegrationOracleDBCDCSnapshotFilters(t *testing.T) {
 oracledb_cdc:
   connection_string: %s
   stream_snapshot: true
-  snapshot:
-    filters:
-      testdb.foo: "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"
-      TESTDB.FOO2: "SELECT ID, NAME FROM TESTDB.FOO2 WHERE ID > 500"
+  snapshot_filters:
+    testdb.foo: "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"
+    TESTDB.FOO2: "SELECT ID, NAME FROM TESTDB.FOO2 WHERE ID > 500"
   snapshot_max_batch_size: 10
   max_parallel_snapshot_tables: 3
   logminer:

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -138,7 +138,11 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 			tableName = table.FullName()
 		)
 		l := s.log.With("src_table", tableName)
-		l.Infof("Launching snapshot of table '%s'", tableName)
+		if _, hasFilter := s.filters[tableName]; hasFilter {
+			l.Infof("Launching snapshot of table '%s' with snapshot filter", tableName)
+		} else {
+			l.Infof("Launching snapshot of table '%s'", tableName)
+		}
 
 		switch {
 		case s.pdbName != "":

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -30,6 +30,7 @@ import (
 type Snapshot struct {
 	dbPool                  *sql.DB
 	tables                  []UserTable
+	filters                 map[string]string
 	publisher               ChangePublisher
 	log                     *service.Logger
 	snapshotStatusMetric    *service.MetricGauge
@@ -46,6 +47,7 @@ type Snapshot struct {
 func NewSnapshot(ctx context.Context,
 	connectionString string,
 	tables []UserTable,
+	filters map[string]string,
 	publisher ChangePublisher,
 	lobEnabled bool,
 	pdbName string,
@@ -65,6 +67,7 @@ func NewSnapshot(ctx context.Context,
 	s := &Snapshot{
 		dbPool:                  db,
 		tables:                  tables,
+		filters:                 filters,
 		publisher:               publisher,
 		lobEnabled:              lobEnabled,
 		pdbName:                 pdbName,
@@ -229,7 +232,8 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 // lastSeenPksValues is mutated in place with the PK values from the last row of the batch,
 // so the caller can pass it as pksForQuery on the next iteration.
 func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable, tablePks []string, pksForQuery map[string]any, lastSeenPksValues map[string]any, maxBatchSize int, tableName string) (batchCount int, err error) {
-	batchRows, err := querySnapshotTable(ctx, tx, table, tablePks, pksForQuery, maxBatchSize)
+	customQuery := s.filters[table.FullName()]
+	batchRows, err := querySnapshotTable(ctx, tx, table, tablePks, pksForQuery, maxBatchSize, customQuery)
 	if err != nil {
 		return 0, fmt.Errorf("execute snapshot table query: %w", err)
 	}
@@ -342,18 +346,30 @@ func getTablePrimaryKeys(ctx context.Context, tx *sql.Tx, table UserTable) ([]st
 	return pks, nil
 }
 
-func querySnapshotTable(ctx context.Context, tx *sql.Tx, table UserTable, pk []string, lastSeenPkVal map[string]any, limit int) (*sql.Rows, error) {
+func querySnapshotTable(ctx context.Context, tx *sql.Tx, table UserTable, pk []string, lastSeenPkVal map[string]any, limit int, customQuery string) (*sql.Rows, error) {
 	// Oracle uses FETCH FIRST instead of TOP, and it comes at the end
-	snapshotQueryParts := []string{
-		fmt.Sprintf(`SELECT * FROM "%s"."%s"`, table.Schema, table.Name),
+	if lastSeenPkVal == nil {
+		// No cursor: use custom query directly to avoid a redundant wrapping subquery.
+		var base string
+		if customQuery != "" {
+			base = customQuery
+		} else {
+			base = fmt.Sprintf(`SELECT * FROM "%s"."%s"`, table.Schema, table.Name)
+		}
+		q := strings.Join([]string{base, buildOrderByClause(pk), fmt.Sprintf("FETCH FIRST %d ROWS ONLY", limit)}, " ")
+		return tx.QueryContext(ctx, q)
 	}
 
-	if lastSeenPkVal == nil {
-		snapshotQueryParts = append(snapshotQueryParts, buildOrderByClause(pk))
-		snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("FETCH FIRST %d ROWS ONLY", limit))
-
-		q := strings.Join(snapshotQueryParts, " ")
-		return tx.QueryContext(ctx, q)
+	// Cursor pagination requires a WHERE clause; wrap the custom query in a subquery so the
+	// added WHERE does not conflict with any WHERE already present in customQuery.
+	var tableSource string
+	if customQuery != "" {
+		tableSource = fmt.Sprintf("(%s) t", customQuery)
+	} else {
+		tableSource = fmt.Sprintf(`"%s"."%s"`, table.Schema, table.Name)
+	}
+	snapshotQueryParts := []string{
+		"SELECT * FROM " + tableSource,
 	}
 
 	// Build lexicographic comparison for composite keys

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	goora "github.com/sijms/go-ora/v2/network"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redpanda-data/benthos/v4/public/schema"
@@ -24,6 +25,11 @@ import (
 
 	"github.com/redpanda-data/connect/v4/internal/sqlutil"
 )
+
+// errCodeInvalidIdentifier is Oracle's ORA-00904, raised when a query references a
+// column that doesn't exist in its source. Used to detect a custom snapshot filter
+// that doesn't project all of a table's primary key columns - see querySnapshotTable.
+const errCodeInvalidIdentifier = 904
 
 // Snapshot is responsible for creating snapshots of existing tables based on the Tables
 // configuration value.
@@ -411,7 +417,18 @@ func querySnapshotTable(ctx context.Context, tx *sql.Tx, table UserTable, pk []s
 	snapshotQueryParts = append(snapshotQueryParts, buildOrderByClause(pk))
 	snapshotQueryParts = append(snapshotQueryParts, fmt.Sprintf("FETCH FIRST %d ROWS ONLY", limit))
 	q := strings.Join(snapshotQueryParts, " ")
-	return tx.QueryContext(ctx, q, lastSeenPkVals...)
+	rows, err := tx.QueryContext(ctx, q, lastSeenPkVals...)
+	if err != nil {
+		var oraErr *goora.OracleError
+		if customQuery != "" && errors.As(err, &oraErr) && oraErr.ErrCode == errCodeInvalidIdentifier {
+			return nil, fmt.Errorf("%w\n\nThis usually means the snapshot filter for table '%s' doesn't project all of its primary key columns (%s). "+
+				"Cursor-based pagination filters and sorts on the full primary key against the filter's own result set, "+
+				"so every primary key column must be included in the filter's SELECT list even if it otherwise selects only a subset of columns",
+				err, table.FullName(), strings.Join(pk, ", "))
+		}
+		return nil, err
+	}
+	return rows, nil
 }
 
 // Close safely closes all open connections opened for the snapshotting process.

--- a/internal/impl/oracledb/replication/snapshot_filter.go
+++ b/internal/impl/oracledb/replication/snapshot_filter.go
@@ -1,0 +1,340 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// clauseKeywords are words that may legally follow a FROM table reference without
+// being mistaken for a table alias.
+var clauseKeywords = map[string]bool{
+	"where": true, "order": true, "group": true, "having": true,
+	"connect": true, "start": true, "fetch": true, "for": true,
+	"union": true, "intersect": true, "minus": true,
+	"model": true, "pivot": true, "unpivot": true,
+}
+
+// ValidateSnapshotFilters validates that the snapshot filters are SELECT statements
+// referencing exactly one simple table - no joins, subqueries, or UNION/INTERSECT/MINUS
+// combinations - and that each filter's table matches its map key.
+//
+// This is a hand-rolled scan rather than a full SQL parse, in the same spirit as
+// oracledb/logminer/sqlredo: these queries only ever take the fixed shape
+// `SELECT ... FROM <table> [alias] [WHERE ...]`, so a full grammar isn't needed to
+// reject anything else.
+func ValidateSnapshotFilters(filters map[string]string) error {
+	for table, query := range filters {
+		parsedTable, err := parseFilterTable(table, query)
+		if err != nil {
+			return err
+		}
+		if strings.ToUpper(table) != parsedTable {
+			return fmt.Errorf("snapshot filter key %q does not match the table referenced in the query (%q)", table, parsedTable)
+		}
+	}
+	return nil
+}
+
+// parseFilterTable validates query and returns the uppercased, optionally
+// schema-qualified table name referenced in its FROM clause.
+func parseFilterTable(table, query string) (string, error) {
+	sc := &filterScanner{s: strings.TrimRight(strings.TrimSpace(query), " \t\n\r;")}
+	sc.ws()
+	if !sc.keyword("select") {
+		return "", fmt.Errorf("snapshot filter for table %q must be a SELECT statement", table)
+	}
+
+	found, err := sc.skipToFrom()
+	if err != nil {
+		return "", fmt.Errorf("snapshot filter for table %q is not valid SQL: %w", table, err)
+	}
+	if !found {
+		return "", fmt.Errorf("snapshot filter for table %q is not valid SQL: missing FROM clause", table)
+	}
+	sc.ws()
+
+	tableName, err := sc.readTableName()
+	if err != nil {
+		return "", fmt.Errorf("snapshot filter for table %q must reference a simple table name: %w", table, err)
+	}
+	sc.ws()
+
+	switch {
+	case sc.done():
+	case sc.s[sc.i] == ',':
+		return "", fmt.Errorf("snapshot filter for table %q must query exactly one table", table)
+	case sc.joinKeyword():
+		return "", fmt.Errorf("snapshot filter for table %q must reference a simple table name", table)
+	default:
+		if err := sc.skipOptionalAlias(); err != nil {
+			return "", fmt.Errorf("snapshot filter for table %q must reference a simple table name: %w", table, err)
+		}
+	}
+
+	if err := sc.checkRemainder(); err != nil {
+		return "", fmt.Errorf("snapshot filter for table %q is not valid SQL: %w", table, err)
+	}
+
+	return tableName, nil
+}
+
+// filterScanner is a forward-only cursor over a snapshot filter SQL string.
+// Character-by-character, no regex.
+type filterScanner struct {
+	s string
+	i int
+}
+
+func (sc *filterScanner) done() bool { return sc.i >= len(sc.s) }
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+func isIdentStartByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isIdentByte(b byte) bool {
+	return isIdentStartByte(b) || b == '$' || b == '#' || (b >= '0' && b <= '9')
+}
+
+func (sc *filterScanner) ws() {
+	for sc.i < len(sc.s) && isSpaceByte(sc.s[sc.i]) {
+		sc.i++
+	}
+}
+
+// keyword matches kw (lowercase ASCII) at the current position case-insensitively,
+// requiring word boundaries on both sides. Advances sc.i and returns true on a match;
+// otherwise no-ops and returns false.
+func (sc *filterScanner) keyword(kw string) bool {
+	if sc.i > 0 && isIdentByte(sc.s[sc.i-1]) {
+		return false
+	}
+	if sc.i+len(kw) > len(sc.s) {
+		return false
+	}
+	for j := 0; j < len(kw); j++ {
+		c := sc.s[sc.i+j]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != kw[j] {
+			return false
+		}
+	}
+	end := sc.i + len(kw)
+	if end < len(sc.s) && isIdentByte(sc.s[end]) {
+		return false
+	}
+	sc.i += len(kw)
+	return true
+}
+
+// joinKeyword reports (and consumes) whether the scanner is positioned at a join
+// keyword, which indicates the FROM clause references more than one table.
+func (sc *filterScanner) joinKeyword() bool {
+	joinKeywords := []string{"join", "inner", "outer", "left", "right", "full", "cross", "natural"}
+	return slices.ContainsFunc(joinKeywords, sc.keyword)
+}
+
+// peekWord returns the lowercased identifier at the current position without
+// advancing the scanner.
+func (sc *filterScanner) peekWord() string {
+	j := sc.i
+	for j < len(sc.s) && isIdentByte(sc.s[j]) {
+		j++
+	}
+	return strings.ToLower(sc.s[sc.i:j])
+}
+
+// skipQuoted advances past a quoted region opened by q (a single or double quote
+// byte), where q is escaped within the region by doubling it. Returns false if the
+// region is unterminated.
+func (sc *filterScanner) skipQuoted(q byte) bool {
+	sc.i++ // opening quote
+	for sc.i < len(sc.s) {
+		if sc.s[sc.i] == q {
+			if sc.i+1 < len(sc.s) && sc.s[sc.i+1] == q {
+				sc.i += 2 // escaped quote
+				continue
+			}
+			sc.i++ // closing quote
+			return true
+		}
+		sc.i++
+	}
+	return false
+}
+
+// skipToFrom advances past the SELECT list to the top-level FROM keyword, skipping
+// over string/quoted-identifier contents and nested parenthesised expressions
+// (e.g. subqueries or function calls in the select list). Returns false if no
+// top-level FROM is found.
+func (sc *filterScanner) skipToFrom() (bool, error) {
+	depth := 0
+	for !sc.done() {
+		switch sc.s[sc.i] {
+		case '\'':
+			if !sc.skipQuoted('\'') {
+				return false, errors.New("unterminated string literal")
+			}
+			continue
+		case '"':
+			if !sc.skipQuoted('"') {
+				return false, errors.New("unterminated quoted identifier")
+			}
+			continue
+		case '(':
+			depth++
+			sc.i++
+			continue
+		case ')':
+			depth--
+			sc.i++
+			continue
+		}
+		if depth == 0 && sc.keyword("from") {
+			return true, nil
+		}
+		sc.i++
+	}
+	return false, nil
+}
+
+// readIdentifier reads a double-quoted or bare identifier at the current position.
+func (sc *filterScanner) readIdentifier() (string, error) {
+	if sc.done() {
+		return "", errors.New("expected identifier, got end of input")
+	}
+	if sc.s[sc.i] == '"' {
+		sc.i++
+		start := sc.i
+		for sc.i < len(sc.s) && sc.s[sc.i] != '"' {
+			sc.i++
+		}
+		if sc.done() {
+			return "", errors.New("unterminated quoted identifier")
+		}
+		name := sc.s[start:sc.i]
+		sc.i++ // closing "
+		return name, nil
+	}
+	if !isIdentStartByte(sc.s[sc.i]) {
+		snippet := sc.s[sc.i:]
+		if len(snippet) > 20 {
+			snippet = snippet[:20]
+		}
+		return "", fmt.Errorf("expected identifier, got %.20q", snippet)
+	}
+	start := sc.i
+	for sc.i < len(sc.s) && isIdentByte(sc.s[sc.i]) {
+		sc.i++
+	}
+	return sc.s[start:sc.i], nil
+}
+
+// readTableName reads a table reference of the form TABLE or SCHEMA.TABLE (either
+// part optionally double-quoted) and returns it uppercased.
+func (sc *filterScanner) readTableName() (string, error) {
+	first, err := sc.readIdentifier()
+	if err != nil {
+		return "", err
+	}
+	if !sc.done() && sc.s[sc.i] == '.' {
+		sc.i++
+		second, err := sc.readIdentifier()
+		if err != nil {
+			return "", err
+		}
+		return strings.ToUpper(first) + "." + strings.ToUpper(second), nil
+	}
+	return strings.ToUpper(first), nil
+}
+
+// skipOptionalAlias consumes an optional table alias immediately following a FROM
+// table reference, e.g. `t` or `AS t`. It leaves the scanner untouched if what
+// follows is a clause keyword (WHERE, ORDER BY, UNION, ...) rather than an alias.
+func (sc *filterScanner) skipOptionalAlias() error {
+	sc.ws()
+	if sc.done() {
+		return nil
+	}
+	if sc.keyword("as") {
+		sc.ws()
+		_, err := sc.readIdentifier()
+		return err
+	}
+	if sc.s[sc.i] == '"' {
+		_, err := sc.readIdentifier()
+		return err
+	}
+	word := sc.peekWord()
+	if word == "" || clauseKeywords[word] {
+		return nil
+	}
+	_, err := sc.readIdentifier()
+	return err
+}
+
+// checkRemainder scans the rest of the query (WHERE/ORDER BY/etc.) to reject
+// anything that would let the filter reach beyond its single declared table:
+// statement chaining (';') at any depth, and a top-level UNION/INTERSECT/MINUS
+// combining in a second SELECT. Nested subqueries (e.g. inside WHERE ... IN (...))
+// are skipped over rather than rejected.
+func (sc *filterScanner) checkRemainder() error {
+	depth := 0
+	for !sc.done() {
+		switch sc.s[sc.i] {
+		case '\'':
+			if !sc.skipQuoted('\'') {
+				return errors.New("unterminated string literal")
+			}
+			continue
+		case '"':
+			if !sc.skipQuoted('"') {
+				return errors.New("unterminated quoted identifier")
+			}
+			continue
+		case '(':
+			depth++
+			sc.i++
+			continue
+		case ')':
+			depth--
+			if depth < 0 {
+				return errors.New("unbalanced parentheses")
+			}
+			sc.i++
+			continue
+		case ';':
+			return errors.New("must not contain multiple statements")
+		}
+		if depth == 0 {
+			switch {
+			case sc.keyword("union"):
+				return errors.New("must not combine multiple SELECT statements (UNION)")
+			case sc.keyword("intersect"):
+				return errors.New("must not combine multiple SELECT statements (INTERSECT)")
+			case sc.keyword("minus"):
+				return errors.New("must not combine multiple SELECT statements (MINUS)")
+			}
+		}
+		sc.i++
+	}
+	if depth != 0 {
+		return errors.New("unbalanced parentheses")
+	}
+	return nil
+}

--- a/internal/impl/oracledb/replication/snapshot_filter.go
+++ b/internal/impl/oracledb/replication/snapshot_filter.go
@@ -24,6 +24,21 @@ var clauseKeywords = map[string]bool{
 	"model": true, "pivot": true, "unpivot": true,
 }
 
+// NormalizeSnapshotFilterKeys uppercases every key in filters, returning a new map.
+// Returns an error if two keys collide once uppercased (e.g. "testdb.foo" and
+// "TESTDB.FOO" both present), since silently keeping only one would be surprising.
+func NormalizeSnapshotFilterKeys(filters map[string]string) (map[string]string, error) {
+	normalized := make(map[string]string, len(filters))
+	for table, query := range filters {
+		key := strings.ToUpper(table)
+		if _, exists := normalized[key]; exists {
+			return nil, fmt.Errorf("snapshot filter table %q is specified more than once (case-insensitive)", key)
+		}
+		normalized[key] = query
+	}
+	return normalized, nil
+}
+
 // ValidateSnapshotFilters validates that the snapshot filters are SELECT statements
 // referencing exactly one simple table - no joins, subqueries, or UNION/INTERSECT/MINUS
 // combinations - and that each filter's table matches its map key.

--- a/internal/impl/oracledb/replication/snapshot_filter_test.go
+++ b/internal/impl/oracledb/replication/snapshot_filter_test.go
@@ -16,6 +16,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeSnapshotFilterKeys(t *testing.T) {
+	t.Run("uppercases keys, leaves queries untouched", func(t *testing.T) {
+		normalized, err := replication.NormalizeSnapshotFilterKeys(map[string]string{
+			"testdb.foo": "select * from testdb.foo",
+			"TestDB.Bar": "SELECT * FROM TESTDB.BAR",
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"TESTDB.FOO": "select * from testdb.foo",
+			"TESTDB.BAR": "SELECT * FROM TESTDB.BAR",
+		}, normalized)
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		normalized, err := replication.NormalizeSnapshotFilterKeys(map[string]string{})
+		require.NoError(t, err)
+		require.Empty(t, normalized)
+	})
+
+	t.Run("case-insensitive duplicate keys rejected", func(t *testing.T) {
+		_, err := replication.NormalizeSnapshotFilterKeys(map[string]string{
+			"testdb.foo": "SELECT * FROM TESTDB.FOO",
+			"TESTDB.FOO": "SELECT * FROM TESTDB.FOO WHERE ID > 1",
+		})
+		require.ErrorContains(t, err, "specified more than once")
+	})
+}
+
 func TestValidateSnapshotFilters(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/impl/oracledb/replication/snapshot_filter_test.go
+++ b/internal/impl/oracledb/replication/snapshot_filter_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication_test
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSnapshotFilters(t *testing.T) {
+	tests := []struct {
+		name       string
+		filters    map[string]string
+		errContain string
+	}{
+		{
+			name:    "star select",
+			filters: map[string]string{"TESTDB.USERS": "SELECT * FROM TESTDB.USERS"},
+		},
+		{
+			name:    "star select with where",
+			filters: map[string]string{"TESTDB.PRODUCTS": "SELECT * FROM TESTDB.PRODUCTS WHERE ID > 1000"},
+		},
+		{
+			name:    "column list with where",
+			filters: map[string]string{"TESTDB.FOO": "SELECT ID, NAME FROM TESTDB.FOO WHERE ID > 500"},
+		},
+		{
+			name:    "double quoted identifiers",
+			filters: map[string]string{"TESTDB.FOO": `SELECT * FROM "TESTDB"."FOO"`},
+		},
+		{
+			name:    "bare alias",
+			filters: map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO f WHERE f.ID > 500"},
+		},
+		{
+			name:    "AS alias",
+			filters: map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO AS f WHERE f.ID > 500"},
+		},
+		{
+			name:    "unqualified table",
+			filters: map[string]string{"FOO": "SELECT * FROM FOO"},
+		},
+		{
+			name:    "lowercase keywords and identifiers",
+			filters: map[string]string{"TESTDB.FOO": "select * from testdb.foo"},
+		},
+		{
+			name:    "subquery in select list",
+			filters: map[string]string{"TESTDB.FOO": "SELECT (SELECT MAX(ID) FROM OTHER) FROM TESTDB.FOO"},
+		},
+		{
+			name:    "subquery in where clause",
+			filters: map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO WHERE ID IN (SELECT ID FROM OTHER)"},
+		},
+		{
+			name:    "trailing semicolon tolerated",
+			filters: map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO;"},
+		},
+		{
+			name: "multiple valid filters",
+			filters: map[string]string{
+				"TESTDB.FOO":  "SELECT * FROM TESTDB.FOO",
+				"TESTDB.FOO2": "SELECT ID, NAME FROM TESTDB.FOO2 WHERE ID > 500",
+			},
+		},
+		{
+			name:    "empty filters",
+			filters: map[string]string{},
+		},
+		{
+			name:       "not a select statement",
+			filters:    map[string]string{"TESTDB.FOO": "DELETE FROM TESTDB.FOO"},
+			errContain: "must be a SELECT statement",
+		},
+		{
+			name:       "malformed sql missing from",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FRM TESTDB.FOO"},
+			errContain: "is not valid SQL",
+		},
+		{
+			name:       "comma joined tables",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO, TESTDB.BAR"},
+			errContain: "must query exactly one table",
+		},
+		{
+			name:       "explicit join",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO JOIN TESTDB.BAR ON 1=1"},
+			errContain: "must reference a simple table name",
+		},
+		{
+			name:       "subquery as from table",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM (SELECT * FROM TESTDB.FOO) t"},
+			errContain: "must reference a simple table name",
+		},
+		{
+			name:       "union combining a second select",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT ID FROM TESTDB.FOO UNION SELECT PASSWORD FROM SECRETS"},
+			errContain: "UNION",
+		},
+		{
+			name:       "intersect combining a second select",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT ID FROM TESTDB.FOO INTERSECT SELECT PASSWORD FROM SECRETS"},
+			errContain: "INTERSECT",
+		},
+		{
+			name:       "minus combining a second select",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT ID FROM TESTDB.FOO MINUS SELECT PASSWORD FROM SECRETS"},
+			errContain: "MINUS",
+		},
+		{
+			name:       "statement chaining via semicolon",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO; DROP TABLE TESTDB.FOO"},
+			errContain: "multiple statements",
+		},
+		{
+			name:       "unbalanced parentheses",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.FOO WHERE (ID > 1"},
+			errContain: "unbalanced parentheses",
+		},
+		{
+			name:       "table does not match filter key",
+			filters:    map[string]string{"TESTDB.FOO": "SELECT * FROM TESTDB.BAR"},
+			errContain: "does not match the table referenced in the query",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := replication.ValidateSnapshotFilters(tt.filters)
+			if tt.errContain == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.errContain)
+		})
+	}
+}

--- a/internal/impl/oracledb/replication/snapshot_test.go
+++ b/internal/impl/oracledb/replication/snapshot_test.go
@@ -70,7 +70,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "SINGLE_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, nil, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 
@@ -102,7 +102,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "COMPOSITE_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, nil, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 
@@ -136,7 +136,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 			{Schema: "TESTDB", Name: "THREE_COL_KEY_TEST"},
 		}
 
-		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, nil, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
 		require.NoError(t, err)
 		defer snapshot.Close()
 

--- a/internal/impl/oracledb/replication/stream.go
+++ b/internal/impl/oracledb/replication/stream.go
@@ -127,3 +127,19 @@ func ApplyNLSSettings(ctx context.Context, db dbExecer) error {
 	}
 	return nil
 }
+
+// SnapshotFilterTablesExist verifies that tables specified in the filters map exist in the tracked tables.
+func SnapshotFilterTablesExist(userTables []UserTable, filters map[string]string) error {
+	if len(filters) > 0 {
+		known := make(map[string]struct{}, len(userTables))
+		for _, t := range userTables {
+			known[t.FullName()] = struct{}{}
+		}
+		for table := range filters {
+			if _, ok := known[table]; !ok {
+				return fmt.Errorf("snapshot filter references unknown table %q: table not found in monitored tables", table)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds support for controlling the traditional greedy `SELECT * FROM table_to_snapshot` query, allowing the user to reduce the amount of data the snapshot will return, speeding up the snapshot process by excluding columns that aren't of interest or excluding certain groups of rows.

Given the following config:

<img width="944" height="360" alt="image" src="https://github.com/user-attachments/assets/5a2e9b0e-5055-404e-97cd-3337c2f32949" />

We get the following filtered results:

<img width="1508" height="805" alt="image" src="https://github.com/user-attachments/assets/9926f7dd-d462-41f5-a119-e3e81e283a91" />