### PR TITLE
docs: correct CDC connector docs with measured behavior from benchmarking

### DIFF
--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -108,6 +108,16 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+
+== Performance
+
+This input does not read the transaction log directly: SQL Server's CDC capture job scans the log asynchronously and publishes rows into per-table change tables, which this input polls. The capture job is an upstream throughput ceiling shared by every CDC consumer, and delivery is inherently bursty — short idle periods followed by large batches are normal under heavy write load and reflect the capture job's publication cadence, not this input. Under sustained load the practical ceiling is usually the database server's storage bandwidth (CDC multiplies physical write volume several times over across the base table, transaction log, change tables and checkpoints) rather than CPU; the input itself needs very little CPU to keep pace with the capture job.
+
+Operational notes:
+
+- `TRUNCATE TABLE` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
+- On AWS RDS, enable CDC with `msdb.dbo.rds_cdc_enable_db` — `sys.sp_cdc_enable_db` requires sysadmin, which RDS does not grant.
+- Do not stop the CDC capture job (`cdc.<database>_capture`): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
 		
 
 == Fields
@@ -128,7 +138,7 @@ connection_string: sqlserver://username:password@host/instance?param1=value&para
 
 === `stream_snapshot`
 
-If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current Log Sequence Number position.
+If set to true, the connector will query all the existing data as a part of snapshot process. If set to false, no snapshot is taken and on first run streaming begins from the start of each table's existing change table — every change retained by SQL Server's CDC capture and cleanup jobs (three days by default) is replayed, not just changes from the current LSN onward. To begin from the present on a table that already holds change history, disable and re-enable CDC on the table immediately before starting the pipeline so that its change table starts empty.
 
 
 *Type*: `bool`
@@ -244,7 +254,7 @@ The maximum number of messages that can be processed at a given time. Increasing
 
 === `stream_backoff_interval`
 
-The interval between attempts to check for new changes once all data is processed. For low traffic tables increasing this value can reduce network traffic to the server.
+The interval to wait before checking for new changes after a pass over the change tables completes. Each pass drains changes up to the maximum LSN observed as the pass began, then sleeps for this interval while SQL Server's capture job continues to publish. For low traffic tables increasing this value reduces query load on the server. On high traffic tables it directly reduces throughput, because the input sits idle for the full interval between passes; consider lowering it towards `500ms`, which matches the default poll interval of comparable CDC systems.
 
 
 *Type*: `string`
@@ -253,6 +263,8 @@ The interval between attempts to check for new changes once all data is processe
 
 ```yml
 # Examples
+
+stream_backoff_interval: 500ms
 
 stream_backoff_interval: 5s
 

--- a/docs/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -89,6 +89,12 @@ Read from a MongoDB replica set using https://www.mongodb.com/docs/manual/change
 
 By default MongoDB does not propagate changes in all cases. In order to capture all changes (including deletes) in a MongoDB cluster one needs to enable pre and post image saving and the collection needs to also enable saving these pre and post images. For more information see https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[^MongoDB documentation].
 
+== Scaling
+
+All configured collections are consumed through a single database-level change stream: the collection list is a server-side filter on that one stream, not a set of independent streams. Because a change stream is one totally-ordered cursor over the replica set's oplog, throughput does not increase with additional collections, and CPU beyond roughly two cores is not used. This is a property of MongoDB change streams rather than of this input. To scale beyond the single-stream ceiling, shard the cluster — a change stream against a sharded cluster merges parallel per-shard cursors on the server side.
+
+Size the oplog for consumer lag: a change stream resumes from a position in the oplog, so if this input falls behind, or is stopped, for longer than the oplog retains data, the resume position is lost and the stream is invalidated. Ensure the oplog window comfortably exceeds the longest expected lag or downtime under peak write load.
+
 == Metadata
 
 Each message emitted by this plugin has the following metadata:
@@ -197,7 +203,7 @@ The interval between writing checkpoints to the cache.
 
 === `checkpoint_limit`
 
-Sorry! This field is missing documentation.
+The maximum number of messages that can be in flight at a given time. Increasing this limit enables parallel processing and batching at the output level. The stream's resume position is only checkpointed once all messages before it are delivered, preserving at least once delivery guarantees.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -140,6 +140,14 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the rpcn  schema must already exist. Refer to `checkpoint_cache_table_name` for more information.
+
+== Performance
+
+Streaming throughput is bounded by the LogMiner session, not by CPU: each pipeline mines the redo stream through a single synchronous LogMiner reader, so adding cores to Redpanda Connect does not raise the capture rate. To capture more aggregate change volume from one database, run multiple pipelines that each `include` a disjoint set of tables — every pipeline gets its own LogMiner reader.
+
+Large transactions and driver fetch size: the Oracle driver fetches 25 rows per network round trip by default, which can make large committed transactions appear minutes late while the database, network and connector all look idle — each round trip costs a full network exchange, and a large transaction requires thousands of them. Raise the fetch size with the `PREFETCH_ROWS` query parameter on `connection_string`, for example `?PREFETCH_ROWS=1000`.
+
+Redo log retention must cover idle periods, not just outages: the SCN checkpoint only advances when messages are delivered, so a monitored table set that goes idle leaves the checkpoint stationary while the database ages out redo/archive logs. If the checkpointed SCN is no longer available when activity resumes or the pipeline restarts, the input cannot resume and repeatedly fails with ORA-01292. Ensure archive log retention exceeds the longest plausible idle period, and alert on a stagnant checkpoint SCN or repeated ORA errors.
 		
 
 == Fields

--- a/internal/impl/mongodb/cdc/input.go
+++ b/internal/impl/mongodb/cdc/input.go
@@ -65,6 +65,12 @@ func spec() *service.ConfigSpec {
 
 By default MongoDB does not propagate changes in all cases. In order to capture all changes (including deletes) in a MongoDB cluster one needs to enable pre and post image saving and the collection needs to also enable saving these pre and post images. For more information see https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[^MongoDB documentation].
 
+== Scaling
+
+All configured collections are consumed through a single database-level change stream: the collection list is a server-side filter on that one stream, not a set of independent streams. Because a change stream is one totally-ordered cursor over the replica set's oplog, throughput does not increase with additional collections, and CPU beyond roughly two cores is not used. This is a property of MongoDB change streams rather than of this input. To scale beyond the single-stream ceiling, shard the cluster — a change stream against a sharded cluster merges parallel per-shard cursors on the server side.
+
+Size the oplog for consumer lag: a change stream resumes from a position in the oplog, so if this input falls behind, or is stopped, for longer than the oplog retains data, the resume position is lost and the stream is invalidated. Ensure the oplog window comfortably exceeds the longest expected lag or downtime under peak write load.
+
 == Metadata
 
 Each message emitted by this plugin has the following metadata:
@@ -113,7 +119,8 @@ Schema metadata is discovered using a two-tier strategy:
 				Description("The interval between writing checkpoints to the cache.").
 				Default("5s"),
 			service.NewIntField(fieldCheckpointLimit).
-				Description("").
+				Description("The maximum number of messages that can be in flight at a given time. Increasing this limit enables parallel processing and batching at the output level. The stream's resume position is only checkpointed once all messages before it are delivered, preserving at least once delivery guarantees.").
+				ShortDescription("The maximum number of messages that can be in flight at a given time.").
 				Default(1000),
 			service.NewIntField(fieldReadBatchSize).
 				Description("The batch size of documents for MongoDB to return.").

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -85,9 +85,9 @@ Operational notes:
 		Example("sqlserver://username:password@host/instance?param1=value&param2=value"),
 	).
 	Field(service.NewBoolField(fieldStreamSnapshot).
-		Description("If set to true, the connector will query all the existing data as a part of snapshot process. "+
-			"If set to false, no snapshot is taken and on first run streaming begins from the start of each table's existing change table — "+
-			"every change retained by SQL Server's CDC capture and cleanup jobs (three days by default) is replayed, not just changes from the current LSN onward. "+
+		Description("If set to true, the connector will query all the existing data as a part of snapshot process. " +
+			"If set to false, no snapshot is taken and on first run streaming begins from the start of each table's existing change table — " +
+			"every change retained by SQL Server's CDC capture and cleanup jobs (three days by default) is replayed, not just changes from the current LSN onward. " +
 			"To begin from the present on a table that already holds change history, disable and re-enable CDC on the table immediately before starting the pipeline so that its change table starts empty.").
 		ShortDescription("Snapshot existing data first. Otherwise streaming replays everything retained in the change tables.").
 		Example(true).
@@ -135,9 +135,9 @@ Operational notes:
 		Default(1024),
 	).
 	Field(service.NewDurationField(fieldStreamBackoffInterval).
-		Description("The interval to wait before checking for new changes after a pass over the change tables completes. "+
-			"Each pass drains changes up to the maximum LSN observed as the pass began, then sleeps for this interval while SQL Server's capture job continues to publish. "+
-			"For low traffic tables increasing this value reduces query load on the server. "+
+		Description("The interval to wait before checking for new changes after a pass over the change tables completes. " +
+			"Each pass drains changes up to the maximum LSN observed as the pass began, then sleeps for this interval while SQL Server's capture job continues to publish. " +
+			"For low traffic tables increasing this value reduces query load on the server. " +
 			"On high traffic tables it directly reduces throughput, because the input sits idle for the full interval between passes; consider lowering it towards `500ms`, which matches the default poll interval of comparable CDC systems.").
 		ShortDescription("Interval between passes over the change tables. On busy tables lower values increase throughput.").
 		Default("5s").

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -69,14 +69,27 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Microsoft SQL Server based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + fieldCheckpointCacheTableName + "`" + ` for more information.
+
+== Performance
+
+This input does not read the transaction log directly: SQL Server's CDC capture job scans the log asynchronously and publishes rows into per-table change tables, which this input polls. The capture job is an upstream throughput ceiling shared by every CDC consumer, and delivery is inherently bursty — short idle periods followed by large batches are normal under heavy write load and reflect the capture job's publication cadence, not this input. Under sustained load the practical ceiling is usually the database server's storage bandwidth (CDC multiplies physical write volume several times over across the base table, transaction log, change tables and checkpoints) rather than CPU; the input itself needs very little CPU to keep pace with the capture job.
+
+Operational notes:
+
+- ` + "`TRUNCATE TABLE`" + ` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
+- On AWS RDS, enable CDC with ` + "`msdb.dbo.rds_cdc_enable_db`" + ` — ` + "`sys.sp_cdc_enable_db`" + ` requires sysadmin, which RDS does not grant.
+- Do not stop the CDC capture job (` + "`cdc.<database>_capture`" + `): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").
 		Example("sqlserver://username:password@host/instance?param1=value&param2=value"),
 	).
 	Field(service.NewBoolField(fieldStreamSnapshot).
-		Description("If set to true, the connector will query all the existing data as a part of snapshot process. Otherwise, it will start from the current Log Sequence Number position.").
-		ShortDescription("Query all existing data as a snapshot first. Otherwise streaming starts from the current LSN.").
+		Description("If set to true, the connector will query all the existing data as a part of snapshot process. "+
+			"If set to false, no snapshot is taken and on first run streaming begins from the start of each table's existing change table — "+
+			"every change retained by SQL Server's CDC capture and cleanup jobs (three days by default) is replayed, not just changes from the current LSN onward. "+
+			"To begin from the present on a table that already holds change history, disable and re-enable CDC on the table immediately before starting the pipeline so that its change table starts empty.").
+		ShortDescription("Snapshot existing data first. Otherwise streaming replays everything retained in the change tables.").
 		Example(true).
 		Default(false),
 	).
@@ -122,10 +135,13 @@ When using the default Microsoft SQL Server based cache, the Connect user requir
 		Default(1024),
 	).
 	Field(service.NewDurationField(fieldStreamBackoffInterval).
-		Description("The interval between attempts to check for new changes once all data is processed. For low traffic tables increasing this value can reduce network traffic to the server.").
-		ShortDescription("Interval between checks for new changes once all data is processed.").
+		Description("The interval to wait before checking for new changes after a pass over the change tables completes. "+
+			"Each pass drains changes up to the maximum LSN observed as the pass began, then sleeps for this interval while SQL Server's capture job continues to publish. "+
+			"For low traffic tables increasing this value reduces query load on the server. "+
+			"On high traffic tables it directly reduces throughput, because the input sits idle for the full interval between passes; consider lowering it towards `500ms`, which matches the default poll interval of comparable CDC systems.").
+		ShortDescription("Interval between passes over the change tables. On busy tables lower values increase throughput.").
 		Default("5s").
-		Example("5s").Example("1m"),
+		Example("500ms").Example("5s").Example("1m"),
 	).
 	Field(service.NewAutoRetryNacksToggleField()).
 	Field(service.NewBatchPolicyField(fieldBatching))

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -95,6 +95,14 @@ This input adds the following metadata fields to each message:
 == Permissions
 
 When using the default Oracle based cache, the Connect user requires permission to create tables and stored procedures, and the ` + "rpcn" + `  schema must already exist. Refer to ` + "`" + ociFieldCheckpointCacheTableName + "`" + ` for more information.
+
+== Performance
+
+Streaming throughput is bounded by the LogMiner session, not by CPU: each pipeline mines the redo stream through a single synchronous LogMiner reader, so adding cores to Redpanda Connect does not raise the capture rate. To capture more aggregate change volume from one database, run multiple pipelines that each ` + "`include`" + ` a disjoint set of tables — every pipeline gets its own LogMiner reader.
+
+Large transactions and driver fetch size: the Oracle driver fetches 25 rows per network round trip by default, which can make large committed transactions appear minutes late while the database, network and connector all look idle — each round trip costs a full network exchange, and a large transaction requires thousands of them. Raise the fetch size with the ` + "`PREFETCH_ROWS`" + ` query parameter on ` + "`" + ociFieldConnectionString + "`" + `, for example ` + "`?PREFETCH_ROWS=1000`" + `.
+
+Redo log retention must cover idle periods, not just outages: the SCN checkpoint only advances when messages are delivered, so a monitored table set that goes idle leaves the checkpoint stationary while the database ages out redo/archive logs. If the checkpointed SCN is no longer available when activity resumes or the pipeline restarts, the input cannot resume and repeatedly fails with ORA-01292. Ensure archive log retention exceeds the longest plausible idle period, and alert on a stagnant checkpoint SCN or repeated ORA errors.
 		`).
 	Field(service.NewStringField(ociFieldConnectionString).
 		Description("The connection string of the Oracle database to connect to. Additional connection options can be supplied as URL query parameters, for example: `oracle://user:password@host:1522/service?WALLET=/opt/oracle/wallet&SSL=true`.").


### PR DESCRIPTION
## What

Documentation-only changes to three CDC connectors (`microsoft_sql_server_cdc`, `mongodb_cdc`, `oracledb_cdc`), correcting field docs that contradict actual behavior and adding performance/operational guidance. All claims are mechanisms verified in code or measured live during head-to-head benchmarking; no absolute throughput numbers are included. Generated `.adoc` pages regenerated via `task docs`.

## microsoft_sql_server_cdc

- **`stream_snapshot` doc was factually wrong.** It claimed `false` starts "from the current Log Sequence Number position". The code passes a NULL lower bound to the change-table query on first run, so streaming replays each change table from the beginning of what CDC has retained (cleanup default: 3 days) — potentially days of history the user opted out of. Now documents the real behavior and the disable/re-enable CDC escape hatch to truly start from the present.
- **`stream_backoff_interval` hid a throughput cost.** The doc only mentioned reducing network traffic on quiet tables. Each pass drains changes up to the max LSN observed as the pass began, then sleeps the full interval while the capture job keeps publishing — measured on a busy table this leaves the input idle for most of wall clock. Now documents the trade-off and suggests ~500ms for busy tables (matching comparable CDC systems' poll default).
- **New Performance section:** the CDC capture job is an upstream ceiling shared by all consumers; bursty delivery is normal; storage bandwidth (not CPU) is the practical limit under sustained load; `TRUNCATE` is rejected on CDC-enabled tables; RDS requires `msdb.dbo.rds_cdc_enable_db`; a stopped capture job reads as silent zero.

## mongodb_cdc

- **New Scaling section:** all configured collections share a single database-level change stream (one totally-ordered cursor over the oplog), so throughput does not increase with additional collections or with CPU beyond ~2 cores; sharding is the only lever. Also: size the oplog for consumer lag, or the resume position ages out and the stream is invalidated.
- Filled in the empty `checkpoint_limit` description.

## oracledb_cdc

- **New Performance section:** throughput is bounded per LogMiner reader, not CPU — scale by running multiple pipelines over disjoint table sets; the driver's default 25-row prefetch can delay large committed transactions by minutes while everything looks idle (`?PREFETCH_ROWS=1000` on `connection_string`, verified against go-ora v2.9.0); archive log retention must cover idle periods, because the SCN checkpoint only advances on delivered messages (otherwise ORA-01292 retry loop on resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)