### PR TITLE
oracledb_cdc: prevent checkpointing during snapshot

### DIFF
--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -219,9 +219,19 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 	}
 
 	lastMsg := batch[len(batch)-1]
+
+	// ensure we don't checkpoint snapshot batches
+	isSnapshotBatch := false
+	if op, ok := lastMsg.MetaGet("operation"); ok && op == replication.MessageOperationRead.String() {
+		isSnapshotBatch = true
+	}
+
 	var checkpointSCN replication.SCN
-	// Prefer checkpoint_scn (which accounts for open transactions) otherwise fall back to scn.
-	// Snapshot records don't have an scn so we don't track those.
+	// Prefer checkpoint_scn. It accounts for open transactions.
+	// Use scn if checkpoint_scn is absent.
+	// Snapshot rows never carry checkpoint_scn.
+	// All rows in one snapshot run share the same scn, captured once in Snapshot.Prepare().
+	// So the fallback always selects that shared scn for snapshot batches.
 	scnKey := "checkpoint_scn"
 	if _, ok := lastMsg.MetaGet(scnKey); !ok {
 		scnKey = "scn"
@@ -242,6 +252,10 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 		msg: batch,
 		ackFn: func(ctx context.Context, _ error) error {
 			scn := resolveFn()
+			if isSnapshotBatch {
+				// Persisting here would introduce premature-checkpointing.
+				return nil
+			}
 			if scn != nil && scn.IsValid() {
 				return b.cacheSCN(ctx, *scn)
 			}

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -252,14 +252,15 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 		msg: batch,
 		ackFn: func(ctx context.Context, _ error) error {
 			scn := resolveFn()
-			if isSnapshotBatch {
-				// Persisting here would introduce premature-checkpointing.
+			if scn == nil || !scn.IsValid() {
 				return nil
 			}
-			if scn != nil && scn.IsValid() {
-				return b.cacheSCN(ctx, *scn)
+			if isSnapshotBatch && *scn <= checkpointSCN {
+				// Resolved value is this snapshot batch's own shared SCN (or older) —
+				// nothing new to persist, and persisting it would be premature.
+				return nil
 			}
-			return nil
+			return b.cacheSCN(ctx, *scn)
 		},
 	}
 	select {

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package oracledb
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/Jeffail/checkpoint"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
+)
+
+func TestPublishBatch(t *testing.T) {
+	t.Run("snapshot batches never persist via ackFn", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		msg1 := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+
+		require.NoError(t, msg.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "cacheSCN must not be called after acking only the first snapshot batch")
+
+		require.NoError(t, msg1.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "cacheSCN must not be called after acking all snapshot batches")
+	})
+
+	t.Run("streaming batch still persists via ackFn", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		batch := service.MessageBatch{newStreamingMessage("200")}
+		msg := publishAndReceive(t, ctx, publisher, batch)
+		require.NoError(t, msg.ackFn(ctx, nil))
+
+		scns := cachedSCNs()
+		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once for a streaming batch")
+		require.Equal(t, replication.SCN(200), scns[0])
+	})
+
+	t.Run("mixed snapshot and streaming batch persists", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		batch := service.MessageBatch{
+			newSnapshotMessage("100"),
+			newStreamingMessage("300"),
+		}
+		msg := publishAndReceive(t, ctx, publisher, batch)
+		require.NoError(t, msg.ackFn(ctx, nil))
+
+		scns := cachedSCNs()
+		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once for a batch whose last message is streaming")
+		require.Equal(t, replication.SCN(300), scns[0], "expected the streaming SCN from the last message, not the leftover snapshot SCN")
+	})
+}
+
+func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {
+	t.Helper()
+
+	logger := service.NewLoggerFromSlog(slog.Default())
+	cp := checkpoint.NewCapped[replication.SCN](100)
+
+	publisher := newBatchPublisher(nil, cp, logger)
+	t.Cleanup(publisher.Close)
+
+	var (
+		mu         sync.Mutex
+		cachedSCNs []replication.SCN
+	)
+	publisher.cacheSCN = func(_ context.Context, scn replication.SCN) error {
+		mu.Lock()
+		defer mu.Unlock()
+		cachedSCNs = append(cachedSCNs, scn)
+		return nil
+	}
+
+	cachedSCNsFn := func() []replication.SCN {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]replication.SCN(nil), cachedSCNs...)
+	}
+
+	return publisher, cachedSCNsFn
+}
+
+func newSnapshotMessage(scn string) *service.Message {
+	msg := service.NewMessage([]byte("{}"))
+	msg.MetaSet("operation", replication.MessageOperationRead.String())
+	msg.MetaSet("scn", scn)
+	return msg
+}
+
+func newStreamingMessage(checkpointSCN string) *service.Message {
+	msg := service.NewMessage([]byte("{}"))
+	msg.MetaSet("operation", replication.MessageOperationInsert.String())
+	msg.MetaSet("checkpoint_scn", checkpointSCN)
+	return msg
+}
+
+func publishAndReceive(t *testing.T, ctx context.Context, publisher *batchPublisher, batch service.MessageBatch) asyncMessage {
+	t.Helper()
+	go func() {
+		_ = publisher.publishBatch(ctx, batch)
+	}()
+	return <-publisher.msgs()
+}

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -64,6 +64,22 @@ func TestPublishBatch(t *testing.T) {
 		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once for a batch whose last message is streaming")
 		require.Equal(t, replication.SCN(300), scns[0], "expected the streaming SCN from the last message, not the leftover snapshot SCN")
 	})
+
+	t.Run("streaming SCN survives an out-of-order snapshot ack", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		snapshotMsg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		streamingMsg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newStreamingMessage("200")})
+
+		require.NoError(t, streamingMsg.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "cacheSCN must not be called while the snapshot batch is still the unresolved head")
+		require.NoError(t, snapshotMsg.ackFn(ctx, nil))
+
+		scns := cachedSCNs()
+		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once when the snapshot batch resolves the streaming SCN")
+		require.Equal(t, replication.SCN(200), scns[0], "expected the streaming batch's SCN to survive the out-of-order snapshot ack")
+	})
 }
 
 func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {


### PR DESCRIPTION
A recent change to introduce the current SCN to snapshot events had the undesired knock on effect of checkpointing delivery of those snapshot events, which we only want to do when the snapshot process completes. This change reverts that behaviour and adds a set of regression tests.

### Proof of Work

- Before (Red): SCN is captured during snapshot
- After (Green): No SCN is captured during snapshot

<img width="3008" height="1625" alt="image" src="https://github.com/user-attachments/assets/b9f9c631-ba04-4014-bfb1-0c029c737971" />

Snapshot completes and only then does it checkpoint:

<img width="3005" height="1264" alt="image" src="https://github.com/user-attachments/assets/0ea668f3-cf81-46a1-9f7e-dc52eb67f769" />

