### PR TITLE
s3_input: handle s3:TestEvent messages to prevent redelivery

### DIFF
--- a/docs/modules/components/pages/inputs/aws_s3.adoc
+++ b/docs/modules/components/pages/inputs/aws_s3.adoc
@@ -92,6 +92,7 @@ input:
       max_messages: 10
       wait_time_seconds: 0
       nack_visibility_timeout: 0
+      zero_key_warn_interval: 30s
 ```
 
 --
@@ -429,5 +430,22 @@ Custom SQS Nack Visibility timeout in seconds. Default is 0
 *Type*: `int`
 
 *Default*: `0`
+
+=== `sqs.zero_key_warn_interval`
+
+A message from which no target key can be extracted (e.g. due to a misconfigured `key_path`/`bucket_path`) is never deleted, so it's redelivered and re-evaluated repeatedly until the underlying issue is fixed. This field limits how often that condition is logged as a warning, to avoid flooding the logs; every occurrence is still logged at debug level. Set to `0s` to warn on every occurrence.
+
+
+*Type*: `string`
+
+*Default*: `"30s"`
+
+```yml
+# Examples
+
+zero_key_warn_interval: 10s
+
+zero_key_warn_interval: 0s
+```
 
 

--- a/docs/modules/components/pages/inputs/aws_s3.adoc
+++ b/docs/modules/components/pages/inputs/aws_s3.adoc
@@ -107,6 +107,8 @@ If your notification events are being routed to SQS via an SNS topic then the ev
 
 When using SQS please make sure you have sensible values for `sqs.max_messages` and also the visibility timeout of the queue itself. When Redpanda Connect consumes an S3 object the SQS message that triggered it is not deleted until the S3 object has been sent onwards. This ensures at-least-once crash resiliency, but also means that if the S3 object takes longer to process than the visibility timeout of your queue then the same objects might be processed multiple times.
 
+Amazon S3 sends an `s3:TestEvent` notification whenever a bucket's event configuration is saved, to verify the queue is reachable. Redpanda Connect detects these (including via an SNS envelope) and deletes them automatically. Any other message with no extractable target key, for example due to a misconfigured `sqs.key_path`/`sqs.bucket_path`, is logged as a warning and left on the queue instead.
+
 == Download large files
 
 When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. In order to do this a <<scanner, `scanner`>> can be specified that determines how to break the input into smaller individual messages.

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -586,7 +586,10 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 				continue
 			}
 			addDudFn(sqsMsg)
-			s.log.Debug("Extracted zero target keys from SQS message")
+			s.log.Warnf(
+				"Extracted zero target keys from SQS message using key_path %q (bucket_path %q) - this likely indicates a misconfigured key_path/bucket_path, or an unrecognised notification event type: %s",
+				s.conf.SQS.KeyPath, s.conf.SQS.BucketPath, *sqsMsg.Body,
+			)
 			continue
 		}
 

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -42,15 +42,16 @@ import (
 
 const (
 	// S3 Input SQS Fields
-	s3iSQSFieldURL              = "url"
-	s3iSQSFieldEndpoint         = "endpoint"
-	s3iSQSFieldEnvelopePath     = "envelope_path"
-	s3iSQSFieldKeyPath          = "key_path"
-	s3iSQSFieldBucketPath       = "bucket_path"
-	s3iSQSFieldDelayPeriod      = "delay_period"
-	s3iSQSFieldMaxMessages      = "max_messages"
-	s3iSQSFieldWaitTimeSeconds  = "wait_time_seconds"
-	s3iSQSNackVisibilityTimeout = "nack_visibility_timeout"
+	s3iSQSFieldURL                 = "url"
+	s3iSQSFieldEndpoint            = "endpoint"
+	s3iSQSFieldEnvelopePath        = "envelope_path"
+	s3iSQSFieldKeyPath             = "key_path"
+	s3iSQSFieldBucketPath          = "bucket_path"
+	s3iSQSFieldDelayPeriod         = "delay_period"
+	s3iSQSFieldMaxMessages         = "max_messages"
+	s3iSQSFieldWaitTimeSeconds     = "wait_time_seconds"
+	s3iSQSNackVisibilityTimeout    = "nack_visibility_timeout"
+	s3iSQSFieldZeroKeyWarnInterval = "zero_key_warn_interval"
 
 	// S3 Input Fields
 	s3iFieldBucket             = "bucket"
@@ -61,15 +62,16 @@ const (
 )
 
 type s3iSQSConfig struct {
-	URL               string
-	Endpoint          string
-	EnvelopePath      string
-	KeyPath           string
-	BucketPath        string
-	DelayPeriod       string
-	MaxMessages       int64
-	WaitTimeSeconds   int64
-	VisibilityTimeout int32
+	URL                 string
+	Endpoint            string
+	EnvelopePath        string
+	KeyPath             string
+	BucketPath          string
+	DelayPeriod         string
+	MaxMessages         int64
+	WaitTimeSeconds     int64
+	VisibilityTimeout   int32
+	ZeroKeyWarnInterval time.Duration
 }
 
 func s3iSQSConfigFromParsed(pConf *service.ParsedConfig) (conf s3iSQSConfig, err error) {
@@ -98,6 +100,9 @@ func s3iSQSConfigFromParsed(pConf *service.ParsedConfig) (conf s3iSQSConfig, err
 		return
 	}
 	if conf.VisibilityTimeout, err = baws.Int32Field(pConf, s3iSQSNackVisibilityTimeout); err != nil {
+		return
+	}
+	if conf.ZeroKeyWarnInterval, err = pConf.FieldDuration(s3iSQSFieldZeroKeyWarnInterval); err != nil {
 		return
 	}
 	return
@@ -239,6 +244,13 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 					Description("Custom SQS Nack Visibility timeout in seconds. Default is 0").
 					Default(0).
 					Optional(),
+				service.NewDurationField(s3iSQSFieldZeroKeyWarnInterval).
+					Description("A message from which no target key can be extracted (e.g. due to a misconfigured `key_path`/`bucket_path`) is never deleted, so it's redelivered and re-evaluated repeatedly until the underlying issue is fixed. This field limits how often that condition is logged as a warning, to avoid flooding the logs; every occurrence is still logged at debug level. Set to `0s` to warn on every occurrence.").
+					ShortDescription("How often to repeat the warning for a message with no extractable target key.").
+					Example("10s").
+					Example("0s").
+					Default("30s").
+					Advanced(),
 			).
 				Description("Consume SQS messages in order to trigger key downloads.").
 				Optional(),
@@ -409,6 +421,8 @@ type sqsTargetReader struct {
 	nextRequest time.Time
 
 	pending []*s3ObjectTarget
+
+	lastZeroKeyWarnAt time.Time
 }
 
 func newSQSTargetReader(
@@ -588,10 +602,19 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 				continue
 			}
 			addDudFn(sqsMsg)
-			s.log.Warnf(
-				"Extracted zero target keys from SQS message using key_path %q (bucket_path %q) - this likely indicates a misconfigured key_path/bucket_path, or an unrecognised notification event type: %s",
-				s.conf.SQS.KeyPath, s.conf.SQS.BucketPath, *sqsMsg.Body,
-			)
+			// This message is never deleted, so it'll be redelivered
+			// indefinitely if the misconfiguration isn't fixed. Throttle the
+			// warning so that doesn't flood the logs; every occurrence still
+			// gets logged in full at debug level.
+			if now := time.Now(); now.Sub(s.lastZeroKeyWarnAt) >= s.conf.SQS.ZeroKeyWarnInterval {
+				s.lastZeroKeyWarnAt = now
+				s.log.Warnf(
+					"Extracted zero target keys from SQS message using key_path %q (bucket_path %q) - this likely indicates a misconfigured key_path/bucket_path, or an unrecognised notification event type (further occurrences suppressed for %s): %s",
+					s.conf.SQS.KeyPath, s.conf.SQS.BucketPath, s.conf.SQS.ZeroKeyWarnInterval, *sqsMsg.Body,
+				)
+			} else {
+				s.log.Debugf("Extracted zero target keys from SQS message: %s", *sqsMsg.Body)
+			}
 			continue
 		}
 

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -577,6 +577,13 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 			continue
 		}
 		if len(objects) == 0 {
+			if isS3TestEvent(sqsMsg.Body) {
+				s.log.Debugf("Received S3 test event, deleting: %s", *sqsMsg.Body)
+				if err := s.ackSQSMessage(ctx, sqsMsg); err != nil {
+					s.log.Errorf("Failed to delete SQS test event message: %v", err)
+				}
+				continue
+			}
 			addDudFn(sqsMsg)
 			s.log.Debug("Extracted zero target keys from SQS message")
 			continue
@@ -660,6 +667,15 @@ func (s *sqsTargetReader) ackSQSMessage(ctx context.Context, msg sqstypes.Messag
 		ReceiptHandle: msg.ReceiptHandle,
 	})
 	return err
+}
+
+func isS3TestEvent(sqsMsg *string) bool {
+	gObj, err := gabs.ParseJSON([]byte(*sqsMsg))
+	if err != nil {
+		return false
+	}
+	event, ok := gObj.Path("Event").Data().(string)
+	return ok && event == "s3:TestEvent"
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -250,6 +250,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 					Example("10s").
 					Example("0s").
 					Default("30s").
+					LintRule(`root = if this.parse_duration().catch(0) < 0 { [ "` + s3iSQSFieldZeroKeyWarnInterval + ` must not be negative" ] }`).
 					Advanced(),
 			).
 				Description("Consume SQS messages in order to trigger key downloads.").

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -250,7 +250,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 					Example("10s").
 					Example("0s").
 					Default("30s").
-					LintRule(`root = if this.parse_duration().catch(0) < 0 { [ "` + s3iSQSFieldZeroKeyWarnInterval + ` must not be negative" ] }`).
+					LintRule(`root = if this.parse_duration().catch(0) < 0 { [ "`+s3iSQSFieldZeroKeyWarnInterval+` must not be negative" ] }`).
 					Advanced(),
 			).
 				Description("Consume SQS messages in order to trigger key downloads.").
@@ -603,7 +603,6 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 				continue
 			}
 			addDudFn(sqsMsg)
-			// misconfigured event will get redelivered, so support control looding of warn logs.
 			if now := time.Now(); now.Sub(s.lastZeroKeyWarnAt) >= s.conf.SQS.ZeroKeyWarnInterval {
 				s.lastZeroKeyWarnAt = now
 				s.log.Warnf(

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -602,15 +602,12 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 				continue
 			}
 			addDudFn(sqsMsg)
-			// This message is never deleted, so it'll be redelivered
-			// indefinitely if the misconfiguration isn't fixed. Throttle the
-			// warning so that doesn't flood the logs; every occurrence still
-			// gets logged in full at debug level.
+			// misconfigured event will get redelivered, so support control looding of warn logs.
 			if now := time.Now(); now.Sub(s.lastZeroKeyWarnAt) >= s.conf.SQS.ZeroKeyWarnInterval {
 				s.lastZeroKeyWarnAt = now
 				s.log.Warnf(
-					"Extracted zero target keys from SQS message using key_path %q (bucket_path %q) - this likely indicates a misconfigured key_path/bucket_path, or an unrecognised notification event type (further occurrences suppressed for %s): %s",
-					s.conf.SQS.KeyPath, s.conf.SQS.BucketPath, s.conf.SQS.ZeroKeyWarnInterval, *sqsMsg.Body,
+					"Extracted zero target keys from SQS message using key_path %q (bucket_path %q) - this likely indicates a misconfigured key_path/bucket_path, or an unrecognised notification event type: %s",
+					s.conf.SQS.KeyPath, s.conf.SQS.BucketPath, *sqsMsg.Body,
 				)
 			} else {
 				s.log.Debugf("Extracted zero target keys from SQS message: %s", *sqsMsg.Body)

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -472,20 +472,20 @@ func digStrsFromSlices(slice []any) []string {
 	return strs
 }
 
-func (s *sqsTargetReader) parseObjectPaths(sqsMsg *string) ([]s3ObjectTarget, error) {
+func (s *sqsTargetReader) parseObjectPaths(sqsMsg *string) (*gabs.Container, []s3ObjectTarget, error) {
 	gObj, err := gabs.ParseJSON([]byte(*sqsMsg))
 	if err != nil {
-		return nil, fmt.Errorf("parsing SQS message: %v", err)
+		return nil, nil, fmt.Errorf("parsing SQS message: %v", err)
 	}
 
 	if s.conf.SQS.EnvelopePath != "" {
 		d := gObj.Path(s.conf.SQS.EnvelopePath).Data()
 		if str, ok := d.(string); ok {
 			if gObj, err = gabs.ParseJSON([]byte(str)); err != nil {
-				return nil, fmt.Errorf("parsing enveloped message: %v", err)
+				return nil, nil, fmt.Errorf("parsing enveloped message: %v", err)
 			}
 		} else {
-			return nil, fmt.Errorf("expected string at envelope path, found %T", d)
+			return nil, nil, fmt.Errorf("expected string at envelope path, found %T", d)
 		}
 	}
 
@@ -510,14 +510,14 @@ func (s *sqsTargetReader) parseObjectPaths(sqsMsg *string) ([]s3ObjectTarget, er
 	objects := make([]s3ObjectTarget, 0, len(keys))
 	for i, key := range keys {
 		if key, err = url.QueryUnescape(key); err != nil {
-			return nil, fmt.Errorf("parsing key from SQS message: %v", err)
+			return nil, nil, fmt.Errorf("parsing key from SQS message: %v", err)
 		}
 		bucket := s.conf.Bucket
 		if len(buckets) > i {
 			bucket = buckets[i]
 		}
 		if bucket == "" {
-			return nil, errors.New("required bucket was not found in SQS message")
+			return nil, nil, errors.New("required bucket was not found in SQS message")
 		}
 		objects = append(objects, s3ObjectTarget{
 			key:    key,
@@ -525,7 +525,8 @@ func (s *sqsTargetReader) parseObjectPaths(sqsMsg *string) ([]s3ObjectTarget, er
 		})
 	}
 
-	return objects, nil
+	// return gabs.Container to save reparsing
+	return gObj, objects, nil
 }
 
 func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget, error) {
@@ -570,14 +571,14 @@ func (s *sqsTargetReader) readSQSEvents(ctx context.Context) ([]*s3ObjectTarget,
 			continue
 		}
 
-		objects, err := s.parseObjectPaths(sqsMsg.Body)
+		gObj, objects, err := s.parseObjectPaths(sqsMsg.Body)
 		if err != nil {
 			addDudFn(sqsMsg)
 			s.log.Errorf("SQS extract key error: %v", err)
 			continue
 		}
 		if len(objects) == 0 {
-			if isS3TestEvent(sqsMsg.Body) {
+			if isS3TestEvent(gObj) {
 				s.log.Debugf("Received S3 test event, deleting: %s", *sqsMsg.Body)
 				if err := s.ackSQSMessage(ctx, sqsMsg); err != nil {
 					s.log.Errorf("Failed to delete SQS test event message: %v", err)
@@ -669,9 +670,8 @@ func (s *sqsTargetReader) ackSQSMessage(ctx context.Context, msg sqstypes.Messag
 	return err
 }
 
-func isS3TestEvent(sqsMsg *string) bool {
-	gObj, err := gabs.ParseJSON([]byte(*sqsMsg))
-	if err != nil {
+func isS3TestEvent(gObj *gabs.Container) bool {
+	if gObj == nil {
 		return false
 	}
 	event, ok := gObj.Path("Event").Data().(string)

--- a/internal/impl/aws/s3/input.go
+++ b/internal/impl/aws/s3/input.go
@@ -152,6 +152,8 @@ If your notification events are being routed to SQS via an SNS topic then the ev
 
 When using SQS please make sure you have sensible values for `+"`sqs.max_messages`"+` and also the visibility timeout of the queue itself. When Redpanda Connect consumes an S3 object the SQS message that triggered it is not deleted until the S3 object has been sent onwards. This ensures at-least-once crash resiliency, but also means that if the S3 object takes longer to process than the visibility timeout of your queue then the same objects might be processed multiple times.
 
+Amazon S3 sends an `+"`s3:TestEvent`"+` notification whenever a bucket's event configuration is saved, to verify the queue is reachable. Redpanda Connect detects these (including via an SNS envelope) and deletes them automatically. Any other message with no extractable target key, for example due to a misconfigured `+"`sqs.key_path`"+`/`+"`sqs.bucket_path`"+`, is logged as a warning and left on the queue instead.
+
 == Download large files
 
 When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. In order to do this a `+"<<scanner, `scanner`>>"+` can be specified that determines how to break the input into smaller individual messages.

--- a/internal/impl/aws/s3/input_test.go
+++ b/internal/impl/aws/s3/input_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseObjectPathsSNSEnvelope(t *testing.T) {
+	tests := []struct {
+		name            string
+		envelopePath    string
+		body            string
+		expectedKey     string
+		expectedBucket  string
+		expectTestEvent bool
+	}{
+		{
+			name:            "s3 test event",
+			body:            `{"Service":"Amazon S3","Event":"s3:TestEvent","Time":"2025-08-19T17:34:58.550Z","Bucket":"bucket-test","RequestId":"N99ABJ6Q","HostId":"+3DhJHKGDGBwqSTufMSS1UgAMIoRovmGa9vkZwWIb1="}`,
+			expectTestEvent: true,
+		},
+		{
+			name:           "regular object created notification",
+			body:           `{"Records":[{"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"bucket-test"},"object":{"key":"foo.txt"}}}]}`,
+			expectedKey:    "foo.txt",
+			expectedBucket: "bucket-test",
+		},
+		{
+			name: "Event field is not a string",
+			body: `{"Event":123}`,
+		},
+		{
+			name: "Event field missing entirely",
+			body: `{"Service":"Amazon S3"}`,
+		},
+		{
+			name:            "SNS-enveloped test event",
+			envelopePath:    "Message",
+			body:            `{"Type":"Notification","MessageId":"abc","TopicArn":"arn:aws:sns:eu-west-1:000000000000:topic","Message":"{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2025-08-19T17:34:58.550Z\",\"Bucket\":\"bucket-test\",\"RequestId\":\"N99ABJ6Q\",\"HostId\":\"+3DhJHKGDGBwqSTufMSS1UgAMIoRovmGa9vkZwWIb1=\"}"}`,
+			expectTestEvent: true,
+		},
+		{
+			name:           "SNS-enveloped object created notification",
+			envelopePath:   "Message",
+			body:           `{"Type":"Notification","MessageId":"abc","TopicArn":"arn:aws:sns:eu-west-1:000000000000:topic","Message":"{\"Records\":[{\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"bucket\":{\"name\":\"bucket-test\"},\"object\":{\"key\":\"foo.txt\"}}}]}"}`,
+			expectedKey:    "foo.txt",
+			expectedBucket: "bucket-test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := &sqsTargetReader{
+				conf: s3iConfig{
+					SQS: s3iSQSConfig{
+						EnvelopePath: test.envelopePath,
+						KeyPath:      "Records.*.s3.object.key",
+						BucketPath:   "Records.*.s3.bucket.name",
+					},
+				},
+			}
+
+			gObj, objects, err := reader.parseObjectPaths(&test.body)
+			require.NoError(t, err)
+
+			if test.expectedKey == "" {
+				assert.Empty(t, objects)
+			} else {
+				require.Len(t, objects, 1)
+				assert.Equal(t, test.expectedKey, objects[0].key)
+				assert.Equal(t, test.expectedBucket, objects[0].bucket)
+			}
+
+			assert.Equal(t, test.expectTestEvent, isS3TestEvent(gObj))
+		})
+	}
+}

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -25,6 +25,8 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -93,6 +95,90 @@ input:
 			integration.StreamTestOptPort(lsPort),
 			integration.StreamTestOptAllowDupes(),
 		)
+	})
+
+	t.Run("via_sqs_test_event_deleted", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		id := fmt.Sprintf("testevent%d", time.Now().UnixNano())
+		require.NoError(t, awstest.CreateBucketQueue(ctx, lsPort, lsPort, id))
+
+		sqsClient := newLocalStackSQSClient(t, lsPort)
+		queueURL := fmt.Sprintf("http://localhost:%s/000000000000/queue-%s", lsPort, id)
+
+		testEventBody := fmt.Sprintf(
+			`{"Service":"Amazon S3","Event":"s3:TestEvent","Time":"%s","Bucket":"bucket-%s","RequestId":"N99ABJ6Q","HostId":"+3DhJHKGDGBwqSTufMSS1UgAMIoRovmGa9vkZwWIb1="}`,
+			time.Now().UTC().Format(time.RFC3339), id,
+		)
+		_, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    aws.String(queueURL),
+			MessageBody: aws.String(testEventBody),
+		})
+		require.NoError(t, err)
+
+		yaml := fmt.Sprintf(`
+input:
+  aws_s3:
+    bucket: bucket-%s
+    endpoint: http://localhost:%s
+    force_path_style_urls: true
+    region: eu-west-1
+    delete_objects: true
+    sqs:
+      url: %s
+      key_path: Records.*.s3.object.key
+      endpoint: http://localhost:%s
+      wait_time_seconds: 1
+    credentials:
+      id: xxxxx
+      secret: xxxxx
+      token: xxxxx
+`, id, lsPort, queueURL, lsPort)
+
+		builder := service.NewStreamBuilder()
+		require.NoError(t, builder.SetYAML(yaml))
+
+		require.NoError(t, builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+			b, _ := m.AsBytes()
+			t.Fatalf("did not expect any message to be emitted for an s3:TestEvent, got: %s", b)
+			return nil
+		}))
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+
+		runErr := make(chan error, 1)
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+		go func() { runErr <- stream.Run(runCtx) }()
+
+		// The test event should be deleted from the queue rather than left
+		// to be received again indefinitely.
+		assert.Eventually(t, func() bool {
+			out, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+				QueueUrl: aws.String(queueURL),
+				AttributeNames: []sqstypes.QueueAttributeName{
+					sqstypes.QueueAttributeNameApproximateNumberOfMessages,
+					sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+				},
+			})
+			if err != nil {
+				return false
+			}
+			return out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessages)] == "0" &&
+				out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible)] == "0"
+		}, 15*time.Second, 500*time.Millisecond, "test event message should have been deleted from the queue")
+
+		require.NoError(t, stream.StopWithin(10*time.Second))
+		select {
+		case err := <-runErr:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				require.NoError(t, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("stream did not exit after StopWithin returned")
+		}
 	})
 
 	t.Run("via_sqs_lines", func(t *testing.T) {
@@ -391,4 +477,18 @@ func newLocalStackS3Client(t *testing.T, port string) *s3.Client {
 	return s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.UsePathStyle = true
 	})
+}
+
+// newLocalStackSQSClient builds an SQS client pointed at the LocalStack
+// instance on the supplied port, with dummy credentials.
+func newLocalStackSQSClient(t *testing.T, port string) *sqs.Client {
+	t.Helper()
+	endpoint := fmt.Sprintf("http://localhost:%s", port)
+	cfg, err := awsconfig.LoadDefaultConfig(t.Context(),
+		awsconfig.WithRegion("eu-west-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("xxxxx", "xxxxx", "xxxxx")),
+	)
+	require.NoError(t, err)
+	cfg.BaseEndpoint = &endpoint
+	return sqs.NewFromConfig(cfg)
 }

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -15,9 +15,12 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -193,6 +196,99 @@ input:
 		unexpectedMu.Lock()
 		assert.Empty(t, unexpectedMsgs, "did not expect any message to be emitted for an s3:TestEvent")
 		unexpectedMu.Unlock()
+	})
+
+	t.Run("via_sqs_zero_key_non_test_event_warns", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		id := fmt.Sprintf("zerokey%d", time.Now().UnixNano())
+		require.NoError(t, awstest.CreateBucketQueue(ctx, lsPort, lsPort, id))
+
+		sqsClient := newLocalStackSQSClient(t, lsPort)
+		queueURL := fmt.Sprintf("http://localhost:%s/000000000000/queue-%s", lsPort, id)
+
+		// Valid JSON, not an s3:TestEvent, but missing the object key at the
+		// configured key_path - simulates a key_path/bucket_path
+		// misconfiguration (or an unrecognised event type) rather than a
+		// test event, which should be handled differently: warned about and
+		// left on the queue, not silently deleted.
+		misconfiguredBody := fmt.Sprintf(
+			`{"Records":[{"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"bucket-%s"}}}]}`, id,
+		)
+		_, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    aws.String(queueURL),
+			MessageBody: aws.String(misconfiguredBody),
+		})
+		require.NoError(t, err)
+
+		yaml := fmt.Sprintf(`
+input:
+  aws_s3:
+    bucket: bucket-%s
+    endpoint: http://localhost:%s
+    force_path_style_urls: true
+    region: eu-west-1
+    delete_objects: true
+    sqs:
+      url: %s
+      key_path: Records.*.s3.object.key
+      endpoint: http://localhost:%s
+      wait_time_seconds: 1
+    credentials:
+      id: xxxxx
+      secret: xxxxx
+      token: xxxxx
+`, id, lsPort, queueURL, lsPort)
+
+		var logBuf syncBuffer
+		builder := service.NewStreamBuilder()
+		builder.SetLogger(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+		require.NoError(t, builder.SetYAML(yaml))
+		require.NoError(t, builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+			b, _ := m.AsBytes()
+			t.Errorf("did not expect any message to be emitted for a zero-key notification, got: %s", b)
+			return nil
+		}))
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+
+		runErr := make(chan error, 1)
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+		go func() { runErr <- stream.Run(runCtx) }()
+
+		// A non-test-event, zero-key message should be warned about,
+		// identifying the likely key_path misconfiguration, and - unlike an
+		// s3:TestEvent - left on the queue for redelivery rather than
+		// deleted.
+		assert.Eventually(t, func() bool {
+			return strings.Contains(logBuf.String(), "level=WARN") && strings.Contains(logBuf.String(), "key_path")
+		}, 15*time.Second, 500*time.Millisecond, "expected a WARN log identifying a key_path misconfiguration, got logs: %s", &logBuf)
+
+		out, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+			QueueUrl: aws.String(queueURL),
+			AttributeNames: []sqstypes.QueueAttributeName{
+				sqstypes.QueueAttributeNameApproximateNumberOfMessages,
+				sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+			},
+		})
+		require.NoError(t, err)
+		visible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessages)]
+		notVisible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible)]
+		assert.False(t, visible == "0" && notVisible == "0", "misconfigured message should remain on the queue for redelivery, not be deleted")
+
+		require.NoError(t, stream.StopWithin(10*time.Second))
+		select {
+		case err := <-runErr:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				require.NoError(t, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("stream did not exit after StopWithin returned")
+		}
 	})
 
 	t.Run("via_sqs_lines", func(t *testing.T) {
@@ -505,4 +601,21 @@ func newLocalStackSQSClient(t *testing.T, port string) *sqs.Client {
 	require.NoError(t, err)
 	cfg.BaseEndpoint = &endpoint
 	return sqs.NewFromConfig(cfg)
+}
+
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -199,30 +199,49 @@ input:
 	})
 
 	t.Run("via_sqs_zero_key_non_test_event_warns", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-		defer cancel()
-
-		id := fmt.Sprintf("zerokey%d", time.Now().UnixNano())
-		require.NoError(t, awstest.CreateBucketQueue(ctx, lsPort, lsPort, id))
-
-		sqsClient := newLocalStackSQSClient(t, lsPort)
-		queueURL := fmt.Sprintf("http://localhost:%s/000000000000/queue-%s", lsPort, id)
-
 		// Valid JSON, not an s3:TestEvent, but missing the object key at the
 		// configured key_path - simulates a key_path/bucket_path
 		// misconfiguration (or an unrecognised event type) rather than a
 		// test event, which should be handled differently: warned about and
 		// left on the queue, not silently deleted.
-		misconfiguredBody := fmt.Sprintf(
-			`{"Records":[{"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"bucket-%s"}}}]}`, id,
-		)
-		_, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
-			QueueUrl:    aws.String(queueURL),
-			MessageBody: aws.String(misconfiguredBody),
-		})
-		require.NoError(t, err)
+		cases := []struct {
+			name             string
+			warnIntervalYAML string
+			minWarnCount     int
+			expectExactlyOne bool
+		}{
+			{
+				name:             "default interval throttles to one warning",
+				expectExactlyOne: true,
+			},
+			{
+				name:             "zero interval disables throttling",
+				warnIntervalYAML: "      zero_key_warn_interval: 0s\n",
+				minWarnCount:     3,
+			},
+		}
 
-		yaml := fmt.Sprintf(`
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+				defer cancel()
+
+				id := fmt.Sprintf("zerokey%d", time.Now().UnixNano())
+				require.NoError(t, awstest.CreateBucketQueue(ctx, lsPort, lsPort, id))
+
+				sqsClient := newLocalStackSQSClient(t, lsPort)
+				queueURL := fmt.Sprintf("http://localhost:%s/000000000000/queue-%s", lsPort, id)
+
+				misconfiguredBody := fmt.Sprintf(
+					`{"Records":[{"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"bucket-%s"}}}]}`, id,
+				)
+				_, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+					QueueUrl:    aws.String(queueURL),
+					MessageBody: aws.String(misconfiguredBody),
+				})
+				require.NoError(t, err)
+
+				yaml := fmt.Sprintf(`
 input:
   aws_s3:
     bucket: bucket-%s
@@ -235,59 +254,80 @@ input:
       key_path: Records.*.s3.object.key
       endpoint: http://localhost:%s
       wait_time_seconds: 1
-    credentials:
+%s    credentials:
       id: xxxxx
       secret: xxxxx
       token: xxxxx
-`, id, lsPort, queueURL, lsPort)
+`, id, lsPort, queueURL, lsPort, tc.warnIntervalYAML)
 
-		var logBuf syncBuffer
-		builder := service.NewStreamBuilder()
-		builder.SetLogger(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+				var logBuf syncBuffer
+				builder := service.NewStreamBuilder()
+				builder.SetLogger(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-		require.NoError(t, builder.SetYAML(yaml))
-		require.NoError(t, builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
-			b, _ := m.AsBytes()
-			t.Errorf("did not expect any message to be emitted for a zero-key notification, got: %s", b)
-			return nil
-		}))
+				require.NoError(t, builder.SetYAML(yaml))
+				require.NoError(t, builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+					b, _ := m.AsBytes()
+					t.Errorf("did not expect any message to be emitted for a zero-key notification, got: %s", b)
+					return nil
+				}))
 
-		stream, err := builder.Build()
-		require.NoError(t, err)
-
-		runErr := make(chan error, 1)
-		runCtx, runCancel := context.WithCancel(ctx)
-		defer runCancel()
-		go func() { runErr <- stream.Run(runCtx) }()
-
-		// A non-test-event, zero-key message should be warned about,
-		// identifying the likely key_path misconfiguration, and - unlike an
-		// s3:TestEvent - left on the queue for redelivery rather than
-		// deleted.
-		assert.Eventually(t, func() bool {
-			return strings.Contains(logBuf.String(), "level=WARN") && strings.Contains(logBuf.String(), "key_path")
-		}, 15*time.Second, 500*time.Millisecond, "expected a WARN log identifying a key_path misconfiguration, got logs: %s", &logBuf)
-
-		out, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
-			QueueUrl: aws.String(queueURL),
-			AttributeNames: []sqstypes.QueueAttributeName{
-				sqstypes.QueueAttributeNameApproximateNumberOfMessages,
-				sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
-			},
-		})
-		require.NoError(t, err)
-		visible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessages)]
-		notVisible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible)]
-		assert.False(t, visible == "0" && notVisible == "0", "misconfigured message should remain on the queue for redelivery, not be deleted")
-
-		require.NoError(t, stream.StopWithin(10*time.Second))
-		select {
-		case err := <-runErr:
-			if err != nil && !errors.Is(err, context.Canceled) {
+				stream, err := builder.Build()
 				require.NoError(t, err)
-			}
-		case <-time.After(10 * time.Second):
-			t.Fatal("stream did not exit after StopWithin returned")
+
+				runErr := make(chan error, 1)
+				runCtx, runCancel := context.WithCancel(ctx)
+				defer runCancel()
+				go func() { runErr <- stream.Run(runCtx) }()
+
+				// A non-test-event, zero-key message should be warned
+				// about, identifying the likely key_path misconfiguration,
+				// and - unlike an s3:TestEvent - left on the queue for
+				// redelivery rather than deleted.
+				assert.Eventually(t, func() bool {
+					return strings.Contains(logBuf.String(), "level=WARN") && strings.Contains(logBuf.String(), "key_path")
+				}, 15*time.Second, 500*time.Millisecond, "expected a WARN log identifying a key_path misconfiguration, got logs: %s", &logBuf)
+
+				if tc.expectExactlyOne {
+					// The message is redelivered roughly every 500ms (Pop's
+					// empty-read backoff) for as long as it stays
+					// misconfigured, so without throttling this would emit
+					// a fresh WARN with the full body on every cycle. Give
+					// it several more cycles and confirm the WARN stays at
+					// a single occurrence.
+					time.Sleep(3 * time.Second)
+					assert.Equal(t, 1, strings.Count(logBuf.String(), "level=WARN"),
+						"expected the misconfiguration warning to be throttled to a single occurrence, got logs: %s", logBuf.String())
+				} else {
+					// zero_key_warn_interval: 0s disables the throttle, so
+					// the same ~500ms redelivery cycle should produce
+					// multiple WARNs instead of just one.
+					assert.Eventually(t, func() bool {
+						return strings.Count(logBuf.String(), "level=WARN") >= tc.minWarnCount
+					}, 15*time.Second, 500*time.Millisecond, "expected at least %d WARN logs with throttling disabled, got logs: %s", tc.minWarnCount, &logBuf)
+				}
+
+				out, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+					QueueUrl: aws.String(queueURL),
+					AttributeNames: []sqstypes.QueueAttributeName{
+						sqstypes.QueueAttributeNameApproximateNumberOfMessages,
+						sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+					},
+				})
+				require.NoError(t, err)
+				visible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessages)]
+				notVisible := out.Attributes[string(sqstypes.QueueAttributeNameApproximateNumberOfMessagesNotVisible)]
+				assert.False(t, visible == "0" && notVisible == "0", "misconfigured message should remain on the queue for redelivery, not be deleted")
+
+				require.NoError(t, stream.StopWithin(10*time.Second))
+				select {
+				case err := <-runErr:
+					if err != nil && !errors.Is(err, context.Canceled) {
+						require.NoError(t, err)
+					}
+				case <-time.After(10 * time.Second):
+					t.Fatal("stream did not exit after StopWithin returned")
+				}
+			})
 		}
 	})
 

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -140,11 +140,6 @@ input:
 		builder := service.NewStreamBuilder()
 		require.NoError(t, builder.SetYAML(yaml))
 
-		// The consumer func runs on the stream's own goroutine, not the test
-		// goroutine, so failures here must not call t.Fatalf/require (which
-		// call FailNow, only valid from the test goroutine). Instead, record
-		// any unexpected message under a mutex and assert on it below, once
-		// the stream has stopped.
 		var (
 			unexpectedMu   sync.Mutex
 			unexpectedMsgs [][]byte

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -283,8 +283,10 @@ input:
 				// about, identifying the likely key_path misconfiguration,
 				// and - unlike an s3:TestEvent - left on the queue for
 				// redelivery rather than deleted.
+				const zeroKeyWarnMsg = "Extracted zero target keys from SQS message using key_path"
+
 				assert.Eventually(t, func() bool {
-					return strings.Contains(logBuf.String(), "level=WARN") && strings.Contains(logBuf.String(), "key_path")
+					return strings.Contains(logBuf.String(), zeroKeyWarnMsg)
 				}, 15*time.Second, 500*time.Millisecond, "expected a WARN log identifying a key_path misconfiguration, got logs: %s", &logBuf)
 
 				if tc.expectExactlyOne {
@@ -295,14 +297,14 @@ input:
 					// it several more cycles and confirm the WARN stays at
 					// a single occurrence.
 					time.Sleep(3 * time.Second)
-					assert.Equal(t, 1, strings.Count(logBuf.String(), "level=WARN"),
+					assert.Equal(t, 1, strings.Count(logBuf.String(), zeroKeyWarnMsg),
 						"expected the misconfiguration warning to be throttled to a single occurrence, got logs: %s", logBuf.String())
 				} else {
 					// zero_key_warn_interval: 0s disables the throttle, so
 					// the same ~500ms redelivery cycle should produce
 					// multiple WARNs instead of just one.
 					assert.Eventually(t, func() bool {
-						return strings.Count(logBuf.String(), "level=WARN") >= tc.minWarnCount
+						return strings.Count(logBuf.String(), zeroKeyWarnMsg) >= tc.minWarnCount
 					}, 15*time.Second, 500*time.Millisecond, "expected at least %d WARN logs with throttling disabled, got logs: %s", tc.minWarnCount, &logBuf)
 				}
 

--- a/internal/impl/aws/s3/integration_test.go
+++ b/internal/impl/aws/s3/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -139,9 +140,23 @@ input:
 		builder := service.NewStreamBuilder()
 		require.NoError(t, builder.SetYAML(yaml))
 
+		// The consumer func runs on the stream's own goroutine, not the test
+		// goroutine, so failures here must not call t.Fatalf/require (which
+		// call FailNow, only valid from the test goroutine). Instead, record
+		// any unexpected message under a mutex and assert on it below, once
+		// the stream has stopped.
+		var (
+			unexpectedMu   sync.Mutex
+			unexpectedMsgs [][]byte
+		)
 		require.NoError(t, builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
-			b, _ := m.AsBytes()
-			t.Fatalf("did not expect any message to be emitted for an s3:TestEvent, got: %s", b)
+			b, err := m.AsBytes()
+			if err != nil {
+				b = fmt.Appendf(nil, "<failed to read message bytes: %v>", err)
+			}
+			unexpectedMu.Lock()
+			unexpectedMsgs = append(unexpectedMsgs, b)
+			unexpectedMu.Unlock()
 			return nil
 		}))
 
@@ -179,6 +194,10 @@ input:
 		case <-time.After(10 * time.Second):
 			t.Fatal("stream did not exit after StopWithin returned")
 		}
+
+		unexpectedMu.Lock()
+		assert.Empty(t, unexpectedMsgs, "did not expect any message to be emitted for an s3:TestEvent")
+		unexpectedMu.Unlock()
 	})
 
 	t.Run("via_sqs_lines", func(t *testing.T) {


### PR DESCRIPTION
S3 publishes an s3:TestEvent to the configured SQS queue whenever bucket notifications are (re)configured, to verify the queue exists and the bucket owner has permission to publish to it.

Before this change, regular messages got deleted via sqs.DeleteMessage whereas zero-target messages (messages with no bucket+key pair, such as s3:TestEvent) went a different code path to addDudFn which would set the visibility to 0 and make it immediately available, so the same test event gets redelivered and reprocessed indefinitely, spamming Extracted zero target keys from SQS message at DEBUG.

This change ensures we handle s3:TestEvent messages explicitly, acking/deleting them so they don't get redelivered.

### Proof of Work

Run 1: First run shows the delivery of s3:TestEvent resulting in repeated `Extracted zero target keys from SQS message` debug logs.
Run 2: Switch to this branch where we explicitly check for the test events and handle them
Run 3: Revert back to main to validate the s3:TestEvents have been acked.

<img width="3002" height="1237" alt="image" src="https://github.com/user-attachments/assets/63d9a897-1632-4c01-8ca0-38fd6100e0a5" />


For misconfigured events (malformed JSON for instance), these will warn at log then suppress for 30 seconds (but continue to log `Debug`). This way users will be aware of the malformed event without being flooded with `Warn` logs due to re-delivery, but if debug is enabled then they will continue to see them:

<img width="3003" height="1078" alt="image" src="https://github.com/user-attachments/assets/acd84deb-9b0a-4d37-946e-e0ac74329bc6" />