### PR TITLE
mssqlserver_cdc: support table discovery via cdc.change_tables

### DIFF
--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -118,6 +118,7 @@ Operational notes:
 - `TRUNCATE TABLE` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with `msdb.dbo.rds_cdc_enable_db` — `sys.sp_cdc_enable_db` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (`cdc.<database>_capture`): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
+- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table since there is currently no way to specify which one to stream from — the only recourse is to drop one of the two instances on the server.
 		
 
 == Fields

--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -119,7 +119,7 @@ Operational notes:
 - `TRUNCATE TABLE` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with `msdb.dbo.rds_cdc_enable_db` — `sys.sp_cdc_enable_db` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (`cdc.<database>_capture`): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it matches `capture_instance` (an override for exactly that ambiguous case).
+- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances, `capture_instance` is preferred when it matches one of them; otherwise the instance named after the `<schema>_<table>` convention is preferred, with a warning logged; if neither applies, table discovery fails for that table.
 		
 
 == Fields
@@ -201,7 +201,7 @@ exclude: dbo.privatetable
 
 === `capture_instance`
 
-Capture instance to prefer when a table has two CDC capture instances and neither is named after the `<schema>_<table>` convention — for example a migration tool's temporary second instance during an online schema change. Only used as a tie-breaker in that case; tables with a single instance, or where one is convention-named, are unaffected, so it's safe to leave this set permanently. If a table is ambiguous and this doesn't match either of its instances, table discovery still fails for it.
+Capture instance to prefer when a table has two CDC capture instances, such as a migration tool's temporary second instance during an online schema change. Takes priority over the default `<schema>_<table>` naming convention, so it's how to select the new instance during a cutover before the old one is dropped. Tables with a single instance are unaffected, so it's safe to leave this set permanently. If it doesn't match either instance on an ambiguous table, resolution falls back to the convention-named instance where there is one, otherwise table discovery still fails for that table.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -75,7 +75,7 @@ input:
     snapshot_max_batch_size: 1000
     include: [] # No default (required)
     exclude: [] # No default (optional)
-    capture_instances: {}
+    capture_instance: ""
     checkpoint_cache: "" # No default (optional)
     checkpoint_cache_table_name: rpcn.CdcCheckpointCache
     checkpoint_cache_connection_string: sqlserver://username:password@remotehost/instance?param1=value&param2=value # No default (optional)
@@ -119,7 +119,7 @@ Operational notes:
 - `TRUNCATE TABLE` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with `msdb.dbo.rds_cdc_enable_db` — `sys.sp_cdc_enable_db` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (`cdc.<database>_capture`): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it's named in `capture_instances`.
+- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it matches `capture_instance` (an override for exactly that ambiguous case).
 		
 
 == Fields
@@ -199,20 +199,19 @@ Regular expressions for tables to exclude.
 exclude: dbo.privatetable
 ```
 
-=== `capture_instances`
+=== `capture_instance`
 
-Optional per-table override of which CDC capture instance to stream from, keyed by fully qualified table name (`<schema>.<table>`). By default the capture instance is discovered automatically from `cdc.change_tables`, which works even when it isn't named after the `<schema>_<table>` convention — for example when CDC was already enabled on a table by another tool, such as an Oracle GoldenGate feed. This override is only needed when a table has two capture instances and neither is named after that convention, since SQL Server's supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named capture instance alongside the original — in that case table discovery cannot determine which one to stream from on its own.
+Capture instance to prefer when a table has two CDC capture instances and neither is named after the `<schema>_<table>` convention — for example a migration tool's temporary second instance during an online schema change. Only used as a tie-breaker in that case; tables with a single instance, or where one is convention-named, are unaffected, so it's safe to leave this set permanently. If a table is ambiguous and this doesn't match either of its instances, table discovery still fails for it.
 
 
-*Type*: `object`
+*Type*: `string`
 
-*Default*: `{}`
+*Default*: `""`
 
 ```yml
 # Examples
 
-capture_instances:
-  dbo.mytable: OracleGG_914102297
+capture_instance: migration_v2
 ```
 
 === `checkpoint_cache`

--- a/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
+++ b/docs/modules/components/pages/inputs/microsoft_sql_server_cdc.adoc
@@ -75,6 +75,7 @@ input:
     snapshot_max_batch_size: 1000
     include: [] # No default (required)
     exclude: [] # No default (optional)
+    capture_instances: {}
     checkpoint_cache: "" # No default (optional)
     checkpoint_cache_table_name: rpcn.CdcCheckpointCache
     checkpoint_cache_connection_string: sqlserver://username:password@remotehost/instance?param1=value&param2=value # No default (optional)
@@ -118,7 +119,7 @@ Operational notes:
 - `TRUNCATE TABLE` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with `msdb.dbo.rds_cdc_enable_db` — `sys.sp_cdc_enable_db` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (`cdc.<database>_capture`): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table since there is currently no way to specify which one to stream from — the only recourse is to drop one of the two instances on the server.
+- Each table's CDC capture instance is discovered from `cdc.change_tables`, not assumed from the `<schema>_<table>` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the `<schema>_<table>` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it's named in `capture_instances`.
 		
 
 == Fields
@@ -196,6 +197,22 @@ Regular expressions for tables to exclude.
 # Examples
 
 exclude: dbo.privatetable
+```
+
+=== `capture_instances`
+
+Optional per-table override of which CDC capture instance to stream from, keyed by fully qualified table name (`<schema>.<table>`). By default the capture instance is discovered automatically from `cdc.change_tables`, which works even when it isn't named after the `<schema>_<table>` convention — for example when CDC was already enabled on a table by another tool, such as an Oracle GoldenGate feed. This override is only needed when a table has two capture instances and neither is named after that convention, since SQL Server's supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named capture instance alongside the original — in that case table discovery cannot determine which one to stream from on its own.
+
+
+*Type*: `object`
+
+*Default*: `{}`
+
+```yml
+# Examples
+
+capture_instances:
+  dbo.mytable: OracleGG_914102297
 ```
 
 === `checkpoint_cache`

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -35,7 +35,7 @@ const (
 	fieldStreamBackoffInterval           = "stream_backoff_interval"
 	fieldTablesExclude                   = "exclude"
 	fieldTablesInclude                   = "include"
-	fieldCaptureInstances                = "capture_instances"
+	fieldCaptureInstance                 = "capture_instance"
 	fieldCheckpointLimit                 = "checkpoint_limit"
 	fieldCheckpointCache                 = "checkpoint_cache"
 	fieldCheckpointCacheKey              = "checkpoint_cache_key"
@@ -80,7 +80,7 @@ Operational notes:
 - ` + "`TRUNCATE TABLE`" + ` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with ` + "`msdb.dbo.rds_cdc_enable_db`" + ` — ` + "`sys.sp_cdc_enable_db`" + ` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (` + "`cdc.<database>_capture`" + `): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it's named in ` + "`" + fieldCaptureInstances + "`" + `.
+- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it matches ` + "`" + fieldCaptureInstance + "`" + ` (an override for exactly that ambiguous case).
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").
@@ -111,12 +111,13 @@ Operational notes:
 		Example("dbo.privatetable").
 		Optional(),
 	).
-	Field(service.NewStringMapField(fieldCaptureInstances).
-		Description("Optional per-table override of which CDC capture instance to stream from, keyed by fully qualified table name (`<schema>.<table>`). " +
-			"By default the capture instance is discovered automatically from `cdc.change_tables`, which works even when it isn't named after the `<schema>_<table>` convention — for example when CDC was already enabled on a table by another tool, such as an Oracle GoldenGate feed. " +
-			"This override is only needed when a table has two capture instances and neither is named after that convention, since SQL Server's supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named capture instance alongside the original — in that case table discovery cannot determine which one to stream from on its own.").
-		Example(map[string]any{"dbo.mytable": "OracleGG_914102297"}).
-		Default(map[string]any{}).
+	Field(service.NewStringField(fieldCaptureInstance).
+		Description("Capture instance to prefer when a table has two CDC capture instances and neither is named after the `<schema>_<table>` convention — for example a migration tool's temporary second instance during an online schema change. " +
+			"Only used as a tie-breaker in that case; tables with a single instance, or where one is convention-named, are unaffected, so it's safe to leave this set permanently. " +
+			"If a table is ambiguous and this doesn't match either of its instances, table discovery still fails for it.").
+		Example("migration_v2").
+		Default("").
+		Optional().
 		Advanced(),
 	).
 	Field(service.NewStringField(fieldCheckpointCache).
@@ -168,7 +169,7 @@ type config struct {
 	snapshotMaxBatchSize    int
 	snapshotMaxWorkers      int
 	tablesFilter            *confx.RegexpFilter
-	captureInstances        map[string]string
+	captureInstanceOverride string
 	lsnCache                string
 	lsnCacheKey             string
 	cpCacheTableName        string
@@ -233,8 +234,8 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
 		return nil, err
 	}
-	var captureInstances map[string]string
-	if captureInstances, err = conf.FieldStringMap(fieldCaptureInstances); err != nil {
+	var captureInstanceOverride string
+	if captureInstanceOverride, err = conf.FieldString(fieldCaptureInstance); err != nil {
 		return nil, err
 	}
 	// cache
@@ -296,7 +297,7 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 				Include: tableIncludes,
 				Exclude: tableExcludes,
 			},
-			captureInstances: captureInstances,
+			captureInstanceOverride: captureInstanceOverride,
 		},
 		res:       resources,
 		log:       logger,
@@ -354,7 +355,7 @@ func (i *sqlServerCDCInput) Connect(ctx context.Context) error {
 		i.cpCache = cache
 	}
 
-	if userTables, err = replication.VerifyUserDefinedTables(ctx, i.db, i.cfg.tablesFilter, i.cfg.captureInstances, i.log); err != nil {
+	if userTables, err = replication.VerifyUserDefinedTables(ctx, i.db, i.cfg.tablesFilter, i.cfg.captureInstanceOverride, i.log); err != nil {
 		return fmt.Errorf("verifying user defined tables: %w", err)
 	}
 	if cachedLSN, err = i.getCachedLSN(ctx); err != nil {

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -80,7 +80,7 @@ Operational notes:
 - ` + "`TRUNCATE TABLE`" + ` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with ` + "`msdb.dbo.rds_cdc_enable_db`" + ` — ` + "`sys.sp_cdc_enable_db`" + ` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (` + "`cdc.<database>_capture`" + `): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it matches ` + "`" + fieldCaptureInstance + "`" + ` (an override for exactly that ambiguous case).
+- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances, ` + "`" + fieldCaptureInstance + "`" + ` is preferred when it matches one of them; otherwise the instance named after the ` + "`<schema>_<table>`" + ` convention is preferred, with a warning logged; if neither applies, table discovery fails for that table.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").
@@ -112,9 +112,10 @@ Operational notes:
 		Optional(),
 	).
 	Field(service.NewStringField(fieldCaptureInstance).
-		Description("Capture instance to prefer when a table has two CDC capture instances and neither is named after the `<schema>_<table>` convention — for example a migration tool's temporary second instance during an online schema change. " +
-			"Only used as a tie-breaker in that case; tables with a single instance, or where one is convention-named, are unaffected, so it's safe to leave this set permanently. " +
-			"If a table is ambiguous and this doesn't match either of its instances, table discovery still fails for it.").
+		Description("Capture instance to prefer when a table has two CDC capture instances, such as a migration tool's temporary second instance during an online schema change. " +
+			"Takes priority over the default `<schema>_<table>` naming convention, so it's how to select the new instance during a cutover before the old one is dropped. " +
+			"Tables with a single instance are unaffected, so it's safe to leave this set permanently. " +
+			"If it doesn't match either instance on an ambiguous table, resolution falls back to the convention-named instance where there is one, otherwise table discovery still fails for that table.").
 		Example("migration_v2").
 		Default("").
 		Optional().

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -79,6 +79,7 @@ Operational notes:
 - ` + "`TRUNCATE TABLE`" + ` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with ` + "`msdb.dbo.rds_cdc_enable_db`" + ` — ` + "`sys.sp_cdc_enable_db`" + ` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (` + "`cdc.<database>_capture`" + `): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
+- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table since there is currently no way to specify which one to stream from — the only recourse is to drop one of the two instances on the server.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -35,6 +35,7 @@ const (
 	fieldStreamBackoffInterval           = "stream_backoff_interval"
 	fieldTablesExclude                   = "exclude"
 	fieldTablesInclude                   = "include"
+	fieldCaptureInstances                = "capture_instances"
 	fieldCheckpointLimit                 = "checkpoint_limit"
 	fieldCheckpointCache                 = "checkpoint_cache"
 	fieldCheckpointCacheKey              = "checkpoint_cache_key"
@@ -79,7 +80,7 @@ Operational notes:
 - ` + "`TRUNCATE TABLE`" + ` is rejected on a CDC-enabled table. To clear one, disable CDC on the table, truncate, then re-enable.
 - On AWS RDS, enable CDC with ` + "`msdb.dbo.rds_cdc_enable_db`" + ` — ` + "`sys.sp_cdc_enable_db`" + ` requires sysadmin, which RDS does not grant.
 - Do not stop the CDC capture job (` + "`cdc.<database>_capture`" + `): while it is stopped nothing is published to the change tables, so this input reads nothing and reports no error.
-- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table since there is currently no way to specify which one to stream from — the only recourse is to drop one of the two instances on the server.
+- Each table's CDC capture instance is discovered from ` + "`cdc.change_tables`" + `, not assumed from the ` + "`<schema>_<table>`" + ` naming convention, so this works whether CDC was enabled by this input, by hand, or by another tool (e.g. an Oracle GoldenGate feed) under an arbitrary capture instance name. SQL Server allows at most two capture instances per table — its supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named instance alongside the original for the duration of the migration. If a table has two capture instances and one is named after the ` + "`<schema>_<table>`" + ` convention, that one is preferred and a warning is logged; if neither is, table discovery fails for that table unless it's named in ` + "`" + fieldCaptureInstances + "`" + `.
 		`).
 	Field(service.NewStringField(fieldConnectionString).
 		Description("The connection string of the Microsoft SQL Server database to connect to.").
@@ -109,6 +110,14 @@ Operational notes:
 		Description("Regular expressions for tables to exclude.").
 		Example("dbo.privatetable").
 		Optional(),
+	).
+	Field(service.NewStringMapField(fieldCaptureInstances).
+		Description("Optional per-table override of which CDC capture instance to stream from, keyed by fully qualified table name (`<schema>.<table>`). " +
+			"By default the capture instance is discovered automatically from `cdc.change_tables`, which works even when it isn't named after the `<schema>_<table>` convention — for example when CDC was already enabled on a table by another tool, such as an Oracle GoldenGate feed. " +
+			"This override is only needed when a table has two capture instances and neither is named after that convention, since SQL Server's supported way to change a CDC-enabled table's schema without downtime is to run a second, temporarily-named capture instance alongside the original — in that case table discovery cannot determine which one to stream from on its own.").
+		Example(map[string]any{"dbo.mytable": "OracleGG_914102297"}).
+		Default(map[string]any{}).
+		Advanced(),
 	).
 	Field(service.NewStringField(fieldCheckpointCache).
 		Description("A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] to use for storing the current Log Sequence Number (LSN) that has been successfully delivered, this allows Redpanda Connect to continue from that Log Sequence Number (LSN) upon restart, rather than consume the entire state of the change table. If not set the default Microsoft SQL Server based cache will be used, see `" + fieldCheckpointCacheTableName + "` for more information.").
@@ -159,6 +168,7 @@ type config struct {
 	snapshotMaxBatchSize    int
 	snapshotMaxWorkers      int
 	tablesFilter            *confx.RegexpFilter
+	captureInstances        map[string]string
 	lsnCache                string
 	lsnCacheKey             string
 	cpCacheTableName        string
@@ -223,6 +233,10 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 	} else if tableExcludes, err = confx.ParseRegexpPatterns(excludes); err != nil {
 		return nil, err
 	}
+	var captureInstances map[string]string
+	if captureInstances, err = conf.FieldStringMap(fieldCaptureInstances); err != nil {
+		return nil, err
+	}
 	// cache
 	// if no cache component is specified then we fallback to default sql based version
 	if conf.Contains(fieldCheckpointCache) {
@@ -282,6 +296,7 @@ func newMSSQLServerCDCInput(conf *service.ParsedConfig, resources *service.Resou
 				Include: tableIncludes,
 				Exclude: tableExcludes,
 			},
+			captureInstances: captureInstances,
 		},
 		res:       resources,
 		log:       logger,
@@ -339,7 +354,7 @@ func (i *sqlServerCDCInput) Connect(ctx context.Context) error {
 		i.cpCache = cache
 	}
 
-	if userTables, err = replication.VerifyUserDefinedTables(ctx, i.db, i.cfg.tablesFilter, i.log); err != nil {
+	if userTables, err = replication.VerifyUserDefinedTables(ctx, i.db, i.cfg.tablesFilter, i.cfg.captureInstances, i.log); err != nil {
 		return fmt.Errorf("verifying user defined tables: %w", err)
 	}
 	if cachedLSN, err = i.getCachedLSN(ctx); err != nil {

--- a/internal/impl/mssqlserver/integration_test.go
+++ b/internal/impl/mssqlserver/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -517,7 +518,18 @@ microsoft_sql_server_cdc:
 	}
 }
 
-func TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstances(t *testing.T) {
+// TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart
+// confirms documented behaviour: SQL Server's supported online schema-change
+// workflow lets a table carry two capture instances at once (its hard-coded
+// maximum), and neither one has to be default-named. Without a
+// `capture_instances` override, table discovery cannot determine which of the
+// two to stream from, so it treats this as unresolvable ambiguity and the
+// whole input fails to start - even though every other included table is
+// healthy. This is a known, documented limitation (see the input's
+// "Operational notes"), not a bug under test here; see
+// TestIntegration_MicrosoftSQLServerCDC_CaptureInstanceOverrideResolvesAmbiguity
+// for the config field that resolves it.
+func TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart(t *testing.T) {
 	integration.CheckSkip(t)
 
 	connStr, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
@@ -548,14 +560,74 @@ microsoft_sql_server_cdc:
 		_ = stream.Run(runCtx)
 	}()
 
-	time.Sleep(5 * time.Second)
+	assert.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "multiple CDC capture instances")
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected Connect to repeatedly fail with the ambiguous-capture-instance error, since dbo.migrating_table "+
+			"has two non-default-named capture instances and no capture_instances override was configured")
+
 	cancel()
 	require.NoError(t, stream.StopWithin(10*time.Second))
+}
 
-	assert.NotContains(t, logs.String(), "multiple CDC capture instances",
-		"expected the input to start even though dbo.migrating_table has two non-default-named capture "+
-			"instances; there is currently no config field to disambiguate which one to stream from, so "+
-			"Connect fails repeatedly and the whole input never starts")
+// TestIntegration_MicrosoftSQLServerCDC_CaptureInstanceOverrideResolvesAmbiguity
+// confirms the capture_instances config field resolves the ambiguity
+// documented in TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart:
+// given an explicit override naming one of the two capture instances, the
+// input starts successfully and streams from the specified instance.
+func TestIntegration_MicrosoftSQLServerCDC_CaptureInstanceOverrideResolvesAmbiguity(t *testing.T) {
+	integration.CheckSkip(t)
+
+	connStr, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
+
+	db.MustExec(`CREATE SCHEMA rpcn;`)
+	db.MustExec(`CREATE TABLE dbo.migrating_table (id INT NOT NULL PRIMARY KEY);`)
+
+	db.MustEnableCDC(t.Context(), "dbo.migrating_table", "migrating_table_v1")
+	db.MustEnableCDC(t.Context(), "dbo.migrating_table", "migrating_table_v2")
+
+	cfg := `
+microsoft_sql_server_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  include: ["dbo.migrating_table"]
+  capture_instances:
+    dbo.migrating_table: migrating_table_v2`
+
+	var (
+		outBatches   []string
+		outBatchesMu sync.Mutex
+	)
+	streamBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
+	require.NoError(t, streamBuilder.AddBatchConsumerFunc(func(_ context.Context, mb service.MessageBatch) error {
+		msgBytes, err := mb[0].AsBytes()
+		require.NoError(t, err)
+		outBatchesMu.Lock()
+		outBatches = append(outBatches, string(msgBytes))
+		outBatchesMu.Unlock()
+		return nil
+	}))
+
+	stream, err := streamBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(stream.Resources())
+
+	go func() {
+		if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			t.Error(err)
+		}
+	}()
+
+	db.MustExec("INSERT INTO dbo.migrating_table (id) VALUES (1)")
+
+	assert.Eventually(t, func() bool {
+		outBatchesMu.Lock()
+		defer outBatchesMu.Unlock()
+		return len(outBatches) == 1
+	}, time.Minute*2, time.Millisecond*200, "expected the row to be streamed via the overridden capture instance")
+
+	require.NoError(t, stream.StopWithin(time.Second*10))
 }
 
 func TestIntegration_MicrosoftSQLServerCDC_OrderingOfIterator(t *testing.T) {

--- a/internal/impl/mssqlserver/integration_test.go
+++ b/internal/impl/mssqlserver/integration_test.go
@@ -689,7 +689,7 @@ func TestIntegration_MicrosoftSQLServerCDC_SnapshotAndStreaming_AllTypes(t *test
 		)
 	}
 
-	db.MustEnableCDC(t.Context(), "dbo.all_data_types")
+	db.MustEnableCDC(t.Context(), "dbo.all_data_types", mssqlservertest.DefaultCaptureInstance)
 
 	var (
 		outBatches   []string
@@ -855,7 +855,7 @@ func TestIntegration_MicrosoftSQLServerCDC_SchemaMetadata(t *testing.T) {
 	// Disable CDC so the first row becomes a snapshot row, then re-enable CDC.
 	db.MustDisableCDC(t.Context(), "dbo.schema_meta_test")
 	db.MustExecContext(t.Context(), `INSERT INTO dbo.schema_meta_test VALUES (1, N'snapshot', 1, 3.14, SYSDATETIME())`)
-	db.MustEnableCDC(t.Context(), "dbo.schema_meta_test")
+	db.MustEnableCDC(t.Context(), "dbo.schema_meta_test", mssqlservertest.DefaultCaptureInstance)
 
 	type msgMeta struct {
 		schema any

--- a/internal/impl/mssqlserver/integration_test.go
+++ b/internal/impl/mssqlserver/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -514,6 +515,47 @@ microsoft_sql_server_cdc:
 		require.Contains(t, outBatches[len(outBatches)-1], fmt.Sprintf("%d", totalWant))
 		require.NoError(t, streamResume.StopWithin(time.Second*10))
 	}
+}
+
+func TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstances(t *testing.T) {
+	integration.CheckSkip(t)
+
+	connStr, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
+
+	db.MustExec(`CREATE SCHEMA rpcn;`)
+	db.MustExec(`CREATE TABLE dbo.migrating_table (id INT NOT NULL PRIMARY KEY);`)
+
+	db.MustEnableCDC(t.Context(), "dbo.migrating_table", "migrating_table_v1")
+	db.MustEnableCDC(t.Context(), "dbo.migrating_table", "migrating_table_v2")
+
+	cfg := `
+microsoft_sql_server_cdc:
+  connection_string: %s
+  stream_snapshot: false
+  include: ["dbo.migrating_table"]`
+
+	logs := &mssqlservertest.SyncBuffer{}
+	streamBuilder := service.NewStreamBuilder()
+	streamBuilder.SetLogger(slog.New(slog.NewTextHandler(logs, nil)))
+	require.NoError(t, streamBuilder.AddInputYAML(fmt.Sprintf(cfg, connStr)))
+
+	stream, err := streamBuilder.Build()
+	require.NoError(t, err)
+	license.InjectTestService(stream.Resources())
+
+	runCtx, cancel := context.WithCancel(t.Context())
+	go func() {
+		_ = stream.Run(runCtx)
+	}()
+
+	time.Sleep(5 * time.Second)
+	cancel()
+	require.NoError(t, stream.StopWithin(10*time.Second))
+
+	assert.NotContains(t, logs.String(), "multiple CDC capture instances",
+		"expected the input to start even though dbo.migrating_table has two non-default-named capture "+
+			"instances; there is currently no config field to disambiguate which one to stream from, so "+
+			"Connect fails repeatedly and the whole input never starts")
 }
 
 func TestIntegration_MicrosoftSQLServerCDC_OrderingOfIterator(t *testing.T) {

--- a/internal/impl/mssqlserver/integration_test.go
+++ b/internal/impl/mssqlserver/integration_test.go
@@ -518,18 +518,12 @@ microsoft_sql_server_cdc:
 	}
 }
 
-// TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart
-// confirms documented behaviour: SQL Server's supported online schema-change
-// workflow lets a table carry two capture instances at once (its hard-coded
-// maximum), and neither one has to be default-named. Without a
-// `capture_instances` override, table discovery cannot determine which of the
-// two to stream from, so it treats this as unresolvable ambiguity and the
-// whole input fails to start - even though every other included table is
-// healthy. This is a known, documented limitation (see the input's
-// "Operational notes"), not a bug under test here; see
-// TestIntegration_MicrosoftSQLServerCDC_CaptureInstanceOverrideResolvesAmbiguity
-// for the config field that resolves it.
 func TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart(t *testing.T) {
+	// Confirms documented behaviour: a table with two non-convention-named
+	// capture instances and no matching `capture_instance` override is
+	// unresolvably ambiguous, so the whole input fails to start. This is a
+	// known, documented limitation (see "Operational notes").
+
 	integration.CheckSkip(t)
 
 	connStr, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
@@ -564,14 +558,14 @@ microsoft_sql_server_cdc:
 		return strings.Contains(logs.String(), "multiple CDC capture instances")
 	}, 30*time.Second, 500*time.Millisecond,
 		"expected Connect to repeatedly fail with the ambiguous-capture-instance error, since dbo.migrating_table "+
-			"has two non-default-named capture instances and no capture_instances override was configured")
+			"has two non-default-named capture instances and no capture_instance override was configured")
 
 	cancel()
 	require.NoError(t, stream.StopWithin(10*time.Second))
 }
 
 // TestIntegration_MicrosoftSQLServerCDC_CaptureInstanceOverrideResolvesAmbiguity
-// confirms the capture_instances config field resolves the ambiguity
+// confirms the capture_instance config field resolves the ambiguity
 // documented in TestIntegration_MicrosoftSQLServerCDC_TwoNonDefaultCaptureInstancesFailsToStart:
 // given an explicit override naming one of the two capture instances, the
 // input starts successfully and streams from the specified instance.
@@ -591,8 +585,7 @@ microsoft_sql_server_cdc:
   connection_string: %s
   stream_snapshot: false
   include: ["dbo.migrating_table"]
-  capture_instances:
-    dbo.migrating_table: migrating_table_v2`
+  capture_instance: migrating_table_v2`
 
 	var (
 		outBatches   []string

--- a/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
+++ b/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
@@ -91,6 +91,57 @@ end:
 	db.T.Logf("Change Data Capture enabled for table %q", fullTableName)
 }
 
+// MustEnableCDCWithCaptureInstance enables Change Data Capture on the specified table
+// under an explicit, custom-named capture instance rather than relying on the SQL
+// Server default <schema>_<table> naming convention. This simulates CDC having
+// already been enabled on a table by another tool (e.g. Oracle GoldenGate) under
+// an arbitrarily named capture instance.
+// The fullTableName should be in format "schema.table" (e.g., "dbo.all_data_types").
+// If only a table name is provided, defaults to "dbo" schema.
+func (db *TestDB) MustEnableCDCWithCaptureInstance(ctx context.Context, fullTableName, captureInstance string) {
+	db.T.Logf("Enabling Change Data Capture for table %q with capture instance %q", fullTableName, captureInstance)
+	table := strings.Split(fullTableName, ".")
+	if len(table) != 2 {
+		table = []string{"dbo", table[0]}
+	}
+	schema := table[0]
+	tableName := table[1]
+
+	query := fmt.Sprintf(`
+		EXEC sys.sp_cdc_enable_table
+		@source_schema    = '%s',
+		@source_name      = '%s',
+		@role_name        = NULL,
+		@capture_instance = '%s';`, schema, tableName, captureInstance)
+
+	_, err := db.ExecContext(ctx, query)
+	require.NoError(db.T, err)
+
+	// Wait for CDC table to be ready
+	for {
+		var minLSN, maxLSN []byte
+		if err = db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_min_lsn(?)", captureInstance).Scan(&minLSN); err != nil {
+			break
+		}
+		if err := db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_max_lsn()").Scan(&maxLSN); err != nil {
+			break
+		}
+		if minLSN != nil && maxLSN != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			goto end
+		case <-time.After(time.Second):
+		}
+	}
+
+end:
+	require.NoError(db.T, err)
+	db.T.Logf("Change Data Capture enabled for table %q with capture instance %q", fullTableName, captureInstance)
+}
+
 // WaitForCDCChanges waits until the CDC change table for each given source table
 // has at least minRows entries. Under x86 emulation on Apple Silicon the CDC
 // capture agent can be very slow, so tests must poll rather than sleep.

--- a/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
+++ b/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -379,4 +380,22 @@ func MustSetupTestWithMicrosoftSQLServerVersion(t *testing.T) (string, *sql.DB) 
 		assert.NoError(t, db.Close())
 	})
 	return connectionString, db
+}
+
+// SyncBuffer is a concurrency safe io writer for capturing logs
+type SyncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *SyncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *SyncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
+++ b/internal/impl/mssqlserver/mssqlservertest/mssqlservertest.go
@@ -24,6 +24,10 @@ import (
 	tcmssql "github.com/testcontainers/testcontainers-go/modules/mssql"
 )
 
+// DefaultCaptureInstance resolves to conventional look up of <schema>_<table>
+// when empty.
+const DefaultCaptureInstance = ""
+
 // TestDB wraps sql.DB with testing utilities for Microsoft SQL Server integration tests.
 // It provides helper methods for table creation, CDC enablement, and assertions.
 type TestDB struct {
@@ -47,58 +51,7 @@ func (db *TestDB) MustExecContext(ctx context.Context, query string, args ...any
 // MustEnableCDC enables Change Data Capture on the specified table.
 // The fullTableName should be in format "schema.table" (e.g., "dbo.all_data_types").
 // If only a table name is provided, defaults to "dbo" schema.
-func (db *TestDB) MustEnableCDC(ctx context.Context, fullTableName string) {
-	db.T.Logf("Enabling Change Data Capture for table %q", fullTableName)
-	table := strings.Split(fullTableName, ".")
-	if len(table) != 2 {
-		table = []string{"dbo", table[0]}
-	}
-	schema := table[0]
-	tableName := table[1]
-
-	query := fmt.Sprintf(`
-		EXEC sys.sp_cdc_enable_table
-		@source_schema = '%s',
-		@source_name   = '%s',
-		@role_name     = NULL;`, schema, tableName)
-
-	_, err := db.ExecContext(ctx, query)
-	require.NoError(db.T, err)
-
-	// Wait for CDC table to be ready
-	captureInstance := schema + "_" + tableName
-	for {
-		var minLSN, maxLSN []byte
-		if err = db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_min_lsn(?)", captureInstance).Scan(&minLSN); err != nil {
-			break
-		}
-		if err := db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_max_lsn()").Scan(&maxLSN); err != nil {
-			break
-		}
-		if minLSN != nil && maxLSN != nil {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			err = ctx.Err()
-			goto end
-		case <-time.After(time.Second):
-		}
-	}
-
-end:
-	require.NoError(db.T, err)
-	db.T.Logf("Change Data Capture enabled for table %q", fullTableName)
-}
-
-// MustEnableCDCWithCaptureInstance enables Change Data Capture on the specified table
-// under an explicit, custom-named capture instance rather than relying on the SQL
-// Server default <schema>_<table> naming convention. This simulates CDC having
-// already been enabled on a table by another tool (e.g. Oracle GoldenGate) under
-// an arbitrarily named capture instance.
-// The fullTableName should be in format "schema.table" (e.g., "dbo.all_data_types").
-// If only a table name is provided, defaults to "dbo" schema.
-func (db *TestDB) MustEnableCDCWithCaptureInstance(ctx context.Context, fullTableName, captureInstance string) {
+func (db *TestDB) MustEnableCDC(ctx context.Context, fullTableName string, captureInstance string) {
 	db.T.Logf("Enabling Change Data Capture for table %q with capture instance %q", fullTableName, captureInstance)
 	table := strings.Split(fullTableName, ".")
 	if len(table) != 2 {
@@ -107,6 +60,9 @@ func (db *TestDB) MustEnableCDCWithCaptureInstance(ctx context.Context, fullTabl
 	schema := table[0]
 	tableName := table[1]
 
+	if captureInstance == DefaultCaptureInstance {
+		captureInstance = schema + "_" + tableName
+	}
 	query := fmt.Sprintf(`
 		EXEC sys.sp_cdc_enable_table
 		@source_schema    = '%s',
@@ -114,10 +70,26 @@ func (db *TestDB) MustEnableCDCWithCaptureInstance(ctx context.Context, fullTabl
 		@role_name        = NULL,
 		@capture_instance = '%s';`, schema, tableName, captureInstance)
 
-	_, err := db.ExecContext(ctx, query)
-	require.NoError(db.T, err)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		_, err := db.ExecContext(ctx, query)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "SQL Server Agent is starting") || time.Now().After(deadline) {
+			require.NoError(db.T, err)
+		}
+		select {
+		case <-ctx.Done():
+			require.NoError(db.T, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 
 	// Wait for CDC table to be ready
+	var err error
 	for {
 		var minLSN, maxLSN []byte
 		if err = db.QueryRowContext(ctx, "SELECT sys.fn_cdc_get_min_lsn(?)", captureInstance).Scan(&minLSN); err != nil {

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -485,8 +485,8 @@ type captureInstance struct {
 
 // VerifyUserDefinedTables verifies underlying user defined tables based on
 // supplied include/exclude filters, resolving each one's CDC capture
-// instance(s) via cdc.change_tables, or the capture instance config override.
-func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, captureInstanceOverrides map[string]string, log *service.Logger) ([]UserDefinedTable, error) {
+// instance(s) via cdc.change_tables. captureInstanceOverride optionally overrides this.
+func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, capInstanceOverride string, log *service.Logger) ([]UserDefinedTable, error) {
 	q := `
 	SELECT s.name AS SchemaName, t.name AS TableName, ct.capture_instance, ct.start_lsn
 	FROM sys.tables t
@@ -538,7 +538,7 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	userTables := make([]UserDefinedTable, 0, len(order))
 	for _, fullName := range order {
 		tbl := tables[fullName]
-		if err := resolveCaptureInstance(&tbl, instances[fullName], captureInstanceOverrides[fullName], log); err != nil {
+		if err := resolveCaptureInstance(&tbl, instances[fullName], capInstanceOverride, log); err != nil {
 			return nil, err
 		}
 		if len(tbl.startLSN) == 0 {
@@ -555,22 +555,6 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 }
 
 func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, override string, log *service.Logger) error {
-	names := make([]string, len(instances))
-	for i, inst := range instances {
-		names[i] = inst.name
-	}
-
-	if override != "" {
-		for _, inst := range instances {
-			if inst.name == override {
-				tbl.CaptureInstance = inst.name
-				tbl.startLSN = inst.startLSN
-				return nil
-			}
-		}
-		return fmt.Errorf("configured capture instance '%s' for table '%s' does not match any existing CDC capture instance (found: %s)", override, tbl.FullName(), strings.Join(names, ", "))
-	}
-
 	switch len(instances) {
 	case 0:
 		return fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
@@ -578,6 +562,11 @@ func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, 
 		tbl.CaptureInstance = instances[0].name
 		tbl.startLSN = instances[0].startLSN
 		return nil
+	}
+
+	names := make([]string, len(instances))
+	for i, inst := range instances {
+		names[i] = inst.name
 	}
 
 	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
@@ -591,6 +580,17 @@ func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, 
 		tbl.CaptureInstance = inst.name
 		tbl.startLSN = inst.startLSN
 		return nil
+	}
+
+	if override != "" {
+		for _, inst := range instances {
+			if inst.name == override {
+				tbl.CaptureInstance = inst.name
+				tbl.startLSN = inst.startLSN
+				return nil
+			}
+		}
+		return fmt.Errorf("table '%s' has multiple CDC capture instances (%s) and configured capture_instance '%s' does not match either", tbl.FullName(), strings.Join(names, ", "), override)
 	}
 
 	return fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(names, ", "))

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -510,41 +510,8 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	}
 
 	for i, tbl := range userTables {
-		// Resolve the capture instance via source_object_id rather than assuming
-		// the default <schema>_<table> naming convention: CDC may already be
-		// enabled on this table by another tool (e.g. a GoldenGate feed) under an
-		// arbitrarily named capture instance.
-		q := "SELECT capture_instance, start_lsn FROM cdc.change_tables WHERE source_object_id = OBJECT_ID(?)"
-		rows, err := db.QueryContext(ctx, q, tbl.FullName())
-		if err != nil {
-			return nil, fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
-		}
-
-		var captureInstances []string
-		for rows.Next() {
-			var captureInstance string
-			var startLSN LSN
-			if err := rows.Scan(&captureInstance, &startLSN); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("scanning cdc.change_tables row for table '%s': %w", tbl.FullName(), err)
-			}
-			captureInstances = append(captureInstances, captureInstance)
-			tbl.CaptureInstance = captureInstance
-			tbl.startLSN = startLSN
-		}
-		if err := rows.Err(); err != nil {
-			rows.Close()
-			return nil, fmt.Errorf("iterating cdc.change_tables rows for table '%s': %w", tbl.FullName(), err)
-		}
-		rows.Close()
-
-		switch len(captureInstances) {
-		case 0:
-			return nil, fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
-		case 1:
-			// resolved unambiguously above.
-		default:
-			return nil, fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(captureInstances, ", "))
+		if err := resolveCaptureInstance(ctx, db, &tbl); err != nil {
+			return nil, err
 		}
 		if len(tbl.startLSN) == 0 {
 			return nil, fmt.Errorf("field 'start_lsn' in change table '%s' expected to be set but was not", tbl.ToChangeTable())
@@ -557,4 +524,48 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	}
 
 	return userTables, nil
+}
+
+func resolveCaptureInstance(ctx context.Context, db *sql.DB, tbl *UserDefinedTable) error {
+	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
+	var startLSN LSN
+	err := db.QueryRowContext(ctx, "SELECT start_lsn FROM cdc.change_tables WHERE capture_instance = ?", conventionName).Scan(&startLSN)
+	switch {
+	case err == nil:
+		tbl.CaptureInstance = conventionName
+		tbl.startLSN = startLSN
+		return nil
+	case !errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
+	}
+
+	q := "SELECT capture_instance, start_lsn FROM cdc.change_tables WHERE source_object_id = OBJECT_ID(?)"
+	rows, err := db.QueryContext(ctx, q, tbl.FullName())
+	if err != nil {
+		return fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
+	}
+	defer rows.Close()
+
+	var captureInstances []string
+	for rows.Next() {
+		var captureInstance string
+		if err := rows.Scan(&captureInstance, &startLSN); err != nil {
+			return fmt.Errorf("scanning cdc.change_tables row for table '%s': %w", tbl.FullName(), err)
+		}
+		captureInstances = append(captureInstances, captureInstance)
+		tbl.CaptureInstance = captureInstance
+		tbl.startLSN = startLSN
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating cdc.change_tables rows for table '%s': %w", tbl.FullName(), err)
+	}
+
+	switch len(captureInstances) {
+	case 0:
+		return fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
+	case 1:
+		return nil
+	default:
+		return fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(captureInstances, ", "))
+	}
 }

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -461,14 +461,15 @@ func (r *ChangeTableStream) ReadChangeTables(ctx context.Context, db *sql.DB, st
 
 // UserDefinedTable represents a found user's SQL Server table (called a user-defined table) in SQL.
 type UserDefinedTable struct {
-	Schema   string
-	Name     string
-	startLSN LSN
+	Schema          string
+	Name            string
+	CaptureInstance string
+	startLSN        LSN
 }
 
-// ToChangeTable returns a string in the SQL Server change table format of cdc.<schema>_<tablename>_CT.
+// ToChangeTable returns a string in the SQL Server change table format of cdc.<capture_instance>_CT.
 func (t *UserDefinedTable) ToChangeTable() string {
-	return fmt.Sprintf("cdc.%s_%s_CT", t.Schema, t.Name)
+	return fmt.Sprintf("cdc.%s_CT", t.CaptureInstance)
 }
 
 // FullName returns a string of the table name including the schema (ie dbo.<tablename>).
@@ -509,12 +510,41 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	}
 
 	for i, tbl := range userTables {
-		q := "SELECT TOP 1 start_lsn FROM cdc.change_tables WHERE capture_instance = ?"
-		if err := db.QueryRowContext(ctx, q, fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)).Scan(&tbl.startLSN); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, fmt.Errorf("no change table found for table '%s'", tbl.FullName())
+		// Resolve the capture instance via source_object_id rather than assuming
+		// the default <schema>_<table> naming convention: CDC may already be
+		// enabled on this table by another tool (e.g. a GoldenGate feed) under an
+		// arbitrarily named capture instance.
+		q := "SELECT capture_instance, start_lsn FROM cdc.change_tables WHERE source_object_id = OBJECT_ID(?)"
+		rows, err := db.QueryContext(ctx, q, tbl.FullName())
+		if err != nil {
+			return nil, fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
+		}
+
+		var captureInstances []string
+		for rows.Next() {
+			var captureInstance string
+			var startLSN LSN
+			if err := rows.Scan(&captureInstance, &startLSN); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scanning cdc.change_tables row for table '%s': %w", tbl.FullName(), err)
 			}
-			return nil, fmt.Errorf("fetching change tables: %w", err)
+			captureInstances = append(captureInstances, captureInstance)
+			tbl.CaptureInstance = captureInstance
+			tbl.startLSN = startLSN
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("iterating cdc.change_tables rows for table '%s': %w", tbl.FullName(), err)
+		}
+		rows.Close()
+
+		switch len(captureInstances) {
+		case 0:
+			return nil, fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
+		case 1:
+			// resolved unambiguously above.
+		default:
+			return nil, fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(captureInstances, ", "))
 		}
 		if len(tbl.startLSN) == 0 {
 			return nil, fmt.Errorf("field 'start_lsn' in change table '%s' expected to be set but was not", tbl.ToChangeTable())

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -485,8 +485,8 @@ type captureInstance struct {
 
 // VerifyUserDefinedTables verifies underlying user defined tables based on
 // supplied include/exclude filters, resolving each one's CDC capture
-// instance(s) via cdc.change_tables.
-func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, log *service.Logger) ([]UserDefinedTable, error) {
+// instance(s) via cdc.change_tables, or the capture instance config override.
+func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, captureInstanceOverrides map[string]string, log *service.Logger) ([]UserDefinedTable, error) {
 	q := `
 	SELECT s.name AS SchemaName, t.name AS TableName, ct.capture_instance, ct.start_lsn
 	FROM sys.tables t
@@ -538,7 +538,7 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	userTables := make([]UserDefinedTable, 0, len(order))
 	for _, fullName := range order {
 		tbl := tables[fullName]
-		if err := resolveCaptureInstance(&tbl, instances[fullName], log); err != nil {
+		if err := resolveCaptureInstance(&tbl, instances[fullName], captureInstanceOverrides[fullName], log); err != nil {
 			return nil, err
 		}
 		if len(tbl.startLSN) == 0 {
@@ -554,7 +554,23 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	return userTables, nil
 }
 
-func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, log *service.Logger) error {
+func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, override string, log *service.Logger) error {
+	names := make([]string, len(instances))
+	for i, inst := range instances {
+		names[i] = inst.name
+	}
+
+	if override != "" {
+		for _, inst := range instances {
+			if inst.name == override {
+				tbl.CaptureInstance = inst.name
+				tbl.startLSN = inst.startLSN
+				return nil
+			}
+		}
+		return fmt.Errorf("configured capture instance '%s' for table '%s' does not match any existing CDC capture instance (found: %s)", override, tbl.FullName(), strings.Join(names, ", "))
+	}
+
 	switch len(instances) {
 	case 0:
 		return fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
@@ -562,11 +578,6 @@ func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, 
 		tbl.CaptureInstance = instances[0].name
 		tbl.startLSN = instances[0].startLSN
 		return nil
-	}
-
-	names := make([]string, len(instances))
-	for i, inst := range instances {
-		names[i] = inst.name
 	}
 
 	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -477,46 +477,74 @@ func (t *UserDefinedTable) FullName() string {
 	return fmt.Sprintf("%s.%s", t.Schema, t.Name)
 }
 
-// VerifyUserDefinedTables verifies underlying user defined tables based on supplied
-// include and exclude filters, validating the associated change table also exists.
+// captureInstance is one row of cdc.change_tables for a given source table.
+type captureInstance struct {
+	name     string
+	startLSN LSN
+}
+
+// VerifyUserDefinedTables verifies underlying user defined tables based on
+// supplied include/exclude filters, resolving each one's CDC capture
+// instance(s) via cdc.change_tables.
 func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, log *service.Logger) ([]UserDefinedTable, error) {
 	q := `
-	SELECT s.name AS SchemaName, t.name AS TableName
+	SELECT s.name AS SchemaName, t.name AS TableName, ct.capture_instance, ct.start_lsn
 	FROM sys.tables t
 	INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+	LEFT JOIN cdc.change_tables ct ON ct.source_object_id = t.object_id
 	WHERE s.name != 'cdc'
-	ORDER BY s.name, t.name;`
+	ORDER BY s.name, t.name, ct.capture_instance;`
 	rows, err := db.QueryContext(ctx, q)
 	if err != nil {
-		return nil, fmt.Errorf("fetching user defined tables from sys.tables for verification: %w", err)
+		return nil, fmt.Errorf("fetching user defined tables and capture instances for verification: %w", err)
 	}
+	defer rows.Close()
 
-	var userTables []UserDefinedTable
+	var (
+		order     []string
+		tables    = map[string]UserDefinedTable{}
+		instances = map[string][]captureInstance{}
+	)
 	for rows.Next() {
-		var ut UserDefinedTable
-		if err := rows.Scan(&ut.Schema, &ut.Name); err != nil {
+		var (
+			schema, name string
+			instanceName sql.NullString
+			startLSN     LSN
+		)
+		if err := rows.Scan(&schema, &name, &instanceName, &startLSN); err != nil {
 			return nil, fmt.Errorf("scanning sys.tables row for user defined tables: %w", err)
 		}
-		if tableFilter.Matches(fmt.Sprintf("%s.%s", ut.Schema, ut.Name)) {
-			userTables = append(userTables, ut)
+
+		fullName := fmt.Sprintf("%s.%s", schema, name)
+		if !tableFilter.Matches(fullName) {
+			continue
+		}
+		if _, ok := tables[fullName]; !ok {
+			tables[fullName] = UserDefinedTable{Schema: schema, Name: name}
+			order = append(order, fullName)
+		}
+		if instanceName.Valid {
+			instances[fullName] = append(instances[fullName], captureInstance{name: instanceName.String, startLSN: startLSN})
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating through sys.tables for user defined tables: %w", err)
 	}
 
-	if len(userTables) == 0 {
+	if len(order) == 0 {
 		return nil, errors.New("no user defined tables found for given include and exclude filters")
 	}
 
-	for i, tbl := range userTables {
-		if err := resolveCaptureInstance(ctx, db, &tbl); err != nil {
+	userTables := make([]UserDefinedTable, 0, len(order))
+	for _, fullName := range order {
+		tbl := tables[fullName]
+		if err := resolveCaptureInstance(&tbl, instances[fullName], log); err != nil {
 			return nil, err
 		}
 		if len(tbl.startLSN) == 0 {
 			return nil, fmt.Errorf("field 'start_lsn' in change table '%s' expected to be set but was not", tbl.ToChangeTable())
 		}
-		userTables[i] = tbl
+		userTables = append(userTables, tbl)
 	}
 
 	for _, t := range userTables {
@@ -526,46 +554,33 @@ func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx
 	return userTables, nil
 }
 
-func resolveCaptureInstance(ctx context.Context, db *sql.DB, tbl *UserDefinedTable) error {
-	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
-	var startLSN LSN
-	err := db.QueryRowContext(ctx, "SELECT start_lsn FROM cdc.change_tables WHERE capture_instance = ?", conventionName).Scan(&startLSN)
-	switch {
-	case err == nil:
-		tbl.CaptureInstance = conventionName
-		tbl.startLSN = startLSN
-		return nil
-	case !errors.Is(err, sql.ErrNoRows):
-		return fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
-	}
-
-	q := "SELECT capture_instance, start_lsn FROM cdc.change_tables WHERE source_object_id = OBJECT_ID(?)"
-	rows, err := db.QueryContext(ctx, q, tbl.FullName())
-	if err != nil {
-		return fmt.Errorf("fetching change tables for table '%s': %w", tbl.FullName(), err)
-	}
-	defer rows.Close()
-
-	var captureInstances []string
-	for rows.Next() {
-		var captureInstance string
-		if err := rows.Scan(&captureInstance, &startLSN); err != nil {
-			return fmt.Errorf("scanning cdc.change_tables row for table '%s': %w", tbl.FullName(), err)
-		}
-		captureInstances = append(captureInstances, captureInstance)
-		tbl.CaptureInstance = captureInstance
-		tbl.startLSN = startLSN
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating cdc.change_tables rows for table '%s': %w", tbl.FullName(), err)
-	}
-
-	switch len(captureInstances) {
+func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, log *service.Logger) error {
+	switch len(instances) {
 	case 0:
 		return fmt.Errorf("no change table found for table '%s': is CDC enabled for this table?", tbl.FullName())
 	case 1:
+		tbl.CaptureInstance = instances[0].name
+		tbl.startLSN = instances[0].startLSN
 		return nil
-	default:
-		return fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(captureInstances, ", "))
 	}
+
+	names := make([]string, len(instances))
+	for i, inst := range instances {
+		names[i] = inst.name
+	}
+
+	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
+	for _, inst := range instances {
+		if inst.name != conventionName {
+			continue
+		}
+		log.Warnf("Table '%s' has multiple CDC capture instances (%s); preferring the default-named instance '%s'. "+
+			"If this is a mid-migration cutover, drop the old instance once the migration completes.",
+			tbl.FullName(), strings.Join(names, ", "), conventionName)
+		tbl.CaptureInstance = inst.name
+		tbl.startLSN = inst.startLSN
+		return nil
+	}
+
+	return fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(names, ", "))
 }

--- a/internal/impl/mssqlserver/replication/stream.go
+++ b/internal/impl/mssqlserver/replication/stream.go
@@ -485,7 +485,9 @@ type captureInstance struct {
 
 // VerifyUserDefinedTables verifies underlying user defined tables based on
 // supplied include/exclude filters, resolving each one's CDC capture
-// instance(s) via cdc.change_tables. captureInstanceOverride optionally overrides this.
+// instance(s) via cdc.change_tables. capInstanceOverride optionally names a
+// literal capture instance to prefer for a table with two capture instances;
+// see resolveCaptureInstance for the full precedence.
 func VerifyUserDefinedTables(ctx context.Context, db *sql.DB, tableFilter *confx.RegexpFilter, capInstanceOverride string, log *service.Logger) ([]UserDefinedTable, error) {
 	q := `
 	SELECT s.name AS SchemaName, t.name AS TableName, ct.capture_instance, ct.start_lsn
@@ -569,19 +571,6 @@ func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, 
 		names[i] = inst.name
 	}
 
-	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
-	for _, inst := range instances {
-		if inst.name != conventionName {
-			continue
-		}
-		log.Warnf("Table '%s' has multiple CDC capture instances (%s); preferring the default-named instance '%s'. "+
-			"If this is a mid-migration cutover, drop the old instance once the migration completes.",
-			tbl.FullName(), strings.Join(names, ", "), conventionName)
-		tbl.CaptureInstance = inst.name
-		tbl.startLSN = inst.startLSN
-		return nil
-	}
-
 	if override != "" {
 		for _, inst := range instances {
 			if inst.name == override {
@@ -590,8 +579,29 @@ func resolveCaptureInstance(tbl *UserDefinedTable, instances []captureInstance, 
 				return nil
 			}
 		}
-		return fmt.Errorf("table '%s' has multiple CDC capture instances (%s) and configured capture_instance '%s' does not match either", tbl.FullName(), strings.Join(names, ", "), override)
 	}
 
+	conventionName := fmt.Sprintf("%s_%s", tbl.Schema, tbl.Name)
+	for _, inst := range instances {
+		if inst.name != conventionName {
+			continue
+		}
+		if override != "" {
+			log.Warnf("Table '%s' has multiple CDC capture instances (%s); configured capture_instance '%s' does not match either, falling back to the default-named instance '%s'. "+
+				"If this is a mid-migration cutover, check capture_instance matches the new instance's actual name.",
+				tbl.FullName(), strings.Join(names, ", "), override, conventionName)
+		} else {
+			log.Warnf("Table '%s' has multiple CDC capture instances (%s); preferring the default-named instance '%s'. "+
+				"If this is a mid-migration cutover, set capture_instance to the new instance's name, or drop the old one once the migration completes.",
+				tbl.FullName(), strings.Join(names, ", "), conventionName)
+		}
+		tbl.CaptureInstance = inst.name
+		tbl.startLSN = inst.startLSN
+		return nil
+	}
+
+	if override != "" {
+		return fmt.Errorf("table '%s' has multiple CDC capture instances (%s) and configured capture_instance '%s' does not match either", tbl.FullName(), strings.Join(names, ", "), override)
+	}
 	return fmt.Errorf("table '%s' has multiple CDC capture instances (%s): unable to determine which one to stream from", tbl.FullName(), strings.Join(names, ", "))
 }

--- a/internal/impl/mssqlserver/replication/stream_integration_test.go
+++ b/internal/impl/mssqlserver/replication/stream_integration_test.go
@@ -41,19 +41,14 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 			captureInstance = "OracleGG_914102297"
 		)
 		db.MustExec(`CREATE TABLE dbo.custom_capture_test (id INT NOT NULL PRIMARY KEY, data NVARCHAR(100));`)
-		// Simulate CDC having already been enabled on this table by another
-		// tool (e.g. Oracle GoldenGate) under an arbitrarily named capture
-		// instance, rather than the SQL Server default <schema>_<table>.
 		db.MustEnableCDC(t.Context(), fullTableName, captureInstance)
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "", log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, captureInstance, tables[0].CaptureInstance)
 		assert.Equal(t, fmt.Sprintf("cdc.%s_CT", captureInstance), tables[0].ToChangeTable())
 
-		// Insert a row and confirm it's actually picked up from the
-		// correctly-named change table when streaming.
 		db.MustExec("INSERT INTO dbo.custom_capture_test (id, data) VALUES (?, ?)", 1, "hello")
 
 		require.Eventually(t, func() bool {
@@ -110,7 +105,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		logs := &mssqlservertest.SyncBuffer{}
 		warnLog := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(logs, nil)))
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, warnLog)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "", warnLog)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "dbo_migration_capture_test", tables[0].CaptureInstance)
@@ -125,7 +120,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustExec(`CREATE TABLE dbo.default_capture_test (id INT NOT NULL PRIMARY KEY);`)
 		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "", log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "dbo_default_capture_test", tables[0].CaptureInstance)
@@ -139,7 +134,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustEnableCDC(t.Context(), fullTableName, "capture_alpha")
 		db.MustEnableCDC(t.Context(), fullTableName, "capture_beta")
 
-		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
+		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "", log)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "capture_alpha")
 		require.ErrorContains(t, err, "capture_beta")
@@ -152,23 +147,46 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustEnableCDC(t.Context(), fullTableName, "override_alpha")
 		db.MustEnableCDC(t.Context(), fullTableName, "override_beta")
 
-		overrides := map[string]string{fullTableName: "override_beta"}
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), overrides, log)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "override_beta", log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "override_beta", tables[0].CaptureInstance)
 	})
 
-	t.Run("OverrideNotFoundErrors", func(t *testing.T) {
+	t.Run("OverrideNotFoundOnAmbiguousTableErrors", func(t *testing.T) {
 		const fullTableName = "dbo.override_typo_test"
 		db.MustExec(`CREATE TABLE dbo.override_typo_test (id INT NOT NULL PRIMARY KEY);`)
-		db.MustEnableCDC(t.Context(), fullTableName, "the_real_instance")
+		db.MustEnableCDC(t.Context(), fullTableName, "instance_alpha")
+		db.MustEnableCDC(t.Context(), fullTableName, "instance_beta")
 
-		overrides := map[string]string{fullTableName: "typo_instance"}
-		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), overrides, log)
+		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "typo_instance", log)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "typo_instance")
-		require.ErrorContains(t, err, "the_real_instance")
+		require.ErrorContains(t, err, "instance_alpha")
+		require.ErrorContains(t, err, "instance_beta")
+	})
+
+	t.Run("OverrideIgnoredWhenUnambiguous", func(t *testing.T) {
+		const fullTableName = "dbo.override_unambiguous_test"
+		db.MustExec(`CREATE TABLE dbo.override_unambiguous_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, "the_only_instance")
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "some_unrelated_override", log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "the_only_instance", tables[0].CaptureInstance)
+	})
+
+	t.Run("ConventionNamePreferredOverOverride", func(t *testing.T) {
+		const fullTableName = "dbo.override_convention_precedence_test"
+		db.MustExec(`CREATE TABLE dbo.override_convention_precedence_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
+		db.MustEnableCDC(t.Context(), fullTableName, "other_instance")
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "other_instance", log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "dbo_override_convention_precedence_test", tables[0].CaptureInstance)
 	})
 }
 

--- a/internal/impl/mssqlserver/replication/stream_integration_test.go
+++ b/internal/impl/mssqlserver/replication/stream_integration_test.go
@@ -177,7 +177,12 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		assert.Equal(t, "the_only_instance", tables[0].CaptureInstance)
 	})
 
-	t.Run("ConventionNamePreferredOverOverride", func(t *testing.T) {
+	t.Run("OverridePreferredOverConventionName", func(t *testing.T) {
+		// An explicit capture_instance is how an operator selects the new
+		// instance during a mid-migration cutover, before the old
+		// (convention-named) instance is dropped - it must win even though
+		// the other instance is convention-named, or there'd be no way to
+		// cut over until the old instance is gone.
 		const fullTableName = "dbo.override_convention_precedence_test"
 		db.MustExec(`CREATE TABLE dbo.override_convention_precedence_test (id INT NOT NULL PRIMARY KEY);`)
 		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
@@ -186,7 +191,28 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "other_instance", log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
-		assert.Equal(t, "dbo_override_convention_precedence_test", tables[0].CaptureInstance)
+		assert.Equal(t, "other_instance", tables[0].CaptureInstance)
+	})
+
+	t.Run("DefaultNamedInstancePreferredWhenOverrideDoesNotMatch", func(t *testing.T) {
+		// If the configured override doesn't match either instance, resolution
+		// falls back to the convention-named one, and the warning must name
+		// the ignored override so the operator can see why it had no effect.
+		const fullTableName = "dbo.override_fallback_test"
+		db.MustExec(`CREATE TABLE dbo.override_fallback_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
+		db.MustEnableCDC(t.Context(), fullTableName, "fallback_other_instance")
+
+		logs := &mssqlservertest.SyncBuffer{}
+		warnLog := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(logs, nil)))
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), "typo_instance", warnLog)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "dbo_override_fallback_test", tables[0].CaptureInstance)
+
+		assert.Contains(t, logs.String(), "typo_instance")
+		assert.Contains(t, logs.String(), "does not match either")
 	})
 }
 

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -138,7 +138,6 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		require.ErrorContains(t, err, "capture_beta")
 		require.ErrorContains(t, err, "multiple CDC capture instances")
 	})
-
 }
 
 func includeFilterFor(t *testing.T, fullTableName string) *confx.RegexpFilter {

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -46,7 +46,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		// instance, rather than the SQL Server default <schema>_<table>.
 		db.MustEnableCDC(t.Context(), fullTableName, captureInstance)
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, captureInstance, tables[0].CaptureInstance)
@@ -110,7 +110,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		logs := &mssqlservertest.SyncBuffer{}
 		warnLog := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(logs, nil)))
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), warnLog)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, warnLog)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "dbo_migration_capture_test", tables[0].CaptureInstance)
@@ -125,7 +125,7 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustExec(`CREATE TABLE dbo.default_capture_test (id INT NOT NULL PRIMARY KEY);`)
 		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "dbo_default_capture_test", tables[0].CaptureInstance)
@@ -139,11 +139,36 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustEnableCDC(t.Context(), fullTableName, "capture_alpha")
 		db.MustEnableCDC(t.Context(), fullTableName, "capture_beta")
 
-		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), nil, log)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "capture_alpha")
 		require.ErrorContains(t, err, "capture_beta")
 		require.ErrorContains(t, err, "multiple CDC capture instances")
+	})
+
+	t.Run("AmbiguousMultipleCaptureInstancesResolvedByOverride", func(t *testing.T) {
+		const fullTableName = "dbo.ambiguous_override_test"
+		db.MustExec(`CREATE TABLE dbo.ambiguous_override_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, "override_alpha")
+		db.MustEnableCDC(t.Context(), fullTableName, "override_beta")
+
+		overrides := map[string]string{fullTableName: "override_beta"}
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), overrides, log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "override_beta", tables[0].CaptureInstance)
+	})
+
+	t.Run("OverrideNotFoundErrors", func(t *testing.T) {
+		const fullTableName = "dbo.override_typo_test"
+		db.MustExec(`CREATE TABLE dbo.override_typo_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, "the_real_instance")
+
+		overrides := map[string]string{fullTableName: "typo_instance"}
+		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), overrides, log)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "typo_instance")
+		require.ErrorContains(t, err, "the_real_instance")
 	})
 }
 

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -107,10 +107,17 @@ func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.
 		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
 		db.MustEnableCDC(t.Context(), fullTableName, "migration_temp_instance")
 
-		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		logs := &mssqlservertest.SyncBuffer{}
+		warnLog := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(logs, nil)))
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), warnLog)
 		require.NoError(t, err)
 		require.Len(t, tables, 1)
 		assert.Equal(t, "dbo_migration_capture_test", tables[0].CaptureInstance)
+
+		assert.Contains(t, logs.String(), "multiple CDC capture instances")
+		assert.Contains(t, logs.String(), "migration_temp_instance")
+		assert.Contains(t, logs.String(), "dbo_migration_capture_test")
 	})
 
 	t.Run("DefaultNamedCaptureInstance", func(t *testing.T) {

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/confx"
+	"github.com/redpanda-data/connect/v4/internal/impl/mssqlserver/mssqlservertest"
+	"github.com/redpanda-data/connect/v4/internal/impl/mssqlserver/replication"
+)
+
+// includeFilterFor builds a confx.RegexpFilter that matches only the given
+// fully-qualified table name (e.g. "dbo.mytable").
+func includeFilterFor(t *testing.T, fullTableName string) *confx.RegexpFilter {
+	t.Helper()
+	include, err := confx.ParseRegexpPatterns([]string{"^" + regexp.QuoteMeta(fullTableName) + "$"})
+	require.NoError(t, err)
+	return &confx.RegexpFilter{Include: include}
+}
+
+// TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution covers
+// resolving a user table's CDC change table via cdc.change_tables (keyed off
+// source_object_id) rather than assuming the default <schema>_<table> capture
+// instance naming convention.
+func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testing.T) {
+	integration.CheckSkip(t)
+
+	_, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
+	log := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	t.Run("CustomNamedCaptureInstance", func(t *testing.T) {
+		const (
+			fullTableName   = "dbo.custom_capture_test"
+			captureInstance = "OracleGG_914102297"
+		)
+		db.MustExec(`CREATE TABLE dbo.custom_capture_test (id INT NOT NULL PRIMARY KEY, data NVARCHAR(100));`)
+		// Simulate CDC having already been enabled on this table by another
+		// tool (e.g. Oracle GoldenGate) under an arbitrarily named capture
+		// instance, rather than the SQL Server default <schema>_<table>.
+		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, captureInstance)
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, captureInstance, tables[0].CaptureInstance)
+		assert.Equal(t, fmt.Sprintf("cdc.%s_CT", captureInstance), tables[0].ToChangeTable())
+
+		// Insert a row and confirm it's actually picked up from the
+		// correctly-named change table when streaming.
+		db.MustExec("INSERT INTO dbo.custom_capture_test (id, data) VALUES (?, ?)", 1, "hello")
+
+		require.Eventually(t, func() bool {
+			var count int
+			q := fmt.Sprintf("SELECT COUNT(*) FROM cdc.[%s_CT]", captureInstance)
+			if err := db.QueryRowContext(t.Context(), q).Scan(&count); err != nil {
+				return false
+			}
+			return count >= 1
+		}, 2*time.Minute, time.Second, "expected inserted row to appear in custom-named change table")
+
+		publisher := &publisherStub{}
+		streaming := replication.NewChangeTableStream(tables, publisher, 200*time.Millisecond, log)
+
+		streamCtx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- streaming.ReadChangeTables(streamCtx, db.DB, nil)
+		}()
+
+		require.Eventually(t, func() bool {
+			return publisher.count() >= 1
+		}, 2*time.Minute, 100*time.Millisecond, "expected change to be streamed from the resolved custom capture instance")
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Logf("ReadChangeTables returned non-cancellation error after context cancel: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("ReadChangeTables did not return after context cancellation")
+		}
+
+		publisher.mu.Lock()
+		defer publisher.mu.Unlock()
+		require.NotEmpty(t, publisher.messages)
+		msg := publisher.messages[0]
+		assert.Equal(t, "dbo", msg.Schema)
+		assert.Equal(t, "custom_capture_test", msg.Table)
+		assert.Equal(t, "insert", msg.Operation)
+		data, ok := msg.Data.(map[string]any)
+		require.True(t, ok, "expected msg.Data to be map[string]any, got %T", msg.Data)
+		assert.EqualValues(t, 1, data["id"])
+		assert.Equal(t, "hello", data["data"])
+	})
+
+	t.Run("DefaultNamedCaptureInstance", func(t *testing.T) {
+		const fullTableName = "dbo.default_capture_test"
+		db.MustExec(`CREATE TABLE dbo.default_capture_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName)
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "dbo_default_capture_test", tables[0].CaptureInstance)
+		assert.Equal(t, "cdc.dbo_default_capture_test_CT", tables[0].ToChangeTable())
+	})
+
+	t.Run("AmbiguousMultipleCaptureInstances", func(t *testing.T) {
+		const fullTableName = "dbo.ambiguous_capture_test"
+		db.MustExec(`CREATE TABLE dbo.ambiguous_capture_test (id INT NOT NULL PRIMARY KEY);`)
+		// SQL Server allows up to two capture instances per source table.
+		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, "capture_alpha")
+		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, "capture_beta")
+
+		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "capture_alpha")
+		require.ErrorContains(t, err, "capture_beta")
+		require.ErrorContains(t, err, "multiple CDC capture instances")
+	})
+}

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package replication
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCaptureInstance(t *testing.T) {
+	tests := []struct {
+		name         string
+		schema       string
+		table        string
+		instances    []captureInstance
+		override     string
+		wantInstance string
+		warnContains string
+		errContains  string
+	}{
+		{
+			name:        "no instances",
+			schema:      "dbo",
+			table:       "orders",
+			errContains: "no change table found for table 'dbo.orders'",
+		},
+		{
+			name:         "single instance resolves regardless of naming",
+			schema:       "dbo",
+			table:        "orders",
+			instances:    []captureInstance{{name: "OracleGG_914102297", startLSN: LSN{0x01}}},
+			wantInstance: "OracleGG_914102297",
+		},
+		{
+			name:         "single instance ignores an unrelated override",
+			schema:       "dbo",
+			table:        "orders",
+			instances:    []captureInstance{{name: "the_only_instance", startLSN: LSN{0x01}}},
+			override:     "some_unrelated_override",
+			wantInstance: "the_only_instance",
+		},
+		{
+			name:   "two instances, convention-named preferred with warning",
+			schema: "dbo",
+			table:  "orders",
+			instances: []captureInstance{
+				{name: "dbo_orders", startLSN: LSN{0x01}},
+				{name: "migration_temp_instance", startLSN: LSN{0x02}},
+			},
+			wantInstance: "dbo_orders",
+			warnContains: "preferring the default-named instance 'dbo_orders'",
+		},
+		{
+			name:   "two instances, override wins over convention name",
+			schema: "dbo",
+			table:  "orders",
+			instances: []captureInstance{
+				{name: "dbo_orders", startLSN: LSN{0x01}},
+				{name: "migration_v2", startLSN: LSN{0x02}},
+			},
+			override:     "migration_v2",
+			wantInstance: "migration_v2",
+		},
+		{
+			name:   "two instances, override matching neither falls back to convention name with warning",
+			schema: "dbo",
+			table:  "orders",
+			instances: []captureInstance{
+				{name: "dbo_orders", startLSN: LSN{0x01}},
+				{name: "migration_v2", startLSN: LSN{0x02}},
+			},
+			override:     "typo_instance",
+			wantInstance: "dbo_orders",
+			warnContains: "configured capture_instance 'typo_instance' does not match either, falling back to the default-named instance 'dbo_orders'",
+		},
+		{
+			name:   "two instances, neither convention-named, no override: unresolvable",
+			schema: "dbo",
+			table:  "orders",
+			instances: []captureInstance{
+				{name: "instance_alpha", startLSN: LSN{0x01}},
+				{name: "instance_beta", startLSN: LSN{0x02}},
+			},
+			errContains: "unable to determine which one to stream from",
+		},
+		{
+			name:   "two instances, neither convention-named, override matching neither: unresolvable",
+			schema: "dbo",
+			table:  "orders",
+			instances: []captureInstance{
+				{name: "instance_alpha", startLSN: LSN{0x01}},
+				{name: "instance_beta", startLSN: LSN{0x02}},
+			},
+			override:    "typo_instance",
+			errContains: "configured capture_instance 'typo_instance' does not match either",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			log := service.NewLoggerFromSlog(slog.New(slog.NewTextHandler(&logBuf, nil)))
+
+			tbl := &UserDefinedTable{Schema: test.schema, Name: test.table}
+			err := resolveCaptureInstance(tbl, test.instances, test.override, log)
+
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantInstance, tbl.CaptureInstance)
+
+			if test.warnContains != "" {
+				require.Contains(t, logBuf.String(), test.warnContains)
+			} else {
+				require.Empty(t, logBuf.String())
+			}
+		})
+	}
+}

--- a/internal/impl/mssqlserver/replication/stream_test.go
+++ b/internal/impl/mssqlserver/replication/stream_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed as a Redpanda Enterprise file under the Redpanda Community
 // License (the "License"); you may not use this file except in compliance with
@@ -29,20 +29,7 @@ import (
 	"github.com/redpanda-data/connect/v4/internal/impl/mssqlserver/replication"
 )
 
-// includeFilterFor builds a confx.RegexpFilter that matches only the given
-// fully-qualified table name (e.g. "dbo.mytable").
-func includeFilterFor(t *testing.T, fullTableName string) *confx.RegexpFilter {
-	t.Helper()
-	include, err := confx.ParseRegexpPatterns([]string{"^" + regexp.QuoteMeta(fullTableName) + "$"})
-	require.NoError(t, err)
-	return &confx.RegexpFilter{Include: include}
-}
-
-// TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution covers
-// resolving a user table's CDC change table via cdc.change_tables (keyed off
-// source_object_id) rather than assuming the default <schema>_<table> capture
-// instance naming convention.
-func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testing.T) {
+func TestIntegrationVerifyUserDefinedTablesCaptureInstanceResolution(t *testing.T) {
 	integration.CheckSkip(t)
 
 	_, db := mssqlservertest.SetupTestWithMicrosoftSQLServerVersion(t)
@@ -57,7 +44,7 @@ func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testin
 		// Simulate CDC having already been enabled on this table by another
 		// tool (e.g. Oracle GoldenGate) under an arbitrarily named capture
 		// instance, rather than the SQL Server default <schema>_<table>.
-		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, captureInstance)
+		db.MustEnableCDC(t.Context(), fullTableName, captureInstance)
 
 		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
 		require.NoError(t, err)
@@ -114,10 +101,22 @@ func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testin
 		assert.Equal(t, "hello", data["data"])
 	})
 
+	t.Run("DefaultNamedInstanceAmongMultiplePreferred", func(t *testing.T) {
+		const fullTableName = "dbo.migration_capture_test"
+		db.MustExec(`CREATE TABLE dbo.migration_capture_test (id INT NOT NULL PRIMARY KEY);`)
+		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
+		db.MustEnableCDC(t.Context(), fullTableName, "migration_temp_instance")
+
+		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
+		require.NoError(t, err)
+		require.Len(t, tables, 1)
+		assert.Equal(t, "dbo_migration_capture_test", tables[0].CaptureInstance)
+	})
+
 	t.Run("DefaultNamedCaptureInstance", func(t *testing.T) {
 		const fullTableName = "dbo.default_capture_test"
 		db.MustExec(`CREATE TABLE dbo.default_capture_test (id INT NOT NULL PRIMARY KEY);`)
-		db.MustEnableCDC(t.Context(), fullTableName)
+		db.MustEnableCDC(t.Context(), fullTableName, mssqlservertest.DefaultCaptureInstance)
 
 		tables, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
 		require.NoError(t, err)
@@ -130,8 +129,8 @@ func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testin
 		const fullTableName = "dbo.ambiguous_capture_test"
 		db.MustExec(`CREATE TABLE dbo.ambiguous_capture_test (id INT NOT NULL PRIMARY KEY);`)
 		// SQL Server allows up to two capture instances per source table.
-		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, "capture_alpha")
-		db.MustEnableCDCWithCaptureInstance(t.Context(), fullTableName, "capture_beta")
+		db.MustEnableCDC(t.Context(), fullTableName, "capture_alpha")
+		db.MustEnableCDC(t.Context(), fullTableName, "capture_beta")
 
 		_, err := replication.VerifyUserDefinedTables(t.Context(), db.DB, includeFilterFor(t, fullTableName), log)
 		require.Error(t, err)
@@ -139,4 +138,12 @@ func TestIntegration_VerifyUserDefinedTables_CaptureInstanceResolution(t *testin
 		require.ErrorContains(t, err, "capture_beta")
 		require.ErrorContains(t, err, "multiple CDC capture instances")
 	})
+
+}
+
+func includeFilterFor(t *testing.T, fullTableName string) *confx.RegexpFilter {
+	t.Helper()
+	include, err := confx.ParseRegexpPatterns([]string{"^" + regexp.QuoteMeta(fullTableName) + "$"})
+	require.NoError(t, err)
+	return &confx.RegexpFilter{Include: include}
 }


### PR DESCRIPTION
If discovering change tables using the default naming convention (`cdc.<schema>_<tablename>_CT`) fails to resolve to any table then the SQL Server CDC connector will look for matching tables using the `cdc.change_tables` table.