### PR TITLE
postgres_cdc: Add signal detection

### DIFF
--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -99,6 +99,7 @@ input:
       role: "" # No default (optional)
       role_external_id: "" # No default (optional)
       roles: [] # No default (optional)
+    signal_table_name: ""
     auto_replay_nacks: true
     batching:
       count: 0
@@ -562,6 +563,58 @@ Optional external ID for the role assumption.
 *Type*: `string`
 
 *Default*: `""`
+
+=== `signal_table_name`
+
+The name of the table used to send control signals to the connector, excluding the schema. The table must
+exist in the schema configured via the `schema` field, and must not also appear in `tables`
+- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have exactly these columns:
+
+- **id** — any type representable as a string (e.g. `SERIAL`, `BIGSERIAL`, `UUID`, `VARCHAR`)
+- **type** — `VARCHAR` — the signal type (see supported signals below)
+- **data** — `TEXT` — a JSON object containing signal parameters
+
+Create the table with:
+
+```sql
+CREATE TABLE <schema>.<signal_table_name> (
+    id   SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
+```
+
+Signal rows are published as regular output messages (`operation=insert`, `table=<signal_table_name>`).
+To exclude them from downstream processing, filter on the `table` metadata field using a
+`mapping` processor:
+
+```yaml
+pipeline:
+  processors:
+    - mapping: |
+        root = if @table == "rpcn_signal_table" { deleted() } else { this }
+```
+
+**Supported signals**
+
+**`log`** — recognized and logged when received. The `data` column must contain
+a JSON object with a `message` key, whose value is written to the connector's log output.
+
+```sql
+INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message": "Signal message"}');
+```
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+signal_table_name: rpcn_signal_table
+```
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -568,8 +568,8 @@ Optional external ID for the role assumption.
 
 The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the `schema` field, and must not also appear in `tables`
-- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have at least these columns - startup validation checks
+— the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have at least these columns — startup validation checks
 column names only, not types, so a wrong column type (e.g. `data JSONB` instead of `TEXT`)
 is only caught at runtime, on the first signal row read:
 

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -569,7 +569,8 @@ Optional external ID for the role assumption.
 The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the `schema` field, and must not also appear in `tables`
 - the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have exactly these columns:
+it in both places is rejected at startup. It must have at least these columns (startup validation checks
+column names only) with the following column types:
 
 - **id** — any type representable as a string (e.g. `SERIAL`, `BIGSERIAL`, `UUID`, `VARCHAR`)
 - **type** — `VARCHAR` — the signal type (see supported signals below)

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -569,12 +569,13 @@ Optional external ID for the role assumption.
 The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the `schema` field, and must not also appear in `tables`
 - the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have at least these columns (startup validation checks
-column names only) with the following column types:
+it in both places is rejected at startup. It must have at least these columns - startup validation checks
+column names only, not types, so a wrong column type (e.g. `data JSONB` instead of `TEXT`)
+is only caught at runtime, on the first signal row read:
 
 - **id** — any type representable as a string (e.g. `SERIAL`, `BIGSERIAL`, `UUID`, `VARCHAR`)
-- **type** — `VARCHAR` — the signal type (see supported signals below)
-- **data** — `TEXT` — a JSON object containing signal parameters
+- **type** — should be `VARCHAR` or another string type — the signal type (see supported signals below)
+- **data** — should be `TEXT` — a JSON object containing signal parameters
 
 Create the table with:
 

--- a/internal/impl/postgresql/bench/Taskfile.yaml
+++ b/internal/impl/postgresql/bench/Taskfile.yaml
@@ -64,6 +64,18 @@ tasks:
     cmds:
       - psql {{.PG_DSN}} -c "SELECT pg_drop_replication_slot('bench_slot') FROM pg_replication_slots WHERE slot_name = 'bench_slot';"
 
+  psql:create:signal-table:
+    desc: Create rpcn_signal_table in the public schema used for control signalling
+    cmds:
+      - psql {{.PG_DSN}} -c "CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT);"
+
+  psql:signal:log:
+    desc: Insert a log signal into public.rpcn_signal_table to trigger a log entry
+    deps: [psql:create:signal-table]
+    cmds:
+      - |
+        psql {{.PG_DSN}} -c "INSERT INTO public.rpcn_signal_table (type, data) VALUES ('log', '{\"message\": \"Signal message\"}');"
+
   # ── CDC / Snapshot benchmarks ────────────────────────────────────────────────
 
   bench:run:

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -6,6 +6,7 @@ input:
     dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable}
     stream_snapshot: true
     schema: public
+    signal_table_name: rpcn_signal_table
     tables:
       - users
       - products

--- a/internal/impl/postgresql/bench/benchmark_config.yaml
+++ b/internal/impl/postgresql/bench/benchmark_config.yaml
@@ -6,7 +6,6 @@ input:
     dsn: ${PG_DSN:postgres://postgres:postgres@localhost:5432/testdb?sslmode=disable}
     stream_snapshot: true
     schema: public
-    signal_table_name: rpcn_signal_table
     tables:
       - users
       - products

--- a/internal/impl/postgresql/bench/create.sql
+++ b/internal/impl/postgresql/bench/create.sql
@@ -1,4 +1,9 @@
 -- PostgreSQL Benchmark Setup Script
+CREATE TABLE IF NOT EXISTS public.rpcn_signal_table (
+    id SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
 
 CREATE TABLE IF NOT EXISTS public.users (
     id            SERIAL PRIMARY KEY,

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -200,12 +200,13 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the ` + "`schema`" + ` field, and must not also appear in ` + "`" + fieldTables + "`" + `
 - the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have at least these columns (startup validation checks
-column names only) with the following column types:
+it in both places is rejected at startup. It must have at least these columns - startup validation checks
+column names only, not types, so a wrong column type (e.g. ` + "`data JSONB`" + ` instead of ` + "`TEXT`" + `)
+is only caught at runtime, on the first signal row read:
 
 - **id** — any type representable as a string (e.g. ` + "`SERIAL`" + `, ` + "`BIGSERIAL`" + `, ` + "`UUID`" + `, ` + "`VARCHAR`" + `)
-- **type** — ` + "`VARCHAR`" + ` — the signal type (see supported signals below)
-- **data** — ` + "`TEXT`" + ` — a JSON object containing signal parameters
+- **type** — should be ` + "`VARCHAR`" + ` or another string type — the signal type (see supported signals below)
+- **data** — should be ` + "`TEXT`" + ` — a JSON object containing signal parameters
 
 Create the table with:
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -588,9 +588,11 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
-				if _, err := p.controlSig.Listen(ctx, msg); err != nil {
-					// Log it and fall through to the normal emit path below.
-					p.logger.Errorf("failed to detect control signal in change event: %s", err)
+				if p.controlSig.Enabled() {
+					if _, err := p.controlSig.Listen(&msg); err != nil {
+						// Log it and fall through to the normal emit path below.
+						p.logger.Errorf("failed to detect control signal in change event: %s", err)
+					}
 				}
 
 				if mb, err = json.Marshal(msg.Data); err != nil {

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -424,7 +424,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		iamAuthEnabled: iamAuthEnabled,
 	}
 
-	if i.controlSig, err = NewControlSignaller(schema, signalTableName, logger); err != nil {
+	if i.controlSig, err = newControlSignaller(schema, signalTableName, logger); err != nil {
 		return nil, err
 	}
 
@@ -588,8 +588,8 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
-				if p.controlSig.Enabled() {
-					if _, err := p.controlSig.Listen(&msg); err != nil {
+				if p.controlSig.enabled() {
+					if _, err := p.controlSig.listen(&msg); err != nil {
 						// Log it and fall through to the normal emit path below.
 						p.logger.Errorf("failed to detect control signal in change event: %s", err)
 					}

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -199,8 +199,8 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 		Field(service.NewStringField(fieldSignalTableName).
 			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the ` + "`schema`" + ` field, and must not also appear in ` + "`" + fieldTables + "`" + `
-- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have at least these columns - startup validation checks
+— the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have at least these columns — startup validation checks
 column names only, not types, so a wrong column type (e.g. ` + "`data JSONB`" + ` instead of ` + "`TEXT`" + `)
 is only caught at runtime, on the first signal row read:
 

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
 	"github.com/redpanda-data/connect/v4/internal/license"
 )
 
@@ -46,6 +47,7 @@ const (
 	fieldMaxParallelSnapshotTables = "max_parallel_snapshot_tables"
 	fieldUnchangedToastValue       = "unchanged_toast_value"
 	fieldHeartbeatInterval         = "heartbeat_interval"
+	fieldSignalTableName           = "signal_table_name"
 	fieldAWSIAMAuth                = "aws"
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
@@ -194,6 +196,48 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Description("AWS IAM authentication configuration for PostgreSQL instances. When enabled, IAM credentials are used to generate temporary authentication tokens instead of a static password.").
 			Advanced().
 			Optional()).
+		Field(service.NewStringField(fieldSignalTableName).
+			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
+exist in the schema configured via the ` + "`schema`" + ` field, and must not also appear in ` + "`" + fieldTables + "`" + `
+- the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
+it in both places is rejected at startup. It must have exactly these columns:
+
+- **id** — any type representable as a string (e.g. ` + "`SERIAL`" + `, ` + "`BIGSERIAL`" + `, ` + "`UUID`" + `, ` + "`VARCHAR`" + `)
+- **type** — ` + "`VARCHAR`" + ` — the signal type (see supported signals below)
+- **data** — ` + "`TEXT`" + ` — a JSON object containing signal parameters
+
+Create the table with:
+
+` + "```sql" + `
+CREATE TABLE <schema>.<signal_table_name> (
+    id   SERIAL PRIMARY KEY,
+    type VARCHAR(32),
+    data TEXT
+);
+` + "```" + `
+
+Signal rows are published as regular output messages (` + "`operation=insert`" + `, ` + "`table=<signal_table_name>`" + `).
+To exclude them from downstream processing, filter on the ` + "`table`" + ` metadata field using a
+` + "`mapping`" + ` processor:
+
+` + "```yaml" + `
+pipeline:
+  processors:
+    - mapping: |
+        root = if @table == "rpcn_signal_table" { deleted() } else { this }
+` + "```" + `
+
+**Supported signals**
+
+**` + "`log`" + `** — recognized and logged when received. The ` + "`data`" + ` column must contain
+a JSON object with a ` + "`message`" + ` key, whose value is written to the connector's log output.
+
+` + "```sql" + `
+INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message": "Signal message"}');
+` + "```").
+			Example("rpcn_signal_table").
+			Default("").
+			Advanced()).
 		Field(service.NewAutoRetryNacksToggleField()).
 		Field(service.NewBatchPolicyField(fieldBatching))
 }
@@ -217,6 +261,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		heartbeatInterval         time.Duration
 		iamAuthEnabled            bool
 		iamAuthTokenBuilder       TokenBuilder
+		signalTableName           string
 	)
 
 	if err := license.CheckRunningEnterprise(mgr); err != nil {
@@ -291,6 +336,26 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		return nil, err
 	}
 
+	if signalTableName, err = conf.FieldString(fieldSignalTableName); err != nil {
+		return nil, err
+	}
+
+	if signalTableName != "" {
+		normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(signalTableName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", fieldSignalTableName, signalTableName, err)
+		}
+		for _, table := range tables {
+			normalizedTable, err := sanitize.NormalizePostgresIdentifier(table)
+			if err != nil {
+				return nil, fmt.Errorf("invalid table name %q: %w", table, err)
+			}
+			if normalizedTable == normalizedSignalTable {
+				return nil, fmt.Errorf("%s %q must not also appear in %s - the signal table is implicitly added to the publication and excluded from snapshot scans", fieldSignalTableName, signalTableName, fieldTables)
+			}
+		}
+	}
+
 	awsConf := conf.Namespace(fieldAWSIAMAuth)
 	iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
 
@@ -342,6 +407,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 			Logger:                   logger,
 			UnchangedToastValue:      unchangedToastValue,
 			HeartbeatInterval:        heartbeatInterval,
+			SignalTableName:          signalTableName,
 		},
 		batching:        batching,
 		checkpointLimit: checkpointLimit,
@@ -354,6 +420,10 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		stopSig:         shutdown.NewSignaller(),
 
 		iamAuthEnabled: iamAuthEnabled,
+	}
+
+	if i.controlSig, err = NewControlSignaller(schema, signalTableName, logger); err != nil {
+		return nil, err
 	}
 
 	// Has stopped is how we notify that we're not connected. This will get reset at connection time.
@@ -397,6 +467,7 @@ type pgStreamInput struct {
 
 	snapshotMetrics *service.MetricGauge
 	replicationLag  *service.MetricGauge
+	controlSig      *postgresSignaller
 	stopSig         *shutdown.Signaller
 
 	// snapshotAckWG tracks in-flight snapshot batches: incremented when a
@@ -515,6 +586,11 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
+				if _, err := p.controlSig.Listen(ctx, msg); err != nil {
+					// Log it and fall through to the normal emit path below.
+					p.logger.Errorf("failed to detect control signal in change event: %s", err)
+				}
+
 				if mb, err = json.Marshal(msg.Data); err != nil {
 					p.logger.Errorf("failure to marshal message: %s", err)
 					break

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -200,7 +200,8 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Description(`The name of the table used to send control signals to the connector, excluding the schema. The table must
 exist in the schema configured via the ` + "`schema`" + ` field, and must not also appear in ` + "`" + fieldTables + "`" + `
 - the signal table is implicitly added to the publication and excluded from snapshot scans, so listing
-it in both places is rejected at startup. It must have exactly these columns:
+it in both places is rejected at startup. It must have at least these columns (startup validation checks
+column names only) with the following column types:
 
 - **id** — any type representable as a string (e.g. ` + "`SERIAL`" + `, ` + "`BIGSERIAL`" + `, ` + "`UUID`" + `, ` + "`VARCHAR`" + `)
 - **type** — ` + "`VARCHAR`" + ` — the signal type (see supported signals below)

--- a/internal/impl/postgresql/input_pg_stream_test.go
+++ b/internal/impl/postgresql/input_pg_stream_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+func TestNewPgStreamInputSignalTableName(t *testing.T) {
+	env := service.NewEnvironment()
+	spec := newPostgresCDCConfig()
+
+	tests := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			name: "no signal table configured",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+`,
+		},
+		{
+			name: "signal table distinct from tables",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+signal_table_name: rpcn_signal_table
+`,
+		},
+		{
+			name: "signal table also listed in tables",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+  - rpcn_signal_table
+signal_table_name: rpcn_signal_table
+`,
+			errContains: `signal_table_name "rpcn_signal_table" must not also appear in tables`,
+		},
+		{
+			name: "signal table matches tables entry under different case-folding",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+  - RPCN_SIGNAL_TABLE
+signal_table_name: rpcn_signal_table
+`,
+			errContains: `signal_table_name "rpcn_signal_table" must not also appear in tables`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := spec.ParseYAML(test.conf, env)
+			require.NoError(t, err)
+
+			mgr := service.MockResources()
+			license.InjectTestService(mgr)
+
+			_, err = newPgStreamInput(pConf, mgr)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-faker/faker/v4"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,28 +31,14 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service/integration"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pgtest"
 	"github.com/redpanda-data/connect/v4/internal/license"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-type FakeFlightRecord struct {
-	RealAddress faker.RealAddress `faker:"real_address"`
-	CreatedAt   int64             `fake:"unix_time"`
-}
-
-func GetFakeFlightRecord() FakeFlightRecord {
-	flightRecord := FakeFlightRecord{}
-	err := faker.FakeData(&flightRecord)
-	if err != nil {
-		panic(err)
-	}
-
-	return flightRecord
-}
-
-func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *sql.DB, error) {
+func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *pgtest.TestDB, error) {
 	ctr, err := testcontainers.Run(t.Context(), "postgres:"+version,
 		testcontainers.WithExposedPorts("5432/tcp"),
 		testcontainers.WithEnv(map[string]string{
@@ -158,7 +143,8 @@ func ResourceWithPostgreSQLVersion(t *testing.T, version string) (string, *sql.D
 		}
 	})
 
-	return databaseURL, db, nil
+	testDB := &pgtest.TestDB{DB: db}
+	return databaseURL, testDB, nil
 }
 
 func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {
@@ -169,7 +155,7 @@ func TestIntegrationPostgresNoTxnMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -218,7 +204,7 @@ pg_stream:
 	}, time.Second*25, time.Millisecond*100)
 
 	for i := 10; i < 20; i++ {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 		_, err = db.Exec(`INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);`, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -261,7 +247,7 @@ pg_stream:
 
 	time.Sleep(time.Second * 5)
 	for i := 20; i < 30; i++ {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -287,7 +273,7 @@ func TestIntegrationPostgresSnapshotAckBarrier(t *testing.T) {
 
 	const rowCount = 5
 	for i := range rowCount {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec(`INSERT INTO "FlightsCompositePK" ("Seq", "Name", "CreatedAt") VALUES ($1, $2, $3);`, i, f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -486,7 +472,7 @@ func TestIntegrationPostgresIncludeTxnMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	for range 10000 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -537,7 +523,7 @@ pg_stream:
 	}, time.Second*25, time.Millisecond*100)
 
 	for range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 		_, err = db.Exec("INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -582,7 +568,7 @@ pg_stream:
 
 	time.Sleep(time.Second * 5)
 	for range 10 {
-		f := GetFakeFlightRecord()
+		f := pgtest.GetFakeFlightRecord()
 		_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 		require.NoError(t, err)
 	}
@@ -704,7 +690,7 @@ func TestIntegrationMultiplePostgresVersions(t *testing.T) {
 			require.NoError(t, err)
 
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 			}
@@ -757,7 +743,7 @@ pg_stream:
 			}, time.Minute, time.Millisecond*100)
 
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 				_, err = db.Exec("INSERT INTO flights_non_streamed (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
@@ -802,7 +788,7 @@ pg_stream:
 
 			time.Sleep(time.Second * 5)
 			for range 1000 {
-				f := GetFakeFlightRecord()
+				f := pgtest.GetFakeFlightRecord()
 				_, err = db.Exec("INSERT INTO flights (name, created_at) VALUES ($1, $2);", f.RealAddress.City, time.Unix(f.CreatedAt, 0).Format(time.RFC3339))
 				require.NoError(t, err)
 			}

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	BatchSize int
 	// If true, include BEGIN and COMMIT messages in the stream
 	IncludeTxnMarkers bool
+	// SignalTableName is the name of the signal table. Rows inserted into this
+	// table are treated as control signals rather than data, and the table is
+	// excluded from snapshot scans.
+	SignalTableName string
 
 	Logger *service.Logger
 

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -176,9 +176,23 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 
 	stream.decodingPluginArguments = pluginArguments
 
+	tablesForPublication := tables
+	if config.SignalTableName != "" {
+		signalTable, err := validateSignalTable(ctx, stream, schema, config)
+		if err != nil {
+			return nil, fmt.Errorf("validating signal table: %w", err)
+		}
+
+		// An empty tables list means the publication covers FOR ALL TABLES, already including the signal table.
+		// Appending it here would collapse that into a single-table publication and silently stop replicating everything else.
+		if len(tables) > 0 {
+			tablesForPublication = append(slices.Clone(tables), signalTable)
+		}
+	}
+
 	pubName := "pglog_stream_" + config.ReplicationSlotName
-	stream.logger.Infof("Creating publication %s for tables: %s", pubName, tables)
-	if err = CreatePublication(ctx, stream.pgConn, pubName, tables); err != nil {
+	stream.logger.Infof("Creating publication %s for tables: %s", pubName, tablesForPublication)
+	if err = CreatePublication(ctx, stream.pgConn, pubName, tablesForPublication); err != nil {
 		return nil, err
 	}
 	cleanups = append(cleanups, func() {
@@ -894,4 +908,53 @@ func (s *Stream) Stop(ctx context.Context) error {
 	case <-s.shutSig.HasStoppedChan():
 	}
 	return err
+}
+
+var requiredSignalTableColumns = []string{"id", "type", "data"}
+
+// validateSignalTable verifies the signal table exists and has the
+// documented id/type/data columns.
+func validateSignalTable(ctx context.Context, stream *Stream, schema string, config *Config) (TableFQN, error) {
+	normalizedSignalTable, err := sanitize.NormalizePostgresIdentifier(config.SignalTableName)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("invalid signal table name %q: %w", config.SignalTableName, err)
+	}
+	signalTable := TableFQN{Schema: schema, Table: normalizedSignalTable}
+
+	wireSchema, err := sanitize.UnquotePostgresIdentifier(signalTable.Schema)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("verifying schema: %w", err)
+	}
+	wireSignalTable, err := sanitize.UnquotePostgresIdentifier(signalTable.Table)
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("verifying signal table name: %w", err)
+	}
+	sql := "SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2"
+	query, err := sanitize.SQLQuery(sql, wireSchema, wireSignalTable)
+	if err != nil {
+		return TableFQN{}, err
+	}
+	res, err := stream.pgConn.Exec(ctx, query).ReadAll()
+	if err != nil {
+		return TableFQN{}, fmt.Errorf("checking signal table %s columns: %w", signalTable, err)
+	}
+	if len(res) == 0 || len(res[0].Rows) == 0 {
+		return signalTable, fmt.Errorf("signal table %s does not exist", signalTable)
+	}
+
+	columns := make(map[string]bool, len(res[0].Rows))
+	for _, row := range res[0].Rows {
+		columns[string(row[0])] = true
+	}
+	var missing []string
+	for _, required := range requiredSignalTableColumns {
+		if !columns[required] {
+			missing = append(missing, required)
+		}
+	}
+	if len(missing) > 0 {
+		return signalTable, fmt.Errorf("signal table %s is missing required column(s): %s", signalTable, strings.Join(missing, ", "))
+	}
+
+	return signalTable, nil
 }

--- a/internal/impl/postgresql/pgtest/pgtest.go
+++ b/internal/impl/postgresql/pgtest/pgtest.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgtest
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// ReceivedMessages is a thread-safe accessor for messages collected by the
+// consumer func startSignallingStream registers.
+type ReceivedMessages struct {
+	mu   sync.Mutex
+	msgs []any
+}
+
+// Add records a received message.
+func (r *ReceivedMessages) Add(m any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = append(r.msgs, m)
+}
+
+// Len returns the number of messages received so far.
+func (r *ReceivedMessages) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.msgs)
+}
+
+// All returns a snapshot of the messages received so far.
+func (r *ReceivedMessages) All() []any {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]any(nil), r.msgs...)
+}
+
+// Reset discards every message received so far.
+func (r *ReceivedMessages) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = nil
+}
+
+// TestLogCapture is an implemention of the slog.Logger interface
+// to support verifying log output.
+type TestLogCapture struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+// Handle records the log record's message.
+func (c *TestLogCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, r.Message)
+	return nil
+}
+
+// Messages returns a snapshot of every message logged so far.
+func (c *TestLogCapture) Messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.messages...)
+}
+
+// WithAttrs returns the receiver unchanged; attributes are not recorded.
+func (c *TestLogCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+
+// WithGroup returns the receiver unchanged; groups are not recorded.
+func (c *TestLogCapture) WithGroup(string) slog.Handler { return c }
+
+// Enabled always returns true so every log record is captured.
+func (*TestLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+// FakeFlightRecord is a fake row shape used to generate test data for
+// integration tests.
+type FakeFlightRecord struct {
+	RealAddress faker.RealAddress `faker:"real_address"`
+	CreatedAt   int64             `fake:"unix_time"`
+}
+
+// GetFakeFlightRecord generates a random FakeFlightRecord, panicking if
+// generation fails.
+func GetFakeFlightRecord() FakeFlightRecord {
+	flightRecord := FakeFlightRecord{}
+	err := faker.FakeData(&flightRecord)
+	if err != nil {
+		panic(err)
+	}
+
+	return flightRecord
+}
+
+// TestDB wraps sql.DB with testing utilities for database integration tests.
+type TestDB struct {
+	*sql.DB
+}
+
+// MustExec executes a SQL query and fails t if an error occurs. t is taken
+// per call, not stored on TestDB, so a call made from inside a subtest fails
+// that subtest rather than reaching for FailNow on a parent *testing.T from
+// the wrong goroutine.
+func (db *TestDB) MustExec(t *testing.T, query string, args ...any) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	require.NoError(t, err)
+}

--- a/internal/impl/postgresql/pgtest/pgtest.go
+++ b/internal/impl/postgresql/pgtest/pgtest.go
@@ -11,7 +11,9 @@ package pgtest
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 
@@ -54,36 +56,68 @@ func (r *ReceivedMessages) Reset() {
 	r.msgs = nil
 }
 
-// TestLogCapture is an implemention of the slog.Logger interface
-// to support verifying log output.
+// TestLogCapture is an implemention of the slog.Logger interface to support
+// verifying log output, including attributes bound via With().
 type TestLogCapture struct {
+	sink  *logSink
+	attrs []slog.Attr
+}
+
+type logSink struct {
 	mu       sync.Mutex
 	messages []string
 }
 
-// Handle records the log record's message.
+func (s *logSink) add(msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, msg)
+}
+
+func (s *logSink) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.messages...)
+}
+
+// Handle records the log record's message, plus any attributes bound via
+// With() or attached directly to the record.
 func (c *TestLogCapture) Handle(_ context.Context, r slog.Record) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.messages = append(c.messages, r.Message)
+	var b strings.Builder
+	b.WriteString(r.Message)
+	for _, a := range c.attrs {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+		return true
+	})
+	c.sink.add(b.String())
 	return nil
 }
 
 // Messages returns a snapshot of every message logged so far.
 func (c *TestLogCapture) Messages() []string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return append([]string(nil), c.messages...)
+	return c.sink.snapshot()
 }
 
-// WithAttrs returns the receiver unchanged; attributes are not recorded.
-func (c *TestLogCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+// WithAttrs returns a handler carrying the given attributes, sharing this
+// capture's underlying sink so messages logged through it are still visible
+// via Messages().
+func (c *TestLogCapture) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &TestLogCapture{sink: c.sink, attrs: append(append([]slog.Attr{}, c.attrs...), attrs...)}
+}
 
 // WithGroup returns the receiver unchanged; groups are not recorded.
 func (c *TestLogCapture) WithGroup(string) slog.Handler { return c }
 
 // Enabled always returns true so every log record is captured.
 func (*TestLogCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+// NewTestLogCapture creates a TestLogCapture ready to use as a slog.Handler.
+func NewTestLogCapture() *TestLogCapture {
+	return &TestLogCapture{sink: &logSink{}}
+}
 
 // FakeFlightRecord is a fake row shape used to generate test data for
 // integration tests.

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -19,15 +19,14 @@ import (
 )
 
 type postgresSignaller struct {
-	Log *service.Logger
+	log *service.Logger
 
 	schema    string
 	tableName string
 }
 
-// NewControlSignaller creates a postgresSignaller that detects signal
-// INSERTs on the given schema.tableName.
-func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
+// newControlSignaller creates a signal listener that checks WAL change entries for control signals.
+func newControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
 	normalizedSchema, err := wireFormPostgresIdentifier(schema)
 	if err != nil {
 		return nil, fmt.Errorf("invalid schema %q: %w", schema, err)
@@ -38,17 +37,17 @@ func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgr
 			return nil, fmt.Errorf("invalid signal table name %q: %w", tableName, err)
 		}
 	}
-	return &postgresSignaller{Log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
+	return &postgresSignaller{log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
 }
 
-// Enabled reports whether a signal table was configured.
-func (s *postgresSignaller) Enabled() bool {
+// enabled reports whether a signal table was configured.
+func (s *postgresSignaller) enabled() bool {
 	return s.tableName != ""
 }
 
-// Listen returns any actionable signal found; signal rows should always be
+// listen returns any actionable signal found; signal rows should always be
 // forwarded downstream as normal messages regardless of the outcome here.
-func (s *postgresSignaller) Listen(msg *pglogicalstream.StreamMessage) (*replication.ControlSignal, error) {
+func (s *postgresSignaller) listen(msg *pglogicalstream.StreamMessage) (*replication.ControlSignal, error) {
 	if msg.Operation != pglogicalstream.InsertOpType {
 		return nil, nil
 	}
@@ -71,7 +70,7 @@ func (s *postgresSignaller) Listen(msg *pglogicalstream.StreamMessage) (*replica
 	}
 
 	sig.ID = fmt.Sprintf("%v", row["id"])
-	log := s.Log.With("id", sig.ID, "type", sig.SignalType)
+	log := s.log.With("id", sig.ID, "type", sig.SignalType)
 
 	if msg.LSN != nil {
 		sig.LSN = []byte(*msg.LSN)

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -11,7 +11,6 @@ package pgstream
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -78,7 +77,7 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 
 	var sig replication.ControlSignal
 	if sig.SignalType, ok = row["type"].(string); !ok {
-		return nil, errors.New("parsing control signals's 'type' data")
+		return nil, fmt.Errorf("expected string for %s.type column, got %T", s.tableName, row["type"])
 	}
 
 	sig.ID = fmt.Sprintf("%v", row["id"])

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -9,7 +9,6 @@
 package pgstream
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -19,8 +18,6 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/replication"
 )
 
-var _ replication.Signaller = (*postgresSignaller)(nil)
-
 type postgresSignaller struct {
 	Log *service.Logger
 
@@ -28,7 +25,7 @@ type postgresSignaller struct {
 	tableName string
 }
 
-// NewControlSignaller creates a replication.Signaller that detects signal
+// NewControlSignaller creates a postgresSignaller that detects signal
 // INSERTs on the given schema.tableName.
 func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
 	normalizedSchema, err := wireFormPostgresIdentifier(schema)
@@ -44,21 +41,14 @@ func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgr
 	return &postgresSignaller{Log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
 }
 
-func wireFormPostgresIdentifier(name string) (string, error) {
-	normalized, err := sanitize.NormalizePostgresIdentifier(name)
-	if err != nil {
-		return "", err
-	}
-	return sanitize.UnquotePostgresIdentifier(normalized)
+// Enabled reports whether a signal table was configured.
+func (s *postgresSignaller) Enabled() bool {
+	return s.tableName != ""
 }
 
 // Listen returns any actionable signal found; signal rows should always be
 // forwarded downstream as normal messages regardless of the outcome here.
-func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.ControlSignal, error) {
-	msg, ok := signal.(pglogicalstream.StreamMessage)
-	if !ok {
-		return nil, nil
-	}
+func (s *postgresSignaller) Listen(msg *pglogicalstream.StreamMessage) (*replication.ControlSignal, error) {
 	if msg.Operation != pglogicalstream.InsertOpType {
 		return nil, nil
 	}
@@ -99,4 +89,12 @@ func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.
 	}
 
 	return &sig, nil
+}
+
+func wireFormPostgresIdentifier(name string) (string, error) {
+	normalized, err := sanitize.NormalizePostgresIdentifier(name)
+	if err != nil {
+		return "", err
+	}
+	return sanitize.UnquotePostgresIdentifier(normalized)
 }

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+	"github.com/redpanda-data/connect/v4/internal/replication"
+)
+
+var _ replication.Signaller = (*postgresSignaller)(nil)
+
+type postgresSignaller struct {
+	Log *service.Logger
+
+	schema    string
+	tableName string
+}
+
+// NewControlSignaller creates a replication.Signaller that detects signal
+// INSERTs on the given schema.tableName.
+func NewControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
+	normalizedSchema, err := wireFormPostgresIdentifier(schema)
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema %q: %w", schema, err)
+	}
+	normalizedTableName := tableName
+	if tableName != "" {
+		if normalizedTableName, err = wireFormPostgresIdentifier(tableName); err != nil {
+			return nil, fmt.Errorf("invalid signal table name %q: %w", tableName, err)
+		}
+	}
+	return &postgresSignaller{Log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
+}
+
+func wireFormPostgresIdentifier(name string) (string, error) {
+	normalized, err := sanitize.NormalizePostgresIdentifier(name)
+	if err != nil {
+		return "", err
+	}
+	return sanitize.UnquotePostgresIdentifier(normalized)
+}
+
+// Listen returns any actionable signal found; signal rows should always be
+// forwarded downstream as normal messages regardless of the outcome here.
+func (s *postgresSignaller) Listen(_ context.Context, signal any) (*replication.ControlSignal, error) {
+	msg, ok := signal.(pglogicalstream.StreamMessage)
+	if !ok {
+		return nil, nil
+	}
+	if msg.Operation != pglogicalstream.InsertOpType {
+		return nil, nil
+	}
+	if msg.Schema != s.schema || msg.Table != s.tableName {
+		return nil, nil
+	}
+
+	row, ok := msg.Data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected map for %s message data, got %T", s.tableName, msg.Data)
+	}
+	dataStr, ok := row["data"].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string for %s.data column, got %T", s.tableName, row["data"])
+	}
+
+	var sig replication.ControlSignal
+	if sig.SignalType, ok = row["type"].(string); !ok {
+		return nil, errors.New("parsing control signals's 'type' data")
+	}
+
+	sig.ID = fmt.Sprintf("%v", row["id"])
+	log := s.Log.With("id", sig.ID, "type", sig.SignalType)
+
+	if msg.LSN != nil {
+		sig.LSN = []byte(*msg.LSN)
+	}
+
+	// validate signal type
+	switch sig.SignalType {
+	case replication.LogSignalType:
+		if err := json.Unmarshal([]byte(dataStr), &sig.LogSignal); err != nil {
+			return nil, fmt.Errorf("unmarshaling control signal %s.data: %w", s.tableName, err)
+		}
+		log.Infof("%s (lsn=%s)", sig.Message, sig.LSN)
+	default:
+		log.Warnf("Control signal %q received but not a recognized type", sig.SignalType)
+	}
+
+	return &sig, nil
+}

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -70,6 +70,52 @@ postgres_cdc:
 		})
 	})
 
+	t.Run("supports string based id column", func(t *testing.T) {
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.uuid_test_events (id SERIAL PRIMARY KEY, name TEXT)`)
+		db.MustExec(t, `INSERT INTO dbo.uuid_test_events (name) VALUES ('initial')`)
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.uuid_signal_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), type VARCHAR(32), data TEXT)`)
+
+		received, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_uuid_id
+    stream_snapshot: true
+    signal_table_name: uuid_signal_table
+    schema: dbo
+    tables:
+      - uuid_test_events
+`, databaseURL))
+
+		// Wait for the initial snapshot to complete before inserting a signal.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
+
+		received.Reset()
+
+		var signalID string
+		require.NoError(t, db.QueryRow(`INSERT INTO dbo.uuid_signal_table (type, data) VALUES ('log', '{"message": "uuid id works"}') RETURNING id`).Scan(&signalID))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "uuid id works") && strings.Contains(m, "id="+signalID) {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a log entry propagating id=%s, got: %v", signalID, logs.Messages())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, received.Len())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.ElementsMatch(t, received.All(), []any{
+			map[string]any{"operation": "insert", "table": "uuid_signal_table", "lsn": "XXX/XXX"},
+		})
+	})
+
 	t.Run("errors when signal table does not exist", func(t *testing.T) {
 		_, logs := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
@@ -331,7 +377,7 @@ postgres_cdc:
 func startSignallingStream(t *testing.T, inputYAML string) (*pgtest.ReceivedMessages, *pgtest.TestLogCapture) {
 	t.Helper()
 
-	logs := &pgtest.TestLogCapture{}
+	logs := pgtest.NewTestLogCapture()
 	streamOutBuilder := service.NewStreamBuilder()
 	streamOutBuilder.SetLogger(slog.New(logs))
 	require.NoError(t, streamOutBuilder.AddInputYAML(inputYAML))

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -32,13 +32,14 @@ func TestIntegrationSignallingConfiguration(t *testing.T) {
 	require.NoError(t, err)
 
 	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
-	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
-	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
-
-	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
-	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
 
 	t.Run("supports signal tables", func(t *testing.T) {
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+
 		received, _ := startSignallingStream(t, fmt.Sprintf(`
 postgres_cdc:
     dsn: %s
@@ -113,6 +114,58 @@ postgres_cdc:
 
 		require.ElementsMatch(t, received.All(), []any{
 			map[string]any{"operation": "insert", "table": "uuid_signal_table", "lsn": "XXX/XXX"},
+		})
+	})
+
+	t.Run("logs a per-row error when data column has the wrong type", func(t *testing.T) {
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.jsonb_test_events (id SERIAL PRIMARY KEY, name TEXT)`)
+		db.MustExec(t, `INSERT INTO dbo.jsonb_test_events (name) VALUES ('initial')`)
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.jsonb_data_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data JSONB)`)
+
+		received, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_jsonb_data
+    stream_snapshot: true
+    signal_table_name: jsonb_data_signal_table
+    schema: dbo
+    tables:
+      - jsonb_test_events
+`, databaseURL))
+
+		// Wait for the initial snapshot to complete before inserting a signal.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
+
+		received.Reset()
+
+		// data decodes as a map, not a string, so Listen must reject it with a
+		// clear error - but the row must still be forwarded downstream, per
+		// Listen's own contract (detection failures never suppress a row).
+		db.MustExec(t, `INSERT INTO dbo.jsonb_data_signal_table (type, data) VALUES ('log', '{"message": "wrong type"}'::jsonb)`)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "expected string for") && strings.Contains(m, "jsonb_data_signal_table.data column") {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a per-row error naming the wrong-typed data column, got: %v", logs.Messages())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// The per-row detection failure must not pause or break the stream -
+		db.MustExec(t, `INSERT INTO dbo.jsonb_test_events (name) VALUES ('after-wrong-type-signal')`)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 2, received.Len())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.ElementsMatch(t, received.All(), []any{
+			map[string]any{"operation": "insert", "table": "jsonb_data_signal_table", "lsn": "XXX/XXX"},
+			map[string]any{"operation": "insert", "table": "jsonb_test_events", "lsn": "XXX/XXX"},
 		})
 	})
 

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pgtest"
+	"github.com/redpanda-data/connect/v4/internal/license"
+)
+
+func TestIntegrationSignallingConfiguration(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.custom_signal_table (id VARCHAR(32), type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	t.Run("supports signal tables", func(t *testing.T) {
+		received, _ := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling
+    stream_snapshot: true
+    signal_table_name: custom_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+		// Wait for the initial snapshot to complete before inserting streaming records.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 2, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
+
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
+		db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 4, received.Len())
+		}, 25*time.Second, 100*time.Millisecond)
+
+		require.ElementsMatch(t, received.All(), []any{
+			map[string]any{"operation": "read", "table": "events"},
+			map[string]any{"operation": "read", "table": "events"},
+			map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+			map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		})
+	})
+
+	t.Run("errors when signal table does not exist", func(t *testing.T) {
+		_, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_missing_signal_table
+    stream_snapshot: true
+    signal_table_name: does_not_exist
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "signal table") && strings.Contains(m, "does not exist") {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a connect error naming the missing signal table, got: %v", logs.Messages())
+		}, 25*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("errors when signal table is missing required columns", func(t *testing.T) {
+		db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.wrong_shape_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), payload TEXT)`)
+
+		_, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_wrong_shape_signal_table
+    stream_snapshot: true
+    signal_table_name: wrong_shape_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var found bool
+			for _, m := range logs.Messages() {
+				if strings.Contains(m, "signal table") && strings.Contains(m, "missing required column") && strings.Contains(m, "data") {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "expected a connect error naming the missing data column, got: %v", logs.Messages())
+		}, 25*time.Second, 100*time.Millisecond)
+	})
+}
+
+func TestIntegrationSignallingDisabledWhenTableNameEmpty(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	// Shaped exactly like a signal table, and replicated as an ordinary data
+	// table below - with signal_table_name left unset, it must never be
+	// treated as one.
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	received, _ := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_disabled
+    stream_snapshot: true
+    schema: dbo
+    tables:
+      - events
+      - rpcn_signal_table
+`, databaseURL))
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, received.Len())
+	}, 25*time.Second, 100*time.Millisecond)
+
+	received.Reset()
+
+	// This row is shaped exactly like a log signal. With signal_table_name
+	// unset, it must be forwarded as an ordinary message rather than detected
+	// as a signal.
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Signal message"}')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('stream')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 2, received.Len())
+	}, 25*time.Second, 100*time.Millisecond)
+
+	require.ElementsMatch(t, received.All(), []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+}
+
+// TestIntegrationSignallingDetectedWithoutInterruptingStream verifies that a
+// recognized log signal is detected and forwarded downstream like any other
+// message, and streaming is never paused, flushed early, or restarted
+// because of it (see postgresSignaller.Listen and processStream's handling
+// of the detected signal in input_pg_stream.go).
+func TestIntegrationSignallingDetectedWithoutInterruptingStream(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	received, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_detect_only
+    stream_snapshot: true
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, received.Len())
+	}, 25*time.Second, 100*time.Millisecond)
+
+	received.Reset()
+
+	// A real log signal, immediately followed by an ordinary insert. If
+	// detection incorrectly paused or restarted the stream, the second
+	// insert would be delayed well past the assertion window below.
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "Hello World"}')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('after-signal')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 2, received.Len())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var found bool
+		for _, m := range logs.Messages() {
+			if strings.Contains(m, "Hello World") {
+				found = true
+				break
+			}
+		}
+		assert.True(c, found, "expected a log entry for the recognized log signal, got: %v", logs.Messages())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// No re-snapshot should ever follow - give it a moment, then confirm
+	// nothing beyond the signal row and the one ordinary insert ever arrives.
+	time.Sleep(500 * time.Millisecond)
+
+	require.ElementsMatch(t, received.All(), []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+}
+
+func TestIntegrationSignallingMalformedRowStillPublished(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('initial')`)
+
+	received, _ := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_malformed
+    stream_snapshot: true
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+    tables:
+      - events
+`, databaseURL))
+
+	// Wait for the initial snapshot row from dbo.events.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, received.Len())
+	}, 25*time.Second, 100*time.Millisecond)
+
+	received.Reset()
+
+	// data is left NULL, so Listen fails to parse this row as a signal
+	// ("expected string for ...data column, got <nil>"). That must not stop
+	// it from being published like any other row.
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type) VALUES ('log')`)
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('after-malformed-signal')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 2, received.Len())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.ElementsMatch(t, received.All(), []any{
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+	})
+}
+
+// TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables verifies
+// that setting signal_table_name while leaving tables empty (the documented
+// FOR ALL TABLES mode - see the tables field docs in input_pg_stream.go)
+// does not collapse the publication down to just the signal table.
+func TestIntegrationSignalTableNameWithEmptyTablesReplicatesAllTables(t *testing.T) {
+	integration.CheckSkip(t)
+	databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+	require.NoError(t, err)
+
+	db.MustExec(t, `CREATE SCHEMA IF NOT EXISTS dbo`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.rpcn_signal_table (id SERIAL PRIMARY KEY, type VARCHAR(32), data TEXT)`)
+	db.MustExec(t, `CREATE TABLE IF NOT EXISTS dbo.events (id SERIAL PRIMARY KEY, name TEXT)`)
+
+	received, logs := startSignallingStream(t, fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_signalling_all_tables
+    signal_table_name: rpcn_signal_table
+    schema: dbo
+`, databaseURL))
+
+	// There's no initial snapshot to synchronize on since tables is empty,
+	// so wait for the stream to confirm replication has actually started
+	// before inserting.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var started bool
+		for _, m := range logs.Messages() {
+			if strings.Contains(m, "Started logical replication on slot") {
+				started = true
+				break
+			}
+		}
+		assert.True(c, started, "expected replication to have started")
+	}, 25*time.Second, 100*time.Millisecond)
+
+	db.MustExec(t, `INSERT INTO dbo.events (name) VALUES ('hello')`)
+	db.MustExec(t, `INSERT INTO dbo.rpcn_signal_table (type, data) VALUES ('log', '{"message": "hi"}')`)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 2, received.Len())
+	}, 25*time.Second, 100*time.Millisecond)
+
+	require.ElementsMatch(t, received.All(), []any{
+		map[string]any{"operation": "insert", "table": "events", "lsn": "XXX/XXX"},
+		map[string]any{"operation": "insert", "table": "rpcn_signal_table", "lsn": "XXX/XXX"},
+	})
+}
+
+func startSignallingStream(t *testing.T, inputYAML string) (*pgtest.ReceivedMessages, *pgtest.TestLogCapture) {
+	t.Helper()
+
+	logs := &pgtest.TestLogCapture{}
+	streamOutBuilder := service.NewStreamBuilder()
+	streamOutBuilder.SetLogger(slog.New(logs))
+	require.NoError(t, streamOutBuilder.AddInputYAML(inputYAML))
+	require.NoError(t, streamOutBuilder.AddProcessorYAML(`mapping: 'root = @'`))
+
+	received := &pgtest.ReceivedMessages{}
+	require.NoError(t, streamOutBuilder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+		for _, msg := range batch {
+			data, err := msg.AsStructured()
+			if err != nil {
+				return err
+			}
+			m := data.(map[string]any)
+			if _, ok := m["lsn"]; ok {
+				m["lsn"] = "XXX/XXX"
+			}
+			delete(m, "schema")
+			delete(m, "commit_ts_ms")
+			received.Add(m)
+		}
+		return nil
+	}))
+
+	streamOut, err := streamOutBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(streamOut.Resources())
+	t.Cleanup(func() {
+		require.NoError(t, streamOut.StopWithin(10*time.Second))
+	})
+
+	go func() {
+		if err := streamOut.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	return received, logs
+}

--- a/internal/impl/postgresql/signaller_integration_test.go
+++ b/internal/impl/postgresql/signaller_integration_test.go
@@ -298,6 +298,7 @@ postgres_cdc:
     slot_name: test_slot_signalling_all_tables
     signal_table_name: rpcn_signal_table
     schema: dbo
+    tables: []
 `, databaseURL))
 
 	// There's no initial snapshot to synchronize on since tables is empty,

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -95,7 +95,7 @@ func TestPostgresSignallerListen(t *testing.T) {
 				Table:     "rpcn_signal_table",
 				Data:      map[string]any{"id": 1, "type": 123, "data": `{"message": "hello"}`},
 			},
-			errContains: "parsing control signals's 'type' data",
+			errContains: "expected string for rpcn_signal_table.type column, got int",
 		},
 		{
 			name: "recognized log type is returned",

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
+	"github.com/redpanda-data/connect/v4/internal/replication"
+)
+
+func TestPostgresSignallerListen(t *testing.T) {
+	lsn := "0/1"
+
+	tests := []struct {
+		name        string
+		event       any
+		errContains string
+		want        *replication.ControlSignal
+	}{
+		{
+			name:  "not a StreamMessage is ignored",
+			event: "not-a-stream-message",
+		},
+		{
+			name: "non-insert operation is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.UpdateOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "non-matching table is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "other_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "non-matching schema is ignored",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "other_schema",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+		},
+		{
+			name: "message data is not a map",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      "not-a-map",
+			},
+			errContains: "expected map for",
+		},
+		{
+			name: "data column is not a string",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": nil},
+			},
+			errContains: "expected string for",
+		},
+		{
+			name: "data column is not valid JSON",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": "log", "data": "not-json"},
+			},
+			errContains: "unmarshaling control signal",
+		},
+		{
+			name: "type column is not a string",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				Data:      map[string]any{"id": 1, "type": 123, "data": `{"message": "hello"}`},
+			},
+			errContains: "parsing control signals's 'type' data",
+		},
+		{
+			name: "recognized log type is returned",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				LSN:       &lsn,
+				Data:      map[string]any{"id": 1, "type": "log", "data": `{"message": "hello"}`},
+			},
+			want: &replication.ControlSignal{ID: "1", SignalType: "log", LogSignal: replication.LogSignal{Message: "hello"}, LSN: []byte(lsn)},
+		},
+		{
+			name: "unrecognized type is still returned",
+			event: pglogicalstream.StreamMessage{
+				Operation: pglogicalstream.InsertOpType,
+				Schema:    "dbo",
+				Table:     "rpcn_signal_table",
+				LSN:       &lsn,
+				Data:      map[string]any{"id": 2, "type": "unsupported", "data": `{"message": "hello"}`},
+			},
+			want: &replication.ControlSignal{ID: "2", SignalType: "unsupported", LSN: []byte(lsn)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := NewControlSignaller("dbo", "rpcn_signal_table", nil)
+			require.NoError(t, err)
+
+			got, err := s.Listen(t.Context(), test.event)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 func TestPostgresSignallerEnabled(t *testing.T) {
-	s, err := NewControlSignaller("dbo", "", nil)
+	s, err := newControlSignaller("dbo", "", nil)
 	require.NoError(t, err)
-	require.False(t, s.Enabled(), "expected Enabled to be false when no signal table is configured")
+	require.False(t, s.enabled(), "expected Enabled to be false when no signal table is configured")
 
-	s, err = NewControlSignaller("dbo", "rpcn_signal_table", nil)
+	s, err = newControlSignaller("dbo", "rpcn_signal_table", nil)
 	require.NoError(t, err)
-	require.True(t, s.Enabled(), "expected Enabled to be true when a signal table is configured")
+	require.True(t, s.enabled(), "expected Enabled to be true when a signal table is configured")
 }
 
 func TestPostgresSignallerListen(t *testing.T) {
@@ -129,10 +129,10 @@ func TestPostgresSignallerListen(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, err := NewControlSignaller("dbo", "rpcn_signal_table", nil)
+			s, err := newControlSignaller("dbo", "rpcn_signal_table", nil)
 			require.NoError(t, err)
 
-			got, err := s.Listen(&test.event)
+			got, err := s.listen(&test.event)
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 				require.Nil(t, got)

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -17,19 +17,25 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/replication"
 )
 
+func TestPostgresSignallerEnabled(t *testing.T) {
+	s, err := NewControlSignaller("dbo", "", nil)
+	require.NoError(t, err)
+	require.False(t, s.Enabled(), "expected Enabled to be false when no signal table is configured")
+
+	s, err = NewControlSignaller("dbo", "rpcn_signal_table", nil)
+	require.NoError(t, err)
+	require.True(t, s.Enabled(), "expected Enabled to be true when a signal table is configured")
+}
+
 func TestPostgresSignallerListen(t *testing.T) {
 	lsn := "0/1"
 
 	tests := []struct {
 		name        string
-		event       any
+		event       pglogicalstream.StreamMessage
 		errContains string
 		want        *replication.ControlSignal
 	}{
-		{
-			name:  "not a StreamMessage is ignored",
-			event: "not-a-stream-message",
-		},
 		{
 			name: "non-insert operation is ignored",
 			event: pglogicalstream.StreamMessage{
@@ -126,7 +132,7 @@ func TestPostgresSignallerListen(t *testing.T) {
 			s, err := NewControlSignaller("dbo", "rpcn_signal_table", nil)
 			require.NoError(t, err)
 
-			got, err := s.Listen(t.Context(), test.event)
+			got, err := s.Listen(&test.event)
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 				require.Nil(t, got)

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication
+
+import "context"
+
+// LogSignalType represents a log signal.
+const LogSignalType = "log"
+
+// LogSignal is the decoded "data" payload for a LogSignalType signal.
+type LogSignal struct {
+	Message string `json:"message"`
+}
+
+// ControlSignal represents a insert into the signal table.
+type ControlSignal struct {
+	ID         string
+	SignalType string
+	LogSignal
+
+	// LSN is the log sequence number/offset the signal was observed at, in
+	// whatever raw form the connector's replication stream represents
+	// positions (e.g. a decimal/hex string, or raw binary bytes for
+	// connectors like Oracle whose SCNs aren't naturally textual). It is
+	// populated by the connector's Listen implementation, not part of the
+	// signal's own encoded payload.
+	LSN []byte `json:"-"`
+}
+
+// Type returns the SignalType or an empty string if ControlSignal is nil.
+func (s *ControlSignal) Type() string {
+	if s != nil {
+		return s.SignalType
+	}
+	return ""
+}
+
+// Signaller is implemented by connector-specific control signal handlers.
+// Listen inspects a decoded replication message and, if it recognizes an
+// actionable signal, returns it directly - in the same call that detected it
+// - so the caller can flush exactly that batch before acting on it, rather
+// than reacting to a separately-scheduled notification a differently-timed
+// flush could race ahead of.
+type Signaller interface {
+	Listen(ctx context.Context, event any) (*ControlSignal, error)
+}

--- a/internal/replication/signalling.go
+++ b/internal/replication/signalling.go
@@ -8,8 +8,6 @@
 
 package replication
 
-import "context"
-
 // LogSignalType represents a log signal.
 const LogSignalType = "log"
 
@@ -39,14 +37,4 @@ func (s *ControlSignal) Type() string {
 		return s.SignalType
 	}
 	return ""
-}
-
-// Signaller is implemented by connector-specific control signal handlers.
-// Listen inspects a decoded replication message and, if it recognizes an
-// actionable signal, returns it directly - in the same call that detected it
-// - so the caller can flush exactly that batch before acting on it, rather
-// than reacting to a separately-scheduled notification a differently-timed
-// flush could race ahead of.
-type Signaller interface {
-	Listen(ctx context.Context, event any) (*ControlSignal, error)
 }


### PR DESCRIPTION
This pull request adds the initial signalling detection mechanism, first supporting `log` signal type that can be used to verify integration. This acts as the foundation to support (incremental) snapshotting new or existing tables without having to restart the connector.

<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/25fb1310-ef15-4b48-b823-bf887d92ef9b" />