### PR TITLE
migrator: support ability to set headers via config

### DIFF
--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -64,6 +64,7 @@ output:
     topic: ${! @kafka_topic }
     topic_replication_factor: "3" # No default (optional)
     sync_topic_acls: false
+    headers: {} # No default (optional)
     max_in_flight: 10
 ```
 
@@ -159,6 +160,7 @@ output:
     sync_topic_interval: 5m
     sync_topic_acls: false
     serverless: false
+    headers: {} # No default (optional)
     provenance_header: redpanda-migrator-provenance
     offset_header: redpanda-migrator-offset
     max_in_flight: 10
@@ -1679,6 +1681,23 @@ Enable serverless mode for Redpanda Cloud serverless clusters. This restricts to
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `headers`
+
+Custom headers to add to migrated records, keyed by header name with interpolated string values. Useful for injecting metadata such as processing timestamps or latency measurements that should surface as header values on the destination cluster. A custom header name that collides with `provenance_header` or `offset_header` is ignored, so those migration-critical headers are always protected.
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+
+*Type*: `object`
+
+
+```yml
+# Examples
+
+headers:
+  x-migration-latency-ms: ${! timestamp_unix_milli() - meta("kafka_timestamp_ms") }
+  x-migration-processed-at: ${! timestamp_unix_milli() }
+```
 
 === `provenance_header`
 

--- a/internal/impl/redpanda/migrator/integration_test.go
+++ b/internal/impl/redpanda/migrator/integration_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/benthos/v4/public/service/integration"
 
+	"github.com/redpanda-data/connect/v4/internal/impl/redpanda/migrator"
 	_ "github.com/redpanda-data/connect/v4/public/components/confluent"
 )
 
@@ -1299,4 +1300,103 @@ logger:
 		})
 		return emptyTotal == 0
 	}, 3*time.Second, 200*time.Millisecond, "Empty topic should have 0 messages on destination")
+}
+
+func TestIntegrationMigratorOutputCustomHeaders(t *testing.T) {
+	integration.CheckSkip(t)
+
+	getHeader := func(headers []kgo.RecordHeader, key string) ([]byte, bool) {
+		for i := len(headers) - 1; i >= 0; i-- {
+			if headers[i].Key == key {
+				return headers[i].Value, true
+			}
+		}
+		return nil, false
+	}
+
+	t.Log("Given: Redpanda clusters without schema registry")
+	src, dst := startRedpandaSourceAndDestination(t)
+	src.SchemaRegistryURL = ""
+	dst.SchemaRegistryURL = ""
+
+	t.Log("When: Migrator is started with a custom header configured, including ones that collide with the default offset and provenance header names")
+	const yamlTmpl = `
+input:
+  redpanda_migrator:
+    seed_brokers:
+      - {{.Src.BrokerAddr}}
+    topics:
+      - {{.Topic}}
+    consumer_group: redpanda_migrator_cg
+output:
+  redpanda_migrator:
+    seed_brokers: [ {{.Dst.BrokerAddr}} ]
+    headers:
+      x-migration-source: 'test-pipeline'
+      {{.OffsetHeader}}: 'should-be-overridden'
+      {{.ProvenanceHeader}}: 'bogus-cluster-id'
+    consumer_groups:
+      interval: 1s
+logger:
+  level: DEBUG
+`
+	tmpl, err := template.New("migrator").Parse(yamlTmpl)
+	require.NoError(t, err)
+
+	data := struct {
+		Src              EmbeddedRedpandaCluster
+		Dst              EmbeddedRedpandaCluster
+		Topic            string
+		OffsetHeader     string
+		ProvenanceHeader string
+	}{
+		Src:              src,
+		Dst:              dst,
+		Topic:            migratorTestTopic,
+		OffsetHeader:     migrator.DefaultOffsetHeader,
+		ProvenanceHeader: migrator.DefaultProvenanceHeader,
+	}
+	var yamlBuf bytes.Buffer
+	require.NoError(t, tmpl.Execute(&yamlBuf, data))
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetYAML(yamlBuf.String()))
+
+	stream, err := sb.Build()
+	require.NoError(t, err)
+
+	go func() {
+		if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+		t.Log("Migrator pipeline shutdown")
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, stream.StopWithin(stopStreamTimeout))
+	})
+
+	t.Log("And: A message is produced to src")
+	src.Produce(migratorTestTopic, []byte("hello"))
+
+	t.Log("Then: The migrated record on dst carries the custom header with the configured value")
+	records := readTopicContent(dst, 1)
+	require.Len(t, records, 1)
+
+	val, ok := getHeader(records[0].Headers, "x-migration-source")
+	require.True(t, ok, "expected custom header %q to be present on migrated record", "x-migration-source")
+	assert.Equal(t, "test-pipeline", string(val))
+
+	t.Log("And: The offset header is not overridden by the colliding custom header value, protecting exact offset migration")
+	offsetVal, ok := getHeader(records[0].Headers, migrator.DefaultOffsetHeader)
+	require.True(t, ok, "expected offset header %q to be present on migrated record", migrator.DefaultOffsetHeader)
+	assert.NotEqual(t, []byte("should-be-overridden"), offsetVal)
+	assert.Equal(t, migrator.EncodeOffsetHeader(0), offsetVal, "offset header should carry the real source offset (0), not the colliding custom header value")
+
+	t.Log("And: The provenance header is not overridden by the colliding custom header value, protecting loop-prevention/data-corruption guards")
+	srcMetadata, err := src.Admin.Metadata(t.Context())
+	require.NoError(t, err)
+	provenanceVal, ok := getHeader(records[0].Headers, migrator.DefaultProvenanceHeader)
+	require.True(t, ok, "expected provenance header %q to be present on migrated record", migrator.DefaultProvenanceHeader)
+	assert.NotEqual(t, []byte("bogus-cluster-id"), provenanceVal)
+	assert.Equal(t, []byte(srcMetadata.Cluster), provenanceVal, "provenance header should carry the real source cluster ID, not the colliding custom header value")
 }

--- a/internal/impl/redpanda/migrator/migrator.go
+++ b/internal/impl/redpanda/migrator/migrator.go
@@ -38,6 +38,7 @@ const (
 	rmoFieldSyncTopicInterval      = "sync_topic_interval"
 	rmoFieldSyncTopicACLs          = "sync_topic_acls"
 	rmoFieldServerless             = "serverless"
+	rmoFieldHeaders                = "headers"
 	rmoFieldProvenanceHeader       = "provenance_header"
 	rmoFieldOffsetHeader           = "offset_header"
 	rmoFieldMaxInFlight            = "max_in_flight"
@@ -273,6 +274,15 @@ output:
 			Description("Enable serverless mode for Redpanda Cloud serverless clusters. This restricts topic configurations and schema features to those supported by serverless environments.").
 			Default(false).
 			Advanced()).
+		Field(service.NewInterpolatedStringMapField(rmoFieldHeaders).
+			Description("Custom headers to add to migrated records, keyed by header name with interpolated string values. " +
+				"Useful for injecting metadata such as processing timestamps or latency measurements that should surface as header values on the destination cluster. " +
+				"A custom header name that collides with `" + rmoFieldProvenanceHeader + "` or `" + rmoFieldOffsetHeader + "` is ignored, so those migration-critical headers are always protected.").
+			Example(map[string]any{
+				"x-migration-processed-at": "${! timestamp_unix_milli() }",
+				"x-migration-latency-ms":   "${! timestamp_unix_milli() - meta(\"kafka_timestamp_ms\") }",
+			}).
+			Optional()).
 		Field(service.NewStringField(rmoFieldProvenanceHeader).
 			Description("Header name to add to migrated records indicating their source cluster. If empty, no provenance header is added.").
 			Default(DefaultProvenanceHeader).
@@ -419,6 +429,7 @@ type Migrator struct {
 	groups groupsMigrator
 	log    *service.Logger
 
+	headers          map[string]*service.InterpolatedString
 	provenanceHeader string
 	offsetHeader     string
 	plumbing         uint8
@@ -480,6 +491,13 @@ func (m *Migrator) initOutputFromParsed(pConf *service.ParsedConfig, mgr *servic
 
 	if err := m.topic.conf.initFromParsed(pConf); err != nil {
 		return err
+	}
+
+	if pConf.Contains(rmoFieldHeaders) {
+		m.headers, err = pConf.FieldInterpolatedStringMap(rmoFieldHeaders)
+		if err != nil {
+			return err
+		}
 	}
 
 	m.provenanceHeader, err = pConf.FieldString(rmoFieldProvenanceHeader)
@@ -676,6 +694,22 @@ func (m *Migrator) messageBatchToFranzRecords(batch service.MessageBatch) ([]kgo
 
 		// Headers (optional)
 		r.Headers = kafka.ExtractHeaders(msg)
+
+		// Custom headers (optional). Names matching provenance_header or
+		// offset_header are skipped so a colliding custom header can never
+		// masquerade as (or overwrite) those migration-critical headers,
+		// which are set below.
+		for name, interp := range m.headers {
+			if name == m.provenanceHeader || name == m.offsetHeader {
+				continue
+			}
+			val, err := interp.TryString(msg)
+			if err != nil {
+				return nil, fmt.Errorf("headers interpolation: %w", err)
+			}
+			r.Headers = kafka.SetHeaderValue(r.Headers, name, []byte(val))
+		}
+
 		if m.provenanceHeader != "" {
 			origin, ok := kafka.GetHeaderValue(r.Headers, m.provenanceHeader)
 			if ok {


### PR DESCRIPTION
This change introduces the ability to set metadata headers on events flowing through the migrator. If the headers already exist on the message then the configured header is ignored.