### PR TITLE
postgres_cdc: Add signal detection

### DIFF
--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -99,6 +99,7 @@ input:
       role: "" # No default (optional)
       role_external_id: "" # No default (optional)
       roles: [] # No default (optional)
+    signal_table_name: ""
     auto_replay_nacks: true
     batching:
       count: 0
@@ -562,6 +563,59 @@ Optional external ID for the role assumption.
 *Type*: `string`
 
 *Default*: `""`
+
+=== `signal_table_name`
+
+The name of the table used to send control signals to the connector, excluding the schema. The table must
+exist in the schema configured via the `schema` field and must have exactly these columns:
+
+- **id** — any type representable as a string (e.g. `SERIAL`, `BIGSERIAL`, `UUID`, `VARCHAR`)
+- **type** — `VARCHAR` — the signal type (see supported signals below)
+- **data** — `TEXT` — a JSON object containing signal parameters
+
+Create the table with:
+
+```sql
+CREATE TABLE <schema>.<signal_table_name> (
+    id   SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
+```
+
+Signal rows are published as regular output messages (`operation=insert`, `table=<signal_table_name>`).
+To exclude them from downstream processing, filter on the `table` metadata field using a
+`mapping` processor:
+
+```yaml
+pipeline:
+  processors:
+    - mapping: |
+        root = if @table == "rpcn_signal_table" { deleted() } else { this }
+```
+
+**Supported signals**
+
+**`trigger-snapshot`** — recognized and logged when received. The `data` column must contain
+a JSON object with a `dataset` key listing the fully-qualified tables (`schema.table`) intended
+for a future re-snapshot. Acting on this signal is not yet implemented; receiving one currently has no
+effect on streaming beyond a log line.
+
+```sql
+INSERT INTO dbo.rpcn_signal_table (type, data)
+VALUES ('trigger-snapshot', '{"dataset": ["dbo.events", "dbo.products"]}');
+```
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+signal_table_name: rpcn_signal_table
+```
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -596,14 +596,11 @@ pipeline:
 
 **Supported signals**
 
-**`trigger-snapshot`** — recognized and logged when received. The `data` column must contain
-a JSON object with a `dataset` key listing the fully-qualified tables (`schema.table`) intended
-for a future re-snapshot. Acting on this signal is not yet implemented; receiving one currently has no
-effect on streaming beyond a log line.
+**`log`** — recognized and logged when received. The `data` column must contain
+a JSON object with a `message` key, whose value is written to the connector's log output.
 
 ```sql
-INSERT INTO dbo.rpcn_signal_table (type, data)
-VALUES ('trigger-snapshot', '{"dataset": ["dbo.events", "dbo.products"]}');
+INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');
 ```
 
 

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -567,7 +567,9 @@ Optional external ID for the role assumption.
 === `signal_table_name`
 
 The name of the table used to send control signals to the connector, excluding the schema. The table must
-exist in the schema configured via the `schema` field and must have exactly these columns:
+exist in the schema configured via the `schema` field, and must not also appear in `tables`
+- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have exactly these columns:
 
 - **id** — any type representable as a string (e.g. `SERIAL`, `BIGSERIAL`, `UUID`, `VARCHAR`)
 - **type** — `VARCHAR` — the signal type (see supported signals below)

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -600,7 +600,7 @@ pipeline:
 a JSON object with a `message` key, whose value is written to the connector's log output.
 
 ```sql
-INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');
+INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message": "Signal message"}');
 ```
 
 

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -64,6 +64,11 @@ tasks:
     cmds:
       - psql {{.PG_DSN}} -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
 
+  psql:create:signal-table:
+    desc: Create rpcn_signal_table in the public schema used for control signalling
+    cmds:
+      - psql {{.PG_DSN}} -c "CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT);"
+
   # ── CDC / Snapshot benchmarks ────────────────────────────────────────────────
 
   bench:run:

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -69,6 +69,13 @@ tasks:
     cmds:
       - psql {{.PG_DSN}} -c "CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT);"
 
+  psql:signal:log:
+    desc: Insert a log signal into public.rpcn_signal_table to trigger a log entry
+    deps: [psql:create:signal-table]
+    cmds:
+      - |
+        psql {{.PG_DSN}} -c "INSERT INTO public.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');"
+
   # ── CDC / Snapshot benchmarks ────────────────────────────────────────────────
 
   bench:run:

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -74,7 +74,7 @@ tasks:
     deps: [psql:create:signal-table]
     cmds:
       - |
-        psql {{.PG_DSN}} -c "INSERT INTO public.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');"
+        psql {{.PG_DSN}} -c "INSERT INTO public.rpcn_signal_table (type, data) VALUES ('log', '{\"message\": \"Signal message\"}');"
 
   # ── CDC / Snapshot benchmarks ────────────────────────────────────────────────
 

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -6,13 +6,13 @@ input:
     dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable}
     stream_snapshot: true
     schema: public
+    signal_table_name: ""
     tables:
       - users
       - products
       - cart
     slot_name: bench_slot
     batching:
-      count: 1000
       period: 1s
 
 # pipeline:

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -23,14 +23,14 @@ input:
 #         root.metadata = @
 
 output:
-  # processors:
-  #   - benchmark:
-  #       interval: 1s
-  #       count_bytes: true
-  file:
-    path: "./benchmark_results.json"
-    codec: lines
-  # drop: {}
+  processors:
+    - benchmark:
+        interval: 1s
+        count_bytes: true
+  # file:
+  #   path: "./benchmark_results.json"
+  #   codec: lines
+  drop: {}
 
 logger:
   level: INFO

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -6,13 +6,14 @@ input:
     dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable}
     stream_snapshot: true
     schema: public
-    signal_table_name: ""
+    signal_table_name: rpcn_signal_table
     tables:
       - users
       - products
       - cart
     slot_name: bench_slot
     batching:
+      count: 1000
       period: 1s
 
 # pipeline:
@@ -22,14 +23,14 @@ input:
 #         root.metadata = @
 
 output:
-  processors:
-    - benchmark:
-        interval: 1s
-        count_bytes: true
-  # file:
-  #   path: "./benchmark_results.json"
-  #   codec: lines
-  drop: {}
+  # processors:
+  #   - benchmark:
+  #       interval: 1s
+  #       count_bytes: true
+  file:
+    path: "./benchmark_results.json"
+    codec: lines
+  # drop: {}
 
 logger:
   level: INFO

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -1,4 +1,9 @@
 -- PostgreSQL Benchmark Setup Script
+CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (
+    id SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
 
 CREATE TABLE IF NOT EXISTS public.users (
     id            SERIAL PRIMARY KEY,

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -1,10 +1,4 @@
 -- PostgreSQL Benchmark Setup Script
-CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (
-    id SERIAL PRIMARY KEY,
-    type VARCHAR(32),
-    data TEXT
-);
-
 CREATE TABLE IF NOT EXISTS public.users (
     id            SERIAL PRIMARY KEY,
     name          VARCHAR(100)    NOT NULL,

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -226,14 +226,11 @@ pipeline:
 
 **Supported signals**
 
-**` + "`trigger-snapshot`" + `** — recognized and logged when received. The ` + "`data`" + ` column must contain
-a JSON object with a ` + "`dataset`" + ` key listing the fully-qualified tables (` + "`schema.table`" + `) intended
-for a future re-snapshot. Acting on this signal is not yet implemented; receiving one currently has no
-effect on streaming beyond a log line.
+**` + "`log`" + `** — recognized and logged when received. The ` + "`data`" + ` column must contain
+a JSON object with a ` + "`message`" + ` key, whose value is written to the connector's log output.
 
 ` + "```sql" + `
-INSERT INTO dbo.rpcn_signal_table (type, data)
-VALUES ('trigger-snapshot', '{"dataset": ["dbo.events", "dbo.products"]}');
+INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');
 ` + "```").
 			Example("rpcn_signal_table").
 			Default("").
@@ -570,7 +567,7 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
-				sig, sigErr := p.controlSig.Listen(ctx, msg)
+				_, sigErr := p.controlSig.Listen(ctx, msg)
 				if sigErr != nil {
 					p.logger.Errorf("failed to detect control signal in change event, skipping message: %s", sigErr)
 					continue
@@ -594,11 +591,6 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				}
 				if msg.BeforeData != nil {
 					batchMsg.MetaSetImmut("before", service.ImmutableAny{V: msg.BeforeData})
-				}
-				if sig != nil {
-					// Re-snapshotting on a signal is not yet implemented -
-					// forward it as a regular message and keep streaming.
-					p.logger.Infof("%q control signal received (lsn=%s) targeting %v; re-snapshotting on signal is not yet implemented, continuing to stream", sig.Type, sig.LSN, sig.Dataset)
 				}
 				if batcher.Add(batchMsg) {
 					flush = true

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
@@ -197,7 +198,9 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Optional()).
 		Field(service.NewStringField(fieldSignalTableName).
 			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
-exist in the schema configured via the ` + "`schema`" + ` field and must have exactly these columns:
+exist in the schema configured via the ` + "`schema`" + ` field, and must not also appear in ` + "`" + fieldTables + "`" + `
+- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have exactly these columns:
 
 - **id** — any type representable as a string (e.g. ` + "`SERIAL`" + `, ` + "`BIGSERIAL`" + `, ` + "`UUID`" + `, ` + "`VARCHAR`" + `)
 - **type** — ` + "`VARCHAR`" + ` — the signal type (see supported signals below)
@@ -335,6 +338,22 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 
 	if signalTableName, err = conf.FieldString(fieldSignalTableName); err != nil {
 		return nil, err
+	}
+
+	if signalTableName != "" {
+		normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(signalTableName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", fieldSignalTableName, signalTableName, err)
+		}
+		for _, table := range tables {
+			normalizedTable, err := sanitize.NormalizePostgresIdentifier(table)
+			if err != nil {
+				return nil, fmt.Errorf("invalid table name %q: %w", table, err)
+			}
+			if normalizedTable == normalizedSignalTable {
+				return nil, fmt.Errorf("%s %q must not also appear in %s - the signal table is implicitly added to the publication and excluded from snapshot scans", fieldSignalTableName, signalTableName, fieldTables)
+			}
+		}
 	}
 
 	awsConf := conf.Namespace(fieldAWSIAMAuth)

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -567,9 +567,8 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
-				_, sigErr := p.controlSig.Listen(ctx, msg)
-				if sigErr != nil {
-					p.logger.Errorf("failed to detect control signal in change event, skipping message: %s", sigErr)
+				if _, err := p.controlSig.Listen(ctx, msg); err != nil {
+					p.logger.Errorf("failed to detect control signal in change event, skipping message: %s", err)
 					continue
 				}
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -230,7 +230,7 @@ pipeline:
 a JSON object with a ` + "`message`" + ` key, whose value is written to the connector's log output.
 
 ` + "```sql" + `
-INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}');
+INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message": "Signal message"}');
 ` + "```").
 			Example("rpcn_signal_table").
 			Default("").

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -568,8 +568,8 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 			)
 			for _, msg := range batch {
 				if _, err := p.controlSig.Listen(ctx, msg); err != nil {
-					p.logger.Errorf("failed to detect control signal in change event, skipping message: %s", err)
-					continue
+					// Log it and fall through to the normal emit path below.
+					p.logger.Errorf("failed to detect control signal in change event: %s", err)
 				}
 
 				if mb, err = json.Marshal(msg.Data); err != nil {

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -46,6 +46,7 @@ const (
 	fieldMaxParallelSnapshotTables = "max_parallel_snapshot_tables"
 	fieldUnchangedToastValue       = "unchanged_toast_value"
 	fieldHeartbeatInterval         = "heartbeat_interval"
+	fieldSignalTableName           = "signal_table_name"
 	fieldAWSIAMAuth                = "aws"
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
@@ -194,6 +195,49 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Description("AWS IAM authentication configuration for PostgreSQL instances. When enabled, IAM credentials are used to generate temporary authentication tokens instead of a static password.").
 			Advanced().
 			Optional()).
+		Field(service.NewStringField(fieldSignalTableName).
+			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
+exist in the schema configured via the ` + "`schema`" + ` field and must have exactly these columns:
+
+- **id** — any type representable as a string (e.g. ` + "`SERIAL`" + `, ` + "`BIGSERIAL`" + `, ` + "`UUID`" + `, ` + "`VARCHAR`" + `)
+- **type** — ` + "`VARCHAR`" + ` — the signal type (see supported signals below)
+- **data** — ` + "`TEXT`" + ` — a JSON object containing signal parameters
+
+Create the table with:
+
+` + "```sql" + `
+CREATE TABLE <schema>.<signal_table_name> (
+    id   SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
+` + "```" + `
+
+Signal rows are published as regular output messages (` + "`operation=insert`" + `, ` + "`table=<signal_table_name>`" + `).
+To exclude them from downstream processing, filter on the ` + "`table`" + ` metadata field using a
+` + "`mapping`" + ` processor:
+
+` + "```yaml" + `
+pipeline:
+  processors:
+    - mapping: |
+        root = if @table == "rpcn_signal_table" { deleted() } else { this }
+` + "```" + `
+
+**Supported signals**
+
+**` + "`trigger-snapshot`" + `** — recognized and logged when received. The ` + "`data`" + ` column must contain
+a JSON object with a ` + "`dataset`" + ` key listing the fully-qualified tables (` + "`schema.table`" + `) intended
+for a future re-snapshot. Acting on this signal is not yet implemented; receiving one currently has no
+effect on streaming beyond a log line.
+
+` + "```sql" + `
+INSERT INTO dbo.rpcn_signal_table (type, data)
+VALUES ('trigger-snapshot', '{"dataset": ["dbo.events", "dbo.products"]}');
+` + "```").
+			Example("rpcn_signal_table").
+			Default("").
+			Advanced()).
 		Field(service.NewAutoRetryNacksToggleField()).
 		Field(service.NewBatchPolicyField(fieldBatching))
 }
@@ -217,6 +261,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		heartbeatInterval         time.Duration
 		iamAuthEnabled            bool
 		iamAuthTokenBuilder       TokenBuilder
+		signalTableName           string
 	)
 
 	if err := license.CheckRunningEnterprise(mgr); err != nil {
@@ -291,6 +336,10 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		return nil, err
 	}
 
+	if signalTableName, err = conf.FieldString(fieldSignalTableName); err != nil {
+		return nil, err
+	}
+
 	awsConf := conf.Namespace(fieldAWSIAMAuth)
 	iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
 
@@ -342,6 +391,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 			Logger:                   logger,
 			UnchangedToastValue:      unchangedToastValue,
 			HeartbeatInterval:        heartbeatInterval,
+			SignalTableName:          signalTableName,
 		},
 		batching:        batching,
 		checkpointLimit: checkpointLimit,
@@ -354,6 +404,10 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		stopSig:         shutdown.NewSignaller(),
 
 		iamAuthEnabled: iamAuthEnabled,
+	}
+
+	if i.controlSig, err = NewControlSignaller(schema, signalTableName, logger); err != nil {
+		return nil, err
 	}
 
 	// Has stopped is how we notify that we're not connected. This will get reset at connection time.
@@ -397,6 +451,7 @@ type pgStreamInput struct {
 
 	snapshotMetrics *service.MetricGauge
 	replicationLag  *service.MetricGauge
+	controlSig      *postgresSignaller
 	stopSig         *shutdown.Signaller
 
 	// snapshotAckWG tracks in-flight snapshot batches: incremented when a
@@ -515,6 +570,12 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
+				sig, sigErr := p.controlSig.Listen(ctx, msg)
+				if sigErr != nil {
+					p.logger.Errorf("failed to detect control signal in change event, skipping message: %s", sigErr)
+					continue
+				}
+
 				if mb, err = json.Marshal(msg.Data); err != nil {
 					p.logger.Errorf("failure to marshal message: %s", err)
 					break
@@ -533,6 +594,11 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				}
 				if msg.BeforeData != nil {
 					batchMsg.MetaSetImmut("before", service.ImmutableAny{V: msg.BeforeData})
+				}
+				if sig != nil {
+					// Re-snapshotting on a signal is not yet implemented -
+					// forward it as a regular message and keep streaming.
+					p.logger.Infof("%q control signal received (lsn=%s) targeting %v; re-snapshotting on signal is not yet implemented, continuing to stream", sig.Type, sig.LSN, sig.Dataset)
 				}
 				if batcher.Add(batchMsg) {
 					flush = true

--- a/internal/impl/postgresql/input_pg_stream_test.go
+++ b/internal/impl/postgresql/input_pg_stream_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+func TestNewPgStreamInputSignalTableName(t *testing.T) {
+	env := service.NewEnvironment()
+	spec := newPostgresCDCConfig()
+
+	tests := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			name: "no signal table configured",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+`,
+		},
+		{
+			name: "signal table distinct from tables",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+signal_table_name: rpcn_signal_table
+`,
+		},
+		{
+			name: "signal table also listed in tables",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+  - rpcn_signal_table
+signal_table_name: rpcn_signal_table
+`,
+			errContains: `signal_table_name "rpcn_signal_table" must not also appear in tables`,
+		},
+		{
+			name: "signal table matches tables entry under different case-folding",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+  - RPCN_SIGNAL_TABLE
+signal_table_name: rpcn_signal_table
+`,
+			errContains: `signal_table_name "rpcn_signal_table" must not also appear in tables`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := spec.ParseYAML(test.conf, env)
+			require.NoError(t, err)
+
+			mgr := service.MockResources()
+			license.InjectTestService(mgr)
+
+			_, err = newPgStreamInput(pConf, mgr)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -53,7 +53,19 @@ func GetFakeFlightRecord() FakeFlightRecord {
 	return flightRecord
 }
 
-func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *sql.DB, error) {
+// TestDB wraps sql.DB with testing utilities for database integration tests.
+type TestDB struct {
+	*sql.DB
+	T *testing.T
+}
+
+// MustExec executes a SQL query and fails the test if an error occurs.
+func (db *TestDB) MustExec(query string, args ...any) {
+	_, err := db.Exec(query, args...)
+	require.NoError(db.T, err)
+}
+
+func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *TestDB, error) {
 	ctr, err := testcontainers.Run(t.Context(), "postgres:"+version,
 		testcontainers.WithExposedPorts("5432/tcp"),
 		testcontainers.WithEnv(map[string]string{
@@ -158,7 +170,8 @@ func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *sql.D
 		}
 	})
 
-	return databaseURL, db, nil
+	testDB := &TestDB{db, t}
+	return databaseURL, testDB, nil
 }
 
 func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-faker/faker/v4"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,40 +31,14 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service/integration"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pgtest"
 	"github.com/redpanda-data/connect/v4/internal/license"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-type FakeFlightRecord struct {
-	RealAddress faker.RealAddress `faker:"real_address"`
-	CreatedAt   int64             `fake:"unix_time"`
-}
-
-func GetFakeFlightRecord() FakeFlightRecord {
-	flightRecord := FakeFlightRecord{}
-	err := faker.FakeData(&flightRecord)
-	if err != nil {
-		panic(err)
-	}
-
-	return flightRecord
-}
-
-// TestDB wraps sql.DB with testing utilities for database integration tests.
-type TestDB struct {
-	*sql.DB
-	T *testing.T
-}
-
-// MustExec executes a SQL query and fails the test if an error occurs.
-func (db *TestDB) MustExec(query string, args ...any) {
-	_, err := db.Exec(query, args...)
-	require.NoError(db.T, err)
-}
-
-func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *TestDB, error) {
+func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *pgtest.TestDB, error) {
 	ctr, err := testcontainers.Run(t.Context(), "postgres:"+version,
 		testcontainers.WithExposedPorts("5432/tcp"),
 		testcontainers.WithEnv(map[string]string{
@@ -170,7 +143,7 @@ func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *TestD
 		}
 	})
 
-	testDB := &TestDB{db, t}
+	testDB := &pgtest.TestDB{DB: db}
 	return databaseURL, testDB, nil
 }
 
@@ -182,7 +155,7 @@ func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -231,7 +204,7 @@ pg_stream:
 	}, time.Second*25, time.Millisecond*100)
 
 	for i := 10; i < 20; i++ {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 		_, err = db.Exec(`INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);`, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -274,7 +247,7 @@ pg_stream:
 
 	time.Sleep(time.Second * 5)
 	for i := 20; i < 30; i++ {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -300,7 +273,7 @@ func TestIntegrationPostgresSnapshotAckBarrier(t *testing.T) {
 
 	const rowCount = 5
 	for i := range rowCount {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -499,7 +472,7 @@ func TestIntegrationPostgresIncludeTxnMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	for range 10000 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -550,7 +523,7 @@ pg_stream:
 	}, time.Second*25, time.Millisecond*100)
 
 	for range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 		_, err = db.Exec("INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -595,7 +568,7 @@ pg_stream:
 
 	time.Sleep(time.Second * 5)
 	for range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -717,7 +690,7 @@ func TestIntegrationMultiplePostgresVersions(t *testing.T) {
 			require.NoError(t, err)
 
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 			}
@@ -770,7 +743,7 @@ pg_stream:
 			}, time.Minute, time.Millisecond*100)
 
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 				_, err = db.Exec("INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -815,7 +788,7 @@ pg_stream:
 
 			time.Sleep(time.Second * 5)
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 			}

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	BatchSize int
 	// If true, include BEGIN and COMMIT messages in the stream
 	IncludeTxnMarkers bool
+	// SignalTableName is the name of the signal table. Rows inserted into this
+	// table are treated as control signals rather than data, and the table is
+	// excluded from snapshot scans.
+	SignalTableName string
 
 	Logger *service.Logger
 

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -176,9 +176,18 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 
 	stream.decodingPluginArguments = pluginArguments
 
+	tablesForPublication := tables
+	if config.SignalTableName != "" {
+		normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid signal table name %q: %w", config.SignalTableName, err)
+		}
+		tablesForPublication = append(slices.Clone(tables), TableFQN{Schema: schema, Table: normalizedSignalTable})
+	}
+
 	pubName := "pglog_stream_" + config.ReplicationSlotName
-	stream.logger.Infof("Creating publication %s for tables: %s", pubName, tables)
-	if err = CreatePublication(ctx, stream.pgConn, pubName, tables); err != nil {
+	stream.logger.Infof("Creating publication %s for tables: %s", pubName, tablesForPublication)
+	if err = CreatePublication(ctx, stream.pgConn, pubName, tablesForPublication); err != nil {
 		return nil, err
 	}
 	cleanups = append(cleanups, func() {

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -910,7 +910,10 @@ func (s *Stream) Stop(ctx context.Context) error {
 	return err
 }
 
-// validateSignalTable verifies the signal table exists
+var requiredSignalTableColumns = []string{"id", "type", "data"}
+
+// validateSignalTable verifies the signal table exists and has the
+// documented id/type/data columns.
 func validateSignalTable(ctx context.Context, stream *Stream, schema string, config *Config) (TableFQN, error) {
 	normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
 	if err != nil {
@@ -926,17 +929,31 @@ func validateSignalTable(ctx context.Context, stream *Stream, schema string, con
 	if err != nil {
 		return TableFQN{}, fmt.Errorf("verifying signal table name: %w", err)
 	}
-	sql := "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2"
+	sql := "SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2"
 	query, err := sanitize.SQLQuery(sql, wireSchema, wireSignalTable)
 	if err != nil {
 		return TableFQN{}, err
 	}
 	res, err := stream.pgConn.Exec(ctx, query).ReadAll()
 	if err != nil {
-		return TableFQN{}, fmt.Errorf("checking signal table %s exists: %w", signalTable, err)
+		return TableFQN{}, fmt.Errorf("checking signal table %s columns: %w", signalTable, err)
 	}
 	if len(res) == 0 || len(res[0].Rows) == 0 {
 		return signalTable, fmt.Errorf("signal table %s does not exist", signalTable)
+	}
+
+	columns := make(map[string]bool, len(res[0].Rows))
+	for _, row := range res[0].Rows {
+		columns[string(row[0])] = true
+	}
+	var missing []string
+	for _, required := range requiredSignalTableColumns {
+		if !columns[required] {
+			missing = append(missing, required)
+		}
+	}
+	if len(missing) > 0 {
+		return signalTable, fmt.Errorf("signal table %s is missing required column(s): %s", signalTable, strings.Join(missing, ", "))
 	}
 
 	return signalTable, nil

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -177,16 +177,17 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	stream.decodingPluginArguments = pluginArguments
 
 	tablesForPublication := tables
-	// An empty tables list means the publication covers FOR ALL TABLES
-	// (see CreatePublication), which already includes the signal table -
-	// appending it here would collapse that into a single-table publication
-	// and silently stop replicating everything else.
-	if config.SignalTableName != "" && len(tables) > 0 {
-		normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
+	if config.SignalTableName != "" {
+		signalTable, err := validateSignalTable(ctx, stream, schema, config)
 		if err != nil {
-			return nil, fmt.Errorf("invalid signal table name %q: %w", config.SignalTableName, err)
+			return nil, fmt.Errorf("validating signal table: %w", err)
 		}
-		tablesForPublication = append(slices.Clone(tables), TableFQN{Schema: schema, Table: normalizedSignalTable})
+
+		// An empty tables list means the publication covers FOR ALL TABLES, already including the signal table.
+		// Appending it here would collapse that into a single-table publication and silently stop replicating everything else.
+		if len(tables) > 0 {
+			tablesForPublication = append(slices.Clone(tables), signalTable)
+		}
 	}
 
 	pubName := "pglog_stream_" + config.ReplicationSlotName
@@ -907,4 +908,36 @@ func (s *Stream) Stop(ctx context.Context) error {
 	case <-s.shutSig.HasStoppedChan():
 	}
 	return err
+}
+
+// validateSignalTable verifies the signal table exists
+func validateSignalTable(ctx context.Context, stream *Stream, schema string, config *Config) (TableFQN, error) {
+	normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("invalid signal table name %q: %w", config.SignalTableName, err)
+	}
+	signalTable := TableFQN{Schema: schema, Table: normalizedSignalTable}
+
+	wireSchema, err := sanitize.UnquotePostgresIdentifier(signalTable.Schema)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("verifying schema: %w", err)
+	}
+	wireSignalTable, err := sanitize.UnquotePostgresIdentifier(signalTable.Table)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("verifying signal table name: %w", err)
+	}
+	sql := "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2"
+	query, err := sanitize.SQLQuery(sql, wireSchema, wireSignalTable)
+	if err != nil {
+		return TableFQN{}, err
+	}
+	res, err := stream.pgConn.Exec(ctx, query).ReadAll()
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("checking signal table %s exists: %w", signalTable, err)
+	}
+	if len(res) == 0 || len(res[0].Rows) == 0 {
+		return signalTable, fmt.Errorf("signal table %s does not exist", signalTable)
+	}
+
+	return signalTable, nil
 }

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -177,7 +177,11 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	stream.decodingPluginArguments = pluginArguments
 
 	tablesForPublication := tables
-	if config.SignalTableName != "" {
+	// An empty tables list means the publication covers FOR ALL TABLES
+	// (see CreatePublication), which already includes the signal table -
+	// appending it here would collapse that into a single-table publication
+	// and silently stop replicating everything else.
+	if config.SignalTableName != "" && len(tables) > 0 {
 		normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid signal table name %q: %w", config.SignalTableName, err)

--- a/internal/impl/postgresql/pgtest/pgtest.go
+++ b/internal/impl/postgresql/pgtest/pgtest.go
@@ -10,8 +10,13 @@ package pgtest
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"sync"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/require"
 )
 
 // ReceivedMessages is a thread-safe accessor for messages collected by the
@@ -79,3 +84,37 @@ func (c *TestLogCapture) WithGroup(string) slog.Handler { return c }
 
 // Enabled always returns true so every log record is captured.
 func (*TestLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+// FakeFlightRecord is a fake row shape used to generate test data for
+// integration tests.
+type FakeFlightRecord struct {
+	RealAddress faker.RealAddress `faker:"real_address"`
+	CreatedAt   int64             `fake:"unix_time"`
+}
+
+// GetFakeFlightRecord generates a random FakeFlightRecord, panicking if
+// generation fails.
+func GetFakeFlightRecord() FakeFlightRecord {
+	flightRecord := FakeFlightRecord{}
+	err := faker.FakeData(&flightRecord)
+	if err != nil {
+		panic(err)
+	}
+
+	return flightRecord
+}
+
+// TestDB wraps sql.DB with testing utilities for database integration tests.
+type TestDB struct {
+	*sql.DB
+}
+
+// MustExec executes a SQL query and fails t if an error occurs. t is taken
+// per call, not stored on TestDB, so a call made from inside a subtest fails
+// that subtest rather than reaching for FailNow on a parent *testing.T from
+// the wrong goroutine.
+func (db *TestDB) MustExec(t *testing.T, query string, args ...any) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	require.NoError(t, err)
+}

--- a/internal/impl/postgresql/pgtest/pgtest.go
+++ b/internal/impl/postgresql/pgtest/pgtest.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgtest
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// ReceivedMessages is a thread-safe accessor for messages collected by the
+// consumer func startSignallingStream registers.
+type ReceivedMessages struct {
+	mu   sync.Mutex
+	msgs []any
+}
+
+// Add records a received message.
+func (r *ReceivedMessages) Add(m any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = append(r.msgs, m)
+}
+
+// Len returns the number of messages received so far.
+func (r *ReceivedMessages) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.msgs)
+}
+
+// All returns a snapshot of the messages received so far.
+func (r *ReceivedMessages) All() []any {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]any(nil), r.msgs...)
+}
+
+// Reset discards every message received so far.
+func (r *ReceivedMessages) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = nil
+}
+
+// TestLogCapture is an implemention of the slog.Logger interface
+// to support verifying log output.
+type TestLogCapture struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+// Handle records the log record's message.
+func (c *TestLogCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, r.Message)
+	return nil
+}
+
+// Messages returns a snapshot of every message logged so far.
+func (c *TestLogCapture) Messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.messages...)
+}
+
+// WithAttrs returns the receiver unchanged; attributes are not recorded.
+func (c *TestLogCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+
+// WithGroup returns the receiver unchanged; groups are not recorded.
+func (c *TestLogCapture) WithGroup(string) slog.Handler { return c }
+
+// Enabled always returns true so every log record is captured.
+func (*TestLogCapture) Enabled(context.Context, slog.Level) bool { return true }

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -94,7 +94,7 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 		if err := json.Unmarshal([]byte(dataStr), &sig.LogSignal); err != nil {
 			return nil, fmt.Errorf("unmarshaling control signal %s.data: %w", s.tableName, err)
 		}
-		s.Log.Infof("%q control signal received (lsn=%s): %s", sig.Type(), sig.LSN, sig.Message)
+		log.Infof("%s (lsn=%s)", sig.Message, sig.LSN)
 	default:
 		log.Warnf("Control signal %q received but not a recognized type", sig.SignalType)
 	}

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
@@ -88,48 +87,20 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 	if !ok {
 		return nil, errors.New("parsing control signals's 'type' data")
 	}
-	sig.Type = evType
-
-	log := s.Log.With("id", sig.ID, "type", sig.Type)
-
-	if !sig.IsSnapshot() {
-		log.Warnf("Control signal %q received but not a recognized action, forwarding as a regular message", sig.Type)
-		return nil, nil
-	}
-
-	// Invalid or no-op signals are not returned as actionable, so streaming
-	// continues uninterrupted.
-	if len(sig.Dataset) == 0 {
-		log.Warnf("Control signal %q received but dataset is empty — ignoring, streaming continues uninterrupted", sig.Type)
-		return nil, nil
-	}
-	if len(tableNamesFromSchema(sig.Dataset, s.schema)) == 0 {
-		log.Warnf("Control signal %q received but dataset %v matched no tables for schema %q — ignoring, streaming continues uninterrupted", sig.Type, sig.Dataset, s.schema)
-		return nil, nil
-	}
-
-	log.Infof("Control signal %q received: operation=%s lsn=%v", sig.Type, msg.Operation, msg.LSN)
+	sig.SignalType = evType
+	log := s.Log.With("id", sig.ID, "type", sig.SignalType)
 
 	if msg.LSN != nil {
 		sig.LSN = []byte(*msg.LSN)
 	}
-	return &sig, nil
-}
 
-func tableNamesFromSchema(collections []string, schema string) []string {
-	if len(collections) == 0 {
-		return nil
+	// validate signal type
+	switch sig.SignalType {
+	case replication.LogSignalType:
+		s.Log.Infof("%q control signal received (lsn=%s): %s", sig.Type(), sig.LSN, sig.Message)
+	default:
+		log.Warnf("Control signal %q received but not a recognized type", sig.SignalType)
 	}
-	tables := make([]string, 0, len(collections))
-	for _, dc := range collections {
-		table := dc
-		if idx := strings.LastIndex(dc, "."); idx >= 0 {
-			if !strings.EqualFold(dc[:idx], schema) {
-				continue
-			}
-			table = dc[idx+1:]
-		}
-		tables = append(tables, table)
-	}
-	return tables
+
+	return &sig, nil
 }

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+	"github.com/redpanda-data/connect/v4/internal/replication"
+)
+
+var _ replication.Signaller = (*postgresSignaller)(nil)
+
+type postgresSignaller struct {
+	Log *service.Logger
+
+	schema    string
+	tableName string
+}
+
+// NewControlSignaller creates a replication.Signaller that detects signal
+// INSERTs on the given schema.tableName.
+func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
+	normalizedSchema, err := wireFormPostgresIdentifier(schema)
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema %q: %w", schema, err)
+	}
+	normalizedTableName := tableName
+	if tableName != "" {
+		if normalizedTableName, err = wireFormPostgresIdentifier(tableName); err != nil {
+			return nil, fmt.Errorf("invalid signal table name %q: %w", tableName, err)
+		}
+	}
+	return &postgresSignaller{Log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
+}
+
+func wireFormPostgresIdentifier(name string) (string, error) {
+	normalized, err := sanitize.NormalizePostgresIdentifier(name)
+	if err != nil {
+		return "", err
+	}
+	return sanitize.UnquotePostgresIdentifier(normalized)
+}
+
+// Listen returns any actionable signal found; signal rows should always be
+// forwarded downstream as normal messages regardless of the outcome here.
+func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.ControlSignal, error) {
+	msg, ok := signal.(pglogicalstream.StreamMessage)
+	if !ok {
+		return nil, nil
+	}
+	if msg.Operation != pglogicalstream.InsertOpType {
+		return nil, nil
+	}
+	if msg.Schema != s.schema || msg.Table != s.tableName {
+		return nil, nil
+	}
+
+	row, ok := msg.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected map for %s message data, got %T", s.tableName, msg.Data)
+	}
+	dataStr, ok := row["data"].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string for %s.data column, got %T", s.tableName, row["data"])
+	}
+
+	var sig replication.ControlSignal
+	if err := json.Unmarshal([]byte(dataStr), &sig); err != nil {
+		return nil, fmt.Errorf("unmarshaling control signal %s.data: %w", s.tableName, err)
+	}
+
+	sig.ID = fmt.Sprintf("%v", row["id"])
+
+	evType, ok := row["type"].(string)
+	if !ok {
+		return nil, errors.New("parsing control signals's 'type' data")
+	}
+	sig.Type = evType
+
+	log := s.Log.With("id", sig.ID, "type", sig.Type)
+
+	if !sig.IsSnapshot() {
+		log.Warnf("Control signal %q received but not a recognized action, forwarding as a regular message", sig.Type)
+		return nil, nil
+	}
+
+	// Invalid or no-op signals are not returned as actionable, so streaming
+	// continues uninterrupted.
+	if len(sig.Dataset) == 0 {
+		log.Warnf("Control signal %q received but dataset is empty — ignoring, streaming continues uninterrupted", sig.Type)
+		return nil, nil
+	}
+	if len(tableNamesFromSchema(sig.Dataset, s.schema)) == 0 {
+		log.Warnf("Control signal %q received but dataset %v matched no tables for schema %q — ignoring, streaming continues uninterrupted", sig.Type, sig.Dataset, s.schema)
+		return nil, nil
+	}
+
+	log.Infof("Control signal %q received: operation=%s lsn=%v", sig.Type, msg.Operation, msg.LSN)
+
+	if msg.LSN != nil {
+		sig.LSN = []byte(*msg.LSN)
+	}
+	return &sig, nil
+}
+
+func tableNamesFromSchema(collections []string, schema string) []string {
+	if len(collections) == 0 {
+		return nil
+	}
+	tables := make([]string, 0, len(collections))
+	for _, dc := range collections {
+		table := dc
+		if idx := strings.LastIndex(dc, "."); idx >= 0 {
+			if !strings.EqualFold(dc[:idx], schema) {
+				continue
+			}
+			table = dc[idx+1:]
+		}
+		tables = append(tables, table)
+	}
+	return tables
+}

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -77,17 +77,11 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 	}
 
 	var sig replication.ControlSignal
-	if err := json.Unmarshal([]byte(dataStr), &sig); err != nil {
-		return nil, fmt.Errorf("unmarshaling control signal %s.data: %w", s.tableName, err)
+	if sig.SignalType, ok = row["type"].(string); !ok {
+		return nil, errors.New("parsing control signals's 'type' data")
 	}
 
 	sig.ID = fmt.Sprintf("%v", row["id"])
-
-	evType, ok := row["type"].(string)
-	if !ok {
-		return nil, errors.New("parsing control signals's 'type' data")
-	}
-	sig.SignalType = evType
 	log := s.Log.With("id", sig.ID, "type", sig.SignalType)
 
 	if msg.LSN != nil {
@@ -97,6 +91,9 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 	// validate signal type
 	switch sig.SignalType {
 	case replication.LogSignalType:
+		if err := json.Unmarshal([]byte(dataStr), &sig.LogSignal); err != nil {
+			return nil, fmt.Errorf("unmarshaling control signal %s.data: %w", s.tableName, err)
+		}
 		s.Log.Infof("%q control signal received (lsn=%s): %s", sig.Type(), sig.LSN, sig.Message)
 	default:
 		log.Warnf("Control signal %q received but not a recognized type", sig.SignalType)

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/redpanda-data/benthos/v4/public/service/integration"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pgtest"
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
@@ -38,7 +38,7 @@ func TestIntegrationSignallingConfiguration(t *testing.T) {
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 
-	template := fmt.Sprintf(`
+	received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling
@@ -47,73 +47,26 @@ postgres_cdc:
     schema: dbo
     tables:
       - events
-`, databaseURL)
-
-	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
-	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
-
-	var (
-		received []any
-		mu       sync.Mutex
-	)
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, msg := range batch {
-			data, err := msg.AsStructured()
-			if err != nil {
-				return err
-			}
-			m := data.(map[string]any)
-			if _, ok := m["lsn"]; ok {
-				m["lsn"] = "XXX/XXX"
-			}
-			delete(m, "schema")
-			delete(m, "commit_ts_ms")
-			received = append(received, m)
-		}
-		return nil
-	}))
-
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
-	t.Cleanup(func() {
-		require.NoError(t, streamOut.StopWithin(5*time.Second))
-	})
-
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+`, databaseURL))
 
 	// Wait for the initial snapshot to complete before inserting streaming records.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 2)
+		assert.Equal(c, 2, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 4)
+		assert.Equal(c, 4, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	require.ElementsMatch(t, received, []any{
+	require.ElementsMatch(t, received.All(), []any{
 		map[string]any{"operation": "read", "table": "events"},
 		map[string]any{"operation": "read", "table": "events"},
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 	})
-	mu.Unlock()
 }
 
 func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {
@@ -130,7 +83,7 @@ func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {
 
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 
-	template := fmt.Sprintf(`
+	received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling_disabled
@@ -139,59 +92,14 @@ postgres_cdc:
     tables:
       - events
       - rpcn_signal_table
-`, databaseURL)
-
-	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
-	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
-
-	var (
-		received []any
-		mu       sync.Mutex
-	)
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, msg := range batch {
-			data, err := msg.AsStructured()
-			if err != nil {
-				return err
-			}
-			m := data.(map[string]any)
-			if _, ok := m["lsn"]; ok {
-				m["lsn"] = "XXX/XXX"
-			}
-			delete(m, "schema")
-			delete(m, "commit_ts_ms")
-			received = append(received, m)
-		}
-		return nil
-	}))
-
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
-	t.Cleanup(func() {
-		require.NoError(t, streamOut.StopWithin(10*time.Second))
-	})
-
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+`, databaseURL))
 
 	// Wait for the initial snapshot row from dbo.events.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 1)
+		assert.Equal(c, 1, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	received = nil
-	mu.Unlock()
+	received.Reset()
 
 	// This row is shaped exactly like a log signal. With signal_table_name
 	// unset, it must be forwarded as an ordinary message rather than detected
@@ -200,17 +108,13 @@ postgres_cdc:
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 2)
+		assert.Equal(c, 2, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	require.ElementsMatch(t, received, []any{
+	require.ElementsMatch(t, received.All(), []any{
 		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 	})
-	mu.Unlock()
 }
 
 // TestIntegrationSignallingDetectedWithoutInterruptingStream verifies that a
@@ -229,7 +133,7 @@ func TestIntegrationSignallingDetectedWithoutInterruptingStream(t *testing.T) {
 
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 
-	template := fmt.Sprintf(`
+	received, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling_detect_only
@@ -238,60 +142,14 @@ postgres_cdc:
     schema: dbo
     tables:
       - events
-`, databaseURL)
-
-	logs := &testLogCapture{}
-	streamOutBuilder := service.NewStreamBuilder()
-	streamOutBuilder.SetLogger(slog.New(logs))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
-	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
-
-	var (
-		received []any
-		mu       sync.Mutex
-	)
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, msg := range batch {
-			data, err := msg.AsStructured()
-			if err != nil {
-				return err
-			}
-			m := data.(map[string]any)
-			if _, ok := m["lsn"]; ok {
-				m["lsn"] = "XXX/XXX"
-			}
-			delete(m, "schema")
-			delete(m, "commit_ts_ms")
-			received = append(received, m)
-		}
-		return nil
-	}))
-
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
-	t.Cleanup(func() {
-		require.NoError(t, streamOut.StopWithin(10*time.Second))
-	})
-
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+`, databaseURL))
 
 	// Wait for the initial snapshot row from dbo.events.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 1)
+		assert.Equal(c, 1, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	received = nil
-	mu.Unlock()
+	received.Reset()
 
 	// A real log signal, immediately followed by an ordinary insert. If
 	// detection incorrectly paused or restarted the stream, the second
@@ -300,9 +158,7 @@ postgres_cdc:
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 2)
+		assert.Equal(c, 2, received.Len())
 	}, 5*time.Second, 100*time.Millisecond)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -320,12 +176,10 @@ postgres_cdc:
 	// nothing beyond the signal row and the one ordinary insert ever arrives.
 	time.Sleep(500 * time.Millisecond)
 
-	mu.Lock()
-	require.ElementsMatch(t, received, []any{
+	require.ElementsMatch(t, received.All(), []any{
 		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 	})
-	mu.Unlock()
 }
 
 func TestIntegrationSignallingMalformedRowStillPublished(t *testing.T) {
@@ -339,7 +193,7 @@ func TestIntegrationSignallingMalformedRowStillPublished(t *testing.T) {
 
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 
-	template := fmt.Sprintf(`
+	received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling_malformed
@@ -348,59 +202,14 @@ postgres_cdc:
     schema: dbo
     tables:
       - events
-`, databaseURL)
-
-	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
-	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
-
-	var (
-		received []any
-		mu       sync.Mutex
-	)
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, msg := range batch {
-			data, err := msg.AsStructured()
-			if err != nil {
-				return err
-			}
-			m := data.(map[string]any)
-			if _, ok := m["lsn"]; ok {
-				m["lsn"] = "XXX/XXX"
-			}
-			delete(m, "schema")
-			delete(m, "commit_ts_ms")
-			received = append(received, m)
-		}
-		return nil
-	}))
-
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
-	t.Cleanup(func() {
-		require.NoError(t, streamOut.StopWithin(10*time.Second))
-	})
-
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+`, databaseURL))
 
 	// Wait for the initial snapshot row from dbo.events.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 1)
+		assert.Equal(c, 1, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	received = nil
-	mu.Unlock()
+	received.Reset()
 
 	// data is left NULL, so Listen fails to parse this row as a signal
 	// ("expected string for ...data column, got <nil>"). That must not stop
@@ -409,17 +218,13 @@ postgres_cdc:
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-malformed-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 2)
+		assert.Equal(c, 2, received.Len())
 	}, 5*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	require.ElementsMatch(t, received, []any{
+	require.ElementsMatch(t, received.All(), []any{
 		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 	})
-	mu.Unlock()
 }
 
 // TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables verifies
@@ -435,55 +240,13 @@ func TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables(t *testing
 	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
 	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
-	template := fmt.Sprintf(`
+	received, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling_all_tables
     signal_table_name: rpcn_signal_table
     schema: dbo
-`, databaseURL)
-
-	logs := &testLogCapture{}
-	streamOutBuilder := service.NewStreamBuilder()
-	streamOutBuilder.SetLogger(slog.New(logs))
-	require.NoError(t, streamOutBuilder.AddInputYAML(template))
-	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
-
-	var (
-		received []any
-		mu       sync.Mutex
-	)
-	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, msg := range batch {
-			data, err := msg.AsStructured()
-			if err != nil {
-				return err
-			}
-			m := data.(map[string]any)
-			if _, ok := m["lsn"]; ok {
-				m["lsn"] = "XXX/XXX"
-			}
-			delete(m, "schema")
-			delete(m, "commit_ts_ms")
-			received = append(received, m)
-		}
-		return nil
-	}))
-
-	streamOut, err := streamOutBuilder.Build()
-	require.NoError(t, err)
-	license.InjectTestService(streamOut.Resources())
-	t.Cleanup(func() {
-		require.NoError(t, streamOut.StopWithin(10*time.Second))
-	})
-
-	go func() {
-		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
-			t.Error(err)
-		}
-	}()
+`, databaseURL))
 
 	// There's no initial snapshot to synchronize on since tables is empty,
 	// so wait for the stream to confirm replication has actually started
@@ -503,37 +266,54 @@ postgres_cdc:
 	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "hi"}')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		mu.Lock()
-		defer mu.Unlock()
-		assert.Len(c, received, 2)
+		assert.Equal(c, 2, received.Len())
 	}, 25*time.Second, 100*time.Millisecond)
 
-	mu.Lock()
-	require.ElementsMatch(t, received, []any{
+	require.ElementsMatch(t, received.All(), []any{
 		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
 		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
 	})
-	mu.Unlock()
 }
 
-type testLogCapture struct {
-	mu       sync.Mutex
-	messages []string
-}
+func startSignallingStream(t *testing.T, inputYAML string) (*pgtest.ReceivedMessages, *pgtest.TestLogCapture) {
+	t.Helper()
 
-func (c *testLogCapture) Handle(_ context.Context, r slog.Record) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.messages = append(c.messages, r.Message)
-	return nil
-}
+	logs := &pgtest.TestLogCapture{}
+	streamOutBuilder := service.NewStreamBuilder()
+	streamOutBuilder.SetLogger(slog.New(logs))
+	require.NoError(t, streamOutBuilder.AddInputYAML(inputYAML))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
 
-func (c *testLogCapture) Messages() []string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return append([]string(nil), c.messages...)
-}
+	received := &pgtest.ReceivedMessages{}
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received.Add(m)
+		}
+		return nil
+	}))
 
-func (c *testLogCapture) WithAttrs([]slog.Attr) slog.Handler     { return c }
-func (c *testLogCapture) WithGroup(string) slog.Handler          { return c }
-func (*testLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	return received, logs
+}

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -328,6 +328,100 @@ postgres_cdc:
 	mu.Unlock()
 }
 
+func TestIntegrationSignallingMalformedRowStillPublished(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_malformed
+    stream_snapshot: true
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL)
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	var (
+		received []any
+		mu       sync.Mutex
+	)
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received = append(received, m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 1)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	received = nil
+	mu.Unlock()
+
+	// data is left NULL, so Listen fails to parse this row as a signal
+	// ("expected string for ...data column, got <nil>"). That must not stop
+	// it from being published like any other row.
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type) VALUES ('log')`)
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-malformed-signal')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 2)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	require.ElementsMatch(t, received, []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+	mu.Unlock()
+}
+
 type testLogCapture struct {
 	mu       sync.Mutex
 	messages []string
@@ -346,6 +440,6 @@ func (c *testLogCapture) Messages() []string {
 	return append([]string(nil), c.messages...)
 }
 
-func (c *testLogCapture) WithAttrs([]slog.Attr) slog.Handler       { return c }
-func (c *testLogCapture) WithGroup(string) slog.Handler            { return c }
-func (_ *testLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+func (c *testLogCapture) WithAttrs([]slog.Attr) slog.Handler     { return c }
+func (c *testLogCapture) WithGroup(string) slog.Handler          { return c }
+func (*testLogCapture) Enabled(context.Context, slog.Level) bool { return true }

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -93,6 +93,32 @@ postgres_cdc:
 			assert.True(c, found, "expected a connect error naming the missing signal table, got: %v", logs.Messages())
 		}, 25*time.Second, 100*time.Millisecond)
 	})
+
+	t.Run("errors when signal table is missing required columns", func(t *testing.T) {
+		db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.wrong_shape_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), payload TEXT)`)
+
+		_, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_wrong_shape_signal_table
+    stream_snapshot: true
+    signal_table_name: wrong_shape_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "signal table") && strings.Contains(m, "missing required column") && strings.Contains(m, "data") {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a connect error naming the missing data column, got: %v", logs.Messages())
+		}, 25*time.Second, 100*time.Millisecond)
+	})
 }
 
 func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -238,8 +240,9 @@ postgres_cdc:
       - events
 `, databaseURL)
 
+	logs := &testLogCapture{}
 	streamOutBuilder := service.NewStreamBuilder()
-	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	streamOutBuilder.SetLogger(slog.New(logs))
 	require.NoError(t, streamOutBuilder.AddInputYAML(template))
 	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
 
@@ -293,13 +296,24 @@ postgres_cdc:
 	// A real log signal, immediately followed by an ordinary insert. If
 	// detection incorrectly paused or restarted the stream, the second
 	// insert would be delayed well past the assertion window below.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Hello World"}')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		mu.Lock()
 		defer mu.Unlock()
 		assert.Len(c, received, 2)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var found bool
+		for _, m := range logs.Messages() {
+			if strings.Contains(m, "Hello World") {
+				found = true
+				break
+			}
+		}
+		assert.True(c, found, "expected a log entry for the recognized log signal, got: %v", logs.Messages())
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// No re-snapshot should ever follow - give it a moment, then confirm
@@ -313,3 +327,25 @@ postgres_cdc:
 	})
 	mu.Unlock()
 }
+
+type testLogCapture struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (c *testLogCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, r.Message)
+	return nil
+}
+
+func (c *testLogCapture) Messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.messages...)
+}
+
+func (c *testLogCapture) WithAttrs([]slog.Attr) slog.Handler       { return c }
+func (c *testLogCapture) WithGroup(string) slog.Handler            { return c }
+func (_ *testLogCapture) Enabled(context.Context, slog.Level) bool { return true }

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -31,12 +31,12 @@ func TestIntegrationSignallingConfiguration(t *testing.T) {
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
 	require.NoError(t, err)
 
-	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
 
 	t.Run("supports signal tables", func(t *testing.T) {
 		received, _ := startSignallingStream(t, fmt.Sprintf(`
@@ -55,8 +55,8 @@ postgres_cdc:
 			assert.Equal(c, 2, received.Len())
 		}, 25*time.Second, 100*time.Millisecond)
 
-		db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
-		db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 4, received.Len())
@@ -95,7 +95,7 @@ postgres_cdc:
 	})
 
 	t.Run("errors when signal table is missing required columns", func(t *testing.T) {
-		db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.wrong_shape_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), payload TEXT)`)
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.wrong_shape_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), payload TEXT)`)
 
 		_, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -126,14 +126,14 @@ func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
 	require.NoError(t, err)
 
-	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
 	// Shaped exactly like a signal table, and replicated as an ordinary data
 	// table below - with signal_table_name left unset, it must never be
 	// treated as one.
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
 
 	received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -156,8 +156,8 @@ postgres_cdc:
 	// This row is shaped exactly like a log signal. With signal_table_name
 	// unset, it must be forwarded as an ordinary message rather than detected
 	// as a signal.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 2, received.Len())
@@ -179,11 +179,11 @@ func TestIntegrationSignallingDetectedWithoutInterruptingStream(t *testing.T) {
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
 	require.NoError(t, err)
 
-	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
 
 	received, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -206,8 +206,8 @@ postgres_cdc:
 	// A real log signal, immediately followed by an ordinary insert. If
 	// detection incorrectly paused or restarted the stream, the second
 	// insert would be delayed well past the assertion window below.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Hello World"}')`)
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-signal')`)
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Hello World"}')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('after-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 2, received.Len())
@@ -239,11 +239,11 @@ func TestIntegrationSignallingMalformedRowStillPublished(t *testing.T) {
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
 	require.NoError(t, err)
 
-	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
 
 	received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -266,8 +266,8 @@ postgres_cdc:
 	// data is left NULL, so Listen fails to parse this row as a signal
 	// ("expected string for ...data column, got <nil>"). That must not stop
 	// it from being published like any other row.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type) VALUES ('log')`)
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-malformed-signal')`)
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type) VALUES ('log')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('after-malformed-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 2, received.Len())
@@ -288,9 +288,9 @@ func TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables(t *testing
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
 	require.NoError(t, err)
 
-	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
-	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
 
 	received, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -314,8 +314,8 @@ postgres_cdc:
 		assert.True(c, started, "expected replication to have started")
 	}, 25*time.Second, 100*time.Millisecond)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('hello')`)
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "hi"}')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('hello')`)
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "hi"}')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 2, received.Len())

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -422,6 +422,100 @@ postgres_cdc:
 	mu.Unlock()
 }
 
+// TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables verifies
+// that setting signal_table_name while leaving tables empty (the documented
+// FOR ALL TABLES mode - see the tables field docs in input_pg_stream.go)
+// does not collapse the publication down to just the signal table.
+func TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_all_tables
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+`, databaseURL)
+
+	logs := &testLogCapture{}
+	streamOutBuilder := service.NewStreamBuilder()
+	streamOutBuilder.SetLogger(slog.New(logs))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	var (
+		received []any
+		mu       sync.Mutex
+	)
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received = append(received, m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// There's no initial snapshot to synchronize on since tables is empty,
+	// so wait for the stream to confirm replication has actually started
+	// before inserting.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var started bool
+		for _, m := range logs.Messages() {
+			if strings.Contains(m, "Started logical replication on slot") {
+				started = true
+				break
+			}
+		}
+		assert.True(c, started, "expected replication to have started")
+	}, 25*time.Second, 100*time.Millisecond)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('hello')`)
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "hi"}')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 2)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	require.ElementsMatch(t, received, []any{
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+	})
+	mu.Unlock()
+}
+
 type testLogCapture struct {
 	mu       sync.Mutex
 	messages []string

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -38,7 +38,8 @@ func TestIntegrationSignallingConfiguration(t *testing.T) {
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
 
-	received, _ := startSignallingStream(t, fmt.Sprintf(`
+	t.Run("supports signal tables", func(t *testing.T) {
+		received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
     slot_name: test_slot_signalling
@@ -49,23 +50,48 @@ postgres_cdc:
       - events
 `, databaseURL))
 
-	// Wait for the initial snapshot to complete before inserting streaming records.
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, 2, received.Len())
-	}, 25*time.Second, 100*time.Millisecond)
+		// Wait for the initial snapshot to complete before inserting streaming records.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 2, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
 
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
-	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+		db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+		db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, 4, received.Len())
-	}, 25*time.Second, 100*time.Millisecond)
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 4, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
 
-	require.ElementsMatch(t, received.All(), []any{
-		map[string]any{"operation": "read", "table": "events"},
-		map[string]any{"operation": "read", "table": "events"},
-		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
-		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		require.ElementsMatch(t, received.All(), []any{
+			map[string]any{"operation": "read", "table": "events"},
+			map[string]any{"operation": "read", "table": "events"},
+			map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+			map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		})
+	})
+
+	t.Run("errors when signal table does not exist", func(t *testing.T) {
+		_, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_missing_signal_table
+    stream_snapshot: true
+    signal_table_name: does_not_exist
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "signal table") && strings.Contains(m, "does not exist") {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a connect error naming the missing signal table, got: %v", logs.Messages())
+		}, 25*time.Second, 100*time.Millisecond)
 	})
 }
 

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/replication"
+)
+
+func TestPostgresSignallerListen(t *testing.T) {
+	lsn := "0/1"
+
+	tests := []struct {
+		name        string
+		event       any
+		errContains string
+		want        *replication.ControlSignal
+	}{
+		{
+			name:  "not a StreamMessage is ignored",
+			event: "not-a-stream-message",
+		},
+		{
+			name: "non-insert operation is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.UpdateOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "non-matching table is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "other_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "non-matching schema is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "other_schema",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "message data is not a map",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      "not-a-map",
+			},
+			errContains: "expected map for",
+		},
+		{
+			name: "data column is not a string",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": nil},
+			},
+			errContains: "expected string for",
+		},
+		{
+			name: "data column is not valid JSON",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": "not-json"},
+			},
+			errContains: "unmarshaling control signal",
+		},
+		{
+			name: "type column is not a string",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": 123, "data": `{"message": "hello"}`},
+			},
+			errContains: "parsing control signals's 'type' data",
+		},
+		{
+			name: "recognized log type is returned",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				LSN:       &lsn,
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+			want: &replication.ControlSignal{ID: "1", SignalType: "log", Message: "hello", LSN: []byte(lsn)},
+		},
+		{
+			name: "unrecognized type is still returned",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				LSN:       &lsn,
+				Data:      map[string]any{"id": 2, "type": "unsupported", "data": `{"message": "hello"}`},
+			},
+			want: &replication.ControlSignal{ID: "2", SignalType: "unsupported", Message: "hello", LSN: []byte(lsn)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := NewControlSignaller("dbo", "rpcn_signal_table", nil)
+			require.NoError(t, err)
+
+			got, err := s.Listen(t.Context(), test.event)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -106,7 +106,7 @@ func TestPostgresSignallerListen(t *testing.T) {
 				LSN:       &lsn,
 				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
 			},
-			want: &replication.ControlSignal{ID: "1", SignalType: "log", Message: "hello", LSN: []byte(lsn)},
+			want: &replication.ControlSignal{ID: "1", SignalType: "log", LogSignal: replication.LogSignal{Message: "hello"}, LSN: []byte(lsn)},
 		},
 		{
 			name: "unrecognized type is still returned",
@@ -117,7 +117,7 @@ func TestPostgresSignallerListen(t *testing.T) {
 				LSN:       &lsn,
 				Data:      map[string]any{"id": 2, "type": "unsupported", "data": `{"message": "hello"}`},
 			},
-			want: &replication.ControlSignal{ID: "2", SignalType: "unsupported", Message: "hello", LSN: []byte(lsn)},
+			want: &replication.ControlSignal{ID: "2", SignalType: "unsupported", LSN: []byte(lsn)},
 		},
 	}
 

--- a/internal/impl/postgresql/signalling_test.go
+++ b/internal/impl/postgresql/signalling_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+func TestIntegrationSignallingConfiguration(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling
+    stream_snapshot: true
+    signal_table_name: custom_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL)
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	var (
+		received []any
+		mu       sync.Mutex
+	)
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received = append(received, m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(5*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// Wait for the initial snapshot to complete before inserting streaming records.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 2)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 4)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	require.ElementsMatch(t, received, []any{
+		map[string]any{"operation": "read", "table": "events"},
+		map[string]any{"operation": "read", "table": "events"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+	mu.Unlock()
+}
+
+func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	// Shaped exactly like a signal table, and replicated as an ordinary data
+	// table below - with signal_table_name left unset, it must never be
+	// treated as one.
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_disabled
+    stream_snapshot: true
+    schema: dbo
+    tables:
+      - events
+      - rpcn_signal_table
+`, databaseURL)
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	var (
+		received []any
+		mu       sync.Mutex
+	)
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received = append(received, m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 1)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	received = nil
+	mu.Unlock()
+
+	// This row is shaped exactly like a trigger-snapshot signal targeting
+	// dbo.events. With signal_table_name unset, it must be forwarded as an
+	// ordinary message rather than detected as a signal.
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('trigger-snapshot', '{"dataset": ["dbo.events"]}')`)
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 2)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	require.ElementsMatch(t, received, []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+	mu.Unlock()
+}
+
+// TestIntegrationSignallingDetectedWithoutInterruptingStream verifies that a
+// recognized trigger-snapshot signal is detected and forwarded downstream
+// like any other message, and streaming is never paused, flushed early, or
+// restarted because of it - re-snapshotting on a signal is not implemented
+// yet (see postgresSignaller.Listen and processStream's handling of the
+// detected signal in input_pg_stream.go).
+func TestIntegrationSignallingDetectedWithoutInterruptingStream(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(`CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(`CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_detect_only
+    stream_snapshot: true
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL)
+
+	streamOutBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamOutBuilder.SetLoggerYAML(`level: DEBUG`))
+	require.NoError(t, streamOutBuilder.AddInputYAML(template))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	var (
+		received []any
+		mu       sync.Mutex
+	)
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received = append(received, m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 1)
+	}, 25*time.Second, 100*time.Millisecond)
+
+	mu.Lock()
+	received = nil
+	mu.Unlock()
+
+	// A real trigger-snapshot signal, immediately followed by an ordinary
+	// insert. If detection incorrectly paused or restarted the stream, the
+	// second insert would be delayed well past the assertion window below.
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('trigger-snapshot', '{"dataset": ["dbo.events"]}')`)
+	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-signal')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(c, received, 2)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// No re-snapshot should ever follow - give it a moment, then confirm
+	// nothing beyond the signal row and the one ordinary insert ever arrives.
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	require.ElementsMatch(t, received, []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+	mu.Unlock()
+}

--- a/internal/impl/postgresql/signalling_test.go
+++ b/internal/impl/postgresql/signalling_test.go
@@ -191,10 +191,10 @@ postgres_cdc:
 	received = nil
 	mu.Unlock()
 
-	// This row is shaped exactly like a trigger-snapshot signal targeting
-	// dbo.events. With signal_table_name unset, it must be forwarded as an
-	// ordinary message rather than detected as a signal.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('trigger-snapshot', '{"dataset": ["dbo.events"]}')`)
+	// This row is shaped exactly like a log signal. With signal_table_name
+	// unset, it must be forwarded as an ordinary message rather than detected
+	// as a signal.
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('stream')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -212,11 +212,10 @@ postgres_cdc:
 }
 
 // TestIntegrationSignallingDetectedWithoutInterruptingStream verifies that a
-// recognized trigger-snapshot signal is detected and forwarded downstream
-// like any other message, and streaming is never paused, flushed early, or
-// restarted because of it - re-snapshotting on a signal is not implemented
-// yet (see postgresSignaller.Listen and processStream's handling of the
-// detected signal in input_pg_stream.go).
+// recognized log signal is detected and forwarded downstream like any other
+// message, and streaming is never paused, flushed early, or restarted
+// because of it (see postgresSignaller.Listen and processStream's handling
+// of the detected signal in input_pg_stream.go).
 func TestIntegrationSignallingDetectedWithoutInterruptingStream(t *testing.T) {
 	integration.CheckSkip(t)
 	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
@@ -291,10 +290,10 @@ postgres_cdc:
 	received = nil
 	mu.Unlock()
 
-	// A real trigger-snapshot signal, immediately followed by an ordinary
-	// insert. If detection incorrectly paused or restarted the stream, the
-	// second insert would be delayed well past the assertion window below.
-	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('trigger-snapshot', '{"dataset": ["dbo.events"]}')`)
+	// A real log signal, immediately followed by an ordinary insert. If
+	// detection incorrectly paused or restarted the stream, the second
+	// insert would be delayed well past the assertion window below.
+	db.MustExec(`INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
 	db.MustExec(`INSERT INTO dbo.events (name) VALUES ('after-signal')`)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -13,11 +13,16 @@ import "context"
 // LogSignalType represents a log signal.
 const LogSignalType = "log"
 
+// LogSignal is the decoded "data" payload for a LogSignalType signal.
+type LogSignal struct {
+	Message string `json:"message"`
+}
+
 // ControlSignal represents a insert into the signal table.
 type ControlSignal struct {
 	ID         string
 	SignalType string
-	Message    string `json:"message"`
+	LogSignal
 
 	// LSN is the log sequence number/offset the signal was observed at, in
 	// whatever raw form the connector's replication stream represents

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -11,7 +11,7 @@ package replication
 import "context"
 
 // LogSignalType represents a log signal.
-var LogSignalType = "log"
+const LogSignalType = "log"
 
 // ControlSignal represents a insert into the signal table.
 type ControlSignal struct {

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication
+
+import "context"
+
+// ControlSignal represents a insert into the signal table.
+type ControlSignal struct {
+	ID      string
+	Type    string
+	Dataset []string `json:"dataset"`
+
+	// LSN is the log sequence number/offset the signal was observed at, in
+	// whatever raw form the connector's replication stream represents
+	// positions (e.g. a decimal/hex string, or raw binary bytes for
+	// connectors like Oracle whose SCNs aren't naturally textual). It is
+	// populated by the connector's Listen implementation, not part of the
+	// signal's own encoded payload.
+	LSN []byte `json:"-"`
+}
+
+// IsSnapshot returns true if the ControlSignal is a snapshot signal.
+func (s *ControlSignal) IsSnapshot() bool {
+	if s == nil {
+		return false
+	}
+
+	return s.Type == "trigger-snapshot"
+}
+
+// Signaller is implemented by connector-specific control signal handlers.
+// Listen inspects a decoded replication message and, if it recognizes an
+// actionable signal, returns it directly - in the same call that detected it
+// - so the caller can flush exactly that batch before acting on it, rather
+// than reacting to a separately-scheduled notification a differently-timed
+// flush could race ahead of.
+type Signaller interface {
+	Listen(ctx context.Context, event any) (*ControlSignal, error)
+}

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -10,11 +10,14 @@ package replication
 
 import "context"
 
+// LogSignalType represents a log signal.
+var LogSignalType = "log"
+
 // ControlSignal represents a insert into the signal table.
 type ControlSignal struct {
-	ID      string
-	Type    string
-	Dataset []string `json:"dataset"`
+	ID         string
+	SignalType string
+	Message    string `json:"message"`
 
 	// LSN is the log sequence number/offset the signal was observed at, in
 	// whatever raw form the connector's replication stream represents
@@ -25,13 +28,12 @@ type ControlSignal struct {
 	LSN []byte `json:"-"`
 }
 
-// IsSnapshot returns true if the ControlSignal is a snapshot signal.
-func (s *ControlSignal) IsSnapshot() bool {
-	if s == nil {
-		return false
+// Type returns the SignalType or an empty string if ControlSignal is nil.
+func (s *ControlSignal) Type() string {
+	if s != nil {
+		return s.SignalType
 	}
-
-	return s.Type == "trigger-snapshot"
+	return ""
 }
 
 // Signaller is implemented by connector-specific control signal handlers.


### PR DESCRIPTION
This pull request adds the initial signalling detection mechanism, first supporting `log` type that can be used to integration. This acts as the foundation to support reshapshotting.

<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/25fb1310-ef15-4b48-b823-bf887d92ef9b" />
