### PR TITLE
oracledb_cdc: improve ability to debug logminer query performance.

### DIFF
--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -1127,7 +1127,11 @@ func (lm *LogMiner) prepareLogsAndStartSession(ctx context.Context, conn *sql.Co
 	if err != nil {
 		return fmt.Errorf("collecting redo logs for logminer: %w", err)
 	}
-	lm.log.Debugf("Collected %d redo log file(s) for LogMiner", len(logFiles))
+	types := make([]string, len(logFiles))
+	for i, f := range logFiles {
+		types[i] = f.Type
+	}
+	lm.log.Debugf("Collected %d redo log file(s) for LogMiner: %v", len(logFiles), types)
 
 	if lm.sessionMgr.logFilesChanged(logFiles) {
 		// Log files have changed (first start or log switch) — full reload required.

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -28,7 +28,7 @@ import (
 var (
 	// captures the time between DB commit and publish
 	publishLatencyMetric = "oracledb_cdc_publish_lag_ns"
-	// captures the time from query execution to the first row being returned by LogMiner
+	// captures the time from query execution to zero or more rows being returned by LogMiner
 	timeToFirstRowMetric = "oracledb_cdc_logminer_time_to_first_row_ns"
 	// https://docs.oracle.com/en/error-help/db/ora-01291/
 	errCodeMissingLogFile = 1291
@@ -926,7 +926,9 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 	)
 	for rows.Next() {
 		if firstRow {
-			lm.timeToFirstRowMetric.Timing(time.Since(queryStart).Nanoseconds())
+			elapsed := time.Since(queryStart)
+			lm.timeToFirstRowMetric.Timing(elapsed.Nanoseconds())
+			lm.log.Debugf("LogMiner query returned first row after %s (scn=%d to %d)", elapsed, startSCN, endSCN)
 			firstRow = false
 		}
 		event := &sqlredo.RedoEvent{}
@@ -981,6 +983,13 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 
 	if err := rows.Err(); err != nil {
 		return err
+	}
+
+	// capture timings if 0 rows
+	if firstRow {
+		elapsed := time.Since(queryStart)
+		lm.timeToFirstRowMetric.Timing(elapsed.Nanoseconds())
+		lm.log.Debugf("LogMiner query returned no rows after %s (scn=%d to %d)", elapsed, startSCN, endSCN)
 	}
 
 	// Flush any incomplete pending event (shouldn't happen in practice).

--- a/internal/impl/oracledb/logminer/session.go
+++ b/internal/impl/oracledb/logminer/session.go
@@ -76,7 +76,7 @@ func (sm *SessionManager) AddLogFile(ctx context.Context, conn *sql.Conn, files 
 			return fmt.Errorf("adding logminer log file '%s' with option '%s': %w", f.FileName, opt, err)
 		}
 
-		sm.log.Debugf("Loaded redo log file '%s' into LogMiner", f.FileName)
+		sm.log.Debugf("Loaded %s redo log file '%s' into LogMiner", f.Type, f.FileName)
 	}
 
 	sm.loadedFiles = files


### PR DESCRIPTION
Because LogMiner depends on redo logs to be configured appropriately on the server, these new debug log lines should help us and customers with diagnosing query performance and Oracle configuration options.

This change also adds the log type to the redo log loading debug logs, which can help identify if the connector is loading an online redo log versus an archived one. Online logs can often have contention as they're being actively written do.