### PR TITLE
jw/backfill api poc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.26.5
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 
+// Prototype: local benthos fork with the SnapshotAsync/SnapshotBatchInput
+// ack-barrier for CDC snapshot phases. Not for merge.
+replace github.com/redpanda-data/benthos/v4 => /Users/joseph.woodward/code/benthos
+
 ignore (
 	./bin
 	./config

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -39,23 +38,8 @@ type batchPublisher struct {
 	// acknowledged downstream. The snapshot->streaming handoff blocks on it so
 	// the post-snapshot SCN is never persisted while snapshot rows are in flight.
 	snapshotAckWG sync.WaitGroup
-	// snapshotNackErr records the first snapshot batch nack. auto_replay_nacks
-	// is user-toggleable, so a nack can be terminal: the gate must fail rather
-	// than let the post-snapshot SCN persist over undelivered rows.
-	snapshotNackMu  sync.Mutex
-	snapshotNackErr error
-
-	// onTerminalNack, when set, is invoked once a batch is rejected
-	// downstream: a nack pins the ordered tracker, so the input must restart
-	// (with a fresh publisher) to resume from the last durable SCN.
-	onTerminalNack func(error)
-	// sealed marks a publisher that has been replaced by a reconnect. Late
-	// acks from its session must not persist checkpoints (they could regress
-	// the new session's positions) nor trigger restarts.
-	sealed atomic.Bool
-
-	log     *service.Logger
-	shutSig *shutdown.Signaller
+	log           *service.Logger
+	shutSig       *shutdown.Signaller
 }
 
 // newBatchPublisher creates an instance of batchPublisher.
@@ -302,36 +286,13 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 		isSnapshot: isSnapshotBatch,
 		msg: asyncMessage{
 			msg: batch,
-			ackFn: func(ctx context.Context, err error) error {
+			// The ack error is deliberately ignored: nacks are replayed by
+			// auto_replay_nacks (the default), and disabling that is a
+			// documented opt-in to DROP rejected messages, so the checkpoint
+			// must advance past them rather than pin the tracker.
+			ackFn: func(ctx context.Context, _ error) error {
 				if isSnapshotBatch {
 					defer b.snapshotAckWG.Done()
-				}
-				if err != nil {
-					// auto_replay_nacks is user-toggleable, so a nack can be
-					// terminal. Never resolve: the checkpoint stays pinned
-					// before this batch so nothing can be persisted past its
-					// undelivered rows. Snapshot nacks additionally fail the
-					// handoff gate so the post-snapshot SCN is not persisted,
-					// and the input restarts with a fresh tracker to resume
-					// from the last durable SCN (the pinned slot would
-					// otherwise wedge checkpointing for the process lifetime).
-					if isSnapshotBatch {
-						b.recordSnapshotNack(err)
-					}
-					if b.sealed.Load() {
-						return err
-					}
-					b.log.Errorf("Batch rejected downstream (snapshot=%v, checkpoint SCN %d): restarting to redeliver from the last durable checkpoint: %v", isSnapshotBatch, checkpointSCN, err)
-					if b.onTerminalNack != nil {
-						b.onTerminalNack(err)
-					}
-					return err
-				}
-				if b.sealed.Load() {
-					// A late ack from a replaced session: resolving its own
-					// tracker is harmless, but persisting could regress the
-					// new session's checkpoints.
-					return nil
 				}
 				scn := resolveFn()
 				if scn == nil || !scn.IsValid() {
@@ -346,31 +307,6 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 			},
 		},
 	}, nil
-}
-
-// seal marks the publisher as replaced; see the sealed field.
-func (b *batchPublisher) seal() {
-	b.sealed.Store(true)
-}
-
-func (b *batchPublisher) recordSnapshotNack(err error) {
-	b.snapshotNackMu.Lock()
-	defer b.snapshotNackMu.Unlock()
-	if b.snapshotNackErr == nil {
-		b.snapshotNackErr = err
-	}
-}
-
-// resetSnapshotGate clears any nack recorded by a previous snapshot attempt so
-// the gate reflects only the current run: the publisher outlives reconnects,
-// and a stale error would fail every retry even after a clean re-run. The
-// WaitGroup is deliberately left untouched — batches from a previous attempt
-// that are still in flight can yet be acked or nacked, and both must keep
-// counting.
-func (b *batchPublisher) resetSnapshotGate() {
-	b.snapshotNackMu.Lock()
-	defer b.snapshotNackMu.Unlock()
-	b.snapshotNackErr = nil
 }
 
 // sendTracked hands a tracked batch to ReadBatch. Must be called WITHOUT
@@ -389,10 +325,10 @@ func (b *batchPublisher) sendTracked(ctx context.Context, tracked *trackedBatch)
 }
 
 // waitSnapshotAcks blocks until every published snapshot batch has been
-// acknowledged or nacked downstream, or until ctx is cancelled (the escape
-// prevents a stalled downstream from wedging shutdown). Any nack fails the
-// gate: with auto_replay_nacks disabled a nack is terminal, so the
-// post-snapshot SCN must not be persisted and the snapshot must re-run.
+// acknowledged (or nacked) downstream, or until ctx is cancelled. Nacked
+// batches release the gate too: redelivery is owned by auto_replay_nacks,
+// and disabling that is a documented opt-in to drop rejections. The ctx
+// escape prevents a permanently-failing downstream from wedging shutdown.
 func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
 	drained := make(chan struct{})
 	go func() {
@@ -402,11 +338,6 @@ func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
 	}()
 	select {
 	case <-drained:
-		b.snapshotNackMu.Lock()
-		defer b.snapshotNackMu.Unlock()
-		if b.snapshotNackErr != nil {
-			return fmt.Errorf("snapshot batch was rejected downstream: %w", b.snapshotNackErr)
-		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -43,6 +44,15 @@ type batchPublisher struct {
 	// than let the post-snapshot SCN persist over undelivered rows.
 	snapshotNackMu  sync.Mutex
 	snapshotNackErr error
+
+	// onTerminalNack, when set, is invoked once a batch is rejected
+	// downstream: a nack pins the ordered tracker, so the input must restart
+	// (with a fresh publisher) to resume from the last durable SCN.
+	onTerminalNack func(error)
+	// sealed marks a publisher that has been replaced by a reconnect. Late
+	// acks from its session must not persist checkpoints (they could regress
+	// the new session's positions) nor trigger restarts.
+	sealed atomic.Bool
 
 	log     *service.Logger
 	shutSig *shutdown.Signaller
@@ -301,12 +311,27 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 					// terminal. Never resolve: the checkpoint stays pinned
 					// before this batch so nothing can be persisted past its
 					// undelivered rows. Snapshot nacks additionally fail the
-					// handoff gate so the post-snapshot SCN is not persisted.
+					// handoff gate so the post-snapshot SCN is not persisted,
+					// and the input restarts with a fresh tracker to resume
+					// from the last durable SCN (the pinned slot would
+					// otherwise wedge checkpointing for the process lifetime).
 					if isSnapshotBatch {
 						b.recordSnapshotNack(err)
 					}
-					b.log.Errorf("Batch rejected downstream (snapshot=%v, checkpoint SCN %d): the checkpoint is now pinned before this batch and the input will stall once checkpoint_limit is reached, unless the batch is redelivered (auto_replay_nacks) or the pipeline restarts: %v", isSnapshotBatch, checkpointSCN, err)
+					if b.sealed.Load() {
+						return err
+					}
+					b.log.Errorf("Batch rejected downstream (snapshot=%v, checkpoint SCN %d): restarting to redeliver from the last durable checkpoint: %v", isSnapshotBatch, checkpointSCN, err)
+					if b.onTerminalNack != nil {
+						b.onTerminalNack(err)
+					}
 					return err
+				}
+				if b.sealed.Load() {
+					// A late ack from a replaced session: resolving its own
+					// tracker is harmless, but persisting could regress the
+					// new session's checkpoints.
+					return nil
 				}
 				scn := resolveFn()
 				if scn == nil || !scn.IsValid() {
@@ -321,6 +346,11 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 			},
 		},
 	}, nil
+}
+
+// seal marks the publisher as replaced; see the sealed field.
+func (b *batchPublisher) seal() {
+	b.sealed.Store(true)
 }
 
 func (b *batchPublisher) recordSnapshotNack(err error) {

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -322,6 +322,23 @@ func (b *batchPublisher) msgs() <-chan asyncMessage {
 	return b.msgChan
 }
 
+// flushCurrent flushes any partial batch still held by the batcher and
+// publishes it, leaving the publisher loop running. Used at the
+// snapshot->streaming handoff so every snapshot row is published (and can be
+// awaited via waitSnapshotAcks) before the post-snapshot SCN is persisted.
+func (b *batchPublisher) flushCurrent(ctx context.Context) error {
+	if b.batcher == nil {
+		return nil
+	}
+	b.batcherMu.Lock()
+	remaining, err := b.batcher.Flush(ctx)
+	b.batcherMu.Unlock()
+	if err != nil || len(remaining) == 0 {
+		return err
+	}
+	return b.publishBatch(ctx, remaining)
+}
+
 // FlushRemaining stops the loop goroutine and then flushes any partial batch
 // still held in the batcher, blocking until it is consumed by ReadBatch.
 func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
@@ -330,14 +347,7 @@ func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
 	}
 	b.shutSig.TriggerSoftStop()
 	<-b.shutSig.HasStoppedChan()
-
-	b.batcherMu.Lock()
-	remaining, err := b.batcher.Flush(ctx)
-	b.batcherMu.Unlock()
-	if err != nil || len(remaining) == 0 {
-		return err
-	}
-	return b.publishBatch(ctx, remaining)
+	return b.flushCurrent(ctx)
 }
 
 // Close signals the publisher's loop goroutine to stop and waits for it to exit.

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -23,39 +23,56 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
 )
 
-// batchPublisher is responsible processing individual events into a batch and flushing
-// them to the pipeline using service.Batcher.
+// batchPublisher processes individual events into batches and flushes them
+// to the pipeline using service.Batcher.
+//
+// Streaming (CDC) rows and snapshot rows are kept on entirely separate
+// paths: streaming rows go through Publish, are tracked against the ordered
+// SCN checkpoint tracker, and are delivered via msgs() to ReadBatch.
+// Snapshot rows go through PublishSnapshot, are never registered with the
+// checkpoint tracker, and are delivered via snapshotMsgs() to
+// oracleDBCDCInput.SnapshotReadBatch. The framework-level SnapshotAsync ack
+// barrier (see input_oracledb_cdc.go) is what now guarantees every snapshot
+// batch is settled before the post-snapshot SCN is persisted, so this type
+// no longer needs its own ack-counting gate for the snapshot phase.
 type batchPublisher struct {
 	batcher   *service.Batcher
 	batcherMu sync.Mutex
 
-	checkpoint *checkpoint.Capped[replication.SCN]
-	msgChan    chan asyncMessage
-	cacheSCN   func(ctx context.Context, scn replication.SCN) error
-	schemas    *schemaCache
+	snapshotBatcher   *service.Batcher
+	snapshotBatcherMu sync.Mutex
 
-	// snapshotAckWG counts published snapshot batches that have not yet been
-	// acknowledged downstream. The snapshot->streaming handoff blocks on it so
-	// the post-snapshot SCN is never persisted while snapshot rows are in flight.
-	snapshotAckWG sync.WaitGroup
-	log           *service.Logger
-	shutSig       *shutdown.Signaller
+	checkpoint      *checkpoint.Capped[replication.SCN]
+	msgChan         chan asyncMessage
+	snapshotMsgChan chan asyncMessage
+
+	cacheSCN func(ctx context.Context, scn replication.SCN) error
+	schemas  *schemaCache
+
+	log     *service.Logger
+	shutSig *shutdown.Signaller
 }
 
 // newBatchPublisher creates an instance of batchPublisher.
-func newBatchPublisher(batcher *service.Batcher, checkpoint *checkpoint.Capped[replication.SCN], logger *service.Logger) *batchPublisher {
+func newBatchPublisher(batcher, snapshotBatcher *service.Batcher, checkpoint *checkpoint.Capped[replication.SCN], logger *service.Logger) *batchPublisher {
 	b := &batchPublisher{
-		batcher:    batcher,
-		checkpoint: checkpoint,
-		msgChan:    make(chan asyncMessage),
-		log:        logger,
-		shutSig:    shutdown.NewSignaller(),
+		batcher:         batcher,
+		snapshotBatcher: snapshotBatcher,
+		checkpoint:      checkpoint,
+		msgChan:         make(chan asyncMessage),
+		snapshotMsgChan: make(chan asyncMessage),
+		log:             logger,
+		shutSig:         shutdown.NewSignaller(),
 	}
 	go b.loop()
 	return b
 }
 
-// loop creates a long-running process that periodically flushes batches by configured interval.
+// loop creates a long-running process that periodically flushes the
+// streaming batcher by configured interval. There's no equivalent timed
+// flush for the snapshot batcher: SnapshotReadBatch drives it synchronously
+// and flushes its trailing partial batch itself once the snapshot's row
+// producer finishes (see flushSnapshotRemaining).
 // lifted from internal/impl/kafka/franz_reader_ordered.go
 func (p *batchPublisher) loop() {
 	defer p.shutSig.TriggerHasStopped()
@@ -93,7 +110,7 @@ func (p *batchPublisher) loop() {
 		flushBatch = flushBatchTicker.C
 	}
 
-	// hardStopCtx survives a soft stop so that an in-flight sendTracked send can
+	// hardStopCtx survives a soft stop so that an in-flight send can
 	// complete before the loop exits. Only a hard stop (triggered by Close)
 	// cancels it, which is the forced-shutdown last resort.
 	hardStopCtx, done := p.shutSig.HardStopCtx(context.Background())
@@ -104,7 +121,8 @@ func (p *batchPublisher) loop() {
 		select {
 		case <-flushBatch:
 			var (
-				tracked  *trackedBatch
+				tracked  asyncMessage
+				hasMsg   bool
 				trackErr error
 			)
 
@@ -128,13 +146,14 @@ func (p *batchPublisher) loop() {
 					return
 				}
 				tracked, trackErr = p.trackBatchLocked(hardStopCtx, sendBatch)
+				hasMsg = trackErr == nil
 			}()
 			if trackErr != nil {
 				return
 			}
 
-			if tracked != nil {
-				if err := p.sendTracked(hardStopCtx, tracked); err != nil {
+			if hasMsg {
+				if err := p.sendStreaming(hardStopCtx, tracked); err != nil {
 					return
 				}
 			}
@@ -144,9 +163,10 @@ func (p *batchPublisher) loop() {
 	}
 }
 
-// Publish turns the provided message into a service.Message before batching and
-// flushing them based on batch size or time elapsed.
-func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEvent) error {
+// buildMessage converts a replication.MessageEvent into a service.Message,
+// applying schema resolution/coercion and metadata common to both streaming
+// and snapshot rows.
+func (b *batchPublisher) buildMessage(ctx context.Context, m *replication.MessageEvent) (*service.Message, error) {
 	// Resolve schema first — needed both for metadata and value coercion.
 	var schemaAny any
 	if b.schemas != nil {
@@ -181,7 +201,7 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 
 	data, err := json.Marshal(m.Data)
 	if err != nil {
-		return fmt.Errorf("marshalling message: %w", err)
+		return nil, fmt.Errorf("marshalling message: %w", err)
 	}
 
 	msg := service.NewMessage(data)
@@ -210,17 +230,32 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	if schemaAny != nil {
 		msg.MetaSetImmut("schema", service.ImmutableAny{V: schemaAny})
 	}
+	return msg, nil
+}
+
+// Publish turns the provided streaming (CDC) event into a service.Message
+// before batching and flushing based on batch size or time elapsed. Every
+// flushed batch is registered with the ordered SCN checkpoint tracker.
+func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEvent) error {
+	msg, err := b.buildMessage(ctx, m)
+	if err != nil {
+		return err
+	}
 
 	// Flush and Track must be atomic: Track order defines the checkpoint
 	// sequence, so another flusher (the timed-flush loop) must not interleave
 	// between our flush and our Track. Only the channel send happens outside
 	// the lock.
-	var tracked *trackedBatch
+	var (
+		tracked asyncMessage
+		hasMsg  bool
+	)
 	b.batcherMu.Lock()
 	if b.batcher.Add(msg) {
 		var flushedBatch []*service.Message
 		if flushedBatch, err = b.batcher.Flush(ctx); err == nil && len(flushedBatch) > 0 {
 			tracked, err = b.trackBatchLocked(ctx, flushedBatch)
+			hasMsg = err == nil
 		}
 	}
 	b.batcherMu.Unlock()
@@ -229,8 +264,8 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	}
 
 	// If a batch was flushed, publish it outside the lock
-	if tracked != nil {
-		if err := b.sendTracked(ctx, tracked); err != nil {
+	if hasMsg {
+		if err := b.sendStreaming(ctx, tracked); err != nil {
 			return fmt.Errorf("publishing flushed batch: %w", err)
 		}
 	}
@@ -238,31 +273,16 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	return nil
 }
 
-// trackedBatch pairs a ready-to-send asyncMessage with the bookkeeping needed
-// to roll back its snapshot-gate slot if the send fails.
-type trackedBatch struct {
-	msg        asyncMessage
-	isSnapshot bool
-}
-
-// trackBatchLocked registers the batch with the ordered checkpoint tracker and
-// builds its ack function. It MUST be called with batcherMu held: Track order
-// defines the checkpoint sequence, so it has to match flush order exactly.
-func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.MessageBatch) (*trackedBatch, error) {
+// trackBatchLocked registers a streaming batch with the ordered checkpoint
+// tracker and builds its ack function. It MUST be called with batcherMu
+// held: Track order defines the checkpoint sequence, so it has to match
+// flush order exactly.
+func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.MessageBatch) (asyncMessage, error) {
 	lastMsg := batch[len(batch)-1]
-
-	// ensure we don't checkpoint snapshot batches
-	isSnapshotBatch := false
-	if op, ok := lastMsg.MetaGet("operation"); ok && op == replication.MessageOperationRead.String() {
-		isSnapshotBatch = true
-	}
 
 	var checkpointSCN replication.SCN
 	// Prefer checkpoint_scn. It accounts for open transactions.
 	// Use scn if checkpoint_scn is absent.
-	// Snapshot rows never carry checkpoint_scn.
-	// All rows in one snapshot run share the same scn, captured once in Snapshot.Prepare().
-	// So the fallback always selects that shared scn for snapshot batches.
 	scnKey := "checkpoint_scn"
 	if _, ok := lastMsg.MetaGet(scnKey); !ok {
 		scnKey = "scn"
@@ -271,77 +291,106 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 		var parseErr error
 		checkpointSCN, parseErr = replication.ParseSCN(scn)
 		if parseErr != nil {
-			return nil, fmt.Errorf("parsing checkpoint SCN: %w", parseErr)
+			return asyncMessage{}, fmt.Errorf("parsing checkpoint SCN: %w", parseErr)
 		}
 	}
 
 	resolveFn, err := b.checkpoint.Track(ctx, checkpointSCN, int64(len(batch)))
 	if err != nil {
-		return nil, fmt.Errorf("tracking SCN checkpoint for batch: %w", err)
+		return asyncMessage{}, fmt.Errorf("tracking SCN checkpoint for batch: %w", err)
 	}
-	if isSnapshotBatch {
-		b.snapshotAckWG.Add(1)
-	}
-	return &trackedBatch{
-		isSnapshot: isSnapshotBatch,
-		msg: asyncMessage{
-			msg: batch,
-			// The ack error is deliberately ignored: nacks are replayed by
-			// auto_replay_nacks (the default), and disabling that is a
-			// documented opt-in to DROP rejected messages, so the checkpoint
-			// must advance past them rather than pin the tracker.
-			ackFn: func(ctx context.Context, _ error) error {
-				if isSnapshotBatch {
-					defer b.snapshotAckWG.Done()
-				}
-				scn := resolveFn()
-				if scn == nil || !scn.IsValid() {
-					return nil
-				}
-				if isSnapshotBatch && *scn <= checkpointSCN {
-					// Resolved value is this snapshot batch's own shared SCN (or older) —
-					// nothing new to persist, and persisting it would be premature.
-					return nil
-				}
-				return b.cacheSCN(ctx, *scn)
-			},
+	return asyncMessage{
+		msg: batch,
+		// The ack error is deliberately ignored: nacks are replayed by
+		// auto_replay_nacks (the default), and disabling that is a
+		// documented opt-in to DROP rejected messages, so the checkpoint
+		// must advance past them rather than pin the tracker.
+		ackFn: func(ctx context.Context, _ error) error {
+			scn := resolveFn()
+			if scn == nil || !scn.IsValid() {
+				return nil
+			}
+			return b.cacheSCN(ctx, *scn)
 		},
 	}, nil
 }
 
-// sendTracked hands a tracked batch to ReadBatch. Must be called WITHOUT
-// batcherMu held (the send blocks until consumed). A failed send releases the
-// batch's snapshot-gate slot.
-func (b *batchPublisher) sendTracked(ctx context.Context, tracked *trackedBatch) error {
+// sendStreaming hands a tracked streaming batch to ReadBatch. Must be called
+// WITHOUT batcherMu held (the send blocks until consumed).
+func (b *batchPublisher) sendStreaming(ctx context.Context, msg asyncMessage) error {
 	select {
-	case b.msgChan <- tracked.msg:
+	case b.msgChan <- msg:
 		return nil
 	case <-ctx.Done():
-		if tracked.isSnapshot {
-			b.snapshotAckWG.Done()
-		}
 		return ctx.Err()
 	}
 }
 
-// waitSnapshotAcks blocks until every published snapshot batch has been
-// acknowledged (or nacked) downstream, or until ctx is cancelled. Nacked
-// batches release the gate too: redelivery is owned by auto_replay_nacks,
-// and disabling that is a documented opt-in to drop rejections. The ctx
-// escape prevents a permanently-failing downstream from wedging shutdown.
-func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
-	drained := make(chan struct{})
-	go func() {
-		// May outlive this call if ctx fires first; bounded by process lifetime.
-		b.snapshotAckWG.Wait()
-		close(drained)
-	}()
+// PublishSnapshot turns the provided snapshot row into a service.Message
+// before batching and flushing based on batch size or time elapsed.
+// Snapshot batches are never registered with the SCN checkpoint tracker:
+// the SnapshotAsync ack barrier in AsyncReader (driven by
+// oracleDBCDCInput.SnapshotReadBatch/SnapshotComplete) guarantees every
+// batch is settled downstream before the post-snapshot SCN is persisted, so
+// there's nothing here that needs ordering against the checkpoint.
+func (b *batchPublisher) PublishSnapshot(ctx context.Context, m *replication.MessageEvent) error {
+	msg, err := b.buildMessage(ctx, m)
+	if err != nil {
+		return err
+	}
+
+	var flushed service.MessageBatch
+	b.snapshotBatcherMu.Lock()
+	if b.snapshotBatcher.Add(msg) {
+		flushed, err = b.snapshotBatcher.Flush(ctx)
+	}
+	b.snapshotBatcherMu.Unlock()
+	if err != nil {
+		return fmt.Errorf("flushing snapshot batch: %w", err)
+	}
+
+	if len(flushed) > 0 {
+		if err := b.sendSnapshot(ctx, flushed); err != nil {
+			return fmt.Errorf("publishing flushed snapshot batch: %w", err)
+		}
+	}
+	return nil
+}
+
+// sendSnapshot hands a flushed snapshot batch to SnapshotReadBatch. Must be
+// called WITHOUT snapshotBatcherMu held (the send blocks until consumed).
+func (b *batchPublisher) sendSnapshot(ctx context.Context, batch service.MessageBatch) error {
+	msg := asyncMessage{
+		msg: batch,
+		// No-op regardless of ack/nack: there's no checkpoint state tied to
+		// a snapshot batch to resolve. A nack is replayed by
+		// AutoRetryNacksBatched (via the framework's independent snapshot
+		// retry list) exactly like a nacked streaming batch would be;
+		// disabling auto_replay_nacks is the documented opt-in to drop it
+		// instead. Either way this ackFn has nothing left to do.
+		ackFn: func(context.Context, error) error { return nil },
+	}
 	select {
-	case <-drained:
+	case b.snapshotMsgChan <- msg:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// flushSnapshotRemaining flushes any partial batch still held by the
+// snapshot batcher and publishes it. Called by SnapshotReadBatch once the
+// snapshot's row producer (replication.Snapshot.Read) has returned, so the
+// final trailing partial batch reaches the pipeline before signalling
+// component.ErrSnapshotComplete.
+func (b *batchPublisher) flushSnapshotRemaining(ctx context.Context) error {
+	b.snapshotBatcherMu.Lock()
+	remaining, err := b.snapshotBatcher.Flush(ctx)
+	b.snapshotBatcherMu.Unlock()
+	if err != nil || len(remaining) == 0 {
+		return err
+	}
+	return b.sendSnapshot(ctx, remaining)
 }
 
 // mapKeys extracts the keys from a map for use in drift detection.
@@ -361,36 +410,8 @@ func (b *batchPublisher) msgs() <-chan asyncMessage {
 	return b.msgChan
 }
 
-// flushCurrent flushes any partial batch still held by the batcher and
-// publishes it, leaving the publisher loop running. Used at the
-// snapshot->streaming handoff so every snapshot row is published (and can be
-// awaited via waitSnapshotAcks) before the post-snapshot SCN is persisted.
-func (b *batchPublisher) flushCurrent(ctx context.Context) error {
-	if b.batcher == nil {
-		return nil
-	}
-	var tracked *trackedBatch
-	b.batcherMu.Lock()
-	remaining, err := b.batcher.Flush(ctx)
-	if err == nil && len(remaining) > 0 {
-		tracked, err = b.trackBatchLocked(ctx, remaining)
-	}
-	b.batcherMu.Unlock()
-	if err != nil || tracked == nil {
-		return err
-	}
-	return b.sendTracked(ctx, tracked)
-}
-
-// FlushRemaining stops the loop goroutine and then flushes any partial batch
-// still held in the batcher, blocking until it is consumed by ReadBatch.
-func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
-	if b.batcher == nil {
-		return nil
-	}
-	b.shutSig.TriggerSoftStop()
-	<-b.shutSig.HasStoppedChan()
-	return b.flushCurrent(ctx)
+func (b *batchPublisher) snapshotMsgs() <-chan asyncMessage {
+	return b.snapshotMsgChan
 }
 
 // Close signals the publisher's loop goroutine to stop and waits for it to exit.
@@ -402,5 +423,8 @@ func (b *batchPublisher) Close() {
 	<-b.shutSig.HasStoppedChan()
 	if b.batcher != nil {
 		_ = b.batcher.Close(context.Background())
+	}
+	if b.snapshotBatcher != nil {
+		_ = b.snapshotBatcher.Close(context.Background())
 	}
 }

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -34,6 +34,11 @@ type batchPublisher struct {
 	cacheSCN   func(ctx context.Context, scn replication.SCN) error
 	schemas    *schemaCache
 
+	// snapshotAckWG counts published snapshot batches that have not yet been
+	// acknowledged downstream. The snapshot->streaming handoff blocks on it so
+	// the post-snapshot SCN is never persisted while snapshot rows are in flight.
+	snapshotAckWG sync.WaitGroup
+
 	log     *service.Logger
 	shutSig *shutdown.Signaller
 }
@@ -251,6 +256,9 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 	msg := asyncMessage{
 		msg: batch,
 		ackFn: func(ctx context.Context, _ error) error {
+			if isSnapshotBatch {
+				defer b.snapshotAckWG.Done()
+			}
 			scn := resolveFn()
 			if scn == nil || !scn.IsValid() {
 				return nil
@@ -263,8 +271,34 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 			return b.cacheSCN(ctx, *scn)
 		},
 	}
+	if isSnapshotBatch {
+		b.snapshotAckWG.Add(1)
+	}
 	select {
 	case b.msgChan <- msg:
+		return nil
+	case <-ctx.Done():
+		if isSnapshotBatch {
+			b.snapshotAckWG.Done()
+		}
+		return ctx.Err()
+	}
+}
+
+// waitSnapshotAcks blocks until every published snapshot batch has been
+// acknowledged (or nacked) downstream, or until ctx is cancelled. Nacked
+// batches release the gate too: redelivery is owned by auto_replay_nacks,
+// and the ctx escape prevents a permanently-failing downstream from
+// wedging shutdown.
+func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
+	drained := make(chan struct{})
+	go func() {
+		// May outlive this call if ctx fires first; bounded by process lifetime.
+		b.snapshotAckWG.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -73,7 +73,11 @@ func (p *batchPublisher) loop() {
 			return
 		}
 
+		// UntilNext reads the batcher's internal state, which concurrent
+		// Publish calls mutate under batcherMu — take the same lock.
+		p.batcherMu.Lock()
 		tNext, exists := p.batcher.UntilNext()
+		p.batcherMu.Unlock()
 		if !exists {
 			if flushBatchTicker != nil {
 				flushBatchTicker.Stop()
@@ -100,9 +104,14 @@ func (p *batchPublisher) loop() {
 		adjustTimedFlush()
 		select {
 		case <-flushBatch:
-			var sendBatch service.MessageBatch
+			var (
+				tracked  *trackedBatch
+				trackErr error
+			)
 
-			// Wrap this in a closure to make locking/unlocking easier.
+			// Wrap this in a closure to make locking/unlocking easier. Track
+			// happens under the same lock as the flush so the checkpoint
+			// sequence matches flush order.
 			func() {
 				p.batcherMu.Lock()
 				defer p.batcherMu.Unlock()
@@ -115,13 +124,18 @@ func (p *batchPublisher) loop() {
 					return
 				}
 
+				var sendBatch service.MessageBatch
 				if sendBatch, _ = p.batcher.Flush(hardStopCtx); len(sendBatch) == 0 {
 					return
 				}
+				tracked, trackErr = p.trackBatchLocked(hardStopCtx, sendBatch)
 			}()
+			if trackErr != nil {
+				return
+			}
 
-			if len(sendBatch) > 0 {
-				if err := p.publishBatch(hardStopCtx, sendBatch); err != nil {
+			if tracked != nil {
+				if err := p.sendTracked(hardStopCtx, tracked); err != nil {
 					return
 				}
 			}
@@ -198,10 +212,17 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 		msg.MetaSetImmut("schema", service.ImmutableAny{V: schemaAny})
 	}
 
-	var flushedBatch []*service.Message
+	// Flush and Track must be atomic: Track order defines the checkpoint
+	// sequence, so another flusher (the timed-flush loop) must not interleave
+	// between our flush and our Track. Only the channel send happens outside
+	// the lock.
+	var tracked *trackedBatch
 	b.batcherMu.Lock()
 	if b.batcher.Add(msg) {
-		flushedBatch, err = b.batcher.Flush(ctx)
+		var flushedBatch []*service.Message
+		if flushedBatch, err = b.batcher.Flush(ctx); err == nil && len(flushedBatch) > 0 {
+			tracked, err = b.trackBatchLocked(ctx, flushedBatch)
+		}
 	}
 	b.batcherMu.Unlock()
 	if err != nil {
@@ -209,8 +230,8 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	}
 
 	// If a batch was flushed, publish it outside the lock
-	if len(flushedBatch) > 0 {
-		if err := b.publishBatch(ctx, flushedBatch); err != nil {
+	if tracked != nil {
+		if err := b.sendTracked(ctx, tracked); err != nil {
 			return fmt.Errorf("publishing flushed batch: %w", err)
 		}
 	}
@@ -218,11 +239,34 @@ func (b *batchPublisher) Publish(ctx context.Context, m *replication.MessageEven
 	return nil
 }
 
+// trackedBatch pairs a ready-to-send asyncMessage with the bookkeeping needed
+// to roll back its snapshot-gate slot if the send fails.
+type trackedBatch struct {
+	msg        asyncMessage
+	isSnapshot bool
+}
+
+// publishBatch tracks and sends a batch that was flushed elsewhere. Callers
+// that flush the batcher themselves must instead track under the same lock as
+// their flush (see Publish/loop/flushCurrent) to keep Track order == flush
+// order.
 func (b *batchPublisher) publishBatch(ctx context.Context, batch service.MessageBatch) error {
 	if len(batch) == 0 {
 		return nil
 	}
+	b.batcherMu.Lock()
+	tracked, err := b.trackBatchLocked(ctx, batch)
+	b.batcherMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return b.sendTracked(ctx, tracked)
+}
 
+// trackBatchLocked registers the batch with the ordered checkpoint tracker and
+// builds its ack function. It MUST be called with batcherMu held: Track order
+// defines the checkpoint sequence, so it has to match flush order exactly.
+func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.MessageBatch) (*trackedBatch, error) {
 	lastMsg := batch[len(batch)-1]
 
 	// ensure we don't checkpoint snapshot batches
@@ -245,40 +289,49 @@ func (b *batchPublisher) publishBatch(ctx context.Context, batch service.Message
 		var parseErr error
 		checkpointSCN, parseErr = replication.ParseSCN(scn)
 		if parseErr != nil {
-			return fmt.Errorf("parsing checkpoint SCN: %w", parseErr)
+			return nil, fmt.Errorf("parsing checkpoint SCN: %w", parseErr)
 		}
 	}
 
 	resolveFn, err := b.checkpoint.Track(ctx, checkpointSCN, int64(len(batch)))
 	if err != nil {
-		return fmt.Errorf("tracking SCN checkpoint for batch: %w", err)
-	}
-	msg := asyncMessage{
-		msg: batch,
-		ackFn: func(ctx context.Context, _ error) error {
-			if isSnapshotBatch {
-				defer b.snapshotAckWG.Done()
-			}
-			scn := resolveFn()
-			if scn == nil || !scn.IsValid() {
-				return nil
-			}
-			if isSnapshotBatch && *scn <= checkpointSCN {
-				// Resolved value is this snapshot batch's own shared SCN (or older) —
-				// nothing new to persist, and persisting it would be premature.
-				return nil
-			}
-			return b.cacheSCN(ctx, *scn)
-		},
+		return nil, fmt.Errorf("tracking SCN checkpoint for batch: %w", err)
 	}
 	if isSnapshotBatch {
 		b.snapshotAckWG.Add(1)
 	}
+	return &trackedBatch{
+		isSnapshot: isSnapshotBatch,
+		msg: asyncMessage{
+			msg: batch,
+			ackFn: func(ctx context.Context, _ error) error {
+				if isSnapshotBatch {
+					defer b.snapshotAckWG.Done()
+				}
+				scn := resolveFn()
+				if scn == nil || !scn.IsValid() {
+					return nil
+				}
+				if isSnapshotBatch && *scn <= checkpointSCN {
+					// Resolved value is this snapshot batch's own shared SCN (or older) —
+					// nothing new to persist, and persisting it would be premature.
+					return nil
+				}
+				return b.cacheSCN(ctx, *scn)
+			},
+		},
+	}, nil
+}
+
+// sendTracked hands a tracked batch to ReadBatch. Must be called WITHOUT
+// batcherMu held (the send blocks until consumed). A failed send releases the
+// batch's snapshot-gate slot.
+func (b *batchPublisher) sendTracked(ctx context.Context, tracked *trackedBatch) error {
 	select {
-	case b.msgChan <- msg:
+	case b.msgChan <- tracked.msg:
 		return nil
 	case <-ctx.Done():
-		if isSnapshotBatch {
+		if tracked.isSnapshot {
 			b.snapshotAckWG.Done()
 		}
 		return ctx.Err()
@@ -330,13 +383,17 @@ func (b *batchPublisher) flushCurrent(ctx context.Context) error {
 	if b.batcher == nil {
 		return nil
 	}
+	var tracked *trackedBatch
 	b.batcherMu.Lock()
 	remaining, err := b.batcher.Flush(ctx)
+	if err == nil && len(remaining) > 0 {
+		tracked, err = b.trackBatchLocked(ctx, remaining)
+	}
 	b.batcherMu.Unlock()
-	if err != nil || len(remaining) == 0 {
+	if err != nil || tracked == nil {
 		return err
 	}
-	return b.publishBatch(ctx, remaining)
+	return b.sendTracked(ctx, tracked)
 }
 
 // FlushRemaining stops the loop goroutine and then flushes any partial batch

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -38,6 +38,11 @@ type batchPublisher struct {
 	// acknowledged downstream. The snapshot->streaming handoff blocks on it so
 	// the post-snapshot SCN is never persisted while snapshot rows are in flight.
 	snapshotAckWG sync.WaitGroup
+	// snapshotNackErr records the first snapshot batch nack. auto_replay_nacks
+	// is user-toggleable, so a nack can be terminal: the gate must fail rather
+	// than let the post-snapshot SCN persist over undelivered rows.
+	snapshotNackMu  sync.Mutex
+	snapshotNackErr error
 
 	log     *service.Logger
 	shutSig *shutdown.Signaller
@@ -94,7 +99,7 @@ func (p *batchPublisher) loop() {
 		flushBatch = flushBatchTicker.C
 	}
 
-	// hardStopCtx survives a soft stop so that an in-flight publishBatch send can
+	// hardStopCtx survives a soft stop so that an in-flight sendTracked send can
 	// complete before the loop exits. Only a hard stop (triggered by Close)
 	// cancels it, which is the forced-shutdown last resort.
 	hardStopCtx, done := p.shutSig.HardStopCtx(context.Background())
@@ -246,23 +251,6 @@ type trackedBatch struct {
 	isSnapshot bool
 }
 
-// publishBatch tracks and sends a batch that was flushed elsewhere. Callers
-// that flush the batcher themselves must instead track under the same lock as
-// their flush (see Publish/loop/flushCurrent) to keep Track order == flush
-// order.
-func (b *batchPublisher) publishBatch(ctx context.Context, batch service.MessageBatch) error {
-	if len(batch) == 0 {
-		return nil
-	}
-	b.batcherMu.Lock()
-	tracked, err := b.trackBatchLocked(ctx, batch)
-	b.batcherMu.Unlock()
-	if err != nil {
-		return err
-	}
-	return b.sendTracked(ctx, tracked)
-}
-
 // trackBatchLocked registers the batch with the ordered checkpoint tracker and
 // builds its ack function. It MUST be called with batcherMu held: Track order
 // defines the checkpoint sequence, so it has to match flush order exactly.
@@ -304,9 +292,20 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 		isSnapshot: isSnapshotBatch,
 		msg: asyncMessage{
 			msg: batch,
-			ackFn: func(ctx context.Context, _ error) error {
+			ackFn: func(ctx context.Context, err error) error {
 				if isSnapshotBatch {
 					defer b.snapshotAckWG.Done()
+				}
+				if err != nil {
+					// auto_replay_nacks is user-toggleable, so a nack can be
+					// terminal. Never resolve: the checkpoint stays pinned
+					// before this batch so nothing can be persisted past its
+					// undelivered rows. Snapshot nacks additionally fail the
+					// handoff gate so the post-snapshot SCN is not persisted.
+					if isSnapshotBatch {
+						b.recordSnapshotNack(err)
+					}
+					return err
 				}
 				scn := resolveFn()
 				if scn == nil || !scn.IsValid() {
@@ -321,6 +320,26 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 			},
 		},
 	}, nil
+}
+
+func (b *batchPublisher) recordSnapshotNack(err error) {
+	b.snapshotNackMu.Lock()
+	defer b.snapshotNackMu.Unlock()
+	if b.snapshotNackErr == nil {
+		b.snapshotNackErr = err
+	}
+}
+
+// resetSnapshotGate clears any nack recorded by a previous snapshot attempt so
+// the gate reflects only the current run: the publisher outlives reconnects,
+// and a stale error would fail every retry even after a clean re-run. The
+// WaitGroup is deliberately left untouched — batches from a previous attempt
+// that are still in flight can yet be acked or nacked, and both must keep
+// counting.
+func (b *batchPublisher) resetSnapshotGate() {
+	b.snapshotNackMu.Lock()
+	defer b.snapshotNackMu.Unlock()
+	b.snapshotNackErr = nil
 }
 
 // sendTracked hands a tracked batch to ReadBatch. Must be called WITHOUT
@@ -339,10 +358,10 @@ func (b *batchPublisher) sendTracked(ctx context.Context, tracked *trackedBatch)
 }
 
 // waitSnapshotAcks blocks until every published snapshot batch has been
-// acknowledged (or nacked) downstream, or until ctx is cancelled. Nacked
-// batches release the gate too: redelivery is owned by auto_replay_nacks,
-// and the ctx escape prevents a permanently-failing downstream from
-// wedging shutdown.
+// acknowledged or nacked downstream, or until ctx is cancelled (the escape
+// prevents a stalled downstream from wedging shutdown). Any nack fails the
+// gate: with auto_replay_nacks disabled a nack is terminal, so the
+// post-snapshot SCN must not be persisted and the snapshot must re-run.
 func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
 	drained := make(chan struct{})
 	go func() {
@@ -352,6 +371,11 @@ func (b *batchPublisher) waitSnapshotAcks(ctx context.Context) error {
 	}()
 	select {
 	case <-drained:
+		b.snapshotNackMu.Lock()
+		defer b.snapshotNackMu.Unlock()
+		if b.snapshotNackErr != nil {
+			return fmt.Errorf("snapshot batch was rejected downstream: %w", b.snapshotNackErr)
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -408,7 +432,7 @@ func (b *batchPublisher) FlushRemaining(ctx context.Context) error {
 }
 
 // Close signals the publisher's loop goroutine to stop and waits for it to exit.
-// TriggerHardStop cancels the HardStopCtx used by publishBatch, unblocking any
+// TriggerHardStop cancels the HardStopCtx used by the flush loop, unblocking any
 // send that is waiting on msgChan when no consumer is left.
 func (b *batchPublisher) Close() {
 	b.shutSig.TriggerSoftStop()

--- a/internal/impl/oracledb/batcher.go
+++ b/internal/impl/oracledb/batcher.go
@@ -305,6 +305,7 @@ func (b *batchPublisher) trackBatchLocked(ctx context.Context, batch service.Mes
 					if isSnapshotBatch {
 						b.recordSnapshotNack(err)
 					}
+					b.log.Errorf("Batch rejected downstream (snapshot=%v, checkpoint SCN %d): the checkpoint is now pinned before this batch and the input will stall once checkpoint_limit is reached, unless the batch is redelivered (auto_replay_nacks) or the pipeline restarts: %v", isSnapshotBatch, checkpointSCN, err)
 					return err
 				}
 				scn := resolveFn()

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -91,20 +90,22 @@ func TestPublishBatch(t *testing.T) {
 		require.Equal(t, replication.SCN(200), scns[0], "expected the streaming batch's SCN to survive the out-of-order snapshot ack")
 	})
 
-	t.Run("a nacked batch pins the checkpoint", func(t *testing.T) {
+	t.Run("a nack resolves too: auto_replay_nacks off is an opt-in drop", func(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
 		b1 := publishAndReceive(t, ctx, publisher, streamingEvent(200))
 		b2 := publishAndReceive(t, ctx, publisher, streamingEvent(300))
 
-		// Nack b1: with auto_replay_nacks disabled this is terminal, so b2's
-		// ack must not persist anything past the undelivered b1.
-		nackErr := errors.New("downstream failure")
-		require.ErrorIs(t, b1.ackFn(ctx, nackErr), nackErr)
+		// A nacked batch is deleted per the auto_replay_nacks contract: its
+		// slot resolves so the stream continues past it instead of pinning
+		// the tracker and back-pressuring forever.
+		require.NoError(t, b1.ackFn(ctx, errors.New("downstream failure")))
 		require.NoError(t, b2.ackFn(ctx, nil))
 
-		require.Empty(t, cachedSCNs(), "a checkpoint must never be persisted past a nacked batch")
+		scns := cachedSCNs()
+		require.NotEmpty(t, scns, "the checkpoint must continue advancing past a dropped batch")
+		require.Equal(t, replication.SCN(300), scns[len(scns)-1])
 	})
 }
 
@@ -133,20 +134,15 @@ func TestSnapshotAckGate(t *testing.T) {
 		}
 	})
 
-	t.Run("a nack releases the gate but fails it", func(t *testing.T) {
+	t.Run("a nack also releases the gate", func(t *testing.T) {
 		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
+		publisher, _ := newTestBatchPublisher(t)
 
 		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		nackErr := errors.New("downstream failure")
-		require.ErrorIs(t, msg.ackFn(ctx, nackErr), nackErr)
-
-		// auto_replay_nacks is user-toggleable, so a nack can be terminal:
-		// the gate must report it so the post-snapshot SCN is not persisted
-		// and the snapshot re-runs on restart.
-		err := publisher.waitSnapshotAcks(ctx)
-		require.ErrorIs(t, err, nackErr)
-		require.Empty(t, cachedSCNs())
+		// Nacks count as settled: replay is owned by auto_replay_nacks, and
+		// disabling it is a documented opt-in to drop rejections.
+		require.NoError(t, msg.ackFn(ctx, errors.New("downstream failure")))
+		require.NoError(t, publisher.waitSnapshotAcks(ctx))
 	})
 
 	t.Run("streaming batches do not hold the gate", func(t *testing.T) {
@@ -157,26 +153,6 @@ func TestSnapshotAckGate(t *testing.T) {
 		publishAndReceive(t, ctx, publisher, streamingEvent(200))
 
 		require.NoError(t, publisher.waitSnapshotAcks(ctx))
-	})
-
-	t.Run("a nack fails only the snapshot attempt it belongs to", func(t *testing.T) {
-		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
-
-		// Run 1: a snapshot batch is nacked; the gate fails.
-		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		nackErr := errors.New("downstream failure")
-		require.ErrorIs(t, msg.ackFn(ctx, nackErr), nackErr)
-		require.ErrorIs(t, publisher.waitSnapshotAcks(ctx), nackErr)
-
-		// Run 2 (reconnect reuses the publisher): the gate is reset, the
-		// re-run snapshot acks cleanly, and the gate must pass — a stale
-		// run-1 error here would livelock the input re-snapshotting forever.
-		publisher.resetSnapshotGate()
-		msg2 := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		require.NoError(t, msg2.ackFn(ctx, nil))
-		require.NoError(t, publisher.waitSnapshotAcks(ctx))
-		require.Empty(t, cachedSCNs())
 	})
 
 	t.Run("context cancellation escapes the gate", func(t *testing.T) {
@@ -229,44 +205,6 @@ func TestFlushCurrent(t *testing.T) {
 	// a second publish+flush must work identically.
 	publishEvent(2)
 	receive("publisher loop no longer functional after flushCurrent")
-}
-
-func TestTerminalNack(t *testing.T) {
-	t.Run("invokes onTerminalNack so the input can restart", func(t *testing.T) {
-		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
-
-		var got atomic.Value
-		publisher.onTerminalNack = func(err error) { got.Store(err) }
-
-		am := publishAndReceive(t, ctx, publisher, streamingEvent(200))
-		nackErr := errors.New("downstream failure")
-		require.ErrorIs(t, am.ackFn(ctx, nackErr), nackErr)
-
-		stored, _ := got.Load().(error)
-		require.ErrorIs(t, stored, nackErr)
-		require.Empty(t, cachedSCNs())
-	})
-
-	t.Run("a sealed publisher neither persists nor restarts", func(t *testing.T) {
-		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
-
-		restarted := false
-		publisher.onTerminalNack = func(error) { restarted = true }
-
-		am1 := publishAndReceive(t, ctx, publisher, streamingEvent(200))
-		am2 := publishAndReceive(t, ctx, publisher, streamingEvent(300))
-		publisher.seal()
-
-		// Late ack from a replaced session: must not persist.
-		require.NoError(t, am1.ackFn(ctx, nil))
-		require.Empty(t, cachedSCNs(), "a sealed publisher must not persist checkpoints")
-
-		// Late nack: must not trigger a restart of the new session.
-		require.Error(t, am2.ackFn(ctx, errors.New("late failure")))
-		require.False(t, restarted, "a sealed publisher must not trigger restarts")
-	})
 }
 
 // TestTrackOrderUnderConcurrentFlush stresses the two concurrent flushers (the

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -193,6 +193,79 @@ func TestFlushCurrent(t *testing.T) {
 	receive("publisher loop no longer functional after flushCurrent")
 }
 
+// TestTrackOrderUnderConcurrentFlush stresses the two concurrent flushers (the
+// count-triggered flush in Publish and the timed-flush loop) and asserts the
+// persisted checkpoint never regresses when batches are acked in delivery
+// order. Before Track was moved under the batcher mutex, the two flushers
+// could interleave between flush and Track, registering batches with the
+// ordered tracker in the wrong order and persisting a regressing SCN. Run with
+// -race to also catch the underlying data race structurally.
+func TestTrackOrderUnderConcurrentFlush(t *testing.T) {
+	ctx := t.Context()
+	logger := service.NewLoggerFromSlog(slog.Default())
+	cp := checkpoint.NewCapped[replication.SCN](1000)
+
+	// Count 2 + a tiny period keeps both flush paths active concurrently.
+	batcher, err := (service.BatchPolicy{Count: 2, Period: "1ms"}).NewBatcher(service.MockResources())
+	require.NoError(t, err)
+
+	publisher := newBatchPublisher(batcher, cp, logger)
+	t.Cleanup(publisher.Close)
+
+	var (
+		mu        sync.Mutex
+		persisted []replication.SCN
+	)
+	publisher.cacheSCN = func(_ context.Context, scn replication.SCN) error {
+		mu.Lock()
+		defer mu.Unlock()
+		persisted = append(persisted, scn)
+		return nil
+	}
+
+	// Consumer: ack every batch immediately, in delivery order.
+	consumerDone := make(chan struct{})
+	consumerCtx, stopConsumer := context.WithCancel(ctx)
+	go func() {
+		defer close(consumerDone)
+		for {
+			select {
+			case m := <-publisher.msgs():
+				_ = m.ackFn(ctx, nil)
+			case <-consumerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	const events = 500
+	for i := range events {
+		require.NoError(t, publisher.Publish(ctx, &replication.MessageEvent{
+			Schema:        "S",
+			Table:         "T",
+			Operation:     replication.MessageOperationInsert,
+			CheckpointSCN: replication.SCN(i + 1),
+			Data:          map[string]any{"i": i},
+		}))
+	}
+	require.NoError(t, publisher.flushCurrent(ctx))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(persisted) > 0 && persisted[len(persisted)-1] == replication.SCN(events)
+	}, 10*time.Second, 10*time.Millisecond, "final SCN was never persisted")
+	stopConsumer()
+	<-consumerDone
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i < len(persisted); i++ {
+		require.GreaterOrEqual(t, persisted[i], persisted[i-1],
+			"persisted checkpoint regressed at index %d: %v", i, persisted)
+	}
+}
+
 func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {
 	t.Helper()
 

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -148,6 +148,51 @@ func TestSnapshotAckGate(t *testing.T) {
 	})
 }
 
+func TestFlushCurrent(t *testing.T) {
+	ctx := t.Context()
+	logger := service.NewLoggerFromSlog(slog.Default())
+	cp := checkpoint.NewCapped[replication.SCN](100)
+
+	batcher, err := (service.BatchPolicy{Count: 100}).NewBatcher(service.MockResources())
+	require.NoError(t, err)
+
+	publisher := newBatchPublisher(batcher, cp, logger)
+	t.Cleanup(publisher.Close)
+	publisher.cacheSCN = func(context.Context, replication.SCN) error { return nil }
+
+	publishEvent := func(v int) {
+		t.Helper()
+		require.NoError(t, publisher.Publish(ctx, &replication.MessageEvent{
+			Schema:    "S",
+			Table:     "T",
+			Operation: replication.MessageOperationRead,
+			Data:      map[string]any{"a": v},
+			SCN:       replication.SCN(100),
+		}))
+	}
+	receive := func(failMsg string) {
+		t.Helper()
+		got := make(chan asyncMessage, 1)
+		go func() { got <- <-publisher.msgs() }()
+		require.NoError(t, publisher.flushCurrent(ctx))
+		select {
+		case m := <-got:
+			require.Len(t, m.msg, 1)
+		case <-time.After(5 * time.Second):
+			t.Fatal(failMsg)
+		}
+	}
+
+	// Count=100 keeps a single event buffered in the batcher until flushed.
+	publishEvent(1)
+	receive("flushCurrent did not publish the buffered partial batch")
+
+	// The loop must still be alive after flushCurrent (unlike FlushRemaining):
+	// a second publish+flush must work identically.
+	publishEvent(2)
+	receive("publisher loop no longer functional after flushCurrent")
+}
+
 func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {
 	t.Helper()
 

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -23,22 +23,8 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/oracledb/replication"
 )
 
-func TestPublishBatch(t *testing.T) {
-	t.Run("snapshot batches never persist via ackFn", func(t *testing.T) {
-		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
-
-		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		msg1 := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-
-		require.NoError(t, msg.ackFn(ctx, nil))
-		require.Empty(t, cachedSCNs(), "cacheSCN must not be called after acking only the first snapshot batch")
-
-		require.NoError(t, msg1.ackFn(ctx, nil))
-		require.Empty(t, cachedSCNs(), "cacheSCN must not be called after acking all snapshot batches")
-	})
-
-	t.Run("streaming batch still persists via ackFn", func(t *testing.T) {
+func TestPublish(t *testing.T) {
+	t.Run("streaming batch persists via ackFn", func(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
@@ -50,44 +36,20 @@ func TestPublishBatch(t *testing.T) {
 		require.Equal(t, replication.SCN(200), scns[0])
 	})
 
-	t.Run("mixed snapshot and streaming batch persists", func(t *testing.T) {
-		ctx := t.Context()
-		// Count=2 groups the snapshot and streaming events into one batch.
-		publisher, cachedSCNs := newTestBatchPublisherWithCount(t, 2)
-
-		got := make(chan asyncMessage, 1)
-		go func() { got <- <-publisher.msgs() }()
-		require.NoError(t, publisher.Publish(ctx, snapshotEvent(100)))
-		require.NoError(t, publisher.Publish(ctx, streamingEvent(300)))
-
-		var msg asyncMessage
-		select {
-		case msg = <-got:
-			require.Len(t, msg.msg, 2)
-		case <-time.After(5 * time.Second):
-			t.Fatal("mixed batch was never published")
-		}
-		require.NoError(t, msg.ackFn(ctx, nil))
-
-		scns := cachedSCNs()
-		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once for a batch whose last message is streaming")
-		require.Equal(t, replication.SCN(300), scns[0], "expected the streaming SCN from the last message, not the leftover snapshot SCN")
-	})
-
-	t.Run("streaming SCN survives an out-of-order snapshot ack", func(t *testing.T) {
+	t.Run("SCN persists in delivery order regardless of ack order", func(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		snapshotMsg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		streamingMsg := publishAndReceive(t, ctx, publisher, streamingEvent(200))
+		first := publishAndReceive(t, ctx, publisher, streamingEvent(100))
+		second := publishAndReceive(t, ctx, publisher, streamingEvent(200))
 
-		require.NoError(t, streamingMsg.ackFn(ctx, nil))
-		require.Empty(t, cachedSCNs(), "cacheSCN must not be called while the snapshot batch is still the unresolved head")
-		require.NoError(t, snapshotMsg.ackFn(ctx, nil))
+		require.NoError(t, second.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "cacheSCN must not be called while an earlier batch is still the unresolved head")
 
+		require.NoError(t, first.ackFn(ctx, nil))
 		scns := cachedSCNs()
-		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once when the snapshot batch resolves the streaming SCN")
-		require.Equal(t, replication.SCN(200), scns[0], "expected the streaming batch's SCN to survive the out-of-order snapshot ack")
+		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once once the head resolves")
+		require.Equal(t, replication.SCN(200), scns[0], "expected the later batch's SCN to survive the out-of-order ack")
 	})
 
 	t.Run("a nack resolves too: auto_replay_nacks off is an opt-in drop", func(t *testing.T) {
@@ -109,87 +71,61 @@ func TestPublishBatch(t *testing.T) {
 	})
 }
 
-func TestSnapshotAckGate(t *testing.T) {
-	t.Run("blocks until the snapshot batch is acked", func(t *testing.T) {
+func TestPublishSnapshot(t *testing.T) {
+	t.Run("snapshot batches never persist via ackFn", func(t *testing.T) {
 		ctx := t.Context()
-		publisher, _ := newTestBatchPublisher(t)
+		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-
-		done := make(chan error, 1)
-		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
-
-		select {
-		case err := <-done:
-			t.Fatalf("waitSnapshotAcks returned before the snapshot batch was acked: %v", err)
-		case <-time.After(100 * time.Millisecond):
-		}
+		msg := publishSnapshotAndReceive(t, ctx, publisher, snapshotEvent(100))
+		msg1 := publishSnapshotAndReceive(t, ctx, publisher, snapshotEvent(100))
 
 		require.NoError(t, msg.ackFn(ctx, nil))
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-		case <-time.After(5 * time.Second):
-			t.Fatal("waitSnapshotAcks did not return after the snapshot batch was acked")
-		}
+		require.NoError(t, msg1.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "cacheSCN must never be called for a snapshot batch: SnapshotComplete owns persisting the post-snapshot SCN")
 	})
 
-	t.Run("a nack also releases the gate", func(t *testing.T) {
+	t.Run("a nack is also a no-op: replay is owned by AutoRetryNacksBatched", func(t *testing.T) {
 		ctx := t.Context()
-		publisher, _ := newTestBatchPublisher(t)
+		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-		// Nacks count as settled: replay is owned by auto_replay_nacks, and
-		// disabling it is a documented opt-in to drop rejections.
+		msg := publishSnapshotAndReceive(t, ctx, publisher, snapshotEvent(100))
 		require.NoError(t, msg.ackFn(ctx, errors.New("downstream failure")))
-		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+		require.Empty(t, cachedSCNs())
 	})
 
-	t.Run("streaming batches do not hold the gate", func(t *testing.T) {
+	t.Run("streaming batches are delivered separately from snapshot batches", func(t *testing.T) {
 		ctx := t.Context()
 		publisher, _ := newTestBatchPublisher(t)
 
-		// Published but never acked: must not block the gate.
-		publishAndReceive(t, ctx, publisher, streamingEvent(200))
-
-		require.NoError(t, publisher.waitSnapshotAcks(ctx))
-	})
-
-	t.Run("context cancellation escapes the gate", func(t *testing.T) {
-		publisher, _ := newTestBatchPublisher(t)
-
-		ctx, cancel := context.WithCancel(t.Context())
-		publishAndReceive(t, ctx, publisher, snapshotEvent(100))
-
-		done := make(chan error, 1)
-		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
-		cancel()
-
+		go func() { _ = publisher.Publish(ctx, streamingEvent(200)) }()
 		select {
-		case err := <-done:
-			require.ErrorIs(t, err, context.Canceled)
+		case <-publisher.snapshotMsgs():
+			t.Fatal("a streaming batch must never be delivered on the snapshot channel")
+		case m := <-publisher.msgs():
+			require.Len(t, m.msg, 1)
 		case <-time.After(5 * time.Second):
-			t.Fatal("waitSnapshotAcks did not return after context cancellation")
+			t.Fatal("streaming batch was never published")
 		}
 	})
 }
 
-func TestFlushCurrent(t *testing.T) {
+func TestFlushSnapshotRemaining(t *testing.T) {
 	ctx := t.Context()
-	// Count=100 keeps published events buffered in the batcher until flushed.
+	// Count=100 keeps published events buffered in the snapshot batcher
+	// until explicitly flushed.
 	publisher, _ := newTestBatchPublisherWithCount(t, 100)
 
 	publishEvent := func(v int) {
 		t.Helper()
 		e := snapshotEvent(100)
 		e.Data = map[string]any{"a": v}
-		require.NoError(t, publisher.Publish(ctx, e))
+		require.NoError(t, publisher.PublishSnapshot(ctx, e))
 	}
 	receive := func(failMsg string) {
 		t.Helper()
 		got := make(chan asyncMessage, 1)
-		go func() { got <- <-publisher.msgs() }()
-		require.NoError(t, publisher.flushCurrent(ctx))
+		go func() { got <- <-publisher.snapshotMsgs() }()
+		require.NoError(t, publisher.flushSnapshotRemaining(ctx))
 		select {
 		case m := <-got:
 			require.Len(t, m.msg, 1)
@@ -199,12 +135,12 @@ func TestFlushCurrent(t *testing.T) {
 	}
 
 	publishEvent(1)
-	receive("flushCurrent did not publish the buffered partial batch")
+	receive("flushSnapshotRemaining did not publish the buffered partial batch")
 
-	// The loop must still be alive after flushCurrent (unlike FlushRemaining):
-	// a second publish+flush must work identically.
+	// The loop and snapshot batcher must still be usable afterwards: a
+	// second publish+flush must work identically.
 	publishEvent(2)
-	receive("publisher loop no longer functional after flushCurrent")
+	receive("snapshot batcher no longer functional after flushSnapshotRemaining")
 }
 
 // TestTrackOrderUnderConcurrentFlush stresses the two concurrent flushers (the
@@ -220,10 +156,13 @@ func TestTrackOrderUnderConcurrentFlush(t *testing.T) {
 	cp := checkpoint.NewCapped[replication.SCN](1000)
 
 	// Count 2 + a tiny period keeps both flush paths active concurrently.
-	batcher, err := (service.BatchPolicy{Count: 2, Period: "1ms"}).NewBatcher(service.MockResources())
+	policy := service.BatchPolicy{Count: 2, Period: "1ms"}
+	batcher, err := policy.NewBatcher(service.MockResources())
+	require.NoError(t, err)
+	snapshotBatcher, err := policy.NewBatcher(service.MockResources())
 	require.NoError(t, err)
 
-	publisher := newBatchPublisher(batcher, cp, logger)
+	publisher := newBatchPublisher(batcher, snapshotBatcher, cp, logger)
 	t.Cleanup(publisher.Close)
 
 	var (
@@ -262,7 +201,6 @@ func TestTrackOrderUnderConcurrentFlush(t *testing.T) {
 			Data:          map[string]any{"i": i},
 		}))
 	}
-	require.NoError(t, publisher.flushCurrent(ctx))
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -280,9 +218,9 @@ func TestTrackOrderUnderConcurrentFlush(t *testing.T) {
 	}
 }
 
-// newTestBatchPublisher builds a publisher whose batcher flushes on every
+// newTestBatchPublisher builds a publisher whose batchers flush on every
 // published event (count=1), so tests drive the production
-// Publish->trackBatchLocked->sendTracked path directly.
+// Publish/PublishSnapshot->trackBatchLocked->send path directly.
 func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {
 	t.Helper()
 	return newTestBatchPublisherWithCount(t, 1)
@@ -294,10 +232,13 @@ func newTestBatchPublisherWithCount(t *testing.T, count int) (*batchPublisher, f
 	logger := service.NewLoggerFromSlog(slog.Default())
 	cp := checkpoint.NewCapped[replication.SCN](100)
 
-	batcher, err := (service.BatchPolicy{Count: count}).NewBatcher(service.MockResources())
+	policy := service.BatchPolicy{Count: count}
+	batcher, err := policy.NewBatcher(service.MockResources())
+	require.NoError(t, err)
+	snapshotBatcher, err := policy.NewBatcher(service.MockResources())
 	require.NoError(t, err)
 
-	publisher := newBatchPublisher(batcher, cp, logger)
+	publisher := newBatchPublisher(batcher, snapshotBatcher, cp, logger)
 	t.Cleanup(publisher.Close)
 
 	var (
@@ -340,13 +281,24 @@ func streamingEvent(checkpointSCN replication.SCN) *replication.MessageEvent {
 	}
 }
 
-// publishAndReceive publishes a single event through the production Publish
-// path (count=1 batcher: every event flushes, tracks, and sends immediately)
-// and returns the delivered asyncMessage.
+// publishAndReceive publishes a single streaming event through the
+// production Publish path (count=1 batcher: every event flushes, tracks, and
+// sends immediately) and returns the delivered asyncMessage.
 func publishAndReceive(t *testing.T, ctx context.Context, publisher *batchPublisher, event *replication.MessageEvent) asyncMessage {
 	t.Helper()
 	go func() {
 		_ = publisher.Publish(ctx, event)
 	}()
 	return <-publisher.msgs()
+}
+
+// publishSnapshotAndReceive is publishAndReceive's snapshot-phase
+// counterpart: it drives the production PublishSnapshot path and returns
+// the delivered asyncMessage from the snapshot channel.
+func publishSnapshotAndReceive(t *testing.T, ctx context.Context, publisher *batchPublisher, event *replication.MessageEvent) asyncMessage {
+	t.Helper()
+	go func() {
+		_ = publisher.PublishSnapshot(ctx, event)
+	}()
+	return <-publisher.snapshotMsgs()
 }

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -228,6 +229,44 @@ func TestFlushCurrent(t *testing.T) {
 	// a second publish+flush must work identically.
 	publishEvent(2)
 	receive("publisher loop no longer functional after flushCurrent")
+}
+
+func TestTerminalNack(t *testing.T) {
+	t.Run("invokes onTerminalNack so the input can restart", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		var got atomic.Value
+		publisher.onTerminalNack = func(err error) { got.Store(err) }
+
+		am := publishAndReceive(t, ctx, publisher, streamingEvent(200))
+		nackErr := errors.New("downstream failure")
+		require.ErrorIs(t, am.ackFn(ctx, nackErr), nackErr)
+
+		stored, _ := got.Load().(error)
+		require.ErrorIs(t, stored, nackErr)
+		require.Empty(t, cachedSCNs())
+	})
+
+	t.Run("a sealed publisher neither persists nor restarts", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		restarted := false
+		publisher.onTerminalNack = func(error) { restarted = true }
+
+		am1 := publishAndReceive(t, ctx, publisher, streamingEvent(200))
+		am2 := publishAndReceive(t, ctx, publisher, streamingEvent(300))
+		publisher.seal()
+
+		// Late ack from a replaced session: must not persist.
+		require.NoError(t, am1.ackFn(ctx, nil))
+		require.Empty(t, cachedSCNs(), "a sealed publisher must not persist checkpoints")
+
+		// Late nack: must not trigger a restart of the new session.
+		require.Error(t, am2.ackFn(ctx, errors.New("late failure")))
+		require.False(t, restarted, "a sealed publisher must not trigger restarts")
+	})
 }
 
 // TestTrackOrderUnderConcurrentFlush stresses the two concurrent flushers (the

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -10,9 +10,11 @@ package oracledb
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Jeffail/checkpoint"
 	"github.com/stretchr/testify/require"
@@ -79,6 +81,70 @@ func TestPublishBatch(t *testing.T) {
 		scns := cachedSCNs()
 		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once when the snapshot batch resolves the streaming SCN")
 		require.Equal(t, replication.SCN(200), scns[0], "expected the streaming batch's SCN to survive the out-of-order snapshot ack")
+	})
+}
+
+func TestSnapshotAckGate(t *testing.T) {
+	t.Run("blocks until the snapshot batch is acked", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, _ := newTestBatchPublisher(t)
+
+		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+
+		done := make(chan error, 1)
+		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
+
+		select {
+		case err := <-done:
+			t.Fatalf("waitSnapshotAcks returned before the snapshot batch was acked: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		require.NoError(t, msg.ackFn(ctx, nil))
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("waitSnapshotAcks did not return after the snapshot batch was acked")
+		}
+	})
+
+	t.Run("a nack also releases the gate", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, _ := newTestBatchPublisher(t)
+
+		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		require.NoError(t, msg.ackFn(ctx, errors.New("downstream failure")))
+
+		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+	})
+
+	t.Run("streaming batches do not hold the gate", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, _ := newTestBatchPublisher(t)
+
+		// Published but never acked: must not block the gate.
+		publishAndReceive(t, ctx, publisher, service.MessageBatch{newStreamingMessage("200")})
+
+		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+	})
+
+	t.Run("context cancellation escapes the gate", func(t *testing.T) {
+		publisher, _ := newTestBatchPublisher(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+
+		done := make(chan error, 1)
+		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
+		cancel()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("waitSnapshotAcks did not return after context cancellation")
+		}
 	})
 }
 

--- a/internal/impl/oracledb/batcher_test.go
+++ b/internal/impl/oracledb/batcher_test.go
@@ -28,8 +28,8 @@ func TestPublishBatch(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
-		msg1 := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
+		msg1 := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
 
 		require.NoError(t, msg.ackFn(ctx, nil))
 		require.Empty(t, cachedSCNs(), "cacheSCN must not be called after acking only the first snapshot batch")
@@ -42,8 +42,7 @@ func TestPublishBatch(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		batch := service.MessageBatch{newStreamingMessage("200")}
-		msg := publishAndReceive(t, ctx, publisher, batch)
+		msg := publishAndReceive(t, ctx, publisher, streamingEvent(200))
 		require.NoError(t, msg.ackFn(ctx, nil))
 
 		scns := cachedSCNs()
@@ -53,13 +52,21 @@ func TestPublishBatch(t *testing.T) {
 
 	t.Run("mixed snapshot and streaming batch persists", func(t *testing.T) {
 		ctx := t.Context()
-		publisher, cachedSCNs := newTestBatchPublisher(t)
+		// Count=2 groups the snapshot and streaming events into one batch.
+		publisher, cachedSCNs := newTestBatchPublisherWithCount(t, 2)
 
-		batch := service.MessageBatch{
-			newSnapshotMessage("100"),
-			newStreamingMessage("300"),
+		got := make(chan asyncMessage, 1)
+		go func() { got <- <-publisher.msgs() }()
+		require.NoError(t, publisher.Publish(ctx, snapshotEvent(100)))
+		require.NoError(t, publisher.Publish(ctx, streamingEvent(300)))
+
+		var msg asyncMessage
+		select {
+		case msg = <-got:
+			require.Len(t, msg.msg, 2)
+		case <-time.After(5 * time.Second):
+			t.Fatal("mixed batch was never published")
 		}
-		msg := publishAndReceive(t, ctx, publisher, batch)
 		require.NoError(t, msg.ackFn(ctx, nil))
 
 		scns := cachedSCNs()
@@ -71,8 +78,8 @@ func TestPublishBatch(t *testing.T) {
 		ctx := t.Context()
 		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		snapshotMsg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
-		streamingMsg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newStreamingMessage("200")})
+		snapshotMsg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
+		streamingMsg := publishAndReceive(t, ctx, publisher, streamingEvent(200))
 
 		require.NoError(t, streamingMsg.ackFn(ctx, nil))
 		require.Empty(t, cachedSCNs(), "cacheSCN must not be called while the snapshot batch is still the unresolved head")
@@ -82,6 +89,22 @@ func TestPublishBatch(t *testing.T) {
 		require.Len(t, scns, 1, "expected cacheSCN to be called exactly once when the snapshot batch resolves the streaming SCN")
 		require.Equal(t, replication.SCN(200), scns[0], "expected the streaming batch's SCN to survive the out-of-order snapshot ack")
 	})
+
+	t.Run("a nacked batch pins the checkpoint", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		b1 := publishAndReceive(t, ctx, publisher, streamingEvent(200))
+		b2 := publishAndReceive(t, ctx, publisher, streamingEvent(300))
+
+		// Nack b1: with auto_replay_nacks disabled this is terminal, so b2's
+		// ack must not persist anything past the undelivered b1.
+		nackErr := errors.New("downstream failure")
+		require.ErrorIs(t, b1.ackFn(ctx, nackErr), nackErr)
+		require.NoError(t, b2.ackFn(ctx, nil))
+
+		require.Empty(t, cachedSCNs(), "a checkpoint must never be persisted past a nacked batch")
+	})
 }
 
 func TestSnapshotAckGate(t *testing.T) {
@@ -89,7 +112,7 @@ func TestSnapshotAckGate(t *testing.T) {
 		ctx := t.Context()
 		publisher, _ := newTestBatchPublisher(t)
 
-		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
 
 		done := make(chan error, 1)
 		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
@@ -109,14 +132,20 @@ func TestSnapshotAckGate(t *testing.T) {
 		}
 	})
 
-	t.Run("a nack also releases the gate", func(t *testing.T) {
+	t.Run("a nack releases the gate but fails it", func(t *testing.T) {
 		ctx := t.Context()
-		publisher, _ := newTestBatchPublisher(t)
+		publisher, cachedSCNs := newTestBatchPublisher(t)
 
-		msg := publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
-		require.NoError(t, msg.ackFn(ctx, errors.New("downstream failure")))
+		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
+		nackErr := errors.New("downstream failure")
+		require.ErrorIs(t, msg.ackFn(ctx, nackErr), nackErr)
 
-		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+		// auto_replay_nacks is user-toggleable, so a nack can be terminal:
+		// the gate must report it so the post-snapshot SCN is not persisted
+		// and the snapshot re-runs on restart.
+		err := publisher.waitSnapshotAcks(ctx)
+		require.ErrorIs(t, err, nackErr)
+		require.Empty(t, cachedSCNs())
 	})
 
 	t.Run("streaming batches do not hold the gate", func(t *testing.T) {
@@ -124,16 +153,36 @@ func TestSnapshotAckGate(t *testing.T) {
 		publisher, _ := newTestBatchPublisher(t)
 
 		// Published but never acked: must not block the gate.
-		publishAndReceive(t, ctx, publisher, service.MessageBatch{newStreamingMessage("200")})
+		publishAndReceive(t, ctx, publisher, streamingEvent(200))
 
 		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+	})
+
+	t.Run("a nack fails only the snapshot attempt it belongs to", func(t *testing.T) {
+		ctx := t.Context()
+		publisher, cachedSCNs := newTestBatchPublisher(t)
+
+		// Run 1: a snapshot batch is nacked; the gate fails.
+		msg := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
+		nackErr := errors.New("downstream failure")
+		require.ErrorIs(t, msg.ackFn(ctx, nackErr), nackErr)
+		require.ErrorIs(t, publisher.waitSnapshotAcks(ctx), nackErr)
+
+		// Run 2 (reconnect reuses the publisher): the gate is reset, the
+		// re-run snapshot acks cleanly, and the gate must pass — a stale
+		// run-1 error here would livelock the input re-snapshotting forever.
+		publisher.resetSnapshotGate()
+		msg2 := publishAndReceive(t, ctx, publisher, snapshotEvent(100))
+		require.NoError(t, msg2.ackFn(ctx, nil))
+		require.NoError(t, publisher.waitSnapshotAcks(ctx))
+		require.Empty(t, cachedSCNs())
 	})
 
 	t.Run("context cancellation escapes the gate", func(t *testing.T) {
 		publisher, _ := newTestBatchPublisher(t)
 
 		ctx, cancel := context.WithCancel(t.Context())
-		publishAndReceive(t, ctx, publisher, service.MessageBatch{newSnapshotMessage("100")})
+		publishAndReceive(t, ctx, publisher, snapshotEvent(100))
 
 		done := make(chan error, 1)
 		go func() { done <- publisher.waitSnapshotAcks(ctx) }()
@@ -150,25 +199,14 @@ func TestSnapshotAckGate(t *testing.T) {
 
 func TestFlushCurrent(t *testing.T) {
 	ctx := t.Context()
-	logger := service.NewLoggerFromSlog(slog.Default())
-	cp := checkpoint.NewCapped[replication.SCN](100)
-
-	batcher, err := (service.BatchPolicy{Count: 100}).NewBatcher(service.MockResources())
-	require.NoError(t, err)
-
-	publisher := newBatchPublisher(batcher, cp, logger)
-	t.Cleanup(publisher.Close)
-	publisher.cacheSCN = func(context.Context, replication.SCN) error { return nil }
+	// Count=100 keeps published events buffered in the batcher until flushed.
+	publisher, _ := newTestBatchPublisherWithCount(t, 100)
 
 	publishEvent := func(v int) {
 		t.Helper()
-		require.NoError(t, publisher.Publish(ctx, &replication.MessageEvent{
-			Schema:    "S",
-			Table:     "T",
-			Operation: replication.MessageOperationRead,
-			Data:      map[string]any{"a": v},
-			SCN:       replication.SCN(100),
-		}))
+		e := snapshotEvent(100)
+		e.Data = map[string]any{"a": v}
+		require.NoError(t, publisher.Publish(ctx, e))
 	}
 	receive := func(failMsg string) {
 		t.Helper()
@@ -183,7 +221,6 @@ func TestFlushCurrent(t *testing.T) {
 		}
 	}
 
-	// Count=100 keeps a single event buffered in the batcher until flushed.
 	publishEvent(1)
 	receive("flushCurrent did not publish the buffered partial batch")
 
@@ -266,13 +303,24 @@ func TestTrackOrderUnderConcurrentFlush(t *testing.T) {
 	}
 }
 
+// newTestBatchPublisher builds a publisher whose batcher flushes on every
+// published event (count=1), so tests drive the production
+// Publish->trackBatchLocked->sendTracked path directly.
 func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.SCN) {
+	t.Helper()
+	return newTestBatchPublisherWithCount(t, 1)
+}
+
+func newTestBatchPublisherWithCount(t *testing.T, count int) (*batchPublisher, func() []replication.SCN) {
 	t.Helper()
 
 	logger := service.NewLoggerFromSlog(slog.Default())
 	cp := checkpoint.NewCapped[replication.SCN](100)
 
-	publisher := newBatchPublisher(nil, cp, logger)
+	batcher, err := (service.BatchPolicy{Count: count}).NewBatcher(service.MockResources())
+	require.NoError(t, err)
+
+	publisher := newBatchPublisher(batcher, cp, logger)
 	t.Cleanup(publisher.Close)
 
 	var (
@@ -295,24 +343,33 @@ func newTestBatchPublisher(t *testing.T) (*batchPublisher, func() []replication.
 	return publisher, cachedSCNsFn
 }
 
-func newSnapshotMessage(scn string) *service.Message {
-	msg := service.NewMessage([]byte("{}"))
-	msg.MetaSet("operation", replication.MessageOperationRead.String())
-	msg.MetaSet("scn", scn)
-	return msg
+func snapshotEvent(scn replication.SCN) *replication.MessageEvent {
+	return &replication.MessageEvent{
+		Schema:    "S",
+		Table:     "T",
+		Operation: replication.MessageOperationRead,
+		SCN:       scn,
+		Data:      map[string]any{"a": 1},
+	}
 }
 
-func newStreamingMessage(checkpointSCN string) *service.Message {
-	msg := service.NewMessage([]byte("{}"))
-	msg.MetaSet("operation", replication.MessageOperationInsert.String())
-	msg.MetaSet("checkpoint_scn", checkpointSCN)
-	return msg
+func streamingEvent(checkpointSCN replication.SCN) *replication.MessageEvent {
+	return &replication.MessageEvent{
+		Schema:        "S",
+		Table:         "T",
+		Operation:     replication.MessageOperationInsert,
+		CheckpointSCN: checkpointSCN,
+		Data:          map[string]any{"a": 1},
+	}
 }
 
-func publishAndReceive(t *testing.T, ctx context.Context, publisher *batchPublisher, batch service.MessageBatch) asyncMessage {
+// publishAndReceive publishes a single event through the production Publish
+// path (count=1 batcher: every event flushes, tracks, and sends immediately)
+// and returns the delivered asyncMessage.
+func publishAndReceive(t *testing.T, ctx context.Context, publisher *batchPublisher, event *replication.MessageEvent) asyncMessage {
 	t.Helper()
 	go func() {
-		_ = publisher.publishBatch(ctx, batch)
+		_ = publisher.Publish(ctx, event)
 	}()
 	return <-publisher.msgs()
 }

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -632,7 +632,11 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 				return
 			}
 			if err = o.publisher.waitSnapshotAcks(softCtx); err != nil {
-				o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
+				} else {
+					o.log.Errorf("Snapshot batch was rejected downstream. Snapshot will re-run on restart (may cause duplicate data): %s", err)
+				}
 				o.stopSig.TriggerHasStopped()
 				return
 			}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -607,6 +607,9 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {
+			// The publisher outlives reconnects: clear any nack recorded by a
+			// previous snapshot attempt so the gate judges only this run.
+			o.publisher.resetSnapshotGate()
 			if startSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					o.log.Infof("Snapshotting stopped: %s", err)

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -261,13 +261,6 @@ type oracleDBCDCInput struct {
 	publisher *batchPublisher
 	metrics   *service.Metrics
 
-	// batching and checkpointLimit rebuild the publisher (batcher + ordered
-	// checkpoint tracker) on every Connect: a terminal nack pins a tracker
-	// slot by design, and only a fresh tracker lets the restart resume from
-	// the last durable SCN instead of staying wedged behind the stale slot.
-	batching        service.BatchPolicy
-	checkpointLimit int
-
 	stopSig          *shutdown.Signaller
 	snapshotOnlyDone atomic.Bool
 	log              *service.Logger
@@ -410,15 +403,13 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 				Exclude: tableExcludes,
 			},
 		},
-		lmCfg:           lmCfg,
-		res:             resources,
-		log:             logger,
-		metrics:         resources.Metrics(),
-		stopSig:         shutdown.NewSignaller(),
-		publisher:       newBatchPublisher(batcher, cp, logger),
-		batching:        policy,
-		checkpointLimit: checkpointLimit,
-		cpCache:         cpCache,
+		lmCfg:     lmCfg,
+		res:       resources,
+		log:       logger,
+		metrics:   resources.Metrics(),
+		stopSig:   shutdown.NewSignaller(),
+		publisher: newBatchPublisher(batcher, cp, logger),
+		cpCache:   cpCache,
 	}
 
 	defer func() {
@@ -541,27 +532,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		}
 	}
 
-	// Rebuild the publisher (batcher + ordered checkpoint tracker) for this
-	// connection attempt. A terminal nack pins a tracker slot by design;
-	// reusing the old tracker would leave every future checkpoint stuck
-	// behind the stale slot, wedging the input for the process lifetime
-	// instead of letting this restart resume from the last durable SCN. The
-	// old publisher is sealed so late acks from the previous session cannot
-	// persist stale positions.
-	o.publisher.seal()
-	o.publisher.Close()
-	newBatcher, err := o.batching.NewBatcher(o.res)
-	if err != nil {
-		return fmt.Errorf("creating batcher: %w", err)
-	}
-	o.publisher = newBatchPublisher(newBatcher, checkpoint.NewCapped[replication.SCN](int64(o.checkpointLimit)), o.log)
-	o.publisher.cacheSCN = o.cacheSCN
 	o.publisher.schemas = schemas
-	o.publisher.onTerminalNack = func(error) {
-		// o.stopSig is only replaced while the input is stopped, and sealed
-		// publishers never invoke this, so the signaller here is current.
-		o.stopSig.TriggerSoftStop()
-	}
 
 	if cachedSCN, err = o.getCachedSCN(ctx); err != nil {
 		if errors.Is(err, service.ErrKeyNotFound) {
@@ -637,9 +608,6 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 		// snapshot if no SCN exists then store checkpoint once complete
 		if snapshotter != nil {
-			// The publisher outlives reconnects: clear any nack recorded by a
-			// previous snapshot attempt so the gate judges only this run.
-			o.publisher.resetSnapshotGate()
 			if startSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					o.log.Infof("Snapshotting stopped: %s", err)
@@ -662,11 +630,7 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 				return
 			}
 			if err = o.publisher.waitSnapshotAcks(softCtx); err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
-				} else {
-					o.log.Errorf("Snapshot batch was rejected downstream. Snapshot will re-run on restart (may cause duplicate data): %s", err)
-				}
+				o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
 				o.stopSig.TriggerHasStopped()
 				return
 			}

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -617,6 +617,23 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 				return
 			}
 
+			// Flush the partial snapshot batch still held by the batcher, then
+			// block until every snapshot batch is acknowledged downstream.
+			// Persisting the SCN any earlier would let a crash in this window
+			// skip un-acked snapshot rows on restart. Blocks until acks drain
+			// or soft-stop (no timeout, by design; see postgres_cdc's
+			// equivalent barrier).
+			if err = o.publisher.flushCurrent(softCtx); err != nil {
+				o.log.Errorf("Failed to flush remaining snapshot batches. Snapshot will re-run on restart (may cause duplicate data): %s", err)
+				o.stopSig.TriggerHasStopped()
+				return
+			}
+			if err = o.publisher.waitSnapshotAcks(softCtx); err != nil {
+				o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
+				o.stopSig.TriggerHasStopped()
+				return
+			}
+
 			if err = o.cacheSCN(softCtx, startSCN); err != nil {
 				o.log.Errorf("Failed to capture SCN after snapshot completion. Snapshot will re-run on restart (may cause duplicate data): %s", err)
 				o.stopSig.TriggerHasStopped()

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -252,6 +253,13 @@ type Config struct {
 	PDBName              string
 }
 
+// streamProcessor is the subset of logminer.Miner used to drive streaming
+// once the snapshot phase (if any) has fully settled downstream.
+type streamProcessor interface {
+	FindStartPos(ctx context.Context) (replication.SCN, error)
+	ReadChanges(ctx context.Context, startPos replication.SCN) error
+}
+
 type oracleDBCDCInput struct {
 	cfg   Config
 	lmCfg *logminer.Config
@@ -265,6 +273,23 @@ type oracleDBCDCInput struct {
 	snapshotOnlyDone atomic.Bool
 	log              *service.Logger
 	cpCache          service.Cache
+
+	// Snapshot/streaming handoff state. (Re)populated by Connect() for each
+	// connect cycle and driven by SnapshotReadBatch/SnapshotComplete, which
+	// AsyncReader calls in place of the old snapshot-then-streaming
+	// background goroutine: it guarantees SnapshotComplete only runs once
+	// every batch read via SnapshotReadBatch has been acknowledged (or
+	// nacked) downstream, so it's the safe point to persist startSCN and
+	// kick off streaming.
+	softCtx              context.Context
+	snapshotter          *replication.Snapshot
+	streaming            streamProcessor
+	startSCN             replication.SCN
+	snapshotRanThisCycle bool
+
+	snapshotOnce sync.Once
+	snapshotDone chan struct{}
+	snapshotErr  error
 }
 
 func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resources) (s service.BatchInput, err error) {
@@ -276,7 +301,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 
 		scnCache, scnCacheKey        string
 		tableIncludes, tableExcludes []*regexp.Regexp
-		batcher                      *service.Batcher
+		batcher, snapshotBatcher     *service.Batcher
 		cp                           *checkpoint.Capped[replication.SCN]
 		cpCache                      service.Cache
 		cpCacheTableName             string
@@ -376,6 +401,9 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 	if batcher, err = policy.NewBatcher(resources); err != nil {
 		return nil, err
 	}
+	if snapshotBatcher, err = policy.NewBatcher(resources); err != nil {
+		return nil, err
+	}
 
 	// connecting string flags
 	overrides := make(map[string]string)
@@ -408,7 +436,7 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 		log:       logger,
 		metrics:   resources.Metrics(),
 		stopSig:   shutdown.NewSignaller(),
-		publisher: newBatchPublisher(batcher, cp, logger),
+		publisher: newBatchPublisher(batcher, snapshotBatcher, cp, logger),
 		cpCache:   cpCache,
 	}
 
@@ -553,10 +581,6 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 
 	// setup snapshotting and streaming
 
-	type streamProcessor interface {
-		FindStartPos(ctx context.Context) (replication.SCN, error)
-		ReadChanges(ctx context.Context, startPos replication.SCN) error
-	}
 	var (
 		snapshotter *replication.Snapshot
 		// logminer processor
@@ -594,82 +618,111 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 		o.log.Infof("No cached SCN found, fetched current position from database: %d", cachedSCN)
 	}
 
-	// Reset our stop signal and snapshot-only completion flag
+	// Reset our stop signal, snapshot-only completion flag, and the
+	// per-cycle snapshot handoff state driven by SnapshotReadBatch /
+	// SnapshotComplete below.
 	o.stopSig = shutdown.NewSignaller()
 	o.snapshotOnlyDone.Store(false)
+	o.softCtx, _ = o.stopSig.SoftStopCtx(context.Background())
+	o.snapshotter = snapshotter
+	o.streaming = streaming
+	o.startSCN = cachedSCN
+	o.snapshotRanThisCycle = snapshotter != nil
+	o.snapshotOnce = sync.Once{}
+	o.snapshotDone = nil
+	o.snapshotErr = nil
 
-	go func() {
-		var (
-			err      error
-			startSCN = cachedSCN
-		)
-		softCtx, cancel := o.stopSig.SoftStopCtx(context.Background())
-		defer cancel()
+	return nil
+}
 
-		// snapshot if no SCN exists then store checkpoint once complete
-		if snapshotter != nil {
-			if startSCN, err = o.processSnapshot(softCtx, snapshotter); err != nil {
+// SnapshotReadBatch implements service.SnapshotBatchInput. It lazily starts
+// the snapshot's row producer on its first call, forwards each flushed
+// snapshot batch as it's published, and signals
+// service.ErrSnapshotComplete once the snapshot (including its trailing
+// partial batch) has been fully read. AsyncReader guarantees every batch
+// returned here is acknowledged or nacked downstream before SnapshotComplete
+// is called, replacing the ack-counting barrier this connector used to have
+// to build itself.
+func (o *oracleDBCDCInput) SnapshotReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	if o.snapshotter == nil {
+		return nil, nil, service.ErrSnapshotComplete
+	}
+
+	o.snapshotOnce.Do(func() {
+		o.snapshotDone = make(chan struct{})
+		go func() {
+			defer close(o.snapshotDone)
+
+			startSCN, err := o.processSnapshot(o.softCtx, o.snapshotter)
+			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					o.log.Infof("Snapshotting stopped: %s", err)
 				} else {
 					o.log.Errorf("Snapshotting failed: %s", err)
 				}
-				o.stopSig.TriggerHasStopped()
+				o.snapshotErr = err
 				return
 			}
+			o.startSCN = startSCN
 
-			// Flush the partial snapshot batch still held by the batcher, then
-			// block until every snapshot batch is acknowledged downstream.
-			// Persisting the SCN any earlier would let a crash in this window
-			// skip un-acked snapshot rows on restart. Blocks until acks drain
-			// or soft-stop (no timeout, by design; see postgres_cdc's
-			// equivalent barrier).
-			if err = o.publisher.flushCurrent(softCtx); err != nil {
+			// Flush the trailing partial snapshot batch so every row reaches
+			// SnapshotReadBatch before it signals completion.
+			if err := o.publisher.flushSnapshotRemaining(o.softCtx); err != nil {
 				o.log.Errorf("Failed to flush remaining snapshot batches. Snapshot will re-run on restart (may cause duplicate data): %s", err)
-				o.stopSig.TriggerHasStopped()
-				return
+				o.snapshotErr = err
 			}
-			if err = o.publisher.waitSnapshotAcks(softCtx); err != nil {
-				o.log.Infof("Interrupted while waiting for snapshot acknowledgements. Snapshot will re-run on restart (may cause duplicate data): %s", err)
-				o.stopSig.TriggerHasStopped()
-				return
-			}
+		}()
+	})
 
-			if err = o.cacheSCN(softCtx, startSCN); err != nil {
-				o.log.Errorf("Failed to capture SCN after snapshot completion. Snapshot will re-run on restart (may cause duplicate data): %s", err)
-				o.stopSig.TriggerHasStopped()
-				return
-			}
-
-			o.log.Infof("Successfully captured SCN following snapshot: %d", startSCN)
+	select {
+	case m := <-o.publisher.snapshotMsgs():
+		return m.msg, m.ackFn, nil
+	case <-o.snapshotDone:
+		if o.snapshotErr != nil {
+			return nil, nil, o.snapshotErr
 		}
+		return nil, nil, service.ErrSnapshotComplete
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
 
-		if o.cfg.SnapshotMode.IsSnapshotOnly() {
-			if err = o.publisher.FlushRemaining(softCtx); err != nil {
-				o.log.Errorf("Failed to flush remaining snapshot events: %s", err)
-			}
-			o.log.Infof("Snapshot-only mode complete, stopping at SCN %s", startSCN)
-			o.snapshotOnlyDone.Store(true)
-			o.stopSig.TriggerHasStopped()
-			return
+// SnapshotComplete implements service.SnapshotCompleter. By the time
+// AsyncReader calls this, every snapshot batch is guaranteed settled
+// downstream, so it's safe to persist the post-snapshot SCN before handing
+// off to streaming - the barrier that used to be built by hand with
+// snapshotAckWG/waitSnapshotAcks is now the caller's responsibility.
+func (o *oracleDBCDCInput) SnapshotComplete(ctx context.Context) error {
+	if o.snapshotRanThisCycle {
+		if err := o.cacheSCN(ctx, o.startSCN); err != nil {
+			return fmt.Errorf("capturing SCN after snapshot completion: %w", err)
 		}
+		o.log.Infof("Successfully captured SCN following snapshot: %d", o.startSCN)
+	}
 
-		// streaming
-		wg, _ := errgroup.WithContext(softCtx)
+	if o.cfg.SnapshotMode.IsSnapshotOnly() {
+		o.log.Infof("Snapshot-only mode complete, stopping at SCN %s", o.startSCN)
+		o.snapshotOnlyDone.Store(true)
+		o.stopSig.TriggerHasStopped()
+		return nil
+	}
+
+	startSCN := o.startSCN
+	go func() {
+		wg, _ := errgroup.WithContext(o.softCtx)
 		wg.Go(func() error {
-			if err := streaming.ReadChanges(softCtx, startSCN); err != nil {
+			if err := o.streaming.ReadChanges(o.softCtx, startSCN); err != nil {
 				return fmt.Errorf("streaming from logminer: %w", err)
 			}
 			return nil
 		})
-		if err := wg.Wait(); err != nil && softCtx.Err() == nil && !errors.Is(err, context.Canceled) {
+		if err := wg.Wait(); err != nil && o.softCtx.Err() == nil && !errors.Is(err, context.Canceled) {
 			o.log.Errorf("Error during Oracle CDC Component: %s", err)
 		} else {
 			o.log.Info("Successfully shutdown Oracle CDC Component")
 		}
 		o.stopSig.TriggerHasStopped()
 	}()
-
 	return nil
 }
 

--- a/internal/impl/oracledb/input_oracledb_cdc.go
+++ b/internal/impl/oracledb/input_oracledb_cdc.go
@@ -261,6 +261,13 @@ type oracleDBCDCInput struct {
 	publisher *batchPublisher
 	metrics   *service.Metrics
 
+	// batching and checkpointLimit rebuild the publisher (batcher + ordered
+	// checkpoint tracker) on every Connect: a terminal nack pins a tracker
+	// slot by design, and only a fresh tracker lets the restart resume from
+	// the last durable SCN instead of staying wedged behind the stale slot.
+	batching        service.BatchPolicy
+	checkpointLimit int
+
 	stopSig          *shutdown.Signaller
 	snapshotOnlyDone atomic.Bool
 	log              *service.Logger
@@ -403,13 +410,15 @@ func newOracleDBCDCInput(conf *service.ParsedConfig, resources *service.Resource
 				Exclude: tableExcludes,
 			},
 		},
-		lmCfg:     lmCfg,
-		res:       resources,
-		log:       logger,
-		metrics:   resources.Metrics(),
-		stopSig:   shutdown.NewSignaller(),
-		publisher: newBatchPublisher(batcher, cp, logger),
-		cpCache:   cpCache,
+		lmCfg:           lmCfg,
+		res:             resources,
+		log:             logger,
+		metrics:         resources.Metrics(),
+		stopSig:         shutdown.NewSignaller(),
+		publisher:       newBatchPublisher(batcher, cp, logger),
+		batching:        policy,
+		checkpointLimit: checkpointLimit,
+		cpCache:         cpCache,
 	}
 
 	defer func() {
@@ -531,7 +540,28 @@ func (o *oracleDBCDCInput) Connect(ctx context.Context) (resErr error) {
 			o.log.Warnf("Failed to pre-fetch schema for %s.%s: %v", t.Schema, t.Name, err)
 		}
 	}
+
+	// Rebuild the publisher (batcher + ordered checkpoint tracker) for this
+	// connection attempt. A terminal nack pins a tracker slot by design;
+	// reusing the old tracker would leave every future checkpoint stuck
+	// behind the stale slot, wedging the input for the process lifetime
+	// instead of letting this restart resume from the last durable SCN. The
+	// old publisher is sealed so late acks from the previous session cannot
+	// persist stale positions.
+	o.publisher.seal()
+	o.publisher.Close()
+	newBatcher, err := o.batching.NewBatcher(o.res)
+	if err != nil {
+		return fmt.Errorf("creating batcher: %w", err)
+	}
+	o.publisher = newBatchPublisher(newBatcher, checkpoint.NewCapped[replication.SCN](int64(o.checkpointLimit)), o.log)
+	o.publisher.cacheSCN = o.cacheSCN
 	o.publisher.schemas = schemas
+	o.publisher.onTerminalNack = func(error) {
+		// o.stopSig is only replaced while the input is stopped, and sealed
+		// publishers never invoke this, so the signaller here is current.
+		o.stopSig.TriggerSoftStop()
+	}
 
 	if cachedSCN, err = o.getCachedSCN(ctx); err != nil {
 		if errors.Is(err, service.ErrKeyNotFound) {

--- a/internal/impl/oracledb/integration_test.go
+++ b/internal/impl/oracledb/integration_test.go
@@ -560,6 +560,127 @@ oracledb_cdc:
 	}
 }
 
+// TestIntegrationOracleDBCDCSnapshotAckBarrier verifies that a crash during
+// the snapshot->streaming handoff (after snapshot rows are emitted but before
+// they are acknowledged) does not lose data: because the post-snapshot SCN is
+// only persisted once every snapshot batch is acked, the snapshot must re-run
+// on restart. See CON-504.
+func TestIntegrationOracleDBCDCSnapshotAckBarrier(t *testing.T) {
+	integration.CheckSkip(t)
+
+	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)
+	require.NoError(t, db.CreateTableWithSupplementalLoggingIfNotExists(t.Context(), "testdb.ackbarrier", "CREATE TABLE testdb.ackbarrier (id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY)"))
+
+	const rowCount = 5
+	for range rowCount {
+		db.MustExec("INSERT INTO testdb.ackbarrier (id) VALUES (DEFAULT)")
+	}
+	db.MustExec("COMMIT")
+
+	// batching.count == rowCount forces all snapshot rows into a single output
+	// batch, so the run-1 consumer receives them all at once and can then block
+	// without acking - reproducing the "emitted but not yet acked" handoff state.
+	cfg := fmt.Sprintf(`
+oracledb_cdc:
+  connection_string: %s
+  snapshot_mode: snapshot_and_stream
+  logminer:
+    scn_window_size: 20000
+    min_scn_window_size: 0
+    backoff_interval: 1s
+  include: ["TESTDB.ACKBARRIER"]
+  batching:
+    count: %d
+    period: 1h`, connStr, rowCount)
+
+	// Run 1: receive the snapshot rows but never acknowledge them, then
+	// simulate a crash by cancelling the run before the SCN can be persisted.
+	t.Log("Launching run 1 (blocked consumer, simulated crash)...")
+	received := make(chan struct{}, 1)
+	run1Builder := service.NewStreamBuilder()
+	require.NoError(t, run1Builder.AddInputYAML(cfg))
+	require.NoError(t, run1Builder.SetLoggerYAML(`level: INFO`))
+	require.NoError(t, run1Builder.AddBatchConsumerFunc(func(ctx context.Context, _ service.MessageBatch) error {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		// Block without acking until the simulated crash cancels our context.
+		<-ctx.Done()
+		return ctx.Err()
+	}))
+	run1, err := run1Builder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(run1.Resources())
+
+	run1Ctx, crash := context.WithCancel(t.Context())
+	run1Done := make(chan struct{})
+	go func() {
+		defer close(run1Done)
+		_ = run1.Run(run1Ctx)
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(5 * time.Minute):
+		t.Fatal("snapshot rows were never delivered to the run-1 output")
+	}
+	// Give the input time to reach the ack barrier (and, in the buggy version,
+	// to persist the post-snapshot SCN) before we crash.
+	time.Sleep(5 * time.Second)
+	crash()
+	select {
+	case <-run1Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("run 1 did not stop after the simulated crash")
+	}
+
+	// The barrier must have prevented the post-snapshot SCN from being
+	// persisted, since the snapshot rows were never acknowledged. This is the
+	// core guarantee: without it a cached SCN would exist here and the
+	// snapshot would be skipped on restart, silently losing the un-acked rows.
+	var checkpoints int
+	require.NoError(t, db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM RPCN.CDC_CHECKPOINT_CACHE").Scan(&checkpoints))
+	require.Zero(t, checkpoints, "post-snapshot SCN must not be persisted before snapshot rows are acknowledged")
+
+	// Run 2: restart against the same checkpoint cache. Since run 1 never
+	// acked the snapshot, no SCN was cached, so the snapshot re-runs and every
+	// row is delivered again.
+	t.Log("Launching run 2 (verifying the snapshot re-runs)...")
+	var (
+		readsMu sync.Mutex
+		reads   int
+	)
+	run2Builder := service.NewStreamBuilder()
+	require.NoError(t, run2Builder.AddInputYAML(cfg))
+	require.NoError(t, run2Builder.SetLoggerYAML(`level: INFO`))
+	require.NoError(t, run2Builder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		readsMu.Lock()
+		defer readsMu.Unlock()
+		for _, msg := range mb {
+			if op, _ := msg.MetaGet("operation"); op == "read" {
+				reads++
+			}
+		}
+		return nil
+	}))
+	run2, err := run2Builder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(run2.Resources())
+	go func() {
+		if err := run2.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		readsMu.Lock()
+		defer readsMu.Unlock()
+		assert.Equal(c, rowCount, reads, "snapshot should have re-run and re-delivered every row after the crash")
+	}, 5*time.Minute, 500*time.Millisecond)
+	require.NoError(t, run2.StopWithin(time.Second*30))
+}
+
 func TestIntegrationOracleDBCDCStreaming(t *testing.T) {
 	integration.CheckSkip(t)
 	connStr, db := oracledbtest.SetupTestWithOracleDBVersion(t)

--- a/internal/impl/oracledb/replication/snapshot.go
+++ b/internal/impl/oracledb/replication/snapshot.go
@@ -37,7 +37,7 @@ type Snapshot struct {
 	dbPool                  *sql.DB
 	tables                  []UserTable
 	filters                 map[string]string
-	publisher               ChangePublisher
+	publisher               SnapshotPublisher
 	log                     *service.Logger
 	snapshotStatusMetric    *service.MetricGauge
 	snapshotRowsTotalMetric *service.MetricCounter
@@ -54,7 +54,7 @@ func NewSnapshot(ctx context.Context,
 	connectionString string,
 	tables []UserTable,
 	filters map[string]string,
-	publisher ChangePublisher,
+	publisher SnapshotPublisher,
 	lobEnabled bool,
 	pdbName string,
 	logger *service.Logger,
@@ -306,7 +306,7 @@ func (s *Snapshot) processBatch(ctx context.Context, tx *sql.Tx, table UserTable
 			m.CommitTimestamp = s.commitTimestamp
 		}
 
-		if err = s.publisher.Publish(ctx, &m); err != nil {
+		if err = s.publisher.PublishSnapshot(ctx, &m); err != nil {
 			return 0, fmt.Errorf("handling snapshot table row: %w", err)
 		}
 	}

--- a/internal/impl/oracledb/replication/snapshot_test.go
+++ b/internal/impl/oracledb/replication/snapshot_test.go
@@ -161,14 +161,12 @@ type publisherStub struct {
 	mu       sync.Mutex
 }
 
-func (p *publisherStub) Publish(_ context.Context, msg *replication.MessageEvent) error {
+func (p *publisherStub) PublishSnapshot(_ context.Context, msg *replication.MessageEvent) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.messages = append(p.messages, msg)
 	return nil
 }
-
-func (*publisherStub) Close() {}
 
 func (p *publisherStub) count() int {
 	p.mu.Lock()

--- a/internal/impl/oracledb/replication/stream.go
+++ b/internal/impl/oracledb/replication/stream.go
@@ -31,6 +31,15 @@ type ChangePublisher interface {
 	Close()
 }
 
+// SnapshotPublisher is responsible for handling and processing of a
+// replication.MessageEvent belonging to the initial table snapshot. It is
+// kept distinct from ChangePublisher so a publisher can route snapshot rows
+// through a separate SnapshotAsync ack barrier rather than the ordered SCN
+// checkpoint tracker used for streamed changes.
+type SnapshotPublisher interface {
+	PublishSnapshot(ctx context.Context, msg *MessageEvent) error
+}
+
 // UserTable represents a found user's OracleDB table (called a user-table).
 type UserTable struct {
 	Schema string


### PR DESCRIPTION
- **oracledb_cdc: track in-flight snapshot batch acks in the publisher**
- **oracledb_cdc: add flushCurrent to publish partial batches without stopping the publisher**
- **oracledb_cdc: gate post-snapshot checkpoint on downstream acks**
- **oracledb_cdc: adversarial crash test for the snapshot ack barrier**
- **oracledb_cdc: make batch tracking atomic with batch flushing**
- **oracledb_cdc: fail the snapshot gate on nack, drop orphaned publishBatch**
- **oracledb_cdc: log downstream batch rejections**
- **oracledb_cdc: log downstream snapshot rejections at error level**
- **oracledb_cdc: terminal nacks restart with a fresh tracker**
- **oracledb_cdc: nacks resolve checkpoints (auto_replay_nacks off is an opt-in drop)**
- **oracledb_cdc: poc of dedicated backfill api**
