### PR TITLE
chore: bump to Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/v4
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/99designs/keyring => github.com/Jeffail/keyring v1.2.3
 

--- a/public/bundle/enterprise/go.mod
+++ b/public/bundle/enterprise/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/enterprise/v4
 
-go 1.26.5
+go 1.26.6
 
 require github.com/redpanda-data/connect/v4 v4.105.0
 

--- a/public/bundle/free/go.mod
+++ b/public/bundle/free/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/connect/public/bundle/free/v4
 
-go 1.26.5
+go 1.26.6
 
 require github.com/redpanda-data/connect/v4 v4.105.0
 


### PR DESCRIPTION
Bump to Go 1.26.6 address security vulnerabilities.

> go1.26.6 (released 2026-08-13) includes security fixes to the go command, and the crypto/tls, encoding/asn1, encoding/xml, html/template, net, net/http, and net/url packages, as well as bug fixes to the compiler, the linker, the runtime, and the crypto/tls and os packages. See the [Go 1.26.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.6+label%3ACherryPickApproved) on our issue tracker for details.