### PR TITLE
kafka: reject max_in_flight_requests != 1 with idempotent_write at config time

### DIFF
--- a/docs/modules/components/pages/outputs/kafka_franz.adoc
+++ b/docs/modules/components/pages/outputs/kafka_franz.adoc
@@ -1001,7 +1001,7 @@ max_buffered_bytes: 50mib
 
 === `max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/docs/modules/components/pages/outputs/ockam_kafka.adoc
@@ -571,7 +571,7 @@ max_buffered_bytes: 50mib
 
 === `kafka.max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/outputs/redpanda.adoc
+++ b/docs/modules/components/pages/outputs/redpanda.adoc
@@ -1055,7 +1055,7 @@ max_buffered_bytes: 50mib
 
 === `max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/docs/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -1009,7 +1009,7 @@ max_buffered_bytes: 50mib
 
 === `max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/redpanda/about.adoc
+++ b/docs/modules/components/pages/redpanda/about.adoc
@@ -807,7 +807,7 @@ max_buffered_bytes: 50mib
 
 === `max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/tracers/redpanda.adoc
+++ b/docs/modules/components/pages/tracers/redpanda.adoc
@@ -800,7 +800,7 @@ max_buffered_bytes: 50mib
 
 === `max_in_flight_requests`
 
-The maximum number of produce requests in flight per broker connection. When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.
+The maximum number of produce requests in flight per broker connection. While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.
 
 
 *Type*: `int`

--- a/internal/impl/kafka/franz_writer.go
+++ b/internal/impl/kafka/franz_writer.go
@@ -94,9 +94,11 @@ func FranzProducerLimitsFields() []*service.ConfigField {
 			Example("50mib"),
 		service.NewIntField(kfwFieldMaxInFlightRequestsPerBrkr).
 			Description("The maximum number of produce requests in flight per broker connection. " +
-				"When `idempotent_write` is enabled, this is capped at 5 by the Kafka protocol (and at 1 for Kafka < v1.0.0). " +
-				"When `idempotent_write` is disabled, higher values improve throughput by pipelining requests but may cause out-of-order delivery.").
-			ShortDescription("Maximum produce requests in flight per broker connection. Capped at 5 when idempotent_write is enabled.").
+				"While `idempotent_write` is enabled (the default) this must be `1`, as the client relies on a single in-flight request per broker to guarantee ordering. " +
+				"To use higher values you must set `idempotent_write` to `false`, which allows requests to be pipelined for throughput but may cause duplicate and out-of-order delivery on retries. " +
+				"Note that this is distinct from the output's `max_in_flight` field, which counts message batches being written in parallel rather than produce requests on the wire. " +
+				"A value of `1` is not a throughput ceiling: records from concurrent writes are coalesced into fewer, larger produce requests.").
+			ShortDescription("Maximum produce requests in flight per broker connection. Must be 1 while idempotent_write is enabled.").
 			Advanced().
 			Default(1),
 		service.NewIntField(kfwFieldRecordRetries).
@@ -331,6 +333,19 @@ func FranzProducerOptsFromConfig(conf *service.ParsedConfig) ([]kgo.Opt, error) 
 		return nil, fmt.Errorf("idempotent_write requires acks to be \"all\", got %q", acksStr)
 	}
 
+	// The franz-go client rejects any value other than 1 here while idempotency
+	// is enabled, because it relies on a single in-flight request per broker to
+	// keep producer sequence numbers gapless. Without this check that rejection
+	// surfaces from within Connect() as a retryable connection error, so the
+	// pipeline starts, retries forever and silently produces nothing.
+	maxInFlightRequests, err := conf.FieldInt(kfwFieldMaxInFlightRequestsPerBrkr)
+	if err != nil {
+		return nil, err
+	}
+	if idempotentWrite && maxInFlightRequests != 1 {
+		return nil, fmt.Errorf("idempotent_write requires max_in_flight_requests to be 1, got %d (set idempotent_write to false to use higher values, at the cost of possible duplicate and out-of-order delivery on retries)", maxInFlightRequests)
+	}
+
 	if !idempotentWrite {
 		opts = append(opts, kgo.DisableIdempotentWrite())
 	}
@@ -407,7 +422,8 @@ func FranzWriterConfigLints() string {
   this.partitioner == "manual" && this.partition.or("") == "" => "a partition must be specified when the partitioner is set to manual"
   this.partitioner != "manual" && this.partition.or("") != "" => "a partition cannot be specified unless the partitioner is set to manual"
   this.timestamp.or("") != "" && this.timestamp_ms.or("") != "" => "both timestamp and timestamp_ms cannot be specified simultaneously"
-  this.idempotent_write == true && this.acks.or("all") != "all" => "idempotent_write requires acks to be set to all"
+  this.idempotent_write.or(true) == true && this.acks.or("all") != "all" => "idempotent_write requires acks to be set to all"
+  this.idempotent_write.or(true) == true && this.max_in_flight_requests.or(1) != 1 => "idempotent_write requires max_in_flight_requests to be 1, set idempotent_write to false to use higher values"
 }`
 }
 

--- a/internal/impl/kafka/output_kafka_franz_test.go
+++ b/internal/impl/kafka/output_kafka_franz_test.go
@@ -133,11 +133,119 @@ kafka_franz:
   record_delivery_timeout: "30s"
 `,
 		},
+		{
+			name: "idempotent write with max_in_flight_requests above one",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: true
+  max_in_flight_requests: 5
+`,
+			errContains: "idempotent_write requires max_in_flight_requests to be 1",
+		},
+		{
+			// idempotent_write defaults to true, so omitting it must still be
+			// caught. This is the shape users actually write.
+			name: "default idempotent write with max_in_flight_requests above one",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  max_in_flight_requests: 5
+`,
+			errContains: "idempotent_write requires max_in_flight_requests to be 1",
+		},
+		{
+			name: "idempotent write with max_in_flight_requests of one",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: true
+  max_in_flight_requests: 1
+`,
+		},
+		{
+			name: "non-idempotent write with max_in_flight_requests above one",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  idempotent_write: false
+  max_in_flight_requests: 5
+`,
+		},
+		{
+			// Same latent gap as above, on the pre-existing acks rule.
+			name: "default idempotent write with acks leader",
+			conf: `
+kafka_franz:
+  seed_brokers: [ foo:1234 ]
+  topic: foo
+  acks: leader
+`,
+			errContains: "idempotent_write requires acks to be set to all",
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			err := service.NewStreamBuilder().AddOutputYAML(test.conf)
+			if test.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			}
+		})
+	}
+}
+
+// The linter rules above are the first line of defence, but they can be bypassed
+// (--chilled, or configs built programmatically). Assert that opt construction
+// also rejects the combination, so it fails there rather than surfacing from
+// franz-go inside Connect() as an endlessly retried connection error.
+func TestFranzProducerOptsIdempotencyLimits(t *testing.T) {
+	spec := service.NewConfigSpec().Fields(FranzProducerFields()...)
+
+	testCases := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			name:        "default idempotent write with max_in_flight_requests above one",
+			conf:        `max_in_flight_requests: 5`,
+			errContains: "idempotent_write requires max_in_flight_requests to be 1, got 5",
+		},
+		{
+			name: "explicit idempotent write with max_in_flight_requests above one",
+			conf: `
+idempotent_write: true
+max_in_flight_requests: 2
+`,
+			errContains: "idempotent_write requires max_in_flight_requests to be 1, got 2",
+		},
+		{
+			name: "idempotent write with the default max_in_flight_requests",
+			conf: `idempotent_write: true`,
+		},
+		{
+			name: "non-idempotent write with max_in_flight_requests above one",
+			conf: `
+idempotent_write: false
+max_in_flight_requests: 5
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := spec.ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			_, err = FranzProducerOptsFromConfig(conf)
 			if test.errContains == "" {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
## Problem

Setting `max_in_flight_requests` to any value other than `1` while `idempotent_write` is enabled (the default) produced a pipeline that **passed `lint`, started, and then produced zero records forever**:

```
level=error msg="Failed to connect to redpanda: invalid usage of
MaxProduceRequestsInflightPerBroker with idempotency enabled" path=root.output
```

No fatal error, no non-zero exit — just an endlessly retried connection error at zero throughput.

franz-go is behaving correctly here: it rejects anything but `1` while idempotency is on (`kgo/config.go:232`) because it relies on a single in-flight request per broker to keep producer sequence numbers gapless. The defect is on our side — we applied the option unconditionally and validated only `< 1`, so a permanent config error surfaced from inside `Connect()` where the framework treats it as retryable.

Made more likely by our own field documentation, which described the invalid configuration as valid ("capped at 5 by the Kafka protocol").

## Changes

**1. Validate at config time**, mirroring how the sibling `acks` constraint is already handled:

- A rule in `FranzWriterConfigLints()`, so `lint` catches it before the pipeline runs.
- A check in `FranzProducerOptsFromConfig`, which all affected components funnel through, for paths that bypass lint (`--chilled`, programmatic config construction).

**2. Correct the field documentation.** It said the value is "capped at 5 by the Kafka protocol" when `idempotent_write` is enabled. It is not capped — it must be exactly `1`, so the documented configuration could never start. While there, added two clarifications that caused real confusion:

- This field is **not** `max_in_flight`. That one counts message *batches* written in parallel (default 256 on the `redpanda` output); this one counts unacknowledged produce *requests* per broker connection.
- `1` is **not** a throughput ceiling — records from concurrent writes are coalesced into fewer, larger produce requests.

**3. Fixed a latent gap in the existing `acks` rule.** It matched on `this.idempotent_write == true`, which does not fire when the field is left at its default of `true`, so `acks: leader` with `idempotent_write` omitted was never caught at lint. Both rules now use `.or(true)`. This only surfaces an existing failure earlier — `FranzProducerOptsFromConfig` already rejected those configs at construction time — but it is strictly an addition to the reported bug and easy to split out if preferred.

## Affected components

All six inheriting `FranzProducerFields()`: `redpanda` and `kafka_franz` outputs, `redpanda_migrator`, the global `redpanda` logs/status writer, the `redpanda` tracer, and the `ockam_kafka` output. The older sarama-based `kafka` output is unaffected (different client, no such field).

## Verification

- `go build ./...` clean.
- `go test ./internal/impl/kafka/... ./internal/impl/redpanda/... ./internal/impl/ockam/...` — all pass.
- `task lint` — 0 issues. `task fmt` applied.
- `task docs` — regenerated exactly the 6 expected pages, one line each, no unrelated drift.
- End-to-end against a built binary: the previously-silent config now fails lint with exit 1 and a clear message, while `idempotent_write: false` + `max_in_flight_requests: 5` and plain default configs still lint clean.

New tests: 5 cases added to `TestKafkaFranzOutputBadParams` (covering both the explicit and the defaulted `idempotent_write` shapes) plus `TestFranzProducerOptsIdempotencyLimits`, which asserts the opt-construction path rejects the combination at config parse time rather than at connect time.

## Notes

Found while tuning a customer ingest pipeline (Zendesk 7161), where raising this value was recommended as a tuning step based on the field documentation and had to be retracted after testing.

Fixes CON-522
Fixes DOC-2404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
