### PR TITLE
aws_kinesis: add a poll_interval field to the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- aws_kinesis: Added a `poll_interval` field to the input, setting a minimum period between GetRecords requests per consumed shard. Kinesis shares a limit of 5 GetRecords requests per second per shard across all consumers of a stream, so this allows multiple readers of the same stream to avoid throttling each other. The default (`0s`) preserves the existing polling behavior. ([@prakhargarg105](https://github.com/prakhargarg105))
+
 ## 4.106.0 - 2026-08-20
 
 ### Added

--- a/docs/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/docs/modules/components/pages/inputs/aws_kinesis.adoc
@@ -96,6 +96,7 @@ input:
     rebalance_period: 30s
     lease_period: 30s
     start_from_oldest: true
+    poll_interval: 0s
     region: "" # No default (optional)
     endpoint: "" # No default (optional)
     tcp:
@@ -426,6 +427,16 @@ Whether to consume from the oldest message when a sequence does not yet exist fo
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `poll_interval`
+
+An optional period of time to wait between GetRecords requests made against each consumed shard. Kinesis enforces a limit of 5 GetRecords requests per second per shard, shared across all consumers of the stream, so when multiple consumers read from the same stream setting a poll interval prevents them from throttling each other, e.g. with four consumers of one stream a poll interval of `1s` keeps the collective request rate under the limit. Each request returns up to 10MiB of records, so moderate poll intervals do not generally limit throughput. A value of `0s` disables the wait entirely.
+
+
+*Type*: `string`
+
+*Default*: `"0s"`
+Requires version 4.107.0 or newer
 
 === `region`
 

--- a/internal/impl/aws/kinesis/input.go
+++ b/internal/impl/aws/kinesis/input.go
@@ -51,6 +51,7 @@ const (
 	kiFieldLeasePeriod      = "lease_period"
 	kiFieldRebalancePeriod  = "rebalance_period"
 	kiFieldStartFromOldest  = "start_from_oldest"
+	kiFieldPollInterval     = "poll_interval"
 	kiFieldBatching         = "batching"
 
 	// Kinesis metrics
@@ -67,6 +68,7 @@ type kiConfig struct {
 	LeasePeriod      string
 	RebalancePeriod  string
 	StartFromOldest  bool
+	PollInterval     string
 }
 
 func kinesisInputConfigFromParsed(pConf *service.ParsedConfig) (conf kiConfig, err error) {
@@ -94,6 +96,9 @@ func kinesisInputConfigFromParsed(pConf *service.ParsedConfig) (conf kiConfig, e
 		return
 	}
 	if conf.StartFromOldest, err = pConf.FieldBool(kiFieldStartFromOldest); err != nil {
+		return
+	}
+	if conf.PollInterval, err = pConf.FieldString(kiFieldPollInterval); err != nil {
 		return
 	}
 	return
@@ -177,6 +182,12 @@ Use the `+"`batching`"+` fields to configure an optional xref:configuration:batc
 		service.NewBoolField(kiFieldStartFromOldest).
 			Description("Whether to consume from the oldest message when a sequence does not yet exist for the stream.").
 			Default(true),
+		service.NewDurationField(kiFieldPollInterval).
+			Description("An optional period of time to wait between GetRecords requests made against each consumed shard. Kinesis enforces a limit of 5 GetRecords requests per second per shard, shared across all consumers of the stream, so when multiple consumers read from the same stream setting a poll interval prevents them from throttling each other, e.g. with four consumers of one stream a poll interval of `1s` keeps the collective request rate under the limit. Each request returns up to 10MiB of records, so moderate poll intervals do not generally limit throughput. A value of `0s` disables the wait entirely.").
+			ShortDescription("An optional minimum period of time to wait between GetRecords requests made against each consumed shard.").
+			Default("0s").
+			Version("4.107.0").
+			Advanced(),
 	).
 		Fields(config.SessionFields()...).
 		Field(service.NewBatchPolicyField(kiFieldBatching))
@@ -230,6 +241,7 @@ type kinesisReader struct {
 	stealGracePeriod time.Duration
 	leasePeriod      time.Duration
 	rebalancePeriod  time.Duration
+	pollInterval     time.Duration
 
 	cMut    sync.Mutex
 	msgChan chan asyncMessage
@@ -373,6 +385,11 @@ func newKinesisReaderFromConfig(conf kiConfig, batcher service.BatchPolicy, sess
 	if k.rebalancePeriod, err = time.ParseDuration(k.conf.RebalancePeriod); err != nil {
 		return nil, fmt.Errorf("parsing rebalance period string: %v", err)
 	}
+	if k.conf.PollInterval != "" {
+		if k.pollInterval, err = time.ParseDuration(k.conf.PollInterval); err != nil {
+			return nil, fmt.Errorf("parsing poll interval string: %v", err)
+		}
+	}
 
 	// Initialize metrics
 	k.clientShardsMetric = mgr.Metrics().NewGauge(metricShardsPerClient)
@@ -496,6 +513,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 
 	// Stores consumed records that have yet to be added to the batcher.
 	var pending []types.Record
+	var lastPullTime time.Time
 	var iter string
 	if iter, initErr = k.getIter(info, shardID, startingSequence); initErr != nil {
 		return initErr
@@ -560,16 +578,21 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 		// disturb.
 		unblockPullChan := func() {
 			if nextPullChan == blockedChan {
-				nextPullChan = unblockedChan
+				if wait := k.pollInterval - time.Since(lastPullTime); wait > 0 {
+					nextPullChan = time.After(wait)
+				} else {
+					nextPullChan = unblockedChan
+				}
 			}
 		}
 
 		for {
 			var err error
 			if state == awsKinesisConsumerConsuming && len(pending) == 0 && nextPullChan == unblockedChan {
+				lastPullTime = time.Now()
 				if pending, iter, err = k.getRecords(info, iter); err != nil {
 					if !awsErrIsTimeout(err) {
-						nextPullChan = time.After(boff.NextBackOff())
+						nextPullChan = time.After(max(boff.NextBackOff(), k.pollInterval-time.Since(lastPullTime)))
 
 						var aerr *types.ExpiredIteratorException
 						if errors.As(err, &aerr) {
@@ -585,7 +608,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 						}
 					}
 				} else if len(pending) == 0 {
-					nextPullChan = time.After(boff.NextBackOff())
+					nextPullChan = time.After(max(boff.NextBackOff(), k.pollInterval-time.Since(lastPullTime)))
 				} else {
 					boff.Reset()
 					nextPullChan = blockedChan

--- a/internal/impl/aws/kinesis/input.go
+++ b/internal/impl/aws/kinesis/input.go
@@ -491,6 +491,18 @@ const (
 	awsKinesisConsumerClosing
 )
 
+// nextPullDelay returns how long a shard consumer must wait before its next
+// GetRecords request, combining the retry backoff (zero when the previous
+// request yielded records) with the remaining portion of the configured poll
+// interval since the last request.
+func nextPullDelay(pollInterval time.Duration, lastPull, now time.Time, backoff time.Duration) time.Duration {
+	delay := backoff
+	if wait := pollInterval - now.Sub(lastPull); wait > delay {
+		delay = wait
+	}
+	return delay
+}
+
 func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID, startingSequence string) (initErr error) {
 	defer func() {
 		if initErr != nil {
@@ -578,7 +590,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 		// disturb.
 		unblockPullChan := func() {
 			if nextPullChan == blockedChan {
-				if wait := k.pollInterval - time.Since(lastPullTime); wait > 0 {
+				if wait := nextPullDelay(k.pollInterval, lastPullTime, time.Now(), 0); wait > 0 {
 					nextPullChan = time.After(wait)
 				} else {
 					nextPullChan = unblockedChan
@@ -592,7 +604,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 				lastPullTime = time.Now()
 				if pending, iter, err = k.getRecords(info, iter); err != nil {
 					if !awsErrIsTimeout(err) {
-						nextPullChan = time.After(max(boff.NextBackOff(), k.pollInterval-time.Since(lastPullTime)))
+						nextPullChan = time.After(nextPullDelay(k.pollInterval, lastPullTime, time.Now(), boff.NextBackOff()))
 
 						var aerr *types.ExpiredIteratorException
 						if errors.As(err, &aerr) {
@@ -608,7 +620,7 @@ func (k *kinesisReader) runConsumer(wg *sync.WaitGroup, info streamInfo, shardID
 						}
 					}
 				} else if len(pending) == 0 {
-					nextPullChan = time.After(max(boff.NextBackOff(), k.pollInterval-time.Since(lastPullTime)))
+					nextPullChan = time.After(nextPullDelay(k.pollInterval, lastPullTime, time.Now(), boff.NextBackOff()))
 				} else {
 					boff.Reset()
 					nextPullChan = blockedChan

--- a/internal/impl/aws/kinesis/input_test.go
+++ b/internal/impl/aws/kinesis/input_test.go
@@ -165,3 +165,78 @@ func TestNewKinesisReaderFromConfigPollInterval(t *testing.T) {
 		})
 	}
 }
+
+func TestNextPullDelay(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		pollInterval time.Duration
+		lastPull     time.Time
+		backoff      time.Duration
+		expected     time.Duration
+	}{
+		{
+			name:         "zero poll interval zero backoff",
+			pollInterval: 0,
+			lastPull:     now,
+			backoff:      0,
+			expected:     0,
+		},
+		{
+			name:         "zero poll interval with backoff",
+			pollInterval: 0,
+			lastPull:     now,
+			backoff:      300 * time.Millisecond,
+			expected:     300 * time.Millisecond,
+		},
+		{
+			name:         "poll interval just started zero backoff",
+			pollInterval: time.Second,
+			lastPull:     now,
+			backoff:      0,
+			expected:     time.Second,
+		},
+		{
+			name:         "poll interval partially elapsed zero backoff",
+			pollInterval: time.Second,
+			lastPull:     now.Add(-400 * time.Millisecond),
+			backoff:      0,
+			expected:     600 * time.Millisecond,
+		},
+		{
+			name:         "poll interval fully elapsed zero backoff",
+			pollInterval: time.Second,
+			lastPull:     now.Add(-2 * time.Second),
+			backoff:      0,
+			expected:     0,
+		},
+		{
+			name:         "backoff dominates remaining interval",
+			pollInterval: time.Second,
+			lastPull:     now.Add(-900 * time.Millisecond),
+			backoff:      5 * time.Second,
+			expected:     5 * time.Second,
+		},
+		{
+			name:         "remaining interval dominates backoff",
+			pollInterval: 5 * time.Second,
+			lastPull:     now.Add(-time.Second),
+			backoff:      300 * time.Millisecond,
+			expected:     4 * time.Second,
+		},
+		{
+			name:         "never pulled before",
+			pollInterval: time.Second,
+			lastPull:     time.Time{},
+			backoff:      0,
+			expected:     0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, nextPullDelay(test.pollInterval, test.lastPull, now, test.backoff))
+		})
+	}
+}

--- a/internal/impl/aws/kinesis/input_test.go
+++ b/internal/impl/aws/kinesis/input_test.go
@@ -16,9 +16,13 @@ package kinesis
 
 import (
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 func TestStreamIDParser(t *testing.T) {
@@ -73,6 +77,90 @@ func TestStreamIDParser(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, test.remaining, rem)
 				assert.Equal(t, test.shard, shard)
+			}
+		})
+	}
+}
+
+func TestPollIntervalConfigParsing(t *testing.T) {
+	tests := []struct {
+		name         string
+		conf         string
+		pollInterval string
+	}{
+		{
+			name: "explicit poll interval",
+			conf: `
+streams: [foo]
+poll_interval: 2s
+`,
+			pollInterval: "2s",
+		},
+		{
+			name: "default poll interval",
+			conf: `
+streams: [foo]
+`,
+			pollInterval: "0s",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := kinesisInputSpec().ParseYAML(test.conf, nil)
+			require.NoError(t, err)
+
+			conf, err := kinesisInputConfigFromParsed(pConf)
+			require.NoError(t, err)
+			assert.Equal(t, test.pollInterval, conf.PollInterval)
+		})
+	}
+}
+
+func TestNewKinesisReaderFromConfigPollInterval(t *testing.T) {
+	baseConf := func(pollInterval string) kiConfig {
+		return kiConfig{
+			Streams:          []string{"foo"},
+			CommitPeriod:     "5s",
+			StealGracePeriod: "2s",
+			LeasePeriod:      "30s",
+			RebalancePeriod:  "30s",
+			PollInterval:     pollInterval,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		pollInterval string
+		expected     time.Duration
+		errContains  string
+	}{
+		{
+			name:         "empty poll interval defaults to zero",
+			pollInterval: "",
+			expected:     0,
+		},
+		{
+			name:         "valid poll interval",
+			pollInterval: "750ms",
+			expected:     750 * time.Millisecond,
+		},
+		{
+			name:         "invalid poll interval",
+			pollInterval: "nope",
+			errContains:  "poll interval",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader, err := newKinesisReaderFromConfig(baseConf(test.pollInterval), service.BatchPolicy{}, aws.Config{}, aws.Config{}, service.MockResources())
+			if test.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, reader.pollInterval)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

Kinesis enforces a limit of 5 `GetRecords` requests per second per shard, **shared across all consumers of a stream**. The `aws_kinesis` input currently re-polls each shard as soon as its pending records drain, with no way to pace the polling. As a result, running multiple Redpanda Connect instances against the same stream causes them to throttle each other (`ReadProvisionedThroughputExceeded`), and the readers fall progressively behind — as reported in the community Slack.

## Changes

Adds an advanced `poll_interval` duration field to the `aws_kinesis` input, enforcing a minimum period between `GetRecords` requests per consumed shard — the equivalent of the Kinesis Client Library's `idleTimeBetweenReadsInMillis`, and consistent with the existing `poll_interval` fields on `aws_dynamodb_cdc` and `aws_cloudwatch_logs`.

- When a poll returns records, the next poll waits out the remainder of the interval once pending records drain.
- On errors and empty reads, the wait is the larger of the existing exponential backoff and the remaining interval, so error retries can't burn the shared quota either.
- The default (`0s`) preserves the existing behavior exactly.
- The iterator-preserving contract of `getRecords` and the consumer select-loop structure are unchanged.

Since each `GetRecords` call returns up to 10MiB of records, a moderate interval (e.g. `1s` with four consumers of one stream) keeps the collective request rate under the limit with little throughput cost. For workloads whose aggregate consumption exceeds the shared 2MB/s per-shard read bandwidth, Enhanced Fan-Out (previously attempted in #2413) remains the appropriate long-term solution; this field is the low-risk knob that makes polling consumers coexist today.

## Testing

- New unit tests covering YAML parsing (explicit + default), duration parsing into the reader, backwards compatibility with an unset value, and rejection of invalid durations.
- `go test ./internal/impl/aws/kinesis/` passes; `task lint` reports 0 issues; docs regenerated with `task docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)