### PR TITLE
kafka: share one Redpanda container across integration tests

### DIFF
--- a/internal/impl/kafka/integration_cache_test.go
+++ b/internal/impl/kafka/integration_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import (
 func TestIntegrationCache(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil
@@ -112,7 +112,7 @@ func TestIntegrationCache(t *testing.T) {
 func TestIntegrationCacheStandardized(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil

--- a/internal/impl/kafka/integration_connectivity_test.go
+++ b/internal/impl/kafka/integration_connectivity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import (
 func TestRedpandaConnectionTestIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, _ := startRedpanda(t)
+	brokerAddr, _ := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testtopic", 1) == nil
@@ -250,7 +250,7 @@ redpanda:
 func TestRedpandaConnectionTestPrematureConnectIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, _ := startRedpanda(t)
+	brokerAddr, _ := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testtopic", 1) == nil

--- a/internal/impl/kafka/integration_sarama_test.go
+++ b/internal/impl/kafka/integration_sarama_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import (
 func TestIntegrationSaramaCheckpointOneLockUp(t *testing.T) {
 	integration.CheckSkipExact(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "wcotesttopic", 20) == nil
 	}, time.Minute, time.Second)
@@ -161,7 +161,7 @@ kafka:
 func TestIntegrationSaramaRedpanda(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "pls_ignore_just_testing_connection", 1) == nil
@@ -379,7 +379,7 @@ input:
 func TestIntegrationSaramaOutputFixedTimestamp(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil

--- a/internal/impl/kafka/integration_test.go
+++ b/internal/impl/kafka/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,7 +94,13 @@ func doCreateKafkaTopic(ctx context.Context, address, topicName string, partitio
 	if len(res.Topics) != 1 {
 		return fmt.Errorf("expected one topic in response, saw %d", len(res.Topics))
 	}
-	return kerr.ErrorForCode(res.Topics[0].ErrorCode)
+	// Tolerate a pre-existing topic: tests now share a single package-wide
+	// Redpanda container (see sharedRedpanda), so a fixed-name topic — e.g. a
+	// readiness probe — may already have been created by an earlier test.
+	if err := kerr.ErrorForCode(res.Topics[0].ErrorCode); err != nil && !errors.Is(err, kerr.TopicAlreadyExists) {
+		return err
+	}
+	return nil
 }
 
 func createKafkaTopicSasl(address, id string, partitions int32) error {
@@ -138,7 +144,7 @@ func createKafkaTopicSasl(address, id string, partitions int32) error {
 func TestRedpandaIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil
@@ -401,7 +407,7 @@ output:
 func TestRedpandaSaslIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil
@@ -440,7 +446,7 @@ input:
 func BenchmarkRedpandaIntegration(b *testing.B) {
 	integration.CheckSkip(b)
 
-	brokerAddr, kafkaPortStr := startRedpanda(b)
+	brokerAddr, kafkaPortStr := sharedRedpanda(b)
 
 	require.Eventually(b, func() bool {
 		return createKafkaTopic(b.Context(), brokerAddr, "testingconnection", 1) == nil

--- a/internal/impl/kafka/integration_unordered_test.go
+++ b/internal/impl/kafka/integration_unordered_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import (
 func TestIntegrationUnordered(t *testing.T) {
 	integration.CheckSkip(t)
 
-	brokerAddr, kafkaPortStr := startRedpanda(t)
+	brokerAddr, kafkaPortStr := sharedRedpanda(t)
 
 	require.Eventually(t, func() bool {
 		return createKafkaTopic(t.Context(), brokerAddr, "testingconnection", 1) == nil
@@ -229,7 +229,7 @@ input:
 func BenchmarkIntegrationUnordered(b *testing.B) {
 	integration.CheckSkip(b)
 
-	brokerAddr, kafkaPortStr := startRedpanda(b)
+	brokerAddr, kafkaPortStr := sharedRedpanda(b)
 
 	require.Eventually(b, func() bool {
 		return createKafkaTopic(b.Context(), brokerAddr, "testingconnection", 1) == nil

--- a/internal/impl/kafka/testcontainers_test.go
+++ b/internal/impl/kafka/testcontainers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,11 @@
 package kafka_test
 
 import (
+	"context"
 	"io"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,22 +28,70 @@ import (
 	tcredpanda "github.com/testcontainers/testcontainers-go/modules/redpanda"
 )
 
-// startRedpanda starts a single-node Redpanda container via the testcontainers
-// redpanda module and returns the broker address (host:port) and just the port.
-func startRedpanda(t testing.TB) (brokerAddr, port string) {
+var (
+	sharedRedpandaOnce sync.Once
+	sharedRedpandaCtr  *tcredpanda.Container
+	sharedRedpandaErr  error
+	sharedBrokerAddr   string
+	sharedBrokerPort   string
+)
+
+// sharedRedpanda returns the broker address (host:port) and port of a single
+// package-wide, single-node Redpanda container, starting it on first use.
+//
+// Sharing one container across the many plain-broker integration tests — rather
+// than starting a fresh container per test — keeps the package comfortably
+// within its `go test -timeout` budget. The benthos stream-test harness derives
+// each test's context timeout from the time remaining until the *package*
+// deadline (stream_test_helpers.go: `time.Until(deadline) - 5s`), so a package
+// full of per-test container starts can starve tests that happen to run late
+// under `-shuffle=on`, producing the uniform ~4s "context deadline exceeded"
+// failures (CON-445) and, at the limit, package-level timeouts (CON-453).
+//
+// The container is terminated in TestMain once all tests finish. Tests that need
+// a differently-configured cluster — SASL (startRedpandaWithSASL), multi-broker
+// (startRedpandaCluster), or a source/destination pair (redpandatest) — still
+// start their own containers.
+//
+// Callers must use unique per-test topic and consumer-group names (the stream
+// harness already does, via its generated $ID); createKafkaTopic tolerates a
+// pre-existing topic so shared-cluster readiness probes remain safe.
+func sharedRedpanda(t testing.TB) (brokerAddr, port string) {
 	t.Helper()
 
-	ctr, err := tcredpanda.Run(t.Context(),
-		"docker.redpanda.com/redpandadata/redpanda:latest",
-	)
-	testcontainers.CleanupContainer(t, ctr)
-	require.NoError(t, err)
+	sharedRedpandaOnce.Do(func() {
+		// context.Background(), not t.Context(): the container outlives the
+		// first test that happens to trigger startup.
+		ctx := context.Background()
+		ctr, err := tcredpanda.Run(ctx,
+			"docker.redpanda.com/redpandadata/redpanda:latest",
+		)
+		if err != nil {
+			sharedRedpandaErr = err
+			return
+		}
+		sharedRedpandaCtr = ctr
 
-	brokerAddr, err = ctr.KafkaSeedBroker(t.Context())
-	require.NoError(t, err)
+		addr, err := ctr.KafkaSeedBroker(ctx)
+		if err != nil {
+			sharedRedpandaErr = err
+			return
+		}
+		sharedBrokerAddr, sharedBrokerPort = brokerAddrPort(addr)
+	})
+	require.NoError(t, sharedRedpandaErr)
 
-	brokerAddr, port = brokerAddrPort(brokerAddr)
-	return brokerAddr, port
+	return sharedBrokerAddr, sharedBrokerPort
+}
+
+// TestMain terminates the shared Redpanda container (if one was started) after
+// the package's tests complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedRedpandaCtr != nil {
+		_ = sharedRedpandaCtr.Terminate(context.Background())
+	}
+	os.Exit(code)
 }
 
 // startRedpandaWithSASL starts a single-node Redpanda container with SASL


### PR DESCRIPTION
### what's going on

The kafka integration tests have been flaky for a while, usually in one of two shapes:

1. a whole group of stream subtests failing together with `context deadline exceeded` a few seconds in, and
2. more rarely, the package timing out entirely and getting killed with no per-test attribution.

From what I can tell these are the same underlying thing rather than two separate bugs. Each test in the package spins up its own Redpanda testcontainer, and the package runs with `-shuffle=on`. The benthos stream-test harness sets each test's context timeout to whatever's left of the *package-level* `go test -timeout` deadline (`time.Until(deadline) - 5s` in `stream_test_helpers.go`), rather than a fixed per-test budget. So once the package has enough container-per-test cases, a test that happens to shuffle late can be left with almost no time — every subtest then trips the same ~4s deadline (hence the suspiciously uniform failure times), and if the budget is fully gone the binary just hits the wall.

### what this does

- Starts a single package-wide Redpanda container once (lazy `sync.Once`, torn down in `TestMain`) and reuses it for the plain-broker tests, instead of one container per test.
- Leaves tests that genuinely need a different cluster shape on their own containers — SASL, the multi-broker cluster test, and the source/destination pairs.
- Makes `createKafkaTopic` tolerant of an already-existing topic, since fixed-name topics (readiness probes and the like) now persist on the shared cluster.

### why I think it's safe

The stream-harness tests already use unique per-run topic/consumer-group names, so they don't collide on a shared cluster. The remaining fixed names are either readiness probes (now idempotent) or a data topic used by a single test in a `-count=1` run, and nothing asserts on a cluster-wide topic listing. Each fixed name also keeps a consistent partition count across its uses, so tolerating already-exists can't hand back the wrong partition count.

### verification

Ran the full package locally (`-tags integration -count=1 -shuffle=on`): it passes in ~1m50s using 5 containers, down from ~13 and from pushing right up against the 10m budget, and the uniform deadline failures don't reproduce. `golangci-lint` is clean.

One thing worth flagging for a possible follow-up: the harness's "remaining-budget" timeout model — and the fact that `StreamTestOptTimeout` seems to get silently overridden whenever `-timeout` is set — is arguably the deeper issue, and it lives upstream in benthos. Happy to raise that separately if folks think it's worth it; this change just takes the pressure off by cutting the container churn. Other integration packages with lots of per-test containers might have the same latent thing.

No rush on review — happy to dig in further or adjust the approach if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
