### PR TITLE
mssqlserver_cdc: Convert reading of LSN to binary to avoid LSN corruption due to read collation decoding

### DIFF
--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -200,16 +200,12 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	return created, nil
 }
 
-// validateCacheColumnType ensures cache_val is a type Get can safely recover a 10-byte
-// LSN from via CONVERT(varbinary(10), cache_val): varchar (the only legacy shape this
-// connector has ever produced), or already varbinary/binary. No DDL is run here - the
-// on-disk bytes of a legacy varchar column are already intact, so CONVERT alone recovers
-// them on read without ever touching the table's schema.
-//
-// nvarchar/nchar are rejected: CONVERT on those truncates UTF-16LE bytes silently,
-// corrupting any value >= 5 characters. char is rejected too: DATALENGTH on a
-// fixed-length char(n) column returns the declared length, not the actual content
-// length, so the length validation Get performs on read would false-positive on it.
+// validateCacheColumnType only accepts varchar (legacy) and varbinary (current) - the
+// only two shapes this connector has ever produced. No DDL is run; Get recovers a
+// legacy varchar column via CONVERT on read. nvarchar/nchar are rejected because
+// CONVERT truncates their UTF-16LE bytes silently; char/binary are rejected because
+// DATALENGTH on a fixed-length column returns the declared length, not the actual
+// content length, breaking Get's length check for any n != 10.
 func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
 	var typeName string
 	q := `
@@ -228,7 +224,7 @@ func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string, 
 	case "varchar":
 		log.Infof("Checkpoint cache table '%s' has a legacy varchar cache_val column; LSNs will be recovered via CONVERT on read rather than migrated. No action is required. If a cached value is ever found not to be a valid %d-byte LSN, this pipeline will fail to start until the entry is cleared.", tableName, lsnByteLength)
 		return nil
-	case "varbinary", "binary":
+	case "varbinary":
 		return nil
 	default:
 		return fmt.Errorf("checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar (legacy) or varbinary (current) - manual inspection is required", tableName, typeName)

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -226,7 +226,7 @@ func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string, 
 
 	switch typeName {
 	case "varchar":
-		log.Warnf("Checkpoint cache table '%s' has a legacy varchar cache_val column; LSNs will be recovered via CONVERT on read rather than migrated. No action is required. If a cached value is ever found not to be a valid %d-byte LSN, this pipeline will fail to start until the entry is cleared.", tableName, lsnByteLength)
+		log.Infof("Checkpoint cache table '%s' has a legacy varchar cache_val column; LSNs will be recovered via CONVERT on read rather than migrated. No action is required. If a cached value is ever found not to be a valid %d-byte LSN, this pipeline will fail to start until the entry is cleared.", tableName, lsnByteLength)
 		return nil
 	case "varbinary", "binary":
 		return nil

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -81,11 +81,6 @@ func newCheckpointCache(
 		return nil, fmt.Errorf("connecting to microsoft sql server for caching checkpoints: %w", err)
 	}
 
-	if err := createUpsertStoredProc(ctx, db, cacheTable); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("creating checkpoint cache write stored procedure: %w", err)
-	}
-
 	if created, err := createCacheTable(ctx, db, cacheTable); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("creating checkpoint cache table '%s': %w", cacheTable.String(), err)
@@ -93,6 +88,15 @@ func newCheckpointCache(
 		log.Infof("Created checkpoint cache table '%s'", cacheTable.String())
 	} else {
 		log.Infof("Found existing checkpoint cache table '%s'", cacheTable.String())
+	}
+
+	if err := validateCacheColumnType(ctx, db, cacheTable.String()); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("validating checkpoint cache table '%s': %w", cacheTable.String(), err)
+	}
+	if err := createUpsertStoredProc(ctx, db, cacheTable); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("creating checkpoint cache write stored procedure: %w", err)
 	}
 
 	// create a prepared statement for calling the stored proc (created in same schema as cache table) during Set operations to remove avoidable overhead
@@ -120,20 +124,35 @@ func newCheckpointCache(
 }
 
 // Get a cache item, we only do this at start up, key can be ignored as we only ever store one entry.
+//
+// cache_val is read via CONVERT(varbinary(10), cache_val), which recovers a legacy
+// varchar column byte-for-byte and is a no-op if already varbinary. DATALENGTH guards
+// against CONVERT silently truncating a too-long source.
 func (c *checkpointCache) Get(ctx context.Context, _ string) ([]byte, error) {
 	if c.db == nil {
 		return nil, fmt.Errorf("checkpoint cache not initialised for get operation: %w", service.ErrNotConnected)
 	}
 
-	var val []byte
-	q := "SELECT cache_val FROM %s WHERE cache_key = ?;"
-	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, c.cacheTableName.String()), defaultCacheKey).Scan(&val); err != nil {
+	var (
+		converted []byte
+		rawLen    sql.NullInt64
+	)
+	q := "SELECT CONVERT(varbinary(10), cache_val), DATALENGTH(cache_val) FROM %s WHERE cache_key = ?;"
+	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, c.cacheTableName.String()), defaultCacheKey).Scan(&converted, &rawLen); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, service.ErrKeyNotFound
 		}
 		return nil, fmt.Errorf("querying checkpoint cache: %w", err)
 	}
-	return val, nil
+	if !rawLen.Valid {
+		// cache_val is NULL - no checkpoint cached yet
+		return nil, nil
+	}
+	if rawLen.Int64 != 10 {
+		msg := "checkpoint cache table '%s' has a cache_val entry that is not a valid 10-byte LSN and cannot be safely recovered; please drop the cache entry and resnapshot data if necessary."
+		return nil, fmt.Errorf(msg, c.cacheTableName.String(), c.cacheTableName.String(), defaultCacheKey)
+	}
+	return converted, nil
 }
 
 // Set a cache item, specifying an optional TTL. It is okay for caches to
@@ -167,7 +186,7 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	BEGIN
 		CREATE TABLE %s (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
-			cache_val varchar(100)
+			cache_val varbinary(10)
 		);
 		SET @created = 1;
 	END;
@@ -179,6 +198,38 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	return created, nil
 }
 
+// validateCacheColumnType ensures cache_val is a type Get can safely recover a 10-byte
+// LSN from via CONVERT(varbinary(10), cache_val): varchar (the only legacy shape this
+// connector has ever produced), or already varbinary/binary. No DDL is run here - the
+// on-disk bytes of a legacy varchar column are already intact, so CONVERT alone recovers
+// them on read without ever touching the table's schema.
+//
+// nvarchar/nchar are rejected: CONVERT on those truncates UTF-16LE bytes silently,
+// corrupting any value >= 5 characters. char is rejected too: DATALENGTH on a
+// fixed-length char(n) column returns the declared length, not the actual content
+// length, so the length validation Get performs on read would false-positive on it.
+func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string) error {
+	var typeName string
+	q := `
+	SELECT t.name FROM sys.columns c JOIN sys.types t ON t.user_type_id = c.user_type_id
+	WHERE c.object_id = OBJECT_ID(?) AND c.name = 'cache_val';`
+	if err := db.QueryRowContext(ctx, q, tableName).Scan(&typeName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// table/column not found is unexpected here since createCacheTable runs first,
+			// but treat as nothing to validate rather than failing startup.
+			return nil
+		}
+		return fmt.Errorf("inspecting checkpoint cache column type: %w", err)
+	}
+
+	switch typeName {
+	case "varchar", "varbinary", "binary":
+		return nil
+	default:
+		return fmt.Errorf("checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar (legacy) or varbinary (current) - manual inspection is required", tableName, typeName)
+	}
+}
+
 func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTable) error {
 	storedProcFullName := fmt.Sprintf("[%s].[%s]", cacheTable.schema, defaultStoredProcName)
 	tableName := cacheTable.String()
@@ -186,7 +237,7 @@ func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTab
 	q := `
 	CREATE OR ALTER PROCEDURE %s
 		@Key varchar(7),
-		@Value varchar(100)
+		@Value varbinary(10)
 	AS
 	BEGIN
 		SET NOCOUNT ON;

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -202,10 +202,7 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 
 // validateCacheColumnType only accepts varchar (legacy) and varbinary (current) - the
 // only two shapes this connector has ever produced. No DDL is run; Get recovers a
-// legacy varchar column via CONVERT on read. nvarchar/nchar are rejected because
-// CONVERT truncates their UTF-16LE bytes silently; char/binary are rejected because
-// DATALENGTH on a fixed-length column returns the declared length, not the actual
-// content length, breaking Get's length check for any n != 10.
+// legacy varchar column via CONVERT on read.
 func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
 	var typeName string
 	q := `

--- a/internal/impl/mssqlserver/checkpoint_cache.go
+++ b/internal/impl/mssqlserver/checkpoint_cache.go
@@ -30,6 +30,9 @@ const (
 	// defaultStoredProcName schema is inferred from the provided checkpoint cache config
 	// the stored procedure name cannot be configured by the user
 	defaultStoredProcName = "CdcCheckpointCacheUpdate"
+	// lsnByteLength is the fixed byte width of a SQL Server LSN (Log Sequence Number):
+	// 4 bytes VLF sequence number + 4 bytes log block offset + 2 bytes slot number.
+	lsnByteLength = 10
 )
 
 // allowedTableIdentifiers is used for validating cache table names
@@ -90,7 +93,7 @@ func newCheckpointCache(
 		log.Infof("Found existing checkpoint cache table '%s'", cacheTable.String())
 	}
 
-	if err := validateCacheColumnType(ctx, db, cacheTable.String()); err != nil {
+	if err := validateCacheColumnType(ctx, db, cacheTable.String(), log); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("validating checkpoint cache table '%s': %w", cacheTable.String(), err)
 	}
@@ -137,8 +140,8 @@ func (c *checkpointCache) Get(ctx context.Context, _ string) ([]byte, error) {
 		converted []byte
 		rawLen    sql.NullInt64
 	)
-	q := "SELECT CONVERT(varbinary(10), cache_val), DATALENGTH(cache_val) FROM %s WHERE cache_key = ?;"
-	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, c.cacheTableName.String()), defaultCacheKey).Scan(&converted, &rawLen); err != nil {
+	q := "SELECT CONVERT(varbinary(%d), cache_val), DATALENGTH(cache_val) FROM %s WHERE cache_key = ?;"
+	if err := c.db.QueryRowContext(ctx, fmt.Sprintf(q, lsnByteLength, c.cacheTableName.String()), defaultCacheKey).Scan(&converted, &rawLen); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, service.ErrKeyNotFound
 		}
@@ -148,9 +151,8 @@ func (c *checkpointCache) Get(ctx context.Context, _ string) ([]byte, error) {
 		// cache_val is NULL - no checkpoint cached yet
 		return nil, nil
 	}
-	if rawLen.Int64 != 10 {
-		msg := "checkpoint cache table '%s' has a cache_val entry that is not a valid 10-byte LSN and cannot be safely recovered; please drop the cache entry and resnapshot data if necessary."
-		return nil, fmt.Errorf(msg, c.cacheTableName.String(), c.cacheTableName.String(), defaultCacheKey)
+	if rawLen.Int64 != lsnByteLength {
+		return nil, fmt.Errorf("checkpoint cache table '%s' has a cache_val entry that is not a valid %d-byte LSN and cannot be safely recovered; please drop the cache entry and resnapshot data if necessary", c.cacheTableName.String(), lsnByteLength)
 	}
 	return converted, nil
 }
@@ -186,13 +188,13 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 	BEGIN
 		CREATE TABLE %s (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
-			cache_val varbinary(10)
+			cache_val varbinary(%d)
 		);
 		SET @created = 1;
 	END;
 	SELECT @created;`
 	var created bool
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(q, tbl.schema, tbl.name, tbl.String())).Scan(&created); err != nil {
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(q, tbl.schema, tbl.name, tbl.String(), lsnByteLength)).Scan(&created); err != nil {
 		return false, err
 	}
 	return created, nil
@@ -208,7 +210,7 @@ func createCacheTable(ctx context.Context, db *sql.DB, tbl cacheTable) (bool, er
 // corrupting any value >= 5 characters. char is rejected too: DATALENGTH on a
 // fixed-length char(n) column returns the declared length, not the actual content
 // length, so the length validation Get performs on read would false-positive on it.
-func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string) error {
+func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string, log *service.Logger) error {
 	var typeName string
 	q := `
 	SELECT t.name FROM sys.columns c JOIN sys.types t ON t.user_type_id = c.user_type_id
@@ -223,7 +225,10 @@ func validateCacheColumnType(ctx context.Context, db *sql.DB, tableName string) 
 	}
 
 	switch typeName {
-	case "varchar", "varbinary", "binary":
+	case "varchar":
+		log.Warnf("Checkpoint cache table '%s' has a legacy varchar cache_val column; LSNs will be recovered via CONVERT on read rather than migrated. No action is required. If a cached value is ever found not to be a valid %d-byte LSN, this pipeline will fail to start until the entry is cleared.", tableName, lsnByteLength)
+		return nil
+	case "varbinary", "binary":
 		return nil
 	default:
 		return fmt.Errorf("checkpoint cache table '%s' has a cache_val column of unexpected type '%s'; expected varchar (legacy) or varbinary (current) - manual inspection is required", tableName, typeName)
@@ -237,7 +242,7 @@ func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTab
 	q := `
 	CREATE OR ALTER PROCEDURE %s
 		@Key varchar(7),
-		@Value varbinary(10)
+		@Value varbinary(%d)
 	AS
 	BEGIN
 		SET NOCOUNT ON;
@@ -246,7 +251,7 @@ func createUpsertStoredProc(ctx context.Context, db *sql.DB, cacheTable cacheTab
 		ELSE
 			INSERT INTO %s (cache_key, cache_val) VALUES (@Key, @Value);
 	END;`
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(q, storedProcFullName, tableName, tableName, tableName)); err != nil {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(q, storedProcFullName, lsnByteLength, tableName, tableName, tableName)); err != nil {
 		return err
 	}
 	return nil

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -170,6 +170,42 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.Equal(t, "varchar", typeName)
 	})
 
+	t.Run("Set writes cleanly into a legacy varchar table via the live proc", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn11;`)
+		require.NoError(t, err)
+
+		// Legacy varchar(100) table, but empty - no row is seeded via raw SQL here. This
+		// exercises the actual write path: the stored proc's @Value varbinary(10) parameter
+		// implicitly assigned into a varchar(100) column via Set(), then read back via
+		// Get()'s CONVERT. Confirms that implicit assignment is genuinely byte-preserving
+		// through the live code, not just via a manually-seeded row.
+		_, err = db.Exec(`CREATE TABLE rpcn11.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn11.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, cache.Set(t.Context(), "", highByteLSN, nil))
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got, "Set through the live proc should write byte-preserving data into the still-varchar column")
+
+		// no DDL is ever run - the column must still be varchar
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn11.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "varchar", typeName)
+	})
+
 	t.Run("Get fails on a too-short legacy value rather than resuming from a bogus LSN", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -113,9 +113,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 	integration.CheckSkip(t)
 	connStr, db := mssqlservertest.MustSetupTestWithMicrosoftSQLServerVersion(t)
 
-	// highByteLSN contains bytes >= 0x80 (0x8b, 0xe2), which corrupt when round-tripped
-	// through a character column: the driver's varchar decode path reinterprets them via
-	// the column's collation and re-encodes as UTF-8, expanding the value beyond 10 bytes.
+	// highByteLSN has bytes >= 0x80, which a character column's collation decode corrupts on read.
 	highByteLSN := replication.LSN{0x00, 0x04, 0x8b, 0x73, 0x00, 0x01, 0x73, 0xe2, 0x00, 0x01}
 
 	t.Run("round trips a high-byte LSN cleanly", func(t *testing.T) {
@@ -141,9 +139,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		_, err := db.Exec(`CREATE SCHEMA rpcn2;`)
 		require.NoError(t, err)
 
-		// Recreate the table using the pre-fix schema (cache_val varchar(100)) and write the
-		// LSN bytes directly via a varbinary bind so they land on disk intact, mirroring the
-		// real-world bug: writes round-trip fine, only the varchar *read* path corrupts.
+		// Legacy schema: cache_val varchar(100), seeded with intact on-disk bytes.
 		_, err = db.Exec(`CREATE TABLE rpcn2.CdcCheckpointCache (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
 			cache_val varchar(100)
@@ -176,11 +172,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		_, err := db.Exec(`CREATE SCHEMA rpcn11;`)
 		require.NoError(t, err)
 
-		// Legacy varchar(100) table, but empty - no row is seeded via raw SQL here. This
-		// exercises the actual write path: the stored proc's @Value varbinary(10) parameter
-		// implicitly assigned into a varchar(100) column via Set(), then read back via
-		// Get()'s CONVERT. Confirms that implicit assignment is genuinely byte-preserving
-		// through the live code, not just via a manually-seeded row.
+		// Empty legacy varchar(100) table; Set writes through the live proc, not a seeded row.
 		_, err = db.Exec(`CREATE TABLE rpcn11.CdcCheckpointCache (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
 			cache_val varchar(100)
@@ -241,9 +233,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		_, err := db.Exec(`CREATE SCHEMA rpcn10;`)
 		require.NoError(t, err)
 
-		// CONVERT(varbinary(10), x) truncates a too-long source to exactly 10 bytes with no
-		// error, so this proves DATALENGTH is checked on the raw source alongside the CONVERT
-		// expression, not derived from the (always <= 10 byte) converted result.
+		// DATALENGTH is checked on the raw source, not the always-<=10-byte converted result.
 		overlongVal := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 
 		_, err = db.Exec(`CREATE TABLE rpcn10.CdcCheckpointCache (
@@ -269,12 +259,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		_, err := db.Exec(`CREATE SCHEMA rpcn5;`)
 		require.NoError(t, err)
 
-		// char(100) is deliberately NOT treated as a recoverable legacy shape: DATALENGTH
-		// on a fixed-length char column always returns the declared length (blank-padded),
-		// not the actual content length, so the "<> 10" length check would false-positive
-		// on every row. It must hard-fail startup rather than silently continue: continuing
-		// would still (re)create the stored proc with @Value varbinary(10) against this
-		// unvalidated character column, reproducing the exact corruption this fix exists for.
+		// char: DATALENGTH returns the declared (blank-padded) length, not actual content length.
 		_, err = db.Exec(`CREATE TABLE rpcn5.CdcCheckpointCache (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
 			cache_val char(100)
@@ -289,7 +274,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.ErrorContains(t, err, "unexpected type")
 		require.ErrorContains(t, err, "manual inspection is required")
 
-		// column type must be left exactly as it was, not migrated
+		// column type is left untouched
 		var typeName string
 		require.NoError(t, db.QueryRow(`
 			SELECT t.name FROM sys.columns c
@@ -318,7 +303,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.ErrorContains(t, err, "unexpected type")
 		require.ErrorContains(t, err, "manual inspection is required")
 
-		// column type must be left exactly as it was, not migrated
+		// column type is left untouched
 		var typeName string
 		require.NoError(t, db.QueryRow(`
 			SELECT t.name FROM sys.columns c
@@ -333,8 +318,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		_, err := db.Exec(`CREATE SCHEMA rpcn7;`)
 		require.NoError(t, err)
 
-		// nchar shares char's fixed-length DATALENGTH padding problem and nvarchar's
-		// UTF-16LE expansion problem - unrecoverable for two independent reasons.
+		// nchar: has both char's DATALENGTH padding problem and nvarchar's UTF-16LE expansion problem.
 		_, err = db.Exec(`CREATE TABLE rpcn7.CdcCheckpointCache (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
 			cache_val nchar(100)
@@ -349,7 +333,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.ErrorContains(t, err, "unexpected type")
 		require.ErrorContains(t, err, "manual inspection is required")
 
-		// column type must be left exactly as it was, not migrated
+		// column type is left untouched
 		var typeName string
 		require.NoError(t, db.QueryRow(`
 			SELECT t.name FROM sys.columns c
@@ -358,18 +342,16 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.Equal(t, "nchar", typeName)
 	})
 
-	t.Run("treats an existing binary column as directly readable", func(t *testing.T) {
+	t.Run("fails startup for a binary(20) legacy column rather than permanently hard-failing Get", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := db.Exec(`CREATE SCHEMA rpcn8;`)
 		require.NoError(t, err)
 
-		// binary(10) is a fixed-length binary type, distinct from varbinary(10) but
-		// handled identically - no read-path corruption risk since it's binary, not
-		// character, storage, and CONVERT(varbinary(10), binaryVal) is a no-op.
+		// binary(20): DATALENGTH reports the padded declared length (20), not the actual 10 bytes.
 		_, err = db.Exec(`CREATE TABLE rpcn8.CdcCheckpointCache (
 			cache_key varchar(7) NOT NULL PRIMARY KEY,
-			cache_val binary(10)
+			cache_val binary(20)
 		);`)
 		require.NoError(t, err)
 		_, err = db.Exec(`INSERT INTO rpcn8.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
@@ -377,14 +359,11 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.NoError(t, err)
 
 		cacheTableToCreate := "rpcn8.CdcCheckpointCache"
-		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
-		require.NoError(t, err)
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.ErrorContains(t, err, "unexpected type")
+		require.ErrorContains(t, err, "manual inspection is required")
 
-		got, err := cache.Get(t.Context(), "")
-		require.NoError(t, err)
-		require.Equal(t, []byte(highByteLSN), got)
-
-		// no DDL is ever run - the column type is left exactly as it was
+		// column type must be left exactly as it was, not touched
 		var typeName string
 		require.NoError(t, db.QueryRow(`
 			SELECT t.name FROM sys.columns c
@@ -405,7 +384,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *test
 		require.NoError(t, err)
 		require.NoError(t, cacheA.Set(t.Context(), "", highByteLSN, nil))
 
-		// second construction against the same, already-migrated table must not error
+		// second construction against the same table must not error
 		cacheB, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
 		require.NoError(t, err)
 

--- a/internal/impl/mssqlserver/checkpoint_cache_test.go
+++ b/internal/impl/mssqlserver/checkpoint_cache_test.go
@@ -61,7 +61,7 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache(t *testing.T) {
 
 		// verify set
 		var wanted replication.LSN
-		require.NoError(t, wanted.Scan([]byte("0x0000002d000004b00003")))
+		require.NoError(t, wanted.Scan([]byte{0x00, 0x00, 0x00, 0x2d, 0x00, 0x00, 0x04, 0xb0, 0x00, 0x03}))
 		require.NoError(t, cache.Set(t.Context(), "", wanted, nil))
 
 		// verify get
@@ -106,6 +106,281 @@ func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache(t *testing.T) {
 
 		err = cache.db.PingContext(t.Context())
 		require.Contains(t, err.Error(), "sql: database is closed")
+	})
+}
+
+func TestIntegration_MicrosoftSQLServerCDC_CheckpointCache_ConvertOnRead(t *testing.T) {
+	integration.CheckSkip(t)
+	connStr, db := mssqlservertest.MustSetupTestWithMicrosoftSQLServerVersion(t)
+
+	// highByteLSN contains bytes >= 0x80 (0x8b, 0xe2), which corrupt when round-tripped
+	// through a character column: the driver's varchar decode path reinterprets them via
+	// the column's collation and re-encodes as UTF-8, expanding the value beyond 10 bytes.
+	highByteLSN := replication.LSN{0x00, 0x04, 0x8b, 0x73, 0x00, 0x01, 0x73, 0xe2, 0x00, 0x01}
+
+	t.Run("round trips a high-byte LSN cleanly", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn1;`)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn1.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, cache.Set(t.Context(), "", highByteLSN, nil))
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
+	})
+
+	t.Run("reads a legacy varchar cache table and recovers the true LSN via CONVERT, no DDL", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn2;`)
+		require.NoError(t, err)
+
+		// Recreate the table using the pre-fix schema (cache_val varchar(100)) and write the
+		// LSN bytes directly via a varbinary bind so they land on disk intact, mirroring the
+		// real-world bug: writes round-trip fine, only the varchar *read* path corrupts.
+		_, err = db.Exec(`CREATE TABLE rpcn2.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn2.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn2.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got, "CONVERT-on-read should recover the true on-disk LSN, not a re-corrupted value")
+
+		// no DDL is ever run - the column must still be varchar
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn2.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "varchar", typeName)
+	})
+
+	t.Run("Get fails on a too-short legacy value rather than resuming from a bogus LSN", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn4;`)
+		require.NoError(t, err)
+
+		shortVal := []byte{0x01, 0x02, 0x03, 0x04}
+
+		_, err = db.Exec(`CREATE TABLE rpcn4.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn4.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, shortVal)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn4.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err, "construction only validates the column type, not row values")
+
+		_, err = cache.Get(t.Context(), "")
+		require.ErrorContains(t, err, "cannot be safely recovered")
+
+		var shortAfter []byte
+		require.NoError(t, db.QueryRow(`SELECT cache_val FROM rpcn4.CdcCheckpointCache WHERE cache_key = ?;`, defaultCacheKey).Scan(&shortAfter))
+		require.Equal(t, shortVal, shortAfter, "row should be left untouched, pending manual intervention")
+	})
+
+	t.Run("Get fails on a too-long legacy value, proving source length is checked before truncation", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn10;`)
+		require.NoError(t, err)
+
+		// CONVERT(varbinary(10), x) truncates a too-long source to exactly 10 bytes with no
+		// error, so this proves DATALENGTH is checked on the raw source alongside the CONVERT
+		// expression, not derived from the (always <= 10 byte) converted result.
+		overlongVal := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+
+		_, err = db.Exec(`CREATE TABLE rpcn10.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val varchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn10.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, overlongVal)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn10.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		_, err = cache.Get(t.Context(), "")
+		require.ErrorContains(t, err, "cannot be safely recovered")
+	})
+
+	t.Run("fails startup for a char legacy column rather than corrupting it via a mismatched proc", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn5;`)
+		require.NoError(t, err)
+
+		// char(100) is deliberately NOT treated as a recoverable legacy shape: DATALENGTH
+		// on a fixed-length char column always returns the declared length (blank-padded),
+		// not the actual content length, so the "<> 10" length check would false-positive
+		// on every row. It must hard-fail startup rather than silently continue: continuing
+		// would still (re)create the stored proc with @Value varbinary(10) against this
+		// unvalidated character column, reproducing the exact corruption this fix exists for.
+		_, err = db.Exec(`CREATE TABLE rpcn5.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val char(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn5.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn5.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.ErrorContains(t, err, "unexpected type")
+		require.ErrorContains(t, err, "manual inspection is required")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn5.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "char", typeName)
+	})
+
+	t.Run("fails startup for an nvarchar legacy column rather than corrupting it via a mismatched proc", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn6;`)
+		require.NoError(t, err)
+
+		_, err = db.Exec(`CREATE TABLE rpcn6.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val nvarchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn6.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn6.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.ErrorContains(t, err, "unexpected type")
+		require.ErrorContains(t, err, "manual inspection is required")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn6.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "nvarchar", typeName)
+	})
+
+	t.Run("fails startup for an nchar legacy column rather than corrupting it via a mismatched proc", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn7;`)
+		require.NoError(t, err)
+
+		// nchar shares char's fixed-length DATALENGTH padding problem and nvarchar's
+		// UTF-16LE expansion problem - unrecoverable for two independent reasons.
+		_, err = db.Exec(`CREATE TABLE rpcn7.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val nchar(100)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn7.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn7.CdcCheckpointCache"
+		_, err = newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.ErrorContains(t, err, "unexpected type")
+		require.ErrorContains(t, err, "manual inspection is required")
+
+		// column type must be left exactly as it was, not migrated
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn7.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "nchar", typeName)
+	})
+
+	t.Run("treats an existing binary column as directly readable", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn8;`)
+		require.NoError(t, err)
+
+		// binary(10) is a fixed-length binary type, distinct from varbinary(10) but
+		// handled identically - no read-path corruption risk since it's binary, not
+		// character, storage, and CONVERT(varbinary(10), binaryVal) is a no-op.
+		_, err = db.Exec(`CREATE TABLE rpcn8.CdcCheckpointCache (
+			cache_key varchar(7) NOT NULL PRIMARY KEY,
+			cache_val binary(10)
+		);`)
+		require.NoError(t, err)
+		_, err = db.Exec(`INSERT INTO rpcn8.CdcCheckpointCache (cache_key, cache_val) VALUES (?, ?);`,
+			defaultCacheKey, []byte(highByteLSN))
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn8.CdcCheckpointCache"
+		cache, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		got, err := cache.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
+
+		// no DDL is ever run - the column type is left exactly as it was
+		var typeName string
+		require.NoError(t, db.QueryRow(`
+			SELECT t.name FROM sys.columns c
+			JOIN sys.types t ON t.user_type_id = c.user_type_id
+			WHERE c.object_id = OBJECT_ID('rpcn8.CdcCheckpointCache') AND c.name = 'cache_val';`).Scan(&typeName))
+		require.Equal(t, "binary", typeName)
+	})
+
+	t.Run("is idempotent across multiple constructions", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := db.Exec(`CREATE SCHEMA rpcn3;`)
+		require.NoError(t, err)
+
+		cacheTableToCreate := "rpcn3.CdcCheckpointCache"
+
+		cacheA, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+		require.NoError(t, cacheA.Set(t.Context(), "", highByteLSN, nil))
+
+		// second construction against the same, already-migrated table must not error
+		cacheB, err := newCheckpointCache(context.Background(), connStr, cacheTableToCreate, nil)
+		require.NoError(t, err)
+
+		got, err := cacheB.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
+
+		require.NoError(t, cacheB.Set(t.Context(), "", highByteLSN, nil))
+		got, err = cacheA.Get(t.Context(), "")
+		require.NoError(t, err)
+		require.Equal(t, []byte(highByteLSN), got)
 	})
 }
 


### PR DESCRIPTION
This change handles a data-corruption bug in the SQL Server checkpoint cache where the LSN is stored in a `varchar(100)` column, but `go-mssqldb` decodes varchar reads through the column's collation code page. This only becomes apparent on certain LSN ranges and when read from the cache during a restart as the on-disk bytes of a legacy varchar column are already intact.

This change addresses the problem by:
- Creating the cache column type to `varbinary(10)` for new caches
- Performing a convert on read during start up. 

<img width="1510" height="907" alt="image" src="https://github.com/user-attachments/assets/419b4dfe-73e0-463f-ae98-367db661c211" />

<img width="1507" height="828" alt="image" src="https://github.com/user-attachments/assets/9eeaea18-1e0e-4696-a805-19572a1f18ae" />


