### PR TITLE
claude: correct tools available to godev and tester agents

### DIFF
--- a/.claude/agents/godev.md
+++ b/.claude/agents/godev.md
@@ -1,7 +1,7 @@
 ---
 name: godev
 description: PROACTIVELY handles Go code writing, reviews, refactoring, component architecture, registration, and multi-distribution builds for Redpanda Connect
-tools: bash, file_access, git
+tools: Bash, Read, Write, Edit, Grep, Glob
 model: sonnet
 ---
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,7 +1,7 @@
 ---
 name: tester
 description: PROACTIVELY writes and maintains unit and integration tests for Redpanda Connect using testify, table-driven patterns, testcontainers-go, and the benthos service API
-tools: bash, file_access, git
+tools: Bash, Read, Write, Edit, Grep, Glob
 model: sonnet
 ---
 


### PR DESCRIPTION
This change replaces the non-existent tools with the correct counterparts supported Claude tools https://code.claude.com/docs/en/tools-reference

`git` isn't listed as a tool, so if we wanted to limit access to just `git` we'd need have to do it via permissions (ie.  `"deny": ["Bash"]` plus `"allow": ["Bash(git *)"]`), which may be something we want to do.