### PR TITLE
docs(redpanda_migrator): fix stale on-demand schema registry sync claim

### DIFF
--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -222,7 +222,7 @@ What gets synchronised:
 How it runs:
 
 - Topics: synced on demand. The first write triggers discovery and creation; subsequent writes create on first encounter per topic.
-- Schema Registry: one sync at connect, then triggered when topic record has unknown schema; optional background loop controlled by `schema_registry.interval`.
+- Schema Registry: one sync at connect, then periodic syncing via the background loop controlled by `schema_registry.interval` (set to `0s` to sync only once at connect). Schema IDs unknown at write time are not resynced on demand; they are handled per `schema_registry.strict`.
 - Consumer Groups: background loop controlled by `consumer_groups.interval` and filtered by the current topic mappings.
 
 Guarantees:

--- a/internal/impl/redpanda/migrator/README.md
+++ b/internal/impl/redpanda/migrator/README.md
@@ -324,7 +324,7 @@ sequenceDiagram
 
 - **Initial sync on connect** - One sync when output connects
 - **Optional periodic sync** - Background loop controlled by `interval` setting
-- **On-demand sync** - Triggered when record has unknown schema ID
+- **Unknown schema handling** - A record whose schema ID is not yet synced to the destination is passed through unchanged, or rejected when `strict` is enabled (there is no on-demand resync)
 - **ID translation modes** - Create-or-reuse (translate) vs fixed IDs
 - **Compatibility propagation** - Only when explicitly set per-subject
 

--- a/internal/impl/redpanda/migrator/migrator.go
+++ b/internal/impl/redpanda/migrator/migrator.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ What gets synchronised:
 How it runs:
 
 - Topics: synced on demand. The first write triggers discovery and creation; subsequent writes create on first encounter per topic.
-- Schema Registry: one sync at connect, then triggered when topic record has unknown schema; optional background loop controlled by `+"`schema_registry.interval`"+`.
+- Schema Registry: one sync at connect, then periodic syncing via the background loop controlled by `+"`schema_registry.interval`"+` (set to `+"`0s`"+` to sync only once at connect). Schema IDs unknown at write time are not resynced on demand; they are handled per `+"`schema_registry.strict`"+`.
 - Consumer Groups: background loop controlled by `+"`consumer_groups.interval`"+` and filtered by the current topic mappings.
 
 Guarantees:


### PR DESCRIPTION
## What

The `redpanda_migrator` output docs currently describe an on-demand schema registry sync that's "triggered when a record has an unknown schema". From what I can tell that hot-path resync was removed in 48ad3263 — in the same 4.67.0 release that introduced it — so the described fallback has never actually shipped in a release. Today the destination schema-ID cache is populated only by the sync at connect and the periodic background loop (`schema_registry.interval`); there's no on-demand resync on a cache miss.

This updates the three places that still advertise the removed behaviour to match what the code actually does, and spells out how a record with an unmapped schema ID is handled — passed through unchanged, or rejected when `schema_registry.strict` is enabled.

## Changes

- `internal/impl/redpanda/migrator/migrator.go` — component description ("How it runs")
- `internal/impl/redpanda/migrator/README.md` — Schema Sync Characteristics
- `docs/modules/components/pages/outputs/redpanda_migrator.adoc` — regenerated via `task docs`

## Notes

- Docs-only; no behaviour change.
- The `.adoc` is regenerated via `task docs` (not hand-edited) and its lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)