### PR TITLE
postgres_cdc: default to noop signaller if signal table is not configured

### DIFF
--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -483,7 +483,7 @@ type pgStreamInput struct {
 
 	snapshotMetrics *service.MetricGauge
 	replicationLag  *service.MetricGauge
-	controlSig      *postgresSignaller
+	controlSig      controlSignaller
 	stopSig         *shutdown.Signaller
 
 	// snapshotAckWG tracks in-flight snapshot batches: incremented when a
@@ -602,11 +602,10 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				err   error
 			)
 			for _, msg := range batch {
-				if p.controlSig.enabled() {
-					if _, err := p.controlSig.listen(&msg); err != nil {
-						// Log it and fall through to the normal emit path below.
-						p.logger.Errorf("failed to detect control signal in change event: %s", err)
-					}
+				// noop if not configured
+				if _, err := p.controlSig.listen(&msg); err != nil {
+					// Log it and fall through to the normal emit path below.
+					p.logger.Errorf("failed to detect control signal in change event: %s", err)
 				}
 
 				if mb, err = json.Marshal(msg.Data); err != nil {

--- a/internal/impl/postgresql/signaller.go
+++ b/internal/impl/postgresql/signaller.go
@@ -18,31 +18,39 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/replication"
 )
 
-type postgresSignaller struct {
-	log *service.Logger
+// controlSignaller checks WAL change entries for control signals.
+type controlSignaller interface {
+	listen(msg *pglogicalstream.StreamMessage) (*replication.ControlSignal, error)
+}
 
+type noopSignaller struct{}
+
+func (noopSignaller) listen(*pglogicalstream.StreamMessage) (*replication.ControlSignal, error) {
+	return nil, nil
+}
+
+type postgresSignaller struct {
 	schema    string
 	tableName string
+	log       *service.Logger
 }
 
 // newControlSignaller creates a signal listener that checks WAL change entries for control signals.
-func newControlSignaller(schema, tableName string, log *service.Logger) (*postgresSignaller, error) {
+// If tableName is empty, it returns a no-op signaller.
+func newControlSignaller(schema, tableName string, log *service.Logger) (controlSignaller, error) {
+	if tableName == "" {
+		return noopSignaller{}, nil
+	}
+
 	normalizedSchema, err := wireFormPostgresIdentifier(schema)
 	if err != nil {
 		return nil, fmt.Errorf("invalid schema %q: %w", schema, err)
 	}
-	normalizedTableName := tableName
-	if tableName != "" {
-		if normalizedTableName, err = wireFormPostgresIdentifier(tableName); err != nil {
-			return nil, fmt.Errorf("invalid signal table name %q: %w", tableName, err)
-		}
+	normalizedTableName, err := wireFormPostgresIdentifier(tableName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signal table name %q: %w", tableName, err)
 	}
 	return &postgresSignaller{log: log, schema: normalizedSchema, tableName: normalizedTableName}, nil
-}
-
-// enabled reports whether a signal table was configured.
-func (s *postgresSignaller) enabled() bool {
-	return s.tableName != ""
 }
 
 // listen returns any actionable signal found; signal rows should always be

--- a/internal/impl/postgresql/signaller_test.go
+++ b/internal/impl/postgresql/signaller_test.go
@@ -20,11 +20,11 @@ import (
 func TestPostgresSignallerEnabled(t *testing.T) {
 	s, err := newControlSignaller("dbo", "", nil)
 	require.NoError(t, err)
-	require.False(t, s.enabled(), "expected Enabled to be false when no signal table is configured")
+	require.IsType(t, noopSignaller{}, s, "expected a no-op signaller when no signal table is configured")
 
 	s, err = newControlSignaller("dbo", "rpcn_signal_table", nil)
 	require.NoError(t, err)
-	require.True(t, s.enabled(), "expected Enabled to be true when a signal table is configured")
+	require.IsType(t, &postgresSignaller{}, s, "expected a postgresSignaller when a signal table is configured")
 }
 
 func TestPostgresSignallerListen(t *testing.T) {


### PR DESCRIPTION
A small signalling refactor to default to a no-op signaller instead needing to check if enabled. Simplifies branching logic and code path.