### PR TITLE
Feature/sql hana write

### DIFF
--- a/docs/modules/components/pages/caches/sql.adoc
+++ b/docs/modules/components/pages/caches/sql.adoc
@@ -124,6 +124,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -171,6 +172,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.

--- a/docs/modules/components/pages/inputs/sql_raw.adoc
+++ b/docs/modules/components/pages/inputs/sql_raw.adoc
@@ -129,6 +129,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -176,6 +177,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.
@@ -219,6 +223,7 @@ The query to execute. The style of placeholder to use depends on the driver, som
 | `snowflake` | Question mark |
 | `trino` | Question mark |
 | `gocosmos` | Colon |
+| `hana` | Question mark |
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/inputs/sql_select.adoc
+++ b/docs/modules/components/pages/inputs/sql_select.adoc
@@ -137,6 +137,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -184,6 +185,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.

--- a/docs/modules/components/pages/outputs/sql_insert.adoc
+++ b/docs/modules/components/pages/outputs/sql_insert.adoc
@@ -70,6 +70,7 @@ output:
     prefix: "" # No default (optional)
     suffix: ON CONFLICT (name) DO NOTHING # No default (optional)
     options: [] # No default (optional)
+    upsert: false
     max_in_flight: 64
     init_files: [] # No default (optional)
     init_statement: | # No default (optional)
@@ -146,6 +147,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -193,6 +195,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.
@@ -304,6 +309,15 @@ options:
   - DELAYED
   - IGNORE
 ```
+
+=== `upsert`
+
+When true and driver is `hana`, emit `UPSERT … WITH PRIMARY KEY` instead of `INSERT INTO`. The table must have a primary key; matching rows are updated rather than inserted, preventing duplicates on retry.
+
+
+*Type*: `bool`
+
+*Default*: `false`
 
 === `max_in_flight`
 

--- a/docs/modules/components/pages/outputs/sql_raw.adoc
+++ b/docs/modules/components/pages/outputs/sql_raw.adoc
@@ -203,6 +203,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -250,6 +251,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.
@@ -293,6 +297,7 @@ The query to execute. The style of placeholder to use depends on the driver, som
 | `snowflake` | Question mark |
 | `trino` | Question mark |
 | `gocosmos` | Colon |
+| `hana` | Question mark |
 
 
 *Type*: `string`
@@ -353,6 +358,7 @@ The query to execute. The style of placeholder to use depends on the driver, som
 | `snowflake` | Question mark |
 | `trino` | Question mark |
 | `gocosmos` | Colon |
+| `hana` | Question mark |
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/sql_insert.adoc
+++ b/docs/modules/components/pages/processors/sql_insert.adoc
@@ -134,6 +134,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -181,6 +182,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.

--- a/docs/modules/components/pages/processors/sql_raw.adoc
+++ b/docs/modules/components/pages/processors/sql_raw.adoc
@@ -176,6 +176,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -223,6 +224,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.
@@ -266,6 +270,7 @@ The query to execute. The style of placeholder to use depends on the driver, som
 | `snowflake` | Question mark |
 | `trino` | Question mark |
 | `gocosmos` | Colon |
+| `hana` | Question mark |
 
 
 *Type*: `string`
@@ -336,6 +341,7 @@ The query to execute. The style of placeholder to use depends on the driver, som
 | `snowflake` | Question mark |
 | `trino` | Question mark |
 | `gocosmos` | Colon |
+| `hana` | Question mark |
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/processors/sql_select.adoc
+++ b/docs/modules/components/pages/processors/sql_select.adoc
@@ -137,6 +137,7 @@ Options:
 , `gocosmos`
 , `spanner`
 , `databricks`
+, `hana`
 .
 
 === `dsn`
@@ -184,6 +185,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 | `databricks` 
 | `token:<access-token>@<server-hostname>:<port>/<http-path>` 
+
+| `hana` 
+| `hdb://[user[:password]@]host[:port][?param1=value1&...]` 
 |===
 
 Please note that the `postgres` and `pgx` drivers enforce SSL by default, you can override this with the parameter `sslmode=disable` if required.

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/SAP/go-hdb v1.16.8
 	github.com/a2aproject/a2a-go v0.3.12
 	github.com/apache/arrow-go/v18 v18.6.0
 	github.com/apache/iceberg-go v0.5.1-0.20260506193454-dfc5851d9367

--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,8 @@ github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/RoaringBitmap/roaring/v2 v2.15.0 h1:gCbixa3UiG7g6WUZNVOfEEg2HTc1vR4OVdMkX8t1ZFc=
 github.com/RoaringBitmap/roaring/v2 v2.15.0/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
+github.com/SAP/go-hdb v1.16.8 h1:izRAvO1spNilhxSlYWTVrEkR6DCB8Jn7/8A0McN9Rhc=
+github.com/SAP/go-hdb v1.16.8/go.mod h1:5WEaZ//t+F8iogKaS49KiZLjDJeZLeaLWHsDaN64Htw=
 github.com/a2aproject/a2a-go v0.3.12 h1:l5Yd0UgZrZyEuiMRlj3ybiqxmqXvVhJ8bTyWB7ZlJ2o=
 github.com/a2aproject/a2a-go v0.3.12/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/internal/impl/saphana/bench/saphana-write/Taskfile.yaml
+++ b/internal/impl/saphana/bench/saphana-write/Taskfile.yaml
@@ -1,0 +1,187 @@
+version: "3"
+
+silent: true
+
+vars:
+  HANA_DSN: '{{.HANA_DSN | default (env "HANA_DSN")}}'
+
+tasks:
+  up:
+    desc: Start Kafka
+    cmds:
+      - docker compose up -d
+      - until docker exec rpcns-hana-write-kafka kafka-broker-api-versions --bootstrap-server localhost:9092 > /dev/null 2>&1; do sleep 2; done
+      - echo "Kafka ready"
+
+  down:
+    desc: Stop and remove containers and volumes
+    cmds:
+      - docker compose down -v --remove-orphans
+
+  bench:build:
+    desc: Build the redpanda-connect and loader binaries
+    cmds:
+      - go build -o /tmp/rpcns-hana-write-bench ../../../../../cmd/redpanda-connect/
+      - go build -o /tmp/rpcns-hana-write-bench-load ./load/
+      - echo "Binaries built"
+
+  bench:setup:
+    desc: Create BENCH_WRITES table in HANA (drop + recreate)
+    cmds:
+      - |
+        if [ -z "$HANA_DSN" ]; then echo "HANA_DSN env var required"; exit 1; fi
+        if [ -z "$HANA_SCHEMA" ]; then echo "HANA_SCHEMA env var required"; exit 1; fi
+        HANA_DSN="$HANA_DSN" HANA_SCHEMA="$HANA_SCHEMA" /tmp/rpcns-hana-write-bench-load -setup
+
+  bench:load:
+    desc: "Produce COUNT messages to Kafka topic (e.g. task bench:load COUNT=100000)"
+    vars:
+      COUNT: '{{.COUNT | default "100000"}}'
+      BATCH: '{{.BATCH | default "1000"}}'
+    cmds:
+      - |
+        docker exec rpcns-hana-write-kafka kafka-topics \
+          --bootstrap-server localhost:9092 \
+          --create --if-not-exists \
+          --topic rpcns-hana-bench-write \
+          --partitions 1 --replication-factor 1 > /dev/null 2>&1 || true
+        /tmp/rpcns-hana-write-bench-load \
+          -count {{.COUNT}} \
+          -batch {{.BATCH}} \
+          -brokers localhost:9092 \
+          -topic rpcns-hana-bench-write
+
+  bench:run:
+    desc: "Run write benchmark — reads from Kafka, inserts to HANA (e.g. task bench:run TOTAL=100000 BATCH_COUNT=1000 MAX_IN_FLIGHT=1)"
+    vars:
+      TOTAL: '{{.TOTAL | default "100000"}}'
+      BATCH_COUNT: '{{.BATCH_COUNT | default "10000"}}'
+      MAX_IN_FLIGHT: '{{.MAX_IN_FLIGHT | default "8"}}'
+      CORES: '{{.CORES | default ""}}'
+      RECREATE_TABLE: '{{.RECREATE_TABLE | default "true"}}'
+    cmds:
+      - |
+        set +e
+        if [ -z "$HANA_DSN" ]; then echo "HANA_DSN env var required"; exit 1; fi
+        if [ -z "$HANA_SCHEMA" ]; then echo "HANA_SCHEMA env var required"; exit 1; fi
+
+        CORES="{{.CORES}}"
+        CORES_LABEL="${CORES:-unbounded}"
+        TOTAL={{.TOTAL}}
+        TOPIC="${KAFKA_TOPIC:-rpcns-hana-bench-write}"
+        GROUP="${KAFKA_CONSUMER_GROUP:-rpcns-hana-write-bench-$(date +%s)}"
+
+        # Gracefully stop previous instance so go-hdb can roll back its HANA transaction.
+        # kill -9 bypasses rollback and leaves row locks on BENCH_WRITES (HANA default
+        # lock timeout is 7200s). The bench:setup DROP TABLE below clears any remaining
+        # locks even if the process is force-killed.
+        pkill -TERM -f "/tmp/rpcns-hana-write-bench run" 2>/dev/null || true
+        for _i in $(seq 1 30); do
+          pkill -0 -f "/tmp/rpcns-hana-write-bench run" 2>/dev/null || break
+          sleep 1
+        done
+        pkill -9 -f "/tmp/rpcns-hana-write-bench run" 2>/dev/null || true
+
+        # DROP + CREATE releases any residual HANA row locks and gives a clean baseline.
+        if [ "{{.RECREATE_TABLE}}" = "true" ]; then
+          HANA_DSN="$HANA_DSN" HANA_SCHEMA="$HANA_SCHEMA" /tmp/rpcns-hana-write-bench-load -setup
+        fi
+
+        printf "batch=%-6s  max_in_flight=%-4s  cores=%s\n" "{{.BATCH_COUNT}}" "{{.MAX_IN_FLIGHT}}" "$CORES_LABEL"
+
+        BENCH_BATCH_COUNT={{.BATCH_COUNT}} BENCH_MAX_IN_FLIGHT={{.MAX_IN_FLIGHT}} \
+          HANA_DSN="$HANA_DSN" HANA_SCHEMA="$HANA_SCHEMA" \
+          KAFKA_TOPIC="$TOPIC" KAFKA_CONSUMER_GROUP="$GROUP" \
+          GOMAXPROCS="$CORES" \
+          REDPANDA_LICENSE="$REDPANDA_LICENSE" REDPANDA_LICENSE_FILEPATH="$REDPANDA_LICENSE_FILEPATH" \
+          /tmp/rpcns-hana-write-bench run ./benchmark_config.yaml > /tmp/rpcns_hana_write_bench.log 2>&1 &
+        RPCN_PID=$!
+
+        START=$(date +%s)
+        printf "%-10s  %-12s  %s\n" "TIME" "KAFKA_LAG" "BENCH_MSG/S" >&2
+
+        # Monitor via Kafka consumer group lag. kafka_franz commits offsets only after
+        # WriteBatch returns nil, so LAG=0 guarantees all rows are committed in HANA.
+        # Rolling-stats "0 for N ticks" is unreliable: WriteBatch can block for many
+        # seconds (serialized via bulkMu × max_in_flight), causing extended 0-rate gaps
+        # mid-run that would trigger a false "done" signal.
+        MAX_WAIT=600
+        ELAPSED=0
+        while kill -0 "$RPCN_PID" 2>/dev/null && [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+          sleep 1
+          ELAPSED=$((ELAPSED + 1))
+
+          LOG_RATE=$(grep "rolling stats" /tmp/rpcns_hana_write_bench.log 2>/dev/null \
+            | tail -1 | grep -o 'msg/sec=[0-9]*' | cut -d= -f2)
+          LOG_RATE=${LOG_RATE:-0}
+
+          CG_RAW=$(docker exec rpcns-hana-write-kafka kafka-consumer-groups \
+            --bootstrap-server localhost:9092 --group "$GROUP" --describe 2>/dev/null)
+          if echo "$CG_RAW" | grep -qF "$TOPIC" 2>/dev/null; then
+            # Return "?" if no numeric LAG yet (uncommitted partition shows "-").
+            LAG=$(echo "$CG_RAW" | awk '
+              NR>1 && $6~/^[0-9]+$/ {sum+=$6; n++}
+              END {if (n>0) print sum; else print "?"}')
+          else
+            LAG="?"
+          fi
+
+          printf "%-10s  %-12s  %s msg/s\n" "$(date +%H:%M:%S)" "$LAG" "$LOG_RATE" >&2
+
+          if [ "${LAG}" = "0" ] 2>/dev/null; then break; fi
+        done
+
+        # SIGTERM: when LAG=0, no WriteBatch in flight → benthos exits in <1s.
+        # 3s grace is generous; SIGKILL cleans up edge cases (crash, long batch).
+        # Avoid kill-0 loop: kill -0 returns 0 for zombie processes, causing a
+        # spurious 30s wait even when the process has already exited cleanly.
+        kill "$RPCN_PID" 2>/dev/null || true
+        sleep 3
+        kill -9 "$RPCN_PID" 2>/dev/null || true
+        # Brief bounded wait; don't block on D-state (zombie reaped when shell exits).
+        for _i in $(seq 1 3); do
+          kill -0 "$RPCN_PID" 2>/dev/null || break
+          sleep 1
+        done
+
+        END=$(date +%s)
+        ELAPSED=$((END - START))
+        AVG=$(awk "BEGIN{printf \"%.0f\",${TOTAL}/($ELAPSED>0?$ELAPSED:1)}")
+        echo "---"
+        printf "batch=%-6s  max_in_flight=%-4s  cores=%s\n" "{{.BATCH_COUNT}}" "{{.MAX_IN_FLIGHT}}" "$CORES_LABEL"
+        echo "Total messages : $TOTAL"
+        echo "Elapsed        : ${ELAPSED}s"
+        echo "Avg throughput : ${AVG} msg/s"
+        echo "RESULT batch={{.BATCH_COUNT}} max_in_flight={{.MAX_IN_FLIGHT}} cores=$CORES_LABEL total=$TOTAL elapsed=${ELAPSED}s avg=$AVG"
+
+  bench:matrix:
+    desc: "Sweep batch_count x max_in_flight (e.g. task bench:matrix TOTAL=100000 OUT=results.txt)"
+    vars:
+      TOTAL: '{{.TOTAL | default "100000"}}'
+      OUT: '{{.OUT | default ""}}'
+    cmds:
+      - |
+        OUT_FILE="{{.OUT}}"
+        HDR=$(printf "%-8s  %-14s  %-12s  %-10s  %s\n" "BATCH" "MAX_IN_FLIGHT" "TOTAL" "ELAPSED" "AVG_MSG_S")
+        echo "$HDR"
+        if [ -n "$OUT_FILE" ]; then
+          printf "# sql_insert hdb write  total={{.TOTAL}}\n" > "$OUT_FILE"
+          echo "$HDR" >> "$OUT_FILE"
+        fi
+        for batch in 1000 5000 10000 50000; do
+          for mif in 1 4 8 16; do
+            OUTPUT=$(task bench:run TOTAL={{.TOTAL}} BATCH_COUNT=$batch MAX_IN_FLIGHT=$mif 2>&1) || true
+            R=$(echo "$OUTPUT" | grep "^RESULT " || true)
+            TOT=$(echo "$R" | grep -o 'total=[^ ]*' | cut -d= -f2 || true); TOT=${TOT:-ERROR}
+            EL=$(echo "$R" | grep -o 'elapsed=[^ ]*' | cut -d= -f2 || true); EL=${EL:-?}
+            AV=$(echo "$R" | grep -o 'avg=[^ ]*' | cut -d= -f2 || true); AV=${AV:-0}
+            ROW=$(printf "%-8s  %-14s  %-12s  %-10s  %s\n" "$batch" "$mif" "$TOT" "$EL" "$AV")
+            echo "$ROW"
+            if [ -n "$OUT_FILE" ]; then echo "$ROW" >> "$OUT_FILE"; fi
+          done
+        done
+
+  logs:
+    desc: Tail the last benchmark run log
+    cmds:
+      - tail -f /tmp/rpcns_hana_write_bench.log

--- a/internal/impl/saphana/bench/saphana-write/benchmark_config.yaml
+++ b/internal/impl/saphana/bench/saphana-write/benchmark_config.yaml
@@ -1,0 +1,43 @@
+input:
+  kafka_franz:
+    seed_brokers:
+      - localhost:9092
+    topics: [ ${KAFKA_TOPIC:rpcns-hana-bench-write} ]
+    consumer_group: ${KAFKA_CONSUMER_GROUP:rpcns-hana-write-bench}
+    start_from_oldest: true
+
+output:
+  processors:
+    - benchmark:
+        interval: 1s
+        count_bytes: true
+  sql_insert:
+    driver: hana
+    dsn: ${HANA_DSN}
+    table: '"${HANA_SCHEMA}"."BENCH_WRITES"'
+    columns: [ MSG_ID, USER_ID, PRODUCT_ID, QUANTITY, PRICE, STATUS, NOTES ]
+    args_mapping: |
+      root = [
+        this.msg_id,
+        this.user_id,
+        this.product_id,
+        this.quantity,
+        this.price,
+        this.status,
+        this.notes
+      ]
+    upsert: true
+    max_in_flight: ${BENCH_MAX_IN_FLIGHT:8}
+    batching:
+      count: ${BENCH_BATCH_COUNT:10000}
+      period: 1s
+
+shutdown_timeout: 10s
+
+logger:
+  level: INFO
+
+metrics:
+  prometheus:
+    add_process_metrics: true
+    add_go_metrics: true

--- a/internal/impl/saphana/bench/saphana-write/docker-compose.yaml
+++ b/internal/impl/saphana/bench/saphana-write/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.7.8
+    container_name: rpcns-hana-write-kafka
+    cpus: 3
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CLUSTER_ID: "RpcnHanaWriteBenchCluster1"
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+
+  console:
+    image: redpandadata/console:latest
+    container_name: rpcns-hana-write-console
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_BROKERS: kafka:29092
+    depends_on:
+      kafka:
+        condition: service_healthy

--- a/internal/impl/saphana/bench/saphana-write/load/main.go
+++ b/internal/impl/saphana/bench/saphana-write/load/main.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"time"
+
+	_ "github.com/SAP/go-hdb/driver"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type orderMsg struct {
+	MsgID     int     `json:"msg_id"`
+	UserID    int     `json:"user_id"`
+	ProductID int     `json:"product_id"`
+	Quantity  int     `json:"quantity"`
+	Price     float64 `json:"price"`
+	Status    string  `json:"status"`
+	Notes     string  `json:"notes"`
+}
+
+func main() {
+	setupOnly := flag.Bool("setup", false, "create BENCH_WRITES table in HANA and exit")
+	count := flag.Int("count", 100000, "number of messages to produce to Kafka")
+	batchSize := flag.Int("batch", 1000, "Kafka produce batch size")
+	brokers := flag.String("brokers", "localhost:9092", "Kafka bootstrap brokers (comma-separated)")
+	topic := flag.String("topic", "rpcns-hana-bench-write", "Kafka topic to produce to")
+	flag.Parse()
+
+	if *setupOnly {
+		dsn := requireEnv("HANA_DSN")
+		schema := requireEnv("HANA_SCHEMA")
+		setupTable(dsn, schema)
+		return
+	}
+
+	produceToKafka(*topic, *brokers, *count, *batchSize)
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "%s environment variable is required\n", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func tableRef(schema string) string {
+	return fmt.Sprintf(`"%s"."BENCH_WRITES"`, schema)
+}
+
+func setupTable(dsn, schema string) {
+	ctx := context.Background()
+	db, err := sql.Open("hdb", dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open db: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "ping: %v\n", err)
+		os.Exit(1)
+	}
+
+	ref := tableRef(schema)
+	_, _ = db.ExecContext(ctx, `DROP TABLE `+ref)
+	createSQL := `CREATE COLUMN TABLE ` + ref + ` (` +
+		`MSG_ID INTEGER PRIMARY KEY,` +
+		`USER_ID INTEGER,` +
+		`PRODUCT_ID INTEGER,` +
+		`QUANTITY INTEGER,` +
+		`PRICE DOUBLE,` +
+		`STATUS NVARCHAR(20),` +
+		`NOTES NVARCHAR(200)` +
+		`)`
+	if _, err := db.ExecContext(ctx, createSQL); err != nil {
+		fmt.Fprintf(os.Stderr, "create table: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Table %s created\n", ref)
+}
+
+func produceToKafka(topic, brokers string, count, batchSize int) {
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(brokers),
+		kgo.DefaultProduceTopic(topic),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "kafka client: %v\n", err)
+		os.Exit(1)
+	}
+	defer cl.Close()
+
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	statuses := []string{"pending", "confirmed", "shipped"}
+
+	var produced atomic.Int64
+	start := time.Now()
+
+	stopProg := make(chan struct{})
+	go func() {
+		prev := int64(0)
+		prevT := start
+		for {
+			select {
+			case <-stopProg:
+				return
+			case <-time.After(500 * time.Millisecond):
+				now := time.Now()
+				cur := produced.Load()
+				rate := float64(cur-prev) / now.Sub(prevT).Seconds()
+				fmt.Printf("\r%d / %d  (%.0f msg/s)", cur, count, rate)
+				prev = cur
+				prevT = now
+			}
+		}
+	}()
+
+	records := make([]*kgo.Record, 0, batchSize)
+	for i := 0; i < count; i++ {
+		msg := orderMsg{
+			MsgID:     i + 1,
+			UserID:    rng.Intn(100000) + 1,
+			ProductID: rng.Intn(10000) + 1,
+			Quantity:  rng.Intn(10) + 1,
+			Price:     1.0 + rng.Float64()*999.0,
+			Status:    statuses[rng.Intn(3)],
+			Notes:     fmt.Sprintf("note_%d note_%d", i+1, i+1),
+		}
+		b, _ := json.Marshal(msg)
+		records = append(records, &kgo.Record{Value: b})
+
+		if len(records) >= batchSize {
+			if err := cl.ProduceSync(ctx, records...).FirstErr(); err != nil {
+				fmt.Fprintf(os.Stderr, "\nproduce: %v\n", err)
+				os.Exit(1)
+			}
+			produced.Add(int64(len(records)))
+			records = records[:0]
+		}
+	}
+	if len(records) > 0 {
+		if err := cl.ProduceSync(ctx, records...).FirstErr(); err != nil {
+			fmt.Fprintf(os.Stderr, "\nproduce: %v\n", err)
+			os.Exit(1)
+		}
+		produced.Add(int64(len(records)))
+	}
+
+	close(stopProg)
+	elapsed := time.Since(start)
+	total := int(produced.Load())
+	fmt.Printf("\r%d / %d  (done)                    \n", total, count)
+	fmt.Printf("Produced %d messages in %s (%.0f msg/s)\n", total, elapsed.Round(time.Millisecond), float64(total)/elapsed.Seconds())
+}

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -27,7 +27,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-var driverField = service.NewStringEnumField("driver", "mysql", "postgres", "pgx", "clickhouse", "mssql", "sqlite", "oracle", "snowflake", "trino", "gocosmos", "spanner", "databricks").
+var driverField = service.NewStringEnumField("driver", "mysql", "postgres", "pgx", "clickhouse", "mssql", "sqlite", "oracle", "snowflake", "trino", "gocosmos", "spanner", "databricks", "hana").
 	Description("A database <<drivers, driver>> to use.")
 
 var dsnField = service.NewStringField("dsn").
@@ -74,6 +74,9 @@ The following is a list of supported drivers, their placeholder style, and their
 
 ` + "| `databricks` " + `
 ` + "| `token:<access-token>@<server-hostname>:<port>/<http-path>` " + `
+
+` + "| `hana` " + `
+` + "| `hdb://[user[:password]@]host[:port][?param1=value1&...]` " + `
 |===
 
 Please note that the ` + "`postgres`" + ` and ` + "`pgx`" + ` drivers enforce SSL by default, you can override this with the parameter ` + "`sslmode=disable`" + ` if required.
@@ -167,6 +170,7 @@ func rawQueryField() *service.ConfigField {
 ` + "| `snowflake` | Question mark |" + `
 ` + "| `trino` | Question mark |" + `
 ` + "| `gocosmos` | Colon |" + `
+` + "| `hana` | Question mark |" + `
 `)
 }
 
@@ -307,6 +311,9 @@ func sqlOpenWithReworks(logger *service.Logger, driver, dsn string) (*sql.DB, er
 
 		logger.Warnf("Detected old-style Clickhouse Data Source Name: '%v', replacing with new style: '%v'", dsn, newDSN)
 		dsn = newDSN
+	}
+	if driver == "hana" {
+		driver = "hdb"
 	}
 	return sql.Open(driver, dsn)
 }

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/Masterminds/squirrel"
+	hdbdriver "github.com/SAP/go-hdb/driver"
 
 	"github.com/Jeffail/shutdown"
 
@@ -60,6 +63,10 @@ func sqlInsertOutputConfig() *service.ConfigSpec {
 			Optional().
 			Advanced().
 			Example([]string{"DELAYED", "IGNORE"})).
+		Field(service.NewBoolField("upsert").
+			Description("When true and driver is `hana`, emit `UPSERT … WITH PRIMARY KEY` instead of `INSERT INTO`. The table must have a primary key; matching rows are updated rather than inserted, preventing duplicates on retry.").
+			Default(false).
+			Advanced()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of inserts to run in parallel.").
 			Default(64))
@@ -118,6 +125,7 @@ type sqlInsertOutput struct {
 	dbMut   sync.RWMutex
 
 	useTxStmt     bool
+	hana          *hanaWriter // non-nil when driver == "hana"
 	argsMapping   *bloblang.Executor
 	argsConverter argsConverter
 
@@ -213,6 +221,14 @@ func newSQLInsertOutputFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 		s.builder = s.builder.Options(options...)
 	}
 
+	if s.driver == "hana" {
+		upsert, err := conf.FieldBool("upsert")
+		if err != nil {
+			return nil, err
+		}
+		s.hana = newHANAWriter(tableStr, columns, upsert)
+	}
+
 	if s.connSettings, err = connSettingsFromParsed(conf, mgr); err != nil {
 		return nil, err
 	}
@@ -228,8 +244,14 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 	}
 
 	var err error
-	if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
-		return err
+	if s.hana != nil {
+		if s.db, err = openHANADB(s.dsn); err != nil {
+			return err
+		}
+	} else {
+		if s.db, err = sqlOpenWithReworks(s.logger, s.driver, s.dsn); err != nil {
+			return err
+		}
 	}
 
 	s.connSettings.apply(ctx, s.db, s.logger)
@@ -260,6 +282,10 @@ func (s *sqlInsertOutput) Connect(ctx context.Context) error {
 func (s *sqlInsertOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
 	s.dbMut.RLock()
 	defer s.dbMut.RUnlock()
+
+	if s.hana != nil {
+		return s.hana.writeBatch(ctx, s.db, batch, s.argsMapping)
+	}
 
 	insertBuilder := s.builder
 
@@ -335,4 +361,111 @@ func (s *sqlInsertOutput) Close(ctx context.Context) error {
 		return ctx.Err()
 	}
 	return nil
+}
+
+//------------------------------------------------------------------------------
+// SAP HANA bulk insert/upsert support.
+//
+// go-hdb (github.com/SAP/go-hdb) is used directly instead of the generic
+// sql.Open path because HANA's MT_EXECUTE bulk protocol needs driver-specific
+// connector options (BulkSize) that database/sql's generic interface can't
+// express. Only active when driver == "hana"; every other driver above is
+// unaffected.
+//------------------------------------------------------------------------------
+
+// hanaWriter holds state for go-hdb bulk-insert/upsert operations.
+// It is only created when driver == "hana".
+type hanaWriter struct {
+	execSQL string
+	mu      sync.Mutex
+}
+
+func newHANAWriter(table string, columns []string, upsert bool) *hanaWriter {
+	phs := make([]string, len(columns))
+	for i := range phs {
+		phs[i] = "?"
+	}
+	colList := strings.Join(columns, ", ")
+	phList := strings.Join(phs, ", ")
+	var execSQL string
+	if upsert {
+		execSQL = "UPSERT " + table + " (" + colList + ") VALUES (" + phList + ") WITH PRIMARY KEY"
+	} else {
+		execSQL = "INSERT INTO " + table + " (" + colList + ") VALUES (" + phList + ")"
+	}
+	return &hanaWriter{execSQL: execSQL}
+}
+
+// openHANADB opens a go-hdb connection tuned for bulk insert.
+//
+// We bypass sql.Open and use a DSN connector directly so we can set BulkSize
+// (guarantees one MT_EXECUTE per WriteBatch call) and restore the TCP timeout
+// that NewDSNConnector zeros when the DSN has no timeout= parameter.
+// MaxIdleConns=0 closes the connection after each batch, avoiding HANA
+// server-side post-commit state that can block the next MT_EXECUTE.
+func openHANADB(dsn string) (*sql.DB, error) {
+	ctr, err := hdbdriver.NewDSNConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	ctr.SetTimeout(30 * time.Second)
+	ctr.SetBulkSize(100_000)
+	db := sql.OpenDB(ctr)
+	db.SetMaxIdleConns(0)
+	return db, nil
+}
+
+// writeBatch performs a go-hdb bulk insert/upsert for one benthos batch.
+//
+// mu serialises concurrent calls: concurrent MT_EXECUTE to the same table
+// causes HANA row-level lock contention. (*sql.Conn).ExecContext is used
+// instead of (*sql.DB).ExecContext to avoid the DB-level retry loop that
+// re-invokes the callback with idx already exhausted, silently writing 0 rows.
+func (h *hanaWriter) writeBatch(ctx context.Context, db *sql.DB, batch service.MessageBatch, argsMapping *bloblang.Executor) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var argsExec *service.MessageBatchBloblangExecutor
+	if argsMapping != nil {
+		argsExec = batch.BloblangExecutor(argsMapping)
+	}
+	batchArgs := make([][]any, 0, len(batch))
+	for i := range batch {
+		if argsExec == nil {
+			break
+		}
+		resMsg, err := argsExec.Query(i)
+		if err != nil {
+			return err
+		}
+		iargs, err := resMsg.AsStructured()
+		if err != nil {
+			return err
+		}
+		args, ok := iargs.([]any)
+		if !ok {
+			return fmt.Errorf("mapping returned non-array result: %T", iargs)
+		}
+		batchArgs = append(batchArgs, args)
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	conn, err := db.Conn(execCtx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	idx := 0
+	_, err = conn.ExecContext(execCtx, h.execSQL, func(args []any) error {
+		if idx >= len(batchArgs) {
+			return hdbdriver.ErrEndOfRows
+		}
+		copy(args, batchArgs[idx])
+		idx++
+		return nil
+	})
+	return err
 }

--- a/internal/plugins/info.csv
+++ b/internal/plugins/info.csv
@@ -278,6 +278,7 @@ sql                       ,output    ,SQL                       ,community  ,y  
 sql                       ,processor ,SQL                       ,community  ,y          ,n     ,n              ,use cloud-specific SQL connectors
 sql_driver_clickhouse     ,sql_driver,ClickHouse                ,community  ,n          ,y     ,y              ,
 sql_driver_gocosmos       ,sql_driver,Azure Cosmos DB           ,community  ,n          ,n     ,n              ,not yet certified for cloud
+sql_driver_hana           ,sql_driver,SAP HANA                  ,community  ,n          ,n     ,n              ,not yet certified for cloud
 sql_driver_mssql          ,sql_driver,Microsoft SQL Server      ,community  ,n          ,n     ,n              ,not yet certified for cloud
 sql_driver_mysql          ,sql_driver,MYSQL                     ,certified  ,n          ,y     ,y              ,
 sql_driver_oracle         ,sql_driver,Oracle                    ,certified  ,n          ,y     ,y              ,

--- a/public/components/sql/package.go
+++ b/public/components/sql/package.go
@@ -24,6 +24,7 @@ import (
 
 	// Import all (supported) sql drivers.
 	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/SAP/go-hdb/driver"
 	_ "github.com/databricks/databricks-sql-go"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/googleapis/go-sql-spanner"


### PR DESCRIPTION
  Adds hana as a supported driver for sql_insert (output/processor), backed by github.com/SAP/go-hdb.

  - New hana entry in driverField enum (conn_fields.go), DSN format hdb://[user[:password]@]host[:port][?param1=value1&...], question-mark placeholder
  style.
  - sqlOpenWithReworks maps hana → underlying hdb driver name for database/sql.
  - New upsert bool field on sql_insert: when true (and driver is hana), emits UPSERT … WITH PRIMARY KEY instead of INSERT INTO — requires a primary key on
  the table, updates matching rows instead of inserting, avoids duplicates on retry.
  - New hanaWriter (output_sql_insert.go) implementing go-hdb bulk insert/upsert batching, active only when driver == "hana"; all other drivers unaffected.
  - Registered in public/components/sql/package.go (driver import) and internal/plugins/info.csv (sql_driver_hana, community, not yet certified for cloud).
  - Docs regenerated for sql_insert/sql_raw/sql_select (input/output/processor/cache) reflecting the new driver and upsert field.
  - Added go-hdb to go.mod/go.sum.
  - Added benchmarking harness (internal/impl/saphana/bench/saphana-write/): Taskfile, docker-compose (local Kafka), benchmark_config.yaml (Kafka →
  sql_insert upsert into HANA), and a Kafka load generator (load/main.go) for throughput testing against a real HANA instance.