### PR TITLE
slack: only enforce token prefixes on literal values

### DIFF
--- a/internal/impl/slack/input.go
+++ b/internal/impl/slack/input.go
@@ -33,12 +33,8 @@ func inputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Description(`Connects to Slack using https://api.slack.com/apis/socket-mode[^Socket Mode]. This allows for receiving events, interactions and slash commands. Each message emitted from this input has a @type metadata of the event type "events_api", "interactions" or "slash_commands".`).
 		Fields(
-			service.NewStringField(iFieldAppToken).Description("The Slack App token to use.").LintRule(`
-        root = if !this.has_prefix("xapp-") { [ "field must start with xapp-" ] }
-      `),
-			service.NewStringField(iFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(`
-        root = if !this.has_prefix("xoxb-") { [ "field must start with xoxb-" ] }
-      `),
+			service.NewStringField(iFieldAppToken).Description("The Slack App token to use.").LintRule(tokenLintRule("xapp-")),
+			service.NewStringField(iFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(tokenLintRule("xoxb-")),
 			service.NewAutoRetryNacksToggleField(),
 		).
 		Example(echobotExample())

--- a/internal/impl/slack/input_users.go
+++ b/internal/impl/slack/input_users.go
@@ -31,9 +31,7 @@ func usersInputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Description(`Reads all users in a slack organization (optionally filtered by a team ID).`).
 		Fields(
-			service.NewStringField(iFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(`
-        root = if !this.has_prefix("xoxb-") { [ "field must start with xoxb-" ] }
-      `),
+			service.NewStringField(iFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(tokenLintRule("xoxb-")),
 			service.NewStringField(iFieldTeamID).Description("The team ID to filter by").Default(""),
 			service.NewAutoRetryNacksToggleField(),
 		)

--- a/internal/impl/slack/lint.go
+++ b/internal/impl/slack/lint.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package slack
+
+import "fmt"
+
+// tokenLintRule builds a lint rule asserting that a Slack token field is
+// prefixed with the given token type.
+//
+// Tokens are usually supplied through a secret or environment variable
+// reference such as `${secrets.SLACK_BOT_TOKEN}`. Those references are resolved
+// when a config is read, which is not necessarily before it is linted: a linter
+// without access to the referenced value either sees the reference verbatim or
+// the empty string it falls back to. Neither says anything about the token that
+// is used at runtime, so the prefix is only enforced for literal values.
+func tokenLintRule(prefix string) string {
+	return fmt.Sprintf(
+		`root = if this != "" && !this.has_prefix("${") && !this.has_prefix(%q) { [ "field must start with %s" ] }`,
+		prefix, prefix,
+	)
+}

--- a/internal/impl/slack/lint_test.go
+++ b/internal/impl/slack/lint_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+var tokenLintTests = []struct {
+	name          string
+	componentType string
+	conf          string
+	lintContains  string // empty means: expect no lint errors
+}{
+	{
+		name:          "slack_post literal token",
+		componentType: "output",
+		conf: `
+slack_post:
+  bot_token: "xoxb-not-a-real-token"
+  channel_id: "C0123456789"
+`,
+	},
+	{
+		name:          "slack_post secret token",
+		componentType: "output",
+		conf: `
+slack_post:
+  bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"
+  channel_id: "C0123456789"
+`,
+	},
+	{
+		name:          "slack_post secret token with literal prefix",
+		componentType: "output",
+		conf: `
+slack_post:
+  bot_token: "xoxb-${secrets.SLACK_APP_BOT_TOKEN}"
+  channel_id: "C0123456789"
+`,
+	},
+	{
+		name:          "slack_post literal token of the wrong type",
+		componentType: "output",
+		conf: `
+slack_post:
+  bot_token: "xoxp-not-a-real-token"
+  channel_id: "C0123456789"
+`,
+		lintContains: "field must start with xoxb-",
+	},
+	{
+		name:          "slack_post secret token with a literal prefix of the wrong type",
+		componentType: "output",
+		conf: `
+slack_post:
+  bot_token: "xoxp-${secrets.SLACK_APP_BOT_TOKEN}"
+  channel_id: "C0123456789"
+`,
+		lintContains: "field must start with xoxb-",
+	},
+	{
+		name:          "slack secret tokens",
+		componentType: "input",
+		conf: `
+slack:
+  app_token: "${secrets.SLACK_APP_TOKEN}"
+  bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"
+`,
+	},
+	{
+		name:          "slack literal app token of the wrong type",
+		componentType: "input",
+		conf: `
+slack:
+  app_token: "xoxb-not-a-real-token"
+  bot_token: "xoxb-not-a-real-token"
+`,
+		lintContains: "field must start with xapp-",
+	},
+	{
+		name:          "slack_users secret token",
+		componentType: "input",
+		conf: `
+slack_users:
+  bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"
+`,
+	},
+	{
+		name:          "slack_reaction secret token",
+		componentType: "output",
+		conf: `
+slack_reaction:
+  bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"
+  channel_id: "C0123456789"
+  timestamp: "1234567890.123456"
+  emoji: "eyes"
+`,
+	},
+	{
+		name:          "slack_thread secret token",
+		componentType: "processor",
+		conf: `
+slack_thread:
+  bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"
+  channel_id: "C0123456789"
+  thread_ts: "1234567890.123456"
+`,
+	},
+}
+
+// TestTokenLintRulesUnresolvedSecrets covers linters that leave secret
+// references in place because they cannot resolve them.
+func TestTokenLintRulesUnresolvedSecrets(t *testing.T) {
+	linter := service.GlobalEnvironment().NewComponentConfigLinter()
+	linter.SetEnvVarLookupFunc(func(_ context.Context, key string) (string, bool) {
+		return "${" + key + "}", true
+	})
+	runTokenLintTests(t, linter)
+}
+
+// TestTokenLintRulesEmptySecrets covers linters that substitute secret
+// references they cannot resolve with an empty string.
+func TestTokenLintRulesEmptySecrets(t *testing.T) {
+	linter := service.GlobalEnvironment().NewComponentConfigLinter()
+	linter.SetSkipEnvVarCheck(true)
+	linter.SetEnvVarLookupFunc(func(context.Context, string) (string, bool) {
+		return "", false
+	})
+	runTokenLintTests(t, linter)
+}
+
+func runTokenLintTests(t *testing.T, linter *service.ComponentConfigLinter) {
+	t.Helper()
+
+	for _, test := range tokenLintTests {
+		t.Run(test.name, func(t *testing.T) {
+			lints, err := linter.LintYAML(test.componentType, []byte(test.conf))
+			require.NoError(t, err)
+
+			var combined strings.Builder
+			for _, l := range lints {
+				fmt.Fprintf(&combined, "%v\n", l)
+			}
+
+			if test.lintContains == "" {
+				assert.Empty(t, lints, "expected no lint errors, got: %v", combined.String())
+				return
+			}
+			assert.Contains(t, combined.String(), test.lintContains)
+		})
+	}
+}

--- a/internal/impl/slack/output_post.go
+++ b/internal/impl/slack/output_post.go
@@ -39,9 +39,7 @@ func outputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Description(`Post a new message to a Slack channel using https://api.slack.com/methods/chat.postMessage[^chat.postMessage]`).
 		Fields(
-			service.NewStringField(oFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(`
-        root = if !this.has_prefix("xoxb-") { [ "field must start with xoxb-" ] }
-      `),
+			service.NewStringField(oFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(tokenLintRule("xoxb-")),
 			service.NewInterpolatedStringField(oFieldChannelID).Description("The channel ID to post messages to."),
 			service.NewInterpolatedStringField(oFieldThreadTS).Description("Optional thread timestamp to post messages to.").Default(slack.DEFAULT_MESSAGE_THREAD_TIMESTAMP),
 			service.NewInterpolatedStringField(oFieldText).Description("The text content of the message. Mutually exclusive with `blocks`.").

--- a/internal/impl/slack/output_reaction.go
+++ b/internal/impl/slack/output_reaction.go
@@ -33,9 +33,7 @@ func reactionSpec() *service.ConfigSpec {
 		Fields(
 			service.NewStringField(oFieldBotToken).
 				Description("The Slack Bot User OAuth token to use.").
-				LintRule(`
-        root = if !this.has_prefix("xoxb-") { [ "field must start with xoxb-" ] }
-      `),
+				LintRule(tokenLintRule("xoxb-")),
 			service.NewInterpolatedStringField(oFieldChannelID).
 				Description("The channel ID containing the message to react to."),
 			service.NewInterpolatedStringField(orFieldTimestamp).

--- a/internal/impl/slack/processor_thread.go
+++ b/internal/impl/slack/processor_thread.go
@@ -32,9 +32,7 @@ func threadProcessorSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Description(`Read a thread using the https://api.slack.com/methods/conversations.replies[^Slack API]`).
 		Fields(
-			service.NewStringField(pFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(`
-        root = if !this.has_prefix("xoxb-") { [ "field must start with xoxb-" ] }
-      `),
+			service.NewStringField(pFieldBotToken).Description("The Slack Bot User OAuth token to use.").LintRule(tokenLintRule("xoxb-")),
 			service.NewInterpolatedStringField(pFieldChannelID).Description("The channel ID to read messages from."),
 			service.NewInterpolatedStringField(pFieldThreadTS).Description("The thread timestamp to read the full thread of."),
 		)


### PR DESCRIPTION
Fixes #4511.

`LintRule(has_prefix("xoxb-"))` runs against the raw config value, before interpolation — so a valid `bot_token: "${secrets.SLACK_APP_BOT_TOKEN}"` was rejected at lint time.

Adds a `tokenLintRule(prefix)` helper that skips the prefix check when the value is empty or starts with `${`, and keeps enforcing it for literals so a malformed literal token is still caught.

The issue reports `output_post.go`, but the same rule is duplicated in `input.go` (xapp- and xoxb-), `input_users.go`, `output_reaction.go` and `processor_thread.go` — all five now go through the helper.

A missing required `bot_token` still produces the separate "field is required" lint, so this doesn't hide a misconfiguration.

Adds `lint_test.go` covering all five components: unresolved `${secrets...}`, an env lookup resolving to empty, valid literal, invalid literal, and a secret whose value starts with the prefix.
