### PR TITLE
oracledb_cdc: Improve snapshot performance (~50%) by reusing seeded schema metadata 

### DIFF
--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -294,8 +294,14 @@ func (sc *schemaCache) schemaForEvent(ctx context.Context, table replication.Use
 }
 
 // seedFromColumnMeta populates the cache from column metadata collected during
-// a snapshot transaction. The snapshot's READ ONLY transaction provides a
-// consistent view, so this overrides any pre-fetched entry.
+// a snapshot transaction, overriding any pre-fetched entry — unless meta is
+// the same slice (by identity) already used to seed this table, in which case
+// the rebuild is skipped and the cache is left untouched.
+//
+// The identity check is against the last slice this function was called
+// with, not against whatever is currently cached. If schemaForEvent's
+// catalog-refresh path replaces the cached schema in between, a later call
+// here with the same meta slice will not restore the snapshot-derived one.
 func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []replication.ColumnMeta) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()

--- a/internal/impl/oracledb/schema.go
+++ b/internal/impl/oracledb/schema.go
@@ -132,11 +132,12 @@ func isNumberType(dataType string) bool {
 // catalog query, then switches back. Avoids both CDB_* view privilege issues and
 // separate-connection login issues.
 type schemaCache struct {
-	mu      sync.Mutex
-	schemas map[string]*cachedSchema
-	db      *sql.DB
-	pdbName string // non-empty in CDB mode; triggers ALTER SESSION SET CONTAINER per refresh
-	log     *service.Logger
+	mu         sync.Mutex
+	schemas    map[string]*cachedSchema
+	seededMeta map[string][]replication.ColumnMeta // track the ColumnMeta slice for reuse
+	db         *sql.DB
+	pdbName    string // non-empty in CDB mode; triggers ALTER SESSION SET CONTAINER per refresh
+	log        *service.Logger
 }
 
 type cachedSchema struct {
@@ -150,10 +151,11 @@ type cachedSchema struct {
 // will switch the session to that PDB for each catalog query.
 func newSchemaCache(db *sql.DB, pdbName string, log *service.Logger) *schemaCache {
 	return &schemaCache{
-		schemas: make(map[string]*cachedSchema),
-		db:      db,
-		pdbName: pdbName,
-		log:     log,
+		schemas:    make(map[string]*cachedSchema),
+		seededMeta: make(map[string][]replication.ColumnMeta),
+		db:         db,
+		pdbName:    pdbName,
+		log:        log,
 	}
 }
 
@@ -300,6 +302,11 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 
 	tableKey := table.Schema + "." + table.Name
 
+	if sameColumnMeta(sc.seededMeta[tableKey], meta) {
+		return
+	}
+	sc.seededMeta[tableKey] = meta
+
 	children := make([]schema.Common, 0, len(meta))
 	keySet := make(map[string]struct{}, len(meta))
 	colTypes := make(map[string]schema.Common, len(meta))
@@ -317,6 +324,17 @@ func (sc *schemaCache) seedFromColumnMeta(table replication.UserTable, meta []re
 		Children: children,
 	}
 	sc.schemas[tableKey] = &cachedSchema{schema: c.ToAny(), keys: keySet, colTypes: colTypes}
+}
+
+// sameColumnMeta checks whether a and b are the same underlying slice to enable reuse.
+func sameColumnMeta(a, b []replication.ColumnMeta) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/impl/oracledb/schema_bench_test.go
+++ b/internal/impl/oracledb/schema_bench_test.go
@@ -17,16 +17,16 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
 )
 
-// BenchmarkSeedFromColumnMeta covers the hottest schema-cache path: the
-// publisher re-seeds the cache from driver column metadata for EVERY snapshot
-// row published (batcher.go Publish → seedFromColumnMeta), so per-column
-// type-name mapping cost here is paid once per snapshot message, not once per
-// table. Column set mirrors the integration test's ALL_TYPES table using
-// go-ora driver type-name spellings, as buildColumnMeta reports them.
-func BenchmarkSeedFromColumnMeta(b *testing.B) {
-	sc := newSchemaCache(nil, "", service.NewLoggerFromSlog(slog.Default()))
-	tbl := replication.UserTable{Schema: "TESTDB", Name: "ALL_TYPES"}
-	meta := []replication.ColumnMeta{
+// oracleAllTypesColumnMeta returns a fresh []ColumnMeta describing the
+// integration test's ALL_TYPES table, using go-ora driver type-name
+// spellings as buildColumnMeta reports them. Returning a new slice on every
+// call matters for the benchmarks below: seedFromColumnMeta skips its rebuild
+// when handed the same slice as last time, so measuring the rebuild path
+// requires a distinct slice per call, the same as a new snapshot page's
+// []ColumnMeta is distinct from the previous page's even when the columns
+// are identical (see replication/snapshot.go's buildColumnMeta).
+func oracleAllTypesColumnMeta() []replication.ColumnMeta {
+	return []replication.ColumnMeta{
 		{Name: "ID", TypeName: "NUMBER", Precision: 38, Scale: 255, HasDecimalSize: true},
 		{Name: "NUM_PLAIN", TypeName: "NUMBER", Precision: 38, Scale: 255, HasDecimalSize: true},
 		{Name: "NUM_38", TypeName: "NUMBER", Precision: 38, Scale: 0, HasDecimalSize: true},
@@ -46,9 +46,29 @@ func BenchmarkSeedFromColumnMeta(b *testing.B) {
 		{Name: "RW", TypeName: "RAW"},
 		{Name: "DOC", TypeName: "LongVarChar"},
 	}
+}
 
-	b.ReportAllocs()
-	for b.Loop() {
-		sc.seedFromColumnMeta(tbl, meta)
-	}
+func BenchmarkSeedFromColumnMeta(b *testing.B) {
+	b.Run("rebuild", func(b *testing.B) {
+		sc := newSchemaCache(nil, "", service.NewLoggerFromSlog(slog.Default()))
+		tbl := replication.UserTable{Schema: "TESTDB", Name: "ALL_TYPES"}
+
+		b.ReportAllocs()
+		for b.Loop() {
+			sc.seedFromColumnMeta(tbl, oracleAllTypesColumnMeta())
+		}
+	})
+
+	// After the first call this should cost little more than a mutex lock
+	// and a slice identity check, not a schema rebuild.
+	b.Run("same_slice", func(b *testing.B) {
+		sc := newSchemaCache(nil, "", service.NewLoggerFromSlog(slog.Default()))
+		tbl := replication.UserTable{Schema: "TESTDB", Name: "ALL_TYPES"}
+		meta := oracleAllTypesColumnMeta()
+
+		b.ReportAllocs()
+		for b.Loop() {
+			sc.seedFromColumnMeta(tbl, meta)
+		}
+	})
 }

--- a/internal/impl/oracledb/schema_test.go
+++ b/internal/impl/oracledb/schema_test.go
@@ -573,6 +573,62 @@ func TestSchemaCacheSeedFromColumnMetaOverride(t *testing.T) {
 	require.Len(t, c2.Children, 3)
 }
 
+func TestSeedFromColumnMetaIdentitySkip(t *testing.T) {
+	newMeta := func() []replication.ColumnMeta {
+		return []replication.ColumnMeta{
+			{Name: "A", TypeName: "VARCHAR2"},
+			{Name: "B", TypeName: "NUMBER", Precision: 5, Scale: 0, HasDecimalSize: true},
+		}
+	}
+
+	t.Run("same slice skips rebuild", func(t *testing.T) {
+		sc := testSchemaCache(t)
+		tbl := replication.UserTable{Schema: "S", Name: "T"}
+		meta := newMeta()
+
+		sc.seedFromColumnMeta(tbl, meta)
+		tableKey := tbl.Schema + "." + tbl.Name
+		first := sc.schemas[tableKey]
+		require.NotNil(t, first)
+
+		sc.seedFromColumnMeta(tbl, meta)
+		assert.Same(t, first, sc.schemas[tableKey],
+			"re-seeding with the same slice must skip the rebuild and leave the cached schema untouched")
+	})
+
+	t.Run("different slice with equal content still rebuilds", func(t *testing.T) {
+		sc := testSchemaCache(t)
+		tbl := replication.UserTable{Schema: "S", Name: "T"}
+		meta := newMeta()
+
+		sc.seedFromColumnMeta(tbl, meta)
+		tableKey := tbl.Schema + "." + tbl.Name
+		first := sc.schemas[tableKey]
+		require.NotNil(t, first)
+
+		freshCopy := make([]replication.ColumnMeta, len(meta))
+		copy(freshCopy, meta)
+		sc.seedFromColumnMeta(tbl, freshCopy)
+		assert.NotSame(t, first, sc.schemas[tableKey],
+			"re-seeding with a different (even if equal-content) slice must rebuild the cached schema")
+	})
+
+	t.Run("sameColumnMeta edge cases", func(t *testing.T) {
+		a := newMeta()
+		sameSlice := a
+		equalContent := make([]replication.ColumnMeta, len(a))
+		copy(equalContent, a)
+		var emptyA, emptyB []replication.ColumnMeta
+
+		assert.True(t, sameColumnMeta(a, sameSlice), "identical slice header must be reported as same")
+		assert.True(t, sameColumnMeta(nil, nil), "two nil slices must be reported as same")
+		assert.True(t, sameColumnMeta(emptyA, emptyB), "two nil/empty slices must be reported as same regardless of identity")
+		assert.False(t, sameColumnMeta(a, equalContent), "distinct slices with equal content must not be reported as same")
+		assert.False(t, sameColumnMeta(a, nil), "non-nil vs nil must not be reported as same")
+		assert.False(t, sameColumnMeta(a, a[:1]), "different lengths must not be reported as same")
+	})
+}
+
 func TestSchemaCacheMultiTable(t *testing.T) {
 	sc := testSchemaCache(t)
 	s1 := seedCache(t, sc, "S", "T1", []replication.ColumnMeta{


### PR DESCRIPTION
Currently when snapshotting, every row rebuilds the table schema from metadata. This change checks to see if the column metadata is the same as the previous row by pointer (ie, same slice - which is likely if snapshotting), and will reuse the generated schema.

The results below are without `PREFETCH_ROWS` configured.

Before:

2M rows, avg. 13MB/s took 40 seconds

<img width="1733" height="1492" alt="image" src="https://github.com/user-attachments/assets/c0019f9c-2c61-41b8-828a-fe7aefeb978e" />

After:

2M rows, avg. 25MB/s took 20 seconds (~50% improvement)

<img width="1652" height="1103" alt="image" src="https://github.com/user-attachments/assets/88c6242e-d83c-4572-94b0-e0aefcc7abbb" />