### PR TITLE
kafka: fix unordered consumer deadlock on revoke under backpressure

### DIFF
--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -322,39 +322,32 @@ func (p *partitionTracker) sendBatch(ctx context.Context, b service.MessageBatch
 	return nil
 }
 
-func (p *partitionTracker) add(ctx context.Context, m *msgWithRecord, limit int) (pauseFetch bool) {
-	var sendBatch service.MessageBatch
-	if p.batcher != nil {
-		// Wrap this in a closure to make locking/unlocking easier.
-		func() {
-			p.batcherLock.Lock()
-			defer p.batcherLock.Unlock()
-
-			if p.batcher.Add(m.msg) {
-				// Batch triggered, we flush it here synchronously.
-				sendBatch, _ = p.batcher.Flush(ctx)
-			} else {
-				// Otherwise store the latest record as the representative of the
-				// pending batch offset. This will be used by the timer based
-				// flushing mechanism within loop() if applicable.
-				p.topBatchRecord = m.r
-			}
-		}()
-	} else {
-		sendBatch = service.MessageBatch{m.msg}
+// stage feeds a record into the partition's batcher and returns a batch to
+// dispatch if one is ready (nil otherwise). It never blocks.
+//
+// It must be called with the owning checkpointTracker's lock held, but the
+// returned batch must be dispatched (via sendBatch) *after* that lock is
+// released: dispatching can block on the output channel under backpressure, and
+// blocking there while holding the checkpointTracker lock would deadlock a
+// concurrent revoke. See checkpointTracker.addRecord for the full rationale.
+func (p *partitionTracker) stage(ctx context.Context, m *msgWithRecord) service.MessageBatch {
+	if p.batcher == nil {
+		return service.MessageBatch{m.msg}
 	}
 
-	if len(sendBatch) > 0 {
-		// Ignoring in the error here is fine, it implies shut down has been
-		// triggered and we would only acknowledge the message by committing it
-		// if it were successfully delivered.
-		_ = p.sendBatch(ctx, sendBatch, m.r)
-	}
+	p.batcherLock.Lock()
+	defer p.batcherLock.Unlock()
 
-	p.checkpointerLock.Lock()
-	pauseFetch = p.checkpointer.Pending() >= int64(limit)
-	p.checkpointerLock.Unlock()
-	return
+	if p.batcher.Add(m.msg) {
+		// Batch triggered, we flush it here synchronously.
+		sendBatch, _ := p.batcher.Flush(ctx)
+		return sendBatch
+	}
+	// Otherwise store the latest record as the representative of the pending
+	// batch offset. This will be used by the timer based flushing mechanism
+	// within loop() if applicable.
+	p.topBatchRecord = m.r
+	return nil
 }
 
 func (p *partitionTracker) pauseFetch(limit int) (pauseFetch bool) {
@@ -428,8 +421,18 @@ func (c *checkpointTracker) close() {
 }
 
 func (c *checkpointTracker) addRecord(ctx context.Context, m *msgWithRecord, limit int) (pauseFetch bool) {
+	// We hold c.mut only for the map bookkeeping and the non-blocking batcher
+	// work (stage), then release it before dispatching the batch.
+	//
+	// Dispatching blocks on the (unbuffered) output channel whenever the
+	// pipeline is backpressured. OnPartitionsRevoked/OnPartitionsLost ->
+	// removeTopicPartitions also needs c.mut, so holding it across the dispatch
+	// would let a backpressured output block a rebalance indefinitely. That
+	// wedges franz-go's heartbeat/rejoin loop (it spins waiting for the revoke
+	// callback to return) with the client still alive — a state only a full
+	// connector restart recovers from. Staging under the lock and dispatching
+	// without it keeps revokes responsive.
 	c.mut.Lock()
-	defer c.mut.Unlock()
 
 	topicTracker := c.topics[m.r.Topic]
 	if topicTracker == nil {
@@ -451,7 +454,18 @@ func (c *checkpointTracker) addRecord(ctx context.Context, m *msgWithRecord, lim
 		topicTracker[m.r.Partition] = partTracker
 	}
 
-	return partTracker.add(ctx, m, limit)
+	sendBatch := partTracker.stage(ctx, m)
+
+	c.mut.Unlock()
+
+	if len(sendBatch) > 0 {
+		// Ignoring the error here is fine, it implies shut down has been
+		// triggered and we would only acknowledge the message by committing it
+		// if it were successfully delivered.
+		_ = partTracker.sendBatch(ctx, sendBatch, m.r)
+	}
+
+	return partTracker.pauseFetch(limit)
 }
 
 func (c *checkpointTracker) pauseFetch(topic string, partition int32, limit int) bool {

--- a/internal/impl/kafka/franz_reader_unordered_test.go
+++ b/internal/impl/kafka/franz_reader_unordered_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -145,6 +146,48 @@ func TestUnorderedReassignedPartitionUsesFreshTracker(t *testing.T) {
 	oldBatch.onAck()
 	assert.Equal(t, []int64{100}, rec.offsetsFor("t", 0), "stale ack from revoked tracker must not commit")
 	assert.NotContains(t, rec.offsetsFor("t", 0), int64(5), "old offset 5 must never be committed")
+}
+
+// TestUnorderedRevokeNotBlockedByBackpressuredSend is a regression test for a
+// deadlock: addRecord used to hold the checkpointTracker lock across the
+// dispatch of a batch, which blocks on the (unbuffered) output channel whenever
+// the pipeline is backpressured. A concurrent revoke (removeTopicPartitions,
+// invoked from franz-go's OnPartitionsRevoked/OnPartitionsLost) needs the same
+// lock, so a stalled output blocked the revoke indefinitely — wedging franz-go's
+// heartbeat/rejoin loop with the client still alive, recoverable only by a full
+// connector restart.
+//
+// The unbuffered channel that nothing drains models the stalled downstream. The
+// revoke must still complete promptly.
+func TestUnorderedRevokeNotBlockedByBackpressuredSend(t *testing.T) {
+	rec := newCommitRecorder()
+	batchChan := make(chan batchWithAckFn) // unbuffered: models a stalled output
+	ct := newCheckpointTracker(service.MockResources(), batchChan, rec.commitFunc, service.BatchPolicy{})
+
+	const limit = 1024
+
+	// Dispatch a record whose send blocks because nothing drains batchChan. The
+	// partition's tracker is registered (under the lock) before the send begins.
+	// The cancelable context lets the parked goroutine exit at the end of the
+	// test.
+	sendCtx, cancelSend := context.WithCancel(context.Background())
+	defer cancelSend()
+	go ct.addRecord(sendCtx, unorderedRecord("t", 0, 0), limit)
+
+	// Let the dispatch reach its blocking channel send.
+	time.Sleep(100 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		ct.removeTopicPartitions(context.Background(), map[string][]int32{"t": {0}})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("removeTopicPartitions deadlocked behind a backpressured send")
+	}
 }
 
 // TestUnorderedRevokeRaceNoCommitLeak exercises concurrent acks racing against a


### PR DESCRIPTION
## Problem

The unordered franz reader (`kafka_franz` and `ockam` inputs) can wedge a consumer group such that **only restarting the connector clears it — an upstream/proxy restart does not**.

`checkpointTracker.addRecord` holds `c.mut` across the batch dispatch, and dispatch blocks on the **unbuffered** output channel whenever the pipeline output is backpressured. `removeTopicPartitions` — invoked from franz-go's `OnPartitionsRevoked` / `OnPartitionsLost` — needs the same `c.mut`. So a stalled output blocks the revoke callback indefinitely, which makes franz-go's heartbeat loop spin waiting for the revoke to return and prevents `manage()` from rejoining. The `kgo.Client` stays alive but makes no progress, so nothing short of recreating the client (a full connector restart) recovers.

This showed up in production as a consumer that timed out on `JoinGroup` and only recovered after a connector restart, where restarting the upstream proxy had no effect.

## Fix

Split the work: `stage` performs the non-blocking batcher step under `c.mut`; the blocking dispatch (`sendBatch`) now runs **after** the lock is released. `c.mut` therefore only ever covers map bookkeeping + the non-blocking batcher, never a channel send, so a concurrent revoke can always take the lock and return promptly. The existing `revoked` flag still gates any late ack, so no offset can leak past a revoke, and the batcher stays under the lock as before (no new batcher-vs-close race).

Only the **unordered** reader is affected; the ordered readers (`redpanda`, `redpanda_migrator`, `redpanda_common`) already have a bounded, non-blocking revoke path.

## Test

Added `TestUnorderedRevokeNotBlockedByBackpressuredSend`, which uses an **unbuffered** output channel to model a stalled downstream (the existing tests all use buffered channels, which is why this was never caught) and asserts a revoke completes within 10s.

- Without the fix: `FAIL ... removeTopicPartitions deadlocked behind a backpressured send (10.10s)`
- With the fix: passes; full unordered suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)