### PR TITLE
fix: keep emitting redpanda_lag when unordered_processing is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.103.2 - TBD
+
+### Fixed
+
+- redpanda: Enabling `unordered_processing` no longer renames the consumer lag gauge from `redpanda_lag` to `kafka_lag`. The `redpanda` input now emits `redpanda_lag` in both modes, as documented. ([@prakhargarg105](https://github.com/prakhargarg105), [#4663](https://github.com/redpanda-data/connect/issues/4663))
+
 ## 4.103.1 - 2026-07-31
 
 ### Added

--- a/internal/impl/kafka/franz_reader_ordered.go
+++ b/internal/impl/kafka/franz_reader_ordered.go
@@ -87,6 +87,12 @@ type FranzReaderOrdered struct {
 	topicLagRefreshPeriod time.Duration
 	batchMaxSize          uint64
 
+	// lagMetricName is the name of the consumer lag gauge emitted by this
+	// reader. It is owned by the input rather than the reader so that inputs
+	// which can be served by either reader implementation emit a consistent
+	// metric name.
+	lagMetricName string
+
 	res     *service.Resources
 	log     *service.Logger
 	shutSig *shutdown.Signaller
@@ -100,11 +106,12 @@ func NewFranzReaderOrderedFromConfig(conf *service.ParsedConfig, res *service.Re
 	readBackOff.MaxElapsedTime = 0
 
 	f := FranzReaderOrdered{
-		readBackOff: readBackOff,
-		res:         res,
-		log:         res.Logger(),
-		shutSig:     shutdown.NewSignaller(),
-		clientOpts:  optsFn,
+		readBackOff:   readBackOff,
+		res:           res,
+		log:           res.Logger(),
+		shutSig:       shutdown.NewSignaller(),
+		clientOpts:    optsFn,
+		lagMetricName: lagMetricNameRedpanda,
 	}
 
 	f.consumerGroup, _ = conf.FieldString(kroFieldConsumerGroup)
@@ -534,7 +541,7 @@ func (f *FranzReaderOrdered) Connect(ctx context.Context) error {
 	go func() {
 		var consumerLag *ConsumerLag
 		if f.consumerGroup != "" {
-			topicLagGauge := f.res.Metrics().NewGauge("redpanda_lag", "topic", "partition")
+			topicLagGauge := f.res.Metrics().NewGauge(f.lagMetricName, "topic", "partition")
 			consumerLag = NewConsumerLag(f.Client, f.consumerGroup, f.res.Logger(), topicLagGauge, f.topicLagRefreshPeriod)
 			consumerLag.Start()
 			defer consumerLag.Stop()

--- a/internal/impl/kafka/franz_reader_toggled.go
+++ b/internal/impl/kafka/franz_reader_toggled.go
@@ -70,6 +70,13 @@ func NewFranzReaderToggledFromConfig(conf *service.ParsedConfig, res *service.Re
 
 			clientOpts:         optsFn,
 			franzRecordToMsgFn: FranzRecordToMessageV1,
+
+			// The toggled reader is only used by Redpanda branded inputs, and
+			// toggling unordered processing must not change the name of the
+			// consumer lag gauge, otherwise enabling it silently breaks lag
+			// dashboards and alerts. Hence we deliberately use the Redpanda
+			// name here rather than the default of the unordered reader.
+			lagMetricName: lagMetricNameRedpanda,
 		}
 
 		var err error

--- a/internal/impl/kafka/franz_reader_toggled_test.go
+++ b/internal/impl/kafka/franz_reader_toggled_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// The consumer lag gauge name must not depend on whether unordered processing
+// is enabled, otherwise flipping that field silently breaks lag dashboards and
+// alerts.
+func TestFranzReaderToggledLagMetricName(t *testing.T) {
+	tests := []struct {
+		name string
+		conf string
+	}{
+		{
+			name: "ordered",
+			conf: `
+consumer_group: foogroup
+`,
+		},
+		{
+			name: "unordered",
+			conf: `
+consumer_group: foogroup
+unordered_processing:
+  enabled: true
+`,
+		},
+		{
+			name: "unordered explicitly disabled",
+			conf: `
+consumer_group: foogroup
+unordered_processing:
+  enabled: false
+`,
+		},
+	}
+
+	spec := service.NewConfigSpec().Fields(FranzReaderToggledConfigFields()...)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := spec.ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			rdr, err := NewFranzReaderToggledFromConfig(conf, service.MockResources(), func() ([]kgo.Opt, error) {
+				return nil, nil
+			})
+			require.NoError(t, err)
+
+			var lagMetricName string
+			switch r := rdr.(type) {
+			case *FranzReaderOrdered:
+				lagMetricName = r.lagMetricName
+			case *FranzReaderUnordered:
+				lagMetricName = r.lagMetricName
+			default:
+				t.Fatalf("unexpected reader type %T", rdr)
+			}
+
+			assert.Equal(t, lagMetricNameRedpanda, lagMetricName)
+		})
+	}
+}

--- a/internal/impl/kafka/franz_reader_unordered.go
+++ b/internal/impl/kafka/franz_reader_unordered.go
@@ -97,6 +97,12 @@ type FranzReaderUnordered struct {
 	batchPolicy           service.BatchPolicy
 	topicLagRefreshPeriod time.Duration
 
+	// lagMetricName is the name of the consumer lag gauge emitted by this
+	// reader. It is owned by the input rather than the reader so that inputs
+	// which can be served by either reader implementation emit a consistent
+	// metric name.
+	lagMetricName string
+
 	batchChan atomic.Value
 	res       *service.Resources
 	log       *service.Logger
@@ -117,9 +123,10 @@ func (f *FranzReaderUnordered) storeBatchChan(c chan batchWithAckFn) {
 // Deprecated: Use the toggled variant in future.
 func NewFranzReaderUnorderedFromConfig(conf *service.ParsedConfig, res *service.Resources, opts ...kgo.Opt) (*FranzReaderUnordered, error) {
 	f := FranzReaderUnordered{
-		res:     res,
-		log:     res.Logger(),
-		shutSig: shutdown.NewSignaller(),
+		res:           res,
+		log:           res.Logger(),
+		shutSig:       shutdown.NewSignaller(),
+		lagMetricName: lagMetricNameKafka,
 	}
 	f.clientOpts = func() ([]kgo.Opt, error) {
 		return slices.Clone(opts), nil
@@ -580,7 +587,7 @@ func (f *FranzReaderUnordered) Connect(ctx context.Context) error {
 	go func() {
 		var consumerLag *ConsumerLag
 		if f.consumerGroup != "" {
-			topicLagGauge := f.res.Metrics().NewGauge("kafka_lag", "topic", "partition")
+			topicLagGauge := f.res.Metrics().NewGauge(f.lagMetricName, "topic", "partition")
 			consumerLag = NewConsumerLag(cl, f.consumerGroup, f.res.Logger(), topicLagGauge, f.topicLagRefreshPeriod)
 			consumerLag.Start()
 			defer consumerLag.Stop()

--- a/internal/impl/kafka/lag.go
+++ b/internal/impl/kafka/lag.go
@@ -28,6 +28,16 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
 )
 
+const (
+	// lagMetricNameRedpanda is the consumer lag gauge emitted by the
+	// Redpanda branded inputs (`redpanda`, `redpanda_common` and the migrator).
+	lagMetricNameRedpanda = "redpanda_lag"
+
+	// lagMetricNameKafka is the consumer lag gauge emitted by the Kafka branded
+	// inputs (`kafka_franz`, `ockam_kafka`).
+	lagMetricNameKafka = "kafka_lag"
+)
+
 // ConsumerLag is a struct that manages the consumer lag for Kafka topics.
 type ConsumerLag struct {
 	lagUpdater    *asyncroutine.Periodic


### PR DESCRIPTION

The consumer lag gauge name was chosen by the reader implementation rather than by the input: the ordered reader emitted `redpanda_lag` while the unordered reader emitted `kafka_lag`. Since the `redpanda` input selects between the two readers based on `unordered_processing.enabled`, enabling that field silently renamed the metric, so existing lag dashboards and alerts stopped reporting. It also contradicted the `redpanda` input docs, which promise `redpanda_lag` unconditionally.

Make the gauge name a property of the input by threading it through both readers: the Redpanda branded inputs always emit `redpanda_lag` regardless of which reader serves them, and `kafka_franz` / `ockam_kafka` continue to emit `kafka_lag` so that their dashboards are unaffected.

Fixes #4663