### PR TITLE
ci: stop task docs and lint from silently compiling the entire project on every single CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,17 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Cache Go build/module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-test-cgo1-x_benthos_extra-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-build-test-cgo1-x_benthos_extra-${{ runner.os }}-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libzmq3-dev
@@ -50,6 +61,17 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Cache Go build/module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-lint-cgo0-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-build-lint-cgo0-${{ runner.os }}-
 
       - name: Set version env variables
         run: cat .versions >> $GITHUB_ENV


### PR DESCRIPTION
Docs (and lint) can take a while to run (~5 mins for docs alone), caching this allows us to get some free gains on the CI pipeline at the cost of a little more storage (but still under GitHub's 10GB limit before it starts invalidating caches.