### PR TITLE
oracledb_cdc: remove primary key ordering from unfiltered snapshot

### DIFF
--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -221,7 +221,7 @@ Specifies a number of tables that will be processed in parallel during the snaps
 
 === `snapshot_max_batch_size`
 
-The maximum number of rows to be streamed in a single batch when taking a snapshot. This value does not apply to filtered snapshots when using `snapshot_filters`.
+The maximum number of rows fetched per query when taking a snapshot of a table with a `snapshot_filters` entry configured. Tables without one are streamed through a single unordered cursor, where this value only paces how often a cancellation is checked.
 
 
 *Type*: `int`

--- a/docs/modules/components/pages/inputs/oracledb_cdc.adoc
+++ b/docs/modules/components/pages/inputs/oracledb_cdc.adoc
@@ -221,7 +221,7 @@ Specifies a number of tables that will be processed in parallel during the snaps
 
 === `snapshot_max_batch_size`
 
-The maximum number of rows to be streamed in a single batch when taking a snapshot.
+The maximum number of rows to be streamed in a single batch when taking a snapshot. This value does not apply to filtered snapshots when using `snapshot_filters`.
 
 
 *Type*: `int`

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -142,7 +142,7 @@ Redo log retention must cover idle periods, not just outages: the SCN checkpoint
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").
 		Default(1)).
 	Field(service.NewIntField(ociFieldSnapshotMaxBatchSize).
-		Description("The maximum number of rows to be streamed in a single batch when taking a snapshot.").
+		Description("The maximum number of rows to be streamed in a single batch when taking a snapshot. This value does not apply to filtered snapshots when using `" + ociFieldSnapshotFilters + "`.").
 		Default(1000),
 	).
 	// logminer config

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -142,7 +142,7 @@ Redo log retention must cover idle periods, not just outages: the SCN checkpoint
 		Description("Specifies a number of tables that will be processed in parallel during the snapshot processing stage.").
 		Default(1)).
 	Field(service.NewIntField(ociFieldSnapshotMaxBatchSize).
-		Description("The maximum number of rows to be streamed in a single batch when taking a snapshot. This value does not apply to filtered snapshots when using `" + ociFieldSnapshotFilters + "`.").
+		Description("The maximum number of rows fetched per query when taking a snapshot of a table with a `" + ociFieldSnapshotFilters + "` entry configured. Tables without one are streamed through a single unordered cursor, where this value only paces how often a cancellation is checked.").
 		Default(1000),
 	).
 	// logminer config

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -341,7 +341,7 @@ func (s *Snapshot) publishRow(ctx context.Context, table UserTable, columns []st
 // query so Oracle's optimizer picks a full table scan (sequential multiblock
 // reads) rather than the PK-index-driven, table-access-by-rowid random I/O that
 // ORDER BY pk forces once the table exceeds buffer cache. There's no query-level
-// batching here — maxBatchSize only paces metric flushes and cancellation checks.
+// batching here — maxBatchSize only paces how often cancellation is checked.
 func (s *Snapshot) snapshotTableFullScan(ctx context.Context, tx *sql.Tx, table UserTable, maxBatchSize int, tableName string) (numRowsProcessed int, err error) {
 	q := fmt.Sprintf(`SELECT * FROM "%s"."%s"`, table.Schema, table.Name)
 	rows, err := tx.QueryContext(ctx, q)
@@ -368,7 +368,7 @@ func (s *Snapshot) snapshotTableFullScan(ctx context.Context, tx *sql.Tx, table 
 
 	colMeta := buildColumnMeta(types)
 
-	var sinceFlush int
+	var sinceCancelCheck int
 	for rows.Next() {
 		if err = rows.Scan(values...); err != nil {
 			return numRowsProcessed, err
@@ -379,17 +379,15 @@ func (s *Snapshot) snapshotTableFullScan(ctx context.Context, tx *sql.Tx, table 
 		}
 
 		numRowsProcessed++
-		sinceFlush++
-		if sinceFlush >= maxBatchSize {
-			s.snapshotRowsTotalMetric.Incr(int64(sinceFlush), tableName)
-			sinceFlush = 0
+		s.snapshotRowsTotalMetric.Incr(1, tableName)
+
+		sinceCancelCheck++
+		if sinceCancelCheck >= maxBatchSize {
+			sinceCancelCheck = 0
 			if err = ctx.Err(); err != nil {
 				return numRowsProcessed, err
 			}
 		}
-	}
-	if sinceFlush > 0 {
-		s.snapshotRowsTotalMetric.Incr(int64(sinceFlush), tableName)
 	}
 
 	if err = rows.Err(); err != nil {

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -138,7 +138,8 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 			tableName = table.FullName()
 		)
 		l := s.log.With("src_table", tableName)
-		if _, hasFilter := s.filters[tableName]; hasFilter {
+		customQuery, hasFilter := s.filters[tableName]
+		if hasFilter {
 			l.Infof("Launching snapshot of table '%s' with snapshot filter", tableName)
 		} else {
 			l.Infof("Launching snapshot of table '%s'", tableName)
@@ -196,34 +197,45 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 			}
 		}()
 
-		var tablePks []string
-		if tablePks, err = getTablePrimaryKeys(ctx, tx, table); err != nil {
-			return err
-		}
-
-		l.Debugf("Found primary keys for table '%s': %v", table, tablePks)
-		lastSeenPksValues := map[string]any{}
-		for _, pk := range tablePks {
-			lastSeenPksValues[pk] = nil
-		}
-
-		var (
-			numRowsProcessed int
-			batchCount       int
-		)
-		for {
-			var pksForQuery map[string]any
-			if numRowsProcessed > 0 {
-				pksForQuery = lastSeenPksValues
-			}
-			batchCount, err = s.processBatch(ctx, tx, table, tablePks, pksForQuery, lastSeenPksValues, maxBatchSize, tableName)
-			if err != nil {
-				return fmt.Errorf("processing snapshot batch: %w", err)
+		var numRowsProcessed int
+		if hasFilter {
+			// Custom filters may join or aggregate, so a physical-order scan can't safely
+			// assume every row maps to a stable ROWID/heap position; keep the PK-keyset
+			// pagination path for these.
+			var tablePks []string
+			if tablePks, err = getTablePrimaryKeys(ctx, tx, table); err != nil {
+				return err
 			}
 
-			numRowsProcessed += batchCount
-			if batchCount < maxBatchSize {
-				break
+			l.Debugf("Found primary keys for table '%s': %v", table, tablePks)
+			lastSeenPksValues := map[string]any{}
+			for _, pk := range tablePks {
+				lastSeenPksValues[pk] = nil
+			}
+
+			var batchCount int
+			for {
+				var pksForQuery map[string]any
+				if numRowsProcessed > 0 {
+					pksForQuery = lastSeenPksValues
+				}
+				batchCount, err = s.processBatch(ctx, tx, table, tablePks, pksForQuery, lastSeenPksValues, maxBatchSize, tableName, customQuery)
+				if err != nil {
+					return fmt.Errorf("processing snapshot batch: %w", err)
+				}
+
+				numRowsProcessed += batchCount
+				if batchCount < maxBatchSize {
+					break
+				}
+			}
+		} else {
+			// No filter: read the whole table through a single unordered cursor so Oracle
+			// picks a full table scan (sequential multiblock reads) instead of the
+			// PK-index-driven, table-access-by-rowid random I/O that ORDER BY pk forces
+			// once the table no longer fits in buffer cache.
+			if numRowsProcessed, err = s.snapshotTableFullScan(ctx, tx, table, maxBatchSize, tableName); err != nil {
+				return fmt.Errorf("processing snapshot table scan: %w", err)
 			}
 		}
 
@@ -241,8 +253,7 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 // pksForQuery is passed to querySnapshotTable for cursor-based pagination (nil on first batch).
 // lastSeenPksValues is mutated in place with the PK values from the last row of the batch,
 // so the caller can pass it as pksForQuery on the next iteration.
-func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable, tablePks []string, pksForQuery map[string]any, lastSeenPksValues map[string]any, maxBatchSize int, tableName string) (batchCount int, err error) {
-	customQuery := s.filters[table.FullName()]
+func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable, tablePks []string, pksForQuery map[string]any, lastSeenPksValues map[string]any, maxBatchSize int, tableName, customQuery string) (batchCount int, err error) {
 	batchRows, err := querySnapshotTable(ctx, tx, table, tablePks, pksForQuery, maxBatchSize, customQuery)
 	if err != nil {
 		return 0, fmt.Errorf("execute snapshot table query: %w", err)
@@ -274,40 +285,8 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 			return 0, err
 		}
 
-		var (
-			v      any
-			mapErr error
-		)
-		row := map[string]any{}
-		for idx, value := range values {
-			if v, mapErr = mappers[idx](value); mapErr != nil {
-				return 0, mapErr
-			}
-			if !s.lobEnabled && IsLOBTypeName(types[idx].DatabaseTypeName()) {
-				v = nil
-			}
-			row[columns[idx]] = v
-			if _, ok := lastSeenPksValues[columns[idx]]; ok {
-				lastSeenPksValues[columns[idx]] = value
-			}
-		}
-
-		m := MessageEvent{
-			Table:      table.Name,
-			Schema:     table.Schema,
-			Data:       row,
-			Operation:  MessageOperationRead,
-			ColumnMeta: colMeta,
-		}
-		if s.scn != InvalidSCN {
-			m.SCN = s.scn
-		}
-		if !s.commitTimestamp.IsZero() {
-			m.CommitTimestamp = s.commitTimestamp
-		}
-
-		if err = s.publisher.Publish(ctx, &m); err != nil {
-			return 0, fmt.Errorf("handling snapshot table row: %w", err)
+		if err := s.publishRow(ctx, table, columns, types, values, mappers, colMeta, lastSeenPksValues); err != nil {
+			return 0, err
 		}
 	}
 
@@ -316,6 +295,108 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 	}
 	s.snapshotRowsTotalMetric.Incr(int64(batchCount), tableName)
 	return batchCount, nil
+}
+
+// publishRow maps a single scanned row's values into a MessageEvent and publishes
+// it. When lastSeenPksValues is non-nil, it's mutated in place with this row's
+// primary key values so the caller can resume PK-keyset pagination from it on the
+// next batch; pass nil when there's no keyset cursor to maintain (full table scan).
+func (s *Snapshot) publishRow(ctx context.Context, table UserTable, columns []string, types []*sql.ColumnType, values []any, mappers []func(any) (any, error), colMeta []ColumnMeta, lastSeenPksValues map[string]any) error {
+	row := map[string]any{}
+	for idx, value := range values {
+		v, err := mappers[idx](value)
+		if err != nil {
+			return err
+		}
+		if !s.lobEnabled && IsLOBTypeName(types[idx].DatabaseTypeName()) {
+			v = nil
+		}
+		row[columns[idx]] = v
+		if _, ok := lastSeenPksValues[columns[idx]]; ok {
+			lastSeenPksValues[columns[idx]] = value
+		}
+	}
+
+	m := MessageEvent{
+		Table:      table.Name,
+		Schema:     table.Schema,
+		Data:       row,
+		Operation:  MessageOperationRead,
+		ColumnMeta: colMeta,
+	}
+	if s.scn != InvalidSCN {
+		m.SCN = s.scn
+	}
+	if !s.commitTimestamp.IsZero() {
+		m.CommitTimestamp = s.commitTimestamp
+	}
+
+	if err := s.publisher.Publish(ctx, &m); err != nil {
+		return fmt.Errorf("handling snapshot table row: %w", err)
+	}
+	return nil
+}
+
+// snapshotTableFullScan reads every row of table through a single, unordered
+// query so Oracle's optimizer picks a full table scan (sequential multiblock
+// reads) rather than the PK-index-driven, table-access-by-rowid random I/O that
+// ORDER BY pk forces once the table exceeds buffer cache. There's no query-level
+// batching here — maxBatchSize only paces metric flushes and cancellation checks.
+func (s *Snapshot) snapshotTableFullScan(ctx context.Context, tx *sql.Tx, table UserTable, maxBatchSize int, tableName string) (numRowsProcessed int, err error) {
+	q := fmt.Sprintf(`SELECT * FROM "%s"."%s"`, table.Schema, table.Name)
+	rows, err := tx.QueryContext(ctx, q)
+	if err != nil {
+		return 0, fmt.Errorf("execute snapshot table scan: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("closing snapshot rows: %w", closeErr)
+		}
+	}()
+
+	types, err := rows.ColumnTypes()
+	if err != nil {
+		return 0, fmt.Errorf("fetch column types: %w", err)
+	}
+
+	values, mappers := prepSnapshotScannerAndMappers(types)
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return 0, fmt.Errorf("fetch columns: %w", err)
+	}
+
+	colMeta := buildColumnMeta(types)
+
+	var sinceFlush int
+	for rows.Next() {
+		if err = rows.Scan(values...); err != nil {
+			return numRowsProcessed, err
+		}
+
+		if err = s.publishRow(ctx, table, columns, types, values, mappers, colMeta, nil); err != nil {
+			return numRowsProcessed, err
+		}
+
+		numRowsProcessed++
+		sinceFlush++
+		if sinceFlush >= maxBatchSize {
+			s.snapshotRowsTotalMetric.Incr(int64(sinceFlush), tableName)
+			sinceFlush = 0
+			if err = ctx.Err(); err != nil {
+				return numRowsProcessed, err
+			}
+		}
+	}
+	if sinceFlush > 0 {
+		s.snapshotRowsTotalMetric.Incr(int64(sinceFlush), tableName)
+	}
+
+	if err = rows.Err(); err != nil {
+		return numRowsProcessed, fmt.Errorf("iterating snapshot table row: %w", err)
+	}
+
+	return numRowsProcessed, nil
 }
 
 func getTablePrimaryKeys(ctx context.Context, tx *sql.Tx, table UserTable) ([]string, error) {

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -230,10 +230,8 @@ func (s *Snapshot) snapshotTable(ctx context.Context, table UserTable, maxBatchS
 				}
 			}
 		} else {
-			// No filter: read the whole table through a single unordered cursor so Oracle
-			// picks a full table scan (sequential multiblock reads) instead of the
-			// PK-index-driven, table-access-by-rowid random I/O that ORDER BY pk forces
-			// once the table no longer fits in buffer cache.
+			// No Filter: whole table scan through single unordered cursor is faster due to no
+			// random i/o that ORDER BY forces
 			if numRowsProcessed, err = s.snapshotTableFullScan(ctx, tx, table, maxBatchSize, tableName); err != nil {
 				return fmt.Errorf("processing snapshot table scan: %w", err)
 			}
@@ -297,10 +295,6 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 	return batchCount, nil
 }
 
-// publishRow maps a single scanned row's values into a MessageEvent and publishes
-// it. When lastSeenPksValues is non-nil, it's mutated in place with this row's
-// primary key values so the caller can resume PK-keyset pagination from it on the
-// next batch; pass nil when there's no keyset cursor to maintain (full table scan).
 func (s *Snapshot) publishRow(ctx context.Context, table UserTable, columns []string, types []*sql.ColumnType, values []any, mappers []func(any) (any, error), colMeta []ColumnMeta, lastSeenPksValues map[string]any) error {
 	row := map[string]any{}
 	for idx, value := range values {
@@ -337,11 +331,8 @@ func (s *Snapshot) publishRow(ctx context.Context, table UserTable, columns []st
 	return nil
 }
 
-// snapshotTableFullScan reads every row of table through a single, unordered
-// query so Oracle's optimizer picks a full table scan (sequential multiblock
-// reads) rather than the PK-index-driven, table-access-by-rowid random I/O that
-// ORDER BY pk forces once the table exceeds buffer cache. There's no query-level
-// batching here — maxBatchSize only paces how often cancellation is checked.
+// snapshotTableFullScan performs a single, full unordered scan so Oracle's optimizer
+// picks a full table scan (sequential multiblock reads) over random disk I/O when ordered.
 func (s *Snapshot) snapshotTableFullScan(ctx context.Context, tx *sql.Tx, table UserTable, maxBatchSize int, tableName string) (numRowsProcessed int, err error) {
 	q := fmt.Sprintf(`SELECT * FROM "%s"."%s"`, table.Schema, table.Name)
 	rows, err := tx.QueryContext(ctx, q)

--- a/internal/impl/oracledb/replication/snapshot_test.go
+++ b/internal/impl/oracledb/replication/snapshot_test.go
@@ -10,6 +10,7 @@ package replication_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -78,7 +79,8 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, scn)
 
-		// Read snapshot with small batch size to trigger pagination
+		// No filter configured, so this exercises the unordered full table scan path,
+		// batched by small maxBatchSize.
 		err = snapshot.Read(t.Context(), 1, 12)
 		require.NoError(t, err)
 
@@ -88,7 +90,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("TwoColumnCompositeKey_WithPagination", func(t *testing.T) {
+	t.Run("TwoColumnCompositeKey_FullScan", func(t *testing.T) {
 		var totalRows int
 		for i := range 10 {
 			for j := range 5 {
@@ -110,7 +112,8 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, scn)
 
-		// Read snapshot with small batch size to trigger pagination
+		// No filter configured, so this exercises the unordered full table scan path,
+		// batched by small maxBatchSize.
 		err = snapshot.Read(t.Context(), 1, 10)
 		require.NoError(t, err)
 
@@ -120,7 +123,48 @@ func TestIntegrationSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("ThreeColumnCompositeKey_WithPagination", func(t *testing.T) {
+	t.Run("TwoColumnCompositeKey_WithFilterPagination", func(t *testing.T) {
+		// Offset col1 so these rows occupy a disjoint key range from
+		// TwoColumnCompositeKey_FullScan, which shares this table and is never
+		// truncated between subtests.
+		const col1Offset = 100
+
+		var totalRows int
+		for i := range 10 {
+			for j := range 5 {
+				totalRows++
+				db.MustExec("INSERT INTO TESTDB.composite_key_test (col1, col2, data) VALUES (:1, :2, :3)", col1Offset+i, j, "test-data")
+			}
+		}
+
+		publisher := &publisherStub{}
+		tables := []replication.UserTable{
+			{Schema: "TESTDB", Name: "COMPOSITE_KEY_TEST"},
+		}
+		filters := map[string]string{
+			"TESTDB.COMPOSITE_KEY_TEST": fmt.Sprintf("SELECT col1, col2, data FROM TESTDB.COMPOSITE_KEY_TEST WHERE col1 >= %d", col1Offset),
+		}
+
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, filters, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		require.NoError(t, err)
+		defer snapshot.Close()
+
+		scn, err := snapshot.Prepare(t.Context())
+		require.NoError(t, err)
+		require.NotZero(t, scn)
+
+		// A snapshot filter forces the PK-keyset pagination path, exercising the
+		// composite-key lexicographic WHERE/ORDER BY construction in querySnapshotTable.
+		err = snapshot.Read(t.Context(), 1, 10)
+		require.NoError(t, err)
+
+		assert.Equalf(t, totalRows, publisher.count(), "Expected all %d rows to be captured during snapshot", totalRows)
+		for i, msg := range publisher.messages {
+			assert.Equalf(t, scn, msg.SCN, "Expected snapshot message[%d] to carry the captured SCN", i)
+		}
+	})
+
+	t.Run("ThreeColumnCompositeKey_FullScan", func(t *testing.T) {
 		var totalRows int
 		for i := range 5 {
 			for j := range 3 {
@@ -144,7 +188,51 @@ func TestIntegrationSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, scn)
 
-		// Read snapshot with small batch size to trigger pagination
+		// No filter configured, so this exercises the unordered full table scan path,
+		// batched by small maxBatchSize.
+		err = snapshot.Read(t.Context(), 1, 8)
+		require.NoError(t, err)
+
+		assert.Equalf(t, totalRows, publisher.count(), "Expected all %d rows to be captured during snapshot", totalRows)
+		for i, msg := range publisher.messages {
+			assert.Equalf(t, scn, msg.SCN, "Expected snapshot message[%d] to carry the captured SCN", i)
+		}
+	})
+
+	t.Run("ThreeColumnCompositeKey_WithFilterPagination", func(t *testing.T) {
+		// Offset col1 so these rows occupy a disjoint key range from
+		// ThreeColumnCompositeKey_FullScan, which shares this table and is never
+		// truncated between subtests.
+		const col1Offset = 100
+
+		var totalRows int
+		for i := range 5 {
+			for j := range 3 {
+				for k := range 4 {
+					totalRows++
+					db.MustExec("INSERT INTO TESTDB.three_col_key_test (col1, col2, col3, data) VALUES (:1, :2, :3, :4)", col1Offset+i, j, k, "test-data")
+				}
+			}
+		}
+
+		publisher := &publisherStub{}
+		tables := []replication.UserTable{
+			{Schema: "TESTDB", Name: "THREE_COL_KEY_TEST"},
+		}
+		filters := map[string]string{
+			"TESTDB.THREE_COL_KEY_TEST": fmt.Sprintf("SELECT col1, col2, col3, data FROM TESTDB.THREE_COL_KEY_TEST WHERE col1 >= %d", col1Offset),
+		}
+
+		snapshot, err := replication.NewSnapshot(t.Context(), connStr, tables, filters, publisher, false, "", service.NewLoggerFromSlog(log), service.MockResources().Metrics())
+		require.NoError(t, err)
+		defer snapshot.Close()
+
+		scn, err := snapshot.Prepare(t.Context())
+		require.NoError(t, err)
+		require.NotZero(t, scn)
+
+		// A snapshot filter forces the PK-keyset pagination path, exercising the
+		// composite-key lexicographic WHERE/ORDER BY construction in querySnapshotTable.
 		err = snapshot.Read(t.Context(), 1, 8)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### Problem

By default, OracleDB uses heaped tables which aren't sorted by primary key, meaning snapshotting ordered by primary key can incur high disk I/O as every single row lookup via ROWID forces Oracle to jump to a different physical data block on disk.

### Solution

As this is a full table scan, and not batched/chunked into ranges we can remove ordering which improves overall read performance.

### Proof of Work

#### AWS Benchmark

Benchmarks went from ~9.8MB/s (post cache-warm) to a consistent 98MB/s:

<img width="2046" height="1258" alt="image" src="https://github.com/user-attachments/assets/0fe9c8b8-da1f-4600-87ed-39b31d81147c" />

#### Local Benchmark:

Before: Avg. ~40MB/s

<img width="1825" height="777" alt="image" src="https://github.com/user-attachments/assets/c2a2e9d2-654c-4788-9a8a-1683923852fd" />

After: Avg. ~51MB/s

<img width="1850" height="474" alt="image" src="https://github.com/user-attachments/assets/382ace52-9eab-4364-899c-885ce1968b2e" />
