### PR TITLE
oracledb_cdc: Propagate `V$LOGMNR_CONTENTS.USERNAME` as metadata

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -133,6 +133,7 @@ This input adds the following metadata fields to each message:
 - transaction_id: The Oracle transaction ID in `USN.SLOT.SEQ` format, identifying the transaction that produced the change. Not present on snapshot (`read`) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from `V$LOGMNR_CONTENTS.TIMESTAMP` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. For snapshot (`read`) messages, this reflects Oracle's `SYSTIMESTAMP` at the moment the snapshot SCN was captured, so all snapshot messages share the same value.
+- user_name: The Oracle database username of the session that performed the DML, sourced from `V$LOGMNR_CONTENTS.USERNAME`. Not present on snapshot (`read`) messages, nor on change messages where Oracle reports a NULL or empty username.
 - schema: The table schema, for use with schema-aware downstream processors such as `schema_registry_encode`. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -188,6 +188,9 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	if !m.CommitTimestamp.IsZero() {
 		msg.MetaSet("commit_ts_ms", strconv.FormatInt(m.CommitTimestamp.UnixMilli(), 10))
 	}
+	if m.UserName != "" {
+		msg.MetaSet("user_name", m.UserName)
+	}
 
 	if schemaAny != nil {
 		msg.MetaSetImmut("schema", service.ImmutableAny{V: schemaAny})

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -89,6 +89,7 @@ This input adds the following metadata fields to each message:
 - transaction_id: The Oracle transaction ID in ` + "`USN.SLOT.SEQ`" + ` format, identifying the transaction that produced the change. Not present on snapshot (` + "`read`" + `) messages.
 - source_ts_ms: The timestamp of when Oracle wrote the change record into the redo log, expressed as milliseconds since the Unix epoch. This reflects the database server's wall-clock time at the moment the DML executed, not the transaction commit time.
 - commit_ts_ms: The timestamp of the transaction commit, expressed as milliseconds since the Unix epoch. Sourced from ` + "`V$LOGMNR_CONTENTS.TIMESTAMP`" + ` on the COMMIT redo record — this is Oracle's wall-clock time when the commit was written to the redo log, not a dedicated commit-timestamp column. For snapshot (` + "`read`" + `) messages, this reflects Oracle's ` + "`SYSTIMESTAMP`" + ` at the moment the snapshot SCN was captured, so all snapshot messages share the same value.
+- user_name: The Oracle database username of the session that performed the DML, sourced from ` + "`V$LOGMNR_CONTENTS.USERNAME`" + `. Not present on snapshot (` + "`read`" + `) messages, nor on change messages where Oracle reports a NULL or empty username.
 - schema: The table schema, for use with schema-aware downstream processors such as ` + "`schema_registry_encode`" + `. When new columns are detected in CDC events, the schema is automatically refreshed from the Oracle catalog. Dropped columns are reflected after a connector restart.
 
 == Permissions

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -626,6 +626,11 @@ func TestIntegrationOracleDBCDCStreaming(t *testing.T) {
 			txID, ok := msg.MetaGet("transaction_id")
 			require.Truef(t, ok, "message %d missing 'transaction_id' metadata", i)
 			assert.Regexpf(t, `^\d+\.\d+\.\d+$`, txID, "message %d: transaction_id %q not in USN.SLOT.SEQ format", i, txID)
+
+			// assert user_name metadata - test DML runs as the SYSTEM user
+			userName, ok := msg.MetaGet("user_name")
+			require.Truef(t, ok, "message %d missing 'user_name' metadata", i)
+			assert.Equalf(t, "SYSTEM", userName, "message %d: expected user_name 'SYSTEM', got %q", i, userName)
 		}
 
 		for _, expectedKey := range []string{"TESTDB.FOO", "TESTDB.FOO2", "TESTDB2.BAR"} {

--- a/internal/impl/oracledb/logminer/logminer.go
+++ b/internal/impl/oracledb/logminer/logminer.go
@@ -100,7 +100,7 @@ func NewMiner(db *sql.DB, userTables []replication.UserTable, publisher replicat
 		fmt.Fprintf(&buf, " AND SRC_CON_NAME = '%s'", strings.ReplaceAll(cfg.PDBName, "'", "''"))
 	}
 
-	logMinerQuery := "SELECT SCN, SQL_REDO, OPERATION_CODE, TABLE_NAME, SEG_OWNER, TIMESTAMP, XID, COMMIT_SCN, CSF FROM V$LOGMNR_CONTENTS WHERE SCN > :1 AND SCN <= :2" + buf.String()
+	logMinerQuery := "SELECT SCN, SQL_REDO, OPERATION_CODE, TABLE_NAME, SEG_OWNER, TIMESTAMP, XID, COMMIT_SCN, CSF, USERNAME FROM V$LOGMNR_CONTENTS WHERE SCN > :1 AND SCN <= :2" + buf.String()
 
 	lm := &LogMiner{
 		cfg:                  cfg,
@@ -935,6 +935,7 @@ func (lm *LogMiner) queryLogMinerContents(ctx context.Context, conn *sql.Conn, s
 			&event.TransactionID,
 			&commitSCN,
 			&csf,
+			&event.UserName,
 		); err != nil {
 			return err
 		}
@@ -1166,6 +1167,7 @@ func toMessageEvent(dml *sqlredo.DMLEvent, scn uint64, checkpointSCN uint64, com
 		Timestamp:       dml.Timestamp,
 		TransactionID:   dml.TransactionID.String(),
 		CommitTimestamp: commitTimestamp,
+		UserName:        dml.UserName,
 	}
 
 	switch dml.Operation {

--- a/internal/impl/oracledb/logminer/sqlredo/events.go
+++ b/internal/impl/oracledb/logminer/sqlredo/events.go
@@ -163,6 +163,7 @@ type DMLEvent struct {
 	OldValues     map[string]any
 	Timestamp     time.Time
 	TransactionID TransactionID
+	UserName      string
 }
 
 // RedoEvent represents a redo log row from V$LOGMNR_CONTENTS
@@ -175,4 +176,5 @@ type RedoEvent struct {
 	SchemaName    sql.NullString
 	Timestamp     time.Time
 	TransactionID TransactionID
+	UserName      sql.NullString
 }

--- a/internal/impl/oracledb/logminer/sqlredo/parser.go
+++ b/internal/impl/oracledb/logminer/sqlredo/parser.go
@@ -68,6 +68,9 @@ func (p Parser) RedoEventToDMLEvent(redoEvent *RedoEvent) (DMLEvent, error) {
 	if redoEvent.TableName.Valid {
 		event.Table = redoEvent.TableName.String
 	}
+	if redoEvent.UserName.Valid {
+		event.UserName = redoEvent.UserName.String
+	}
 
 	if strings.TrimSpace(redoEvent.SQLRedo.String) != "" {
 		event.SQLRedo = redoEvent.SQLRedo.String

--- a/internal/impl/oracledb/replication/stream_message.go
+++ b/internal/impl/oracledb/replication/stream_message.go
@@ -127,4 +127,5 @@ type MessageEvent struct {
 	CommitTimestamp time.Time
 	ColumnMeta      []ColumnMeta
 	TransactionID   string
+	UserName        string
 }


### PR DESCRIPTION
This change propagates the `username` column from [`$VLOGMNR_CONTENTS`](https://docs.oracle.com/en/database/oracle/oracle-database/21/refrn/V-LOGMNR_CONTENTS.html) as metadata. 

For snapshots (which don't query LogMiner) the metadata value is omitted, it is also omitted if it's `NULL` or empty (`""`) when reading from LogMiner.

### Proof of Work

Running snapshot and streaming shows that:
- During snapshot the `username` is `NULL`, so the configured bloblang converts it to `""`
- When streaming the `username` value is set to `TESTDB`

<img width="1512" height="919" alt="image" src="https://github.com/user-attachments/assets/7e64269f-96ca-4bcd-8148-ac9d106694aa" />

