### PR TITLE
ci: fix silent Slack release notification failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,9 @@ jobs:
           VERSION="${{ github.ref_name }}"
           COMPARE_URL="${{ github.server_url }}/${{ github.repository }}/compare/${{ github.ref_name }}"
           STATUS="${FAILURES}${LINKS}"
+          # Slack rejects section blocks whose text exceeds 3000 chars, so the
+          # release body is split across multiple section blocks. Empty
+          # sections are dropped (Slack rejects those too).
           jq -n \
             --arg body "$BODY" \
             --arg release_url "$RELEASE_URL" \
@@ -382,21 +385,28 @@ jobs:
             --arg compare_url "$COMPARE_URL" \
             --arg header_icon "$HEADER_ICON" \
             --arg status "$STATUS" \
-            '{
+            'def chunk_lines(limit):
+              split("\n") | reduce .[] as $line ([];
+                if length > 0 and ((.[-1] + "\n" + $line) | length) <= limit
+                then .[0:-1] + [.[-1] + "\n" + $line]
+                else . + [$line]
+                end);
+            {
               text: ("New Redpanda Connect release: " + $version),
               unfurl_links: false,
               unfurl_media: false,
-              blocks: [
+              blocks: ([
                 {type: "header", text: {type: "plain_text", text: ($header_icon + " Redpanda Connect " + $version), emoji: true}},
                 {type: "section", text: {type: "mrkdwn", text: ("*Release:* <" + $release_url + "|" + $version + ">")}},
-                {type: "divider"},
-                {type: "section", text: {type: "mrkdwn", text: $body}},
-                {type: "section", text: {type: "mrkdwn", text: $status}},
-                {type: "actions", elements: [
+                {type: "divider"}
+              ]
+              + ($body | chunk_lines(3000) | map(select(length > 0) | {type: "section", text: {type: "mrkdwn", text: .}}))
+              + (if $status == "" then [] else [{type: "section", text: {type: "mrkdwn", text: $status}}] end)
+              + [{type: "actions", elements: [
                   {type: "button", text: {type: "plain_text", text: ":github: View Release", emoji: true}, url: $release_url},
                   {type: "button", text: {type: "plain_text", text: ":page_facing_up: Full Changelog", emoji: true}, url: $compare_url}
-                ]}
-              ]
+                ]}]
+              )
             }' > "$RUNNER_TEMP/slack_payload.json"
 
       - name: Post changelog to Slack
@@ -405,3 +415,6 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload-file-path: ${{ runner.temp }}/slack_payload.json
+          # Fail the job when the webhook post fails; the default silently
+          # swallows errors and reports success.
+          errors: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,14 @@ jobs:
                 if length > 0 and ((.[-1] + "\n" + $line) | length) <= limit
                 then .[0:-1] + [.[-1] + "\n" + $line]
                 else . + [$line]
-                end);
+                end)
+              # a single line longer than limit lands above as an oversized
+              # chunk; hard-split those so every emitted chunk is bounded
+              | map(. as $chunk | ($chunk | length) as $len |
+                  if $len <= limit then [$chunk]
+                  else [range(0; $len; limit) as $i | $chunk[$i:$i+limit]]
+                  end)
+              | add // [];
             {
               text: ("New Redpanda Connect release: " + $version),
               unfurl_links: false,


### PR DESCRIPTION
The notify-slack job put the entire release body into a single Slack section block, but Slack rejects section text over 3000 characters with invalid_blocks. The slack-github-action step used the default errors: false, which swallows webhook errors entirely, so the job reported success while nothing was posted — v4.105.0 and v4.106.0 announcements were both silently dropped.

Split the release body into multiple section blocks of at most 3000 characters each, drop empty sections (also rejected by Slack), and set errors: true so a failed post fails the job instead of hiding.