### PR TITLE
fix(gcp_cloud_storage): promote Credentials out of the Metadata section

### DIFF
--- a/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
+++ b/docs/modules/components/pages/inputs/gcp_cloud_storage.adoc
@@ -83,7 +83,7 @@ This input adds the following metadata fields to each message:
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].
 
-=== Credentials
+== Credentials
 
 By default Redpanda Connect will use a shared credentials file when connecting to GCP services. You can find out more in xref:guides:cloud/gcp.adoc[].
 

--- a/internal/impl/gcp/input_cloud_storage.go
+++ b/internal/impl/gcp/input_cloud_storage.go
@@ -88,7 +88,7 @@ This input adds the following metadata fields to each message:
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].
 
-=== Credentials
+== Credentials
 
 By default Redpanda Connect will use a shared credentials file when connecting to GCP services. You can find out more in xref:guides:cloud/gcp.adoc[].`).
 		Fields(


### PR DESCRIPTION
## Problem

The `gcp_cloud_storage` input's `Description()` nests **`=== Credentials`** (GCP auth guidance) as a **level-3 subsection under `== Metadata`**. It isn't metadata.

The Redpanda Connect docs tooling extracts the `== Metadata` section verbatim into a regenerated metadata reference partial, and because a level-3 heading doesn't terminate the section, the Credentials note is swept into the generated metadata docs. See the analysis in redpanda-data/rp-connect-docs#459.

## Fix

Promote `=== Credentials` to a sibling **`== Credentials`** section — matching how other components document credentials — so it terminates the Metadata block and no longer leaks into the metadata partial. Regenerated `docs/` page updated to match (heading level only).

## Related

The other offender (`csv` input's `=== Output CSV column order`) lives in `redpanda-data/benthos` and is fixed in redpanda-data/benthos#462. A legitimate use of `===` under Metadata (grouping metadata fields by operation, e.g. the `nats_kv` processor) is intentionally left as-is.