### PR TITLE
mssqlserver_cdc: migrate SQL based checkpoint cache column type to avoid LSN corruption on read collation decoding

### DIFF
--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -108,6 +108,8 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+
+The Connect user also requires `ALTER` permission on the checkpoint cache table, to support schema updates to the checkpoint cache (for example, one-time migrations applied automatically on upgrade).
 		
 
 == Fields

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -264,7 +264,7 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		return fmt.Errorf("validating migrated cache_val length: %w", err)
 	}
 	if invalidRows > 0 {
-		log.Warnf("Checkpoint cache table '%s' had %d recovered LSN value(s) that failed length validation after migration and were reset; affected pipelines will resume from each table's tracked start LSN instead", tableName, invalidRows)
+		log.Warnf("Checkpoint cache table '%s' had %d recovered LSN value(s) that failed length validation after migration and were reset to NULL. On next start, affected pipelines configured with stream_snapshot: true will re-run a full snapshot of every configured table; those with stream_snapshot: false will instead replay each change table from its tracked start LSN.", tableName, invalidRows)
 	}
 
 	return tx.Commit()

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -81,11 +81,6 @@ func newCheckpointCache(
 		return nil, fmt.Errorf("connecting to microsoft sql server for caching checkpoints: %w", err)
 	}
 
-	if err := createUpsertStoredProc(ctx, db, cacheTable); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("creating checkpoint cache write stored procedure: %w", err)
-	}
-
 	if created, err := createCacheTable(ctx, db, cacheTable); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("creating checkpoint cache table '%s': %w", cacheTable.String(), err)
@@ -93,6 +88,15 @@ func newCheckpointCache(
 		log.Infof("Created checkpoint cache table '%s'", cacheTable.String())
 	} else {
 		log.Infof("Found existing checkpoint cache table '%s'", cacheTable.String())
+	}
+
+	if err := cacheTableMigration(ctx, db, cacheTable.String(), log); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrating checkpoint cache table '%s': %w", cacheTable.String(), err)
+	}
+	if err := createUpsertStoredProc(ctx, db, cacheTable); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("creating checkpoint cache write stored procedure: %w", err)
 	}
 
 	// create a prepared statement for calling the stored proc (created in same schema as cache table) during Set operations to remove avoidable overhead
@@ -167,7 +171,7 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	BEGIN
 		CREATE TABLE %s (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
-			cache_val varchar(100)
+			cache_val varbinary(10)
 		);
 		SET @created = 1;
 	END;
@@ -179,6 +183,82 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	return created, nil
 }
 
+// cacheTableMigration converts a legacy character-typed cache_val column to
+// varbinary(10) in place. On-disk bytes are intact even for legacy rows, so
+// the byte-level CONVERT recovers the true LSN rather than resetting it.
+// No-op if the column is already binary.
+//
+// Guarded by sp_getapplock so pipelines sharing one checkpoint table don't
+// race on the rename when starting concurrently.
+func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
+	lockResource := tableName
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning cache migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		lockRes int
+		query   = "DECLARE @res INT; EXEC @res = sp_getapplock @Resource = ?, @LockMode = 'Exclusive'; SELECT @res;"
+	)
+	if err := tx.QueryRowContext(ctx, query, lockResource).Scan(&lockRes); err != nil {
+		return fmt.Errorf("acquiring checkpoint cache migration lock: %w", err)
+	}
+	if lockRes < 0 {
+		return fmt.Errorf("aquiring checkpoint cache migration lock (sp_getapplock returned %d)", lockRes)
+	}
+
+	var isChar bool
+	checkQ := `
+	SELECT CASE WHEN t.name IN ('varchar', 'char', 'nvarchar', 'nchar') THEN 1 ELSE 0 END
+	FROM sys.columns c
+	JOIN sys.types t ON t.user_type_id = c.user_type_id
+	WHERE c.object_id = OBJECT_ID(?) AND c.name = 'cache_val';`
+	if err := tx.QueryRowContext(ctx, checkQ, tableName).Scan(&isChar); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// table/column not found is unexpected here since createCacheTable runs first,
+			// but treat as nothing to migrate rather than failing startup.
+			return tx.Commit()
+		}
+		return fmt.Errorf("inspecting checkpoint cache column type: %w", err)
+	}
+	if !isChar {
+		// already migrated
+		return tx.Commit()
+	}
+
+	log.Warnf("Migrating legacy character-typed cache_val column on checkpoint cache table '%s' to varbinary(10); recovered LSNs will be validated for length", tableName)
+
+	migrationSteps := []string{
+		fmt.Sprintf("ALTER TABLE %s ADD cache_val_bin varbinary(10) NULL;", tableName),
+		fmt.Sprintf("UPDATE %s SET cache_val_bin = CONVERT(varbinary(10), cache_val);", tableName),
+		fmt.Sprintf("ALTER TABLE %s DROP COLUMN cache_val;", tableName),
+		fmt.Sprintf("EXEC sp_rename '%s.cache_val_bin', 'cache_val', 'COLUMN';", tableName),
+	}
+	for _, step := range migrationSteps {
+		if _, err := tx.ExecContext(ctx, step); err != nil {
+			return fmt.Errorf("converting cache_val column to varbinary: %w", err)
+		}
+	}
+
+	validateQ := fmt.Sprintf(`UPDATE %s SET cache_val = NULL WHERE cache_val IS NOT NULL AND DATALENGTH(cache_val) <> 10;`, tableName)
+	res, err := tx.ExecContext(ctx, validateQ)
+	if err != nil {
+		return fmt.Errorf("updating migrated cache_val length: %w", err)
+	}
+	invalidRows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("validating migrated cache_val length: %w", err)
+	}
+	if invalidRows > 0 {
+		log.Warnf("Checkpoint cache table '%s' had %d recovered LSN value(s) that failed length validation after migration and were reset; affected pipelines will resume from each table's tracked start LSN instead", tableName, invalidRows)
+	}
+
+	return tx.Commit()
+}
+
 func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTable) error {
 	storedProcFullName := fmt.Sprintf("[%s].[%s]", cacheTable.schema, defaultStoredProcName)
 	tableName := cacheTable.String()
@@ -186,7 +266,7 @@ func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTab
 	q := `
 	CREATE OR ALTER PROCEDURE %s
 		@Key varchar(7),
-		@Value varchar(100)
+		@Value varbinary(10)
 	AS
 	BEGIN
 		SET NOCOUNT ON;

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -242,6 +242,18 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 
 	log.Warnf("Migrating legacy character-typed cache_val column on checkpoint cache table '%s' to varbinary(10); recovered LSNs will be validated for length", tableName)
 
+	// check length to ensure the source is a genuine 10-byte LSN before converting
+	var invalidRows int64
+	countQ := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE cache_val IS NOT NULL AND DATALENGTH(cache_val) <> 10;`, tableName)
+	if err := tx.QueryRowContext(ctx, countQ).Scan(&invalidRows); err != nil {
+		return fmt.Errorf("checking legacy cache_val length: %w", err)
+	}
+
+	// unfortunately we can't recover here and user would need to clear their cache.
+	if invalidRows > 0 {
+		return fmt.Errorf("checkpoint cache table '%s' has %d cache_val entry/entries that are not a valid 10-byte LSN and cannot be safely recovered; clear the affected row(s) (e.g. UPDATE %s SET cache_val = NULL WHERE DATALENGTH(cache_val) <> 10) and restart - affected pipelines will resume via a full resnapshot if stream_snapshot is true, or by replaying each change table from its tracked start LSN if false", tableName, invalidRows, tableName)
+	}
+
 	migrationSteps := []string{
 		fmt.Sprintf("ALTER TABLE %s ADD cache_val_bin varbinary(10) NULL;", tableName),
 		fmt.Sprintf("UPDATE %s SET cache_val_bin = CONVERT(varbinary(10), cache_val);", tableName),
@@ -252,19 +264,6 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		if _, err := tx.ExecContext(ctx, step); err != nil {
 			return fmt.Errorf("converting cache_val column to varbinary: %w", err)
 		}
-	}
-
-	validateQ := fmt.Sprintf(`UPDATE %s SET cache_val = NULL WHERE cache_val IS NOT NULL AND DATALENGTH(cache_val) <> 10;`, tableName)
-	res, err := tx.ExecContext(ctx, validateQ)
-	if err != nil {
-		return fmt.Errorf("updating migrated cache_val length: %w", err)
-	}
-	invalidRows, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("validating migrated cache_val length: %w", err)
-	}
-	if invalidRows > 0 {
-		log.Warnf("Checkpoint cache table '%s' had %d recovered LSN value(s) that failed length validation after migration and were reset to NULL. On next start, affected pipelines configured with stream_snapshot: true will re-run a full snapshot of every configured table; those with stream_snapshot: false will instead replay each change table from its tracked start LSN.", tableName, invalidRows)
 	}
 
 	return tx.Commit()

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -90,8 +90,8 @@ func newCheckpointCache(
 		log.Infof("Found existing checkpoint cache table '%s'", cacheTable.String())
 	}
 
-	// this and its tests can eventually be deleted when we're happy users have migrated.
-	if err := cacheTableMigration(ctx, db, cacheTable.String(), log); err != nil {
+	// TODO(JoeW) this and its tests can eventually be deleted when we're happy users have migrated.
+	if err := migrateCacheTable(ctx, db, cacheTable.String(), log); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("migrating checkpoint cache table '%s': %w", cacheTable.String(), err)
 	}
@@ -184,14 +184,14 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	return created, nil
 }
 
-// cacheTableMigration converts a legacy character-typed cache_val column to
+// migrateCacheTable converts a legacy character-typed cache_val column to
 // varbinary(10) in place. On-disk bytes are intact even for legacy rows, so
 // the byte-level CONVERT recovers the true LSN rather than resetting it.
 // No-op if the column is already binary.
 //
 // Guarded by sp_getapplock so pipelines sharing one checkpoint table don't
 // race on the rename when starting concurrently.
-func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
+func migrateCacheTable(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
 	lockResource := tableName
 
 	tx, err := db.BeginTx(ctx, nil)
@@ -200,10 +200,8 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var (
-		lockRes int
-		query   = "DECLARE @res INT; EXEC @res = sp_getapplock @Resource = ?, @LockMode = 'Exclusive'; SELECT @res;"
-	)
+	var lockRes int
+	query := "DECLARE @res INT; EXEC @res = sp_getapplock @Resource = ?, @LockMode = 'Exclusive'; SELECT @res;"
 	if err := tx.QueryRowContext(ctx, query, lockResource).Scan(&lockRes); err != nil {
 		return fmt.Errorf("acquiring checkpoint cache migration lock: %w", err)
 	}
@@ -226,17 +224,18 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		return fmt.Errorf("inspecting checkpoint cache column type: %w", err)
 	}
 
-	// varchar/char is the only legacy shape this connector has ever produced, and the
-	// only one where a byte-level CONVERT to varbinary is guaranteed to recover the true
-	// LSN rather than truncating it
+	// varchar is the only legacy shape this connector has ever produced. char is
+	// excluded even though CONVERT can recover it too: DATALENGTH on a fixed-length
+	// char(n) column always returns n (blank-padded), not the actual content length,
+	// so the length check below would false-positive on every row for any n != 10.
 	switch typeName {
 	case "varbinary", "binary":
 		// already migrated - nothing to do
 		return tx.Commit()
-	case "varchar", "char":
+	case "varchar":
 		// handled below
 	default:
-		log.Errorf("Checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar/char (legacy) or varbinary (current). Skipping migration - manual inspection is required.", tableName, typeName)
+		log.Errorf("Checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar (legacy) or varbinary (current). Skipping migration - manual inspection is required.", tableName, typeName)
 		return tx.Commit()
 	}
 
@@ -251,7 +250,7 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 
 	// unfortunately we can't recover here and user would need to clear their cache.
 	if invalidRows > 0 {
-		return fmt.Errorf("checkpoint cache table '%s' has %d cache_val entry/entries that are not a valid 10-byte LSN and cannot be safely recovered; clear the affected row(s) (e.g. UPDATE %s SET cache_val = NULL WHERE DATALENGTH(cache_val) <> 10) and restart - affected pipelines will resume via a full resnapshot if stream_snapshot is true, or by replaying each change table from its tracked start LSN if false", tableName, invalidRows, tableName)
+		return fmt.Errorf("checkpoint cache table '%s' has %d cache_val entries that are not a valid 10-byte LSN and cannot be safely recovered; clear the affected row(s) (e.g. UPDATE %s SET cache_val = NULL WHERE DATALENGTH(cache_val) <> 10) and restart - affected pipelines will resume via a full resnapshot if stream_snapshot is true, or by replaying each change table from its tracked start LSN if false", tableName, invalidRows, tableName)
 	}
 
 	migrationSteps := []string{

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -90,6 +90,7 @@ func newCheckpointCache(
 		log.Infof("Found existing checkpoint cache table '%s'", cacheTable.String())
 	}
 
+	// this and its tests can eventually be deleted when we're happy users have migrated.
 	if err := cacheTableMigration(ctx, db, cacheTable.String(), log); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("migrating checkpoint cache table '%s': %w", cacheTable.String(), err)
@@ -207,7 +208,7 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		return fmt.Errorf("acquiring checkpoint cache migration lock: %w", err)
 	}
 	if lockRes < 0 {
-		return fmt.Errorf("aquiring checkpoint cache migration lock (sp_getapplock returned %d)", lockRes)
+		return fmt.Errorf("acquiring checkpoint cache migration lock (sp_getapplock returned %d)", lockRes)
 	}
 
 	var isChar bool

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -211,13 +211,13 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		return fmt.Errorf("acquiring checkpoint cache migration lock (sp_getapplock returned %d)", lockRes)
 	}
 
-	var isChar bool
+	var typeName string
 	checkQ := `
-	SELECT CASE WHEN t.name IN ('varchar', 'char', 'nvarchar', 'nchar') THEN 1 ELSE 0 END
+	SELECT t.name
 	FROM sys.columns c
 	JOIN sys.types t ON t.user_type_id = c.user_type_id
 	WHERE c.object_id = OBJECT_ID(?) AND c.name = 'cache_val';`
-	if err := tx.QueryRowContext(ctx, checkQ, tableName).Scan(&isChar); err != nil {
+	if err := tx.QueryRowContext(ctx, checkQ, tableName).Scan(&typeName); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// table/column not found is unexpected here since createCacheTable runs first,
 			// but treat as nothing to migrate rather than failing startup.
@@ -225,8 +225,18 @@ func cacheTableMigration(ctx context.Context, db *sql.DB, tableName string, log 
 		}
 		return fmt.Errorf("inspecting checkpoint cache column type: %w", err)
 	}
-	if !isChar {
-		// already migrated
+
+	// varchar/char is the only legacy shape this connector has ever produced, and the
+	// only one where a byte-level CONVERT to varbinary is guaranteed to recover the true
+	// LSN rather than truncating it
+	switch typeName {
+	case "varbinary", "binary":
+		// already migrated - nothing to do
+		return tx.Commit()
+	case "varchar", "char":
+		// handled below
+	default:
+		log.Errorf("Checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar/char (legacy) or varbinary (current). Skipping migration - manual inspection is required.", tableName, typeName)
 		return tx.Commit()
 	}
 

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -198,7 +198,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_Migration(t *testing.
 		cacheTableToCreate := "rpcn4.CdcCheckpointCache"
 		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
 		require.ErrorContains(t, err, "cannot be safely recovered")
-		require.ErrorContains(t, err, "2 cache_val entry/entries")
+		require.ErrorContains(t, err, "2 cache_val entries")
 
 		// migration must not have touched the table: still legacy varchar, values untouched
 		var typeName string
@@ -211,6 +211,132 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_Migration(t *testing.
 		var shortAfter []byte
 		require.NoError(t, db.QueryRow(`SELECT cache_val FROM rpcn4.CdcCheckpointCache WHERE cache_key = ?;`, defaultCacheKey).Scan(&shortAfter))
 		require.Equal(t, shortVal, shortAfter, "row should be left untouched, not reset, pending manual intervention")
+	})
+
+	t.Run("skips migration for a char legacy column rather than misclassifying it", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn5;`)
+		require.NoError(t, err)
+
+		// char(100) is deliberately NOT treated as a recoverable legacy shape: DATALENGTH
+		// on a fixed-length char column always returns the declared length (blank-padded),
+		// not the actual content length, so the "<> 10" length check would false-positive
+		// on every row. It should land in the "unexpected type, skip" branch instead of
+		// being migrated or hard-failing startup.
+		_, err = db.Exec(`CREATE TABLE rpcn5.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val char(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn5.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn5.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err, "unexpected type should be skipped, not fail startup")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn5.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "char", typeName)
+	})
+
+	t.Run("skips migration for an nvarchar legacy column rather than corrupting it", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn6;`)
+		require.NoError(t, err)
+
+		_, err = db.Exec(`CREATE TABLE rpcn6.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val nvarchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn6.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn6.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err, "unexpected type should be skipped, not fail startup")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn6.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "nvarchar", typeName)
+	})
+
+	t.Run("skips migration for an nchar legacy column rather than misclassifying it", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn7;`)
+		require.NoError(t, err)
+
+		// nchar shares char's fixed-length DATALENGTH padding problem and nvarchar's
+		// UTF-16LE expansion problem - unrecoverable for two independent reasons.
+		_, err = db.Exec(`CREATE TABLE rpcn7.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val nchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn7.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn7.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err, "unexpected type should be skipped, not fail startup")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn7.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "nchar", typeName)
+	})
+
+	t.Run("treats an existing binary column as already migrated", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn8;`)
+		require.NoError(t, err)
+
+		// binary(10) is a fixed-length binary type, distinct from varbinary(10) but
+		// handled identically by the "already migrated" branch - no read-path corruption
+		// risk since it's binary, not character, storage.
+		_, err = db.Exec(`CREATE TABLE rpcn8.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val binary(10)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn8.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn8.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		// column type and value must be left exactly as they were - no migration attempted
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn8.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "binary", typeName)
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
 	})
 
 	t.Run("is idempotent across multiple constructions", func(t *testing.T) {

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -61,7 +61,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache(t *testing.T) {
 
 		// verify set
 		var wanted replication.LSN
-		require.NoError(t, wanted.Scan([]byte("0x0000002d000004b00003")))
+		require.NoError(t, wanted.Scan([]byte{0x00, 0x00, 0x00, 0x2d, 0x00, 0x00, 0x04, 0xb0, 0x00, 0x03}))
 		require.NoError(t, cache.Set(t.Context(), "", wanted, nil))
 
 		// verify get
@@ -106,6 +106,94 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache(t *testing.T) {
 
 		err = cache.db.PingContext(t.Context())
 		require.Contains(t, err.Error(), "sql: database is closed")
+	})
+}
+
+func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_Migration(t *testing.T) {
+	integration.CheckSkip(t)
+	connStr, db := mssqlservertest.MustSetupTestWithMicrosoftSQLServerVersion(t)
+
+	// highByteLSN contains bytes >= 0x80 (0x8b, 0xe2), which corrupt when round-tripped
+	// through a character column: the driver's varchar decode path reinterprets them via
+	// the column's collation and re-encodes as UTF-8, expanding the value beyond 10 bytes.
+	highByteLSN := replication.LSN{0x00, 0x04, 0x8b, 0x73, 0x00, 0x01, 0x73, 0xe2, 0x00, 0x01}
+
+	t.Run("round trips a high-byte LSN cleanly", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn1;`)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn1.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, cache.Set(t.Context(), "", highByteLSN, nil))
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
+	})
+
+	t.Run("migrates a legacy varchar cache table and recovers the true LSN", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn2;`)
+		require.NoError(t, err)
+
+		// Recreate the table using the pre-fix schema (cache_val varchar(100)) and write the
+		// LSN bytes directly via a varbinary bind so they land on disk intact, mirroring the
+		// real-world bug: writes round-trip fine, only the varchar *read* path corrupts.
+		_, err = db.Exec(`CREATE TABLE rpcn2.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn2.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn2.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		// column should now be varbinary
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn2.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "varbinary", typeName)
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got, "migration should recover the true on-disk LSN, not a re-corrupted value")
+	})
+
+	t.Run("is idempotent across multiple constructions", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn3;`)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn3.CdcCheckpointCache"
+
+		cacheA, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+		require.NoError(t, cacheA.Set(t.Context(), "", highByteLSN, nil))
+
+		// second construction against the same, already-migrated table must not error
+		cacheB, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		got, err := cacheB.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
+
+		require.NoError(t, cacheB.Set(t.Context(), "", highByteLSN, nil))
+		got, err = cacheA.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
 	})
 }
 

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -170,6 +170,49 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_Migration(t *testing.
 		require.Equal(t, []byte(highByteLSN), got, "migration should recover the true on-disk LSN, not a re-corrupted value")
 	})
 
+	t.Run("fails startup on a genuinely corrupted legacy value rather than resetting it silently", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn4;`)
+		require.NoError(t, err)
+
+		// Two distinct corruption shapes: a too-short value, and a too-long value.
+		// CONVERT(varbinary(10), x) truncates a too-long source to exactly 10 bytes
+		// with no error, so this also proves the source length is validated before
+		// conversion rather than the (always <= 10 byte) converted result afterward.
+		shortVal := []byte{0x01, 0x02, 0x03, 0x04}
+		overlongVal := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+
+		_, err = db.Exec(`CREATE TABLE rpcn4.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn4.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, shortVal)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn4.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			"other", overlongVal)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn4.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.ErrorContains(t, err, "cannot be safely recovered")
+		require.ErrorContains(t, err, "2 cache_val entry/entries")
+
+		// migration must not have touched the table: still legacy varchar, values untouched
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn4.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "varchar", typeName)
+
+		var shortAfter []byte
+		require.NoError(t, db.QueryRow(`SELECT cache_val FROM rpcn4.CdcCheckpointCache WHERE cache_key = ?;`, defaultCacheKey).Scan(&shortAfter))
+		require.Equal(t, shortVal, shortAfter, "row should be left untouched, not reset, pending manual intervention")
+	})
+
 	t.Run("is idempotent across multiple constructions", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -69,6 +69,8 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
+
+The Connect user also requires ` + "`ALTER`" + ` permission on the checkpoint cache table, to support schema updates to the checkpoint cache (for example, one-time migrations applied automatically on upgrade).
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").


### PR DESCRIPTION
This change updates the column type of the SQL Server based checkpoint cache to `varbinary(10)` to avoid instances where the LSN gets corrupted due to read collation as `go-mssqldb` treats the raw bytes as text.

This change allows us to safely migrate the LSN without requiring the cache to be truncated, though it does require the addition al `ALTER` permissions (which is probably a good idea to require on any SQL based CDC connector with an internal cache so we tend to handle migrations within the connector).

There's edge cases where it's possible the LSN is unrecoverable, in which case we fail to start the processor and report that the cache entry needs to be dropped and restarted.

When trying to asses the chance of a customer running into this, it's hard to quantify due to how SQL Server generates LSNs, and it only becomes evident when the connector restarts.

### Proof of Work

Before the connector run and after:

<img width="2447" height="545" alt="image" src="https://github.com/user-attachments/assets/fcdf2112-5d07-4be4-ba87-9b634429081e" />
