### PR TITLE
oracledb_cdc: support the ability to configure a log miner session age

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -56,6 +56,7 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
+      max_session_age: 0s
     snapshot_filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
@@ -99,6 +100,7 @@ input:
       lob_enabled: true
       transaction_cache: "" # No default (optional)
       transaction_cache_key: oracledb_cdc
+      max_session_age: 0s
     snapshot_filters: {} # No default (optional)
     include: [] # No default (required)
     exclude: [] # No default (optional)
@@ -334,6 +336,21 @@ The key prefix used when storing transactions in `transaction_cache`. An alterna
 *Type*: `string`
 
 *Default*: `"oracledb_cdc"`
+
+=== `logminer.max_session_age`
+
+The maximum duration a single LogMiner session may stay open before being forcibly ended and restarted, even if the underlying redo log files haven't changed. By default, a LogMiner session is only restarted when a redo log switch is detected. On databases where switches are infrequent, a session can stay open for a long time, and LogMiner has been observed to accumulate server-side PGA memory (particularly around online catalog dictionary lookups) until Oracle terminates the session with ORA-04036. Setting this forces a periodic restart independent of log switches. Set to 0 (default) to disable and restart only on log switches.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+
+```yml
+# Examples
+
+max_session_age: 20m
+```
 
 === `snapshot_filters`
 

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -62,6 +62,7 @@ const (
 	ociFieldLOBEnabled           = "lob_enabled"
 	ociFieldTransactionCache     = "transaction_cache"
 	ociFieldTransactionCacheKey  = "transaction_cache_key"
+	ociFieldMaxSessionAge        = "max_session_age"
 
 	//-- snapshot specific
 	ociFieldSnapshotFilters = "snapshot_filters"
@@ -181,6 +182,13 @@ This cache is designed for low-latency stores with cheap per-operation cost. Red
 		service.NewStringField(ociFieldTransactionCacheKey).
 			Description("The key prefix used when storing transactions in `"+ociFieldTransactionCache+"`. An alternative prefix must be set if multiple `oracledb_cdc` inputs share the same cache resource, since Oracle transaction IDs (USN.SLOT.SEQ) are only unique within a single Oracle instance and would otherwise collide.").
 			Default(logminer.DefaultTransactionCacheKey).
+			Optional(),
+		service.NewDurationField(ociFieldMaxSessionAge).
+			Description("The maximum duration a single LogMiner session may stay open before being forcibly ended and restarted, even if the underlying redo log files haven't changed. By default, a LogMiner session is only restarted when a redo log switch is detected. On databases where switches are infrequent, a session can stay open for a long time, and LogMiner has been observed to accumulate server-side PGA memory (particularly around online catalog dictionary lookups) until Oracle terminates the session with ORA-04036. Setting this forces a periodic restart independent of log switches. Set to 0 (default) to disable and restart only on log switches.").
+			ShortDescription("Maximum duration before a LogMiner session is force-restarted, independent of redo log switches.").
+			Default(logminer.DefaultMaxSessionAge.String()).
+			Example("20m").
+			LintRule(`root = if this.parse_duration().catch(0) < 0 { [ "`+ociFieldMaxSessionAge+` must be 0 or greater" ] }`).
 			Optional(),
 	).Description("LogMiner configuration settings."),
 	).
@@ -834,6 +842,12 @@ func parseLogMinerConfig(conf *service.ParsedConfig) (*logminer.Config, error) {
 		}
 		if cfg.LOBEnabled, err = lmConf.FieldBool(ociFieldLOBEnabled); err != nil {
 			return nil, err
+		}
+		if cfg.MaxSessionAge, err = lmConf.FieldDuration(ociFieldMaxSessionAge); err != nil {
+			return nil, err
+		}
+		if cfg.MaxSessionAge < 0 {
+			return nil, fmt.Errorf("logminer.%s must be greater than or equal to 0, got %s", ociFieldMaxSessionAge, cfg.MaxSessionAge)
 		}
 		// support cache_resources for buffering logminer transactions
 		if lmConf.Contains(ociFieldTransactionCache) {

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -13,6 +13,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -648,17 +651,19 @@ oracledb_cdc:
     scn_window_size: 20000
     min_scn_window_size: 0
     backoff_interval: 1s
+    max_session_age: 5s
   include: ["TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"]
   exclude: ["TESTDB.DOESNOTEXIST"]
   batching:
     count: 500`
 
+		var logBuf oracledbtest.SyncBuffer
+
 		t.Log("Launching component...")
 		{
 			streamBuilder := service.NewStreamBuilder()
+			streamBuilder.SetLogger(slog.New(slog.NewTextHandler(io.MultiWriter(os.Stdout, &logBuf), &slog.HandlerOptions{Level: slog.LevelDebug})))
 			require.NoError(t, streamBuilder.AddInputYAML(cfg))
-			require.NoError(t, streamBuilder.SetLoggerYAML(`level: INFO`))
-
 			require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
 				for _, msg := range mb {
 					msgChan <- msg
@@ -702,6 +707,13 @@ oracledb_cdc:
 			assert.Len(t, row, 2)
 			assert.Contains(t, row, "ID")
 			assert.EqualValues(t, "1", row["VAL"])
+		})
+
+		t.Run("Session is forcibly ended after max_session_age", func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				return strings.Contains(logBuf.String(), "exceeding max_session_age of 5s")
+			}, 30*time.Second, 4*time.Second,
+				"expected a LogMiner session-expiry debug log entry within max_session_age (5s)")
 		})
 
 		t.Run("Streaming update changes...", func(t *testing.T) {

--- a/internal/impl/oracledb/logminer/config.go
+++ b/internal/impl/oracledb/logminer/config.go
@@ -36,6 +36,10 @@ var (
 	// DefaultTransactionCacheKey is the default prefix used for the transaction buffer cache key.
 	// Only relevant when configuring a (potentially shared) cache_resource transaction buffer.
 	DefaultTransactionCacheKey = "oracledb_cdc"
+	// DefaultMaxSessionAge controls how long a single LogMiner session may remain active
+	// before being forcibly restarted, independent of redo log switches. 0 disables this,
+	// restarting only on log switches (the previous, and still default, behaviour).
+	DefaultMaxSessionAge = 0 * time.Second
 )
 
 // MiningStrategy defines how LogMiner accesses dictionary information
@@ -65,6 +69,7 @@ type Config struct {
 	LOBEnabled             bool
 	PDBName                string
 	TransactionCacheConfig TransactionCacheConfig
+	MaxSessionAge          time.Duration
 }
 
 // NewDefaultConfig returns a Config with default values
@@ -78,5 +83,6 @@ func NewDefaultConfig() *Config {
 		MiningStrategy:        MiningStrategy(DefaultMiningStrategy),
 		MaxTransactionEvents:  DefaultMaxTransactionEvents,
 		LOBEnabled:            DefaultLOBEnabled,
+		MaxSessionAge:         DefaultMaxSessionAge,
 	}
 }

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -198,6 +198,17 @@ func (lm *LogMiner) FindStartPos(ctx context.Context) (replication.SCN, error) {
 	return replication.SCN(currentPos), nil
 }
 
+func (lm *LogMiner) endExpiredIdleSession(ctx context.Context, conn *sql.Conn) {
+	if !lm.sessionMgr.IsExpired(lm.cfg.MaxSessionAge) {
+		return
+	}
+	lm.log.Debugf("LogMiner session has been open for %s, exceeding max_session_age of %s — ending idle session to release accumulated session memory",
+		lm.sessionMgr.Age(), lm.cfg.MaxSessionAge)
+	if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
+		lm.log.Errorf("Failed to end idle LogMiner session: %v", err)
+	}
+}
+
 func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp bool, err error) {
 	// Get database's current SCN to know our target
 	var dbCurrentSCN uint64
@@ -206,10 +217,12 @@ func (lm *LogMiner) miningCycle(ctx context.Context, conn *sql.Conn) (caughtUp b
 	}
 
 	if lm.currentSCN >= dbCurrentSCN {
+		lm.endExpiredIdleSession(ctx, conn)
 		return true, nil
 	}
 
 	if deferMiningCycle(lm.currentSCN, dbCurrentSCN, lm.cfg.MinSCNWindowSize) {
+		lm.endExpiredIdleSession(ctx, conn)
 		return true, nil
 	}
 
@@ -1121,8 +1134,18 @@ func (lm *LogMiner) prepareLogsAndStartSession(ctx context.Context, conn *sql.Co
 	}
 	lm.log.Debugf("Collected %d redo log file(s) for LogMiner: %v", len(logFiles), types)
 
-	if lm.sessionMgr.logFilesChanged(logFiles) {
-		// Log files have changed (first start or log switch) — full reload required.
+	// On databases where redo log switches are infrequent, a LogMiner session can stay
+	// open for hours, accumulating server-side PGA (notably around online catalog
+	// dictionary lookups) until Oracle kills it outright with ORA-04036.
+	sessionExpired := lm.sessionMgr.IsExpired(lm.cfg.MaxSessionAge)
+	if sessionExpired {
+		lm.log.Debugf("LogMiner session has been open for %s, exceeding max_session_age of %s — forcing restart to release accumulated session memory",
+			lm.sessionMgr.Age(), lm.cfg.MaxSessionAge)
+	}
+
+	if lm.sessionMgr.logFilesChanged(logFiles) || sessionExpired {
+		// Log files have changed (first start or log switch), or the session has exceeded
+		// its maximum age — full reload required.
 		if lm.sessionMgr.IsActive() {
 			if err := lm.sessionMgr.EndSession(ctx, conn); err != nil {
 				lm.log.Errorf("Failed to end existing LogMiner session: %v", err)

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -913,7 +913,7 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 	}
 
 	// Use the pre-built query from initialization
-	lm.log.Debugf("Executing LogMiner query with SCN range (scn=%d to %d with window %d): %s", startSCN, endSCN, lm.windowSize, lm.logMinerQuery)
+	lm.log.Debugf("Executing LogMiner query with SCN range (scn=%d to %d with window %d)", startSCN, endSCN, lm.windowSize)
 	queryStart := time.Now()
 	rows, err := conn.QueryContext(ctx, lm.logMinerQuery, startSCN, endSCN)
 	if err != nil {

--- a/internal/impl/oracledb/logminer/session.go
+++ b/internal/impl/oracledb/logminer/session.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -20,11 +21,12 @@ import (
 // SessionManager manages LogMiner sessions, such as loading
 // logs into LogMiner then starting/ending mining sessions.
 type SessionManager struct {
-	cfg         *Config
-	opts        []string
-	active      bool
-	loadedFiles []*LogFile
-	log         *service.Logger
+	cfg           *Config
+	opts          []string
+	active        bool
+	loadedFiles   []*LogFile
+	sessionOpened time.Time
+	log           *service.Logger
 }
 
 // NewSessionManager creates a new SessionManager with the specified configuration.
@@ -80,6 +82,7 @@ func (sm *SessionManager) AddLogFile(ctx context.Context, conn *sql.Conn, files 
 	}
 
 	sm.loadedFiles = files
+	sm.sessionOpened = time.Now()
 	return nil
 }
 
@@ -111,10 +114,27 @@ func (sm *SessionManager) EndSession(ctx context.Context, conn *sql.Conn) error 
 
 	sm.active = false
 	sm.loadedFiles = nil
+	sm.sessionOpened = time.Time{}
 	return nil
 }
 
 // IsActive returns true if a LogMiner session is currently active.
 func (sm *SessionManager) IsActive() bool {
 	return sm.active
+}
+
+// Age returns how long the current LogMiner session has been open since its
+// underlying log files were last (re)loaded via AddLogFile. Returns 0 if no
+// session is active.
+func (sm *SessionManager) Age() time.Duration {
+	if sm.sessionOpened.IsZero() {
+		return 0
+	}
+	return time.Since(sm.sessionOpened)
+}
+
+// IsExpired reports whether the current session has been open for at least
+// maxAge. Always false when no session is active or maxAge is 0 (disabled).
+func (sm *SessionManager) IsExpired(maxAge time.Duration) bool {
+	return maxAge > 0 && sm.active && sm.Age() >= maxAge
 }

--- a/internal/impl/oracledb/logminer/session_test.go
+++ b/internal/impl/oracledb/logminer/session_test.go
@@ -1,0 +1,367 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package logminer
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestSessionManager(t *testing.T) {
+	t.Run("Age", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		sm := NewSessionManager(cfg, service.NewLoggerFromSlog(slog.Default()))
+
+		assert.Equal(t, time.Duration(0), sm.Age(), "age must be zero before any session has been opened")
+
+		files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+		conn, _ := newFakeSQLConn(t, files)
+
+		require.NoError(t, sm.AddLogFile(t.Context(), conn, files))
+		assert.GreaterOrEqual(t, sm.Age(), time.Duration(0), "age must be non-negative once a session is active")
+
+		firstAge := sm.Age()
+		time.Sleep(5 * time.Millisecond)
+		assert.Greater(t, sm.Age(), firstAge, "age must keep increasing while the session remains open")
+
+		require.NoError(t, sm.EndSession(t.Context(), conn))
+		assert.Equal(t, time.Duration(0), sm.Age(), "age must reset to zero once the session has ended")
+	})
+
+	t.Run("PrepareLogsAndStartSessionRestartsOnMaxSessionAge", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		cfg.MaxSessionAge = 20 * time.Millisecond
+
+		logger := service.NewLoggerFromSlog(slog.Default())
+		lm := &LogMiner{
+			cfg:          cfg,
+			sessionMgr:   NewSessionManager(cfg, logger),
+			logCollector: NewLogFileCollector(),
+			log:          logger,
+		}
+
+		files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+		conn, fc := newFakeSQLConn(t, files)
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 100, 200))
+		require.True(t, lm.sessionMgr.IsActive())
+		require.Equal(t, 1, fc.count("ADD_LOGFILE"), "first call has no prior session, so it must add log files")
+		require.Equal(t, 0, fc.count("END_LOGMNR"), "first call has no prior session, so there is nothing to end")
+
+		// Artificially age the session well past MaxSessionAge without changing the
+		// underlying log files - the only thing that can trigger a restart here is age.
+		lm.sessionMgr.sessionOpened = time.Now().Add(-time.Hour)
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 200, 300))
+
+		assert.Equal(t, 1, fc.count("END_LOGMNR"),
+			"a stale session must be explicitly ended even though the log file set is unchanged")
+		assert.Equal(t, 2, fc.count("ADD_LOGFILE"),
+			"log files must be reloaded when the session is restarted due to age")
+		assert.Equal(t, 2, fc.count("START_LOGMNR"),
+			"a new mining session must be started after the restart")
+		assert.Less(t, lm.sessionMgr.Age(), 5*time.Second,
+			"AddLogFile must have refreshed sessionOpened, resetting the reported session age")
+	})
+
+	t.Run("MiningCycleEndsExpiredSessionWhenCaughtUp", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		cfg.MaxSessionAge = 20 * time.Millisecond
+
+		logger := service.NewLoggerFromSlog(slog.Default())
+		lm := &LogMiner{
+			cfg:          cfg,
+			sessionMgr:   NewSessionManager(cfg, logger),
+			logCollector: NewLogFileCollector(),
+			log:          logger,
+		}
+
+		files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+		conn, fc := newFakeSQLConn(t, files)
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 100, 200))
+		require.True(t, lm.sessionMgr.IsActive())
+
+		// Database is caught up with what we've already mined, and the session
+		// was opened well beyond MaxSessionAge - miningCycle must still end it
+		// even though no productive mining work happens on this cycle.
+		lm.currentSCN = 200
+		fc.currentSCN = 200
+		lm.sessionMgr.sessionOpened = time.Now().Add(-time.Hour)
+
+		caughtUp, err := lm.miningCycle(t.Context(), conn)
+		require.NoError(t, err)
+		assert.True(t, caughtUp, "miningCycle must report caught up when currentSCN >= dbCurrentSCN")
+		assert.Equal(t, 1, fc.count("END_LOGMNR"),
+			"an idle session that has exceeded max_session_age must be ended even while caught up")
+		assert.False(t, lm.sessionMgr.IsActive())
+	})
+
+	t.Run("MiningCycleCaughtUpDoesNotEndSessionWhenNotExpired", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			maxSessionAge time.Duration
+			sessionAge    time.Duration
+		}{
+			{
+				name:          "max_session_age disabled (default)",
+				maxSessionAge: 0,
+				sessionAge:    24 * time.Hour,
+			},
+			{
+				name:          "max_session_age configured but not yet exceeded",
+				maxSessionAge: time.Hour,
+				sessionAge:    time.Millisecond,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				cfg := NewDefaultConfig()
+				cfg.MaxSessionAge = test.maxSessionAge
+
+				logger := service.NewLoggerFromSlog(slog.Default())
+				lm := &LogMiner{
+					cfg:          cfg,
+					sessionMgr:   NewSessionManager(cfg, logger),
+					logCollector: NewLogFileCollector(),
+					log:          logger,
+				}
+
+				files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+				conn, fc := newFakeSQLConn(t, files)
+
+				require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 100, 200))
+				require.True(t, lm.sessionMgr.IsActive())
+
+				lm.currentSCN = 200
+				fc.currentSCN = 200
+				lm.sessionMgr.sessionOpened = time.Now().Add(-test.sessionAge)
+
+				caughtUp, err := lm.miningCycle(t.Context(), conn)
+				require.NoError(t, err)
+				assert.True(t, caughtUp)
+				assert.Equal(t, 0, fc.count("END_LOGMNR"),
+					"session must remain open while caught up if it has not exceeded max_session_age")
+				assert.True(t, lm.sessionMgr.IsActive())
+			})
+		}
+	})
+
+	t.Run("MiningCycleEndsExpiredSessionWhenDeferring", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		cfg.MaxSessionAge = 20 * time.Millisecond
+		require.Greater(t, cfg.MinSCNWindowSize, 0, "test relies on a positive MinSCNWindowSize to trigger deferral")
+
+		logger := service.NewLoggerFromSlog(slog.Default())
+		lm := &LogMiner{
+			cfg:          cfg,
+			sessionMgr:   NewSessionManager(cfg, logger),
+			logCollector: NewLogFileCollector(),
+			log:          logger,
+		}
+
+		files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+		conn, fc := newFakeSQLConn(t, files)
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 100, 200))
+		require.True(t, lm.sessionMgr.IsActive())
+
+		// Database has advanced past currentSCN, but by less than MinSCNWindowSize,
+		// so miningCycle defers rather than mining - this must still end a stale session.
+		lm.currentSCN = 200
+		fc.currentSCN = 200 + uint64(cfg.MinSCNWindowSize) - 1
+		lm.sessionMgr.sessionOpened = time.Now().Add(-time.Hour)
+
+		caughtUp, err := lm.miningCycle(t.Context(), conn)
+		require.NoError(t, err)
+		assert.True(t, caughtUp, "miningCycle must report caught up (deferred) when the SCN gap is below MinSCNWindowSize")
+		assert.Equal(t, 1, fc.count("END_LOGMNR"),
+			"an idle session that has exceeded max_session_age must be ended even while deferring")
+		assert.False(t, lm.sessionMgr.IsActive())
+	})
+
+	t.Run("PrepareLogsAndStartSessionDefaultMaxSessionAgeDoesNotRestart", func(t *testing.T) {
+		cfg := NewDefaultConfig()
+		require.Equal(t, time.Duration(0), cfg.MaxSessionAge, "default MaxSessionAge must remain disabled")
+
+		logger := service.NewLoggerFromSlog(slog.Default())
+		lm := &LogMiner{
+			cfg:          cfg,
+			sessionMgr:   NewSessionManager(cfg, logger),
+			logCollector: NewLogFileCollector(),
+			log:          logger,
+		}
+
+		files := []*LogFile{{FileName: "redo01.log", FirstSCN: 1, NextSCN: 1000, Sequence: 1, Type: "ONLINE", Thread: 1}}
+		conn, fc := newFakeSQLConn(t, files)
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 100, 200))
+		require.Equal(t, 1, fc.count("ADD_LOGFILE"))
+
+		// Artificially age the session far beyond any sane max_session_age value,
+		// with the log file set left unchanged. With MaxSessionAge disabled this
+		// must have no effect on whether a restart occurs.
+		lm.sessionMgr.sessionOpened = time.Now().Add(-24 * time.Hour)
+		staleOpened := lm.sessionMgr.sessionOpened
+
+		require.NoError(t, lm.prepareLogsAndStartSession(t.Context(), conn, 200, 300))
+
+		assert.Equal(t, 0, fc.count("END_LOGMNR"),
+			"session must not be ended when MaxSessionAge is disabled (0)")
+		assert.Equal(t, 1, fc.count("ADD_LOGFILE"),
+			"log files must not be reloaded when neither the file set changed nor MaxSessionAge is exceeded")
+		assert.Equal(t, staleOpened, lm.sessionMgr.sessionOpened,
+			"sessionOpened must be untouched since AddLogFile was not re-invoked")
+		assert.Equal(t, 2, fc.count("START_LOGMNR"),
+			"StartSession is always invoked on every call regardless of a restart")
+	})
+}
+
+// --- fake database/sql driver used to exercise SessionManager/LogMiner
+// session logic without a real Oracle connection. Only the subset of
+// database/sql/driver behaviour exercised by prepareLogsAndStartSession
+// (querying V$LOGMNR-style log file listings and executing DBMS_LOGMNR
+// PL/SQL blocks) is implemented. ---
+
+var fakeDriverSeq atomic.Int64
+
+func newFakeSQLConn(t *testing.T, files []*LogFile) (*sql.Conn, *fakeConn) {
+	t.Helper()
+
+	fc := &fakeConn{logFiles: files}
+	name := fmt.Sprintf("fakeoracle_%d", fakeDriverSeq.Add(1))
+	sql.Register(name, &fakeDriver{conn: fc})
+
+	db, err := sql.Open(name, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn, fc
+}
+
+type fakeDriver struct {
+	conn *fakeConn
+}
+
+func (d *fakeDriver) Open(string) (driver.Conn, error) {
+	return d.conn, nil
+}
+
+type fakeConn struct {
+	mu         sync.Mutex
+	logFiles   []*LogFile
+	execs      []string
+	currentSCN uint64
+}
+
+func (c *fakeConn) count(substr string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, e := range c.execs {
+		if strings.Contains(e, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+func (*fakeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("fakeConn: Prepare not supported, expected ExecContext/QueryContext usage")
+}
+
+func (*fakeConn) Close() error { return nil }
+
+func (*fakeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("fakeConn: transactions not supported")
+}
+
+func (c *fakeConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if strings.Contains(query, "CURRENT_SCN") {
+		return &fakeSCNRow{scn: c.currentSCN}, nil
+	}
+	return &fakeRows{files: c.logFiles}, nil
+}
+
+func (c *fakeConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.execs = append(c.execs, query)
+	return driver.ResultNoRows, nil
+}
+
+// fakeRows implements driver.Rows over the LogFileCollector.GetLogsBySCNRange
+// column set: FILE_NAME, FIRST_CHANGE, NEXT_CHANGE, SEQ, TYPE, THREAD.
+type fakeRows struct {
+	files []*LogFile
+	idx   int
+}
+
+func (*fakeRows) Columns() []string {
+	return []string{"FILE_NAME", "FIRST_CHANGE", "NEXT_CHANGE", "SEQ", "TYPE", "THREAD"}
+}
+
+func (*fakeRows) Close() error { return nil }
+
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.files) {
+		return io.EOF
+	}
+	f := r.files[r.idx]
+	dest[0] = f.FileName
+	dest[1] = int64(f.FirstSCN)
+	dest[2] = int64(f.NextSCN)
+	dest[3] = f.Sequence
+	dest[4] = f.Type
+	dest[5] = int64(f.Thread)
+	r.idx++
+	return nil
+}
+
+// fakeSCNRow implements driver.Rows over a single CURRENT_SCN value, satisfying
+// miningCycle's `SELECT CURRENT_SCN FROM V$DATABASE` query.
+type fakeSCNRow struct {
+	scn  uint64
+	done bool
+}
+
+func (*fakeSCNRow) Columns() []string { return []string{"CURRENT_SCN"} }
+
+func (*fakeSCNRow) Close() error { return nil }
+
+func (r *fakeSCNRow) Next(dest []driver.Value) error {
+	if r.done {
+		return io.EOF
+	}
+	dest[0] = int64(r.scn)
+	r.done = true
+	return nil
+}

--- a/internal/impl/oracledb/oracledbtest/oracledbtest.go
+++ b/internal/impl/oracledb/oracledbtest/oracledbtest.go
@@ -9,6 +9,7 @@
 package oracledbtest
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -429,4 +430,22 @@ func startContainer(t *testing.T, ctx context.Context) containerCfg {
 		connStr: connStr,
 		port:    port,
 	}
+}
+
+// SyncBuffer a buffer used for buffering log output
+type SyncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *SyncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *SyncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
This change adds a `logminer.max_session_age` config option to force periodic restarts of LogMiner sessions, bounding server-side PGA growth on databases where redo log switches are infrequent.

### Proof of Work

Two runs of 1,000,000 records each shows that between runs when it was quiet the session was ended, freeing up PGA memory within Oracle.

<img width="3005" height="1639" alt="image" src="https://github.com/user-attachments/assets/ac250fda-9826-41ff-b64c-680efc46db6a" />

With no `max_session_age` value set, LogMiner will leave the session open:

<img width="2992" height="1624" alt="image" src="https://github.com/user-attachments/assets/af298b4a-478d-4f69-a6b4-2ea0602d7b1d" />
