### PR TITLE
sftp: advertise rsa-sha2 host key algorithms for pinned RSA keys (CON-542)

### DIFF
--- a/internal/impl/sftp/config.go
+++ b/internal/impl/sftp/config.go
@@ -101,6 +101,26 @@ func getKey(pConf *service.ParsedConfig, mgr *service.Resources, keyField, keyFi
 	return key, nil
 }
 
+// hostKeyAlgorithmsForKeyFormat maps a pinned host key's format (as reported
+// by ssh.PublicKey.Type()) to the set of signature algorithms that should be
+// advertised via ssh.ClientConfig.HostKeyAlgorithms. HostKeyAlgorithms takes
+// signature algorithms, not key formats, and RSA keys correspond to three
+// signature algorithms (the modern SHA-2 variants plus the legacy SHA-1
+// "ssh-rsa"). Modern OpenSSH servers (8.8+) disable the SHA-1 variant, so all
+// three must be advertised for the handshake to succeed. Since the host key
+// itself is pinned via ssh.FixedHostKey, advertising the legacy algorithm
+// alongside the SHA-2 ones does not weaken verification.
+func hostKeyAlgorithmsForKeyFormat(keyFormat string) []string {
+	switch keyFormat {
+	case ssh.KeyAlgoRSA:
+		return []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSA}
+	case ssh.CertAlgoRSAv01:
+		return []string{ssh.CertAlgoRSASHA256v01, ssh.CertAlgoRSASHA512v01, ssh.CertAlgoRSAv01}
+	default:
+		return []string{keyFormat}
+	}
+}
+
 func sshAuthConfigFromParsed(pConf *service.ParsedConfig, mgr *service.Resources) (*ssh.ClientConfig, error) {
 	var err error
 
@@ -164,7 +184,7 @@ func sshAuthConfigFromParsed(pConf *service.ParsedConfig, mgr *service.Resources
 		if err != nil {
 			return nil, fmt.Errorf("error parsing host public key: %s", err)
 		}
-		hostKeyAlgorithms = []string{hostKey.Type()}
+		hostKeyAlgorithms = hostKeyAlgorithmsForKeyFormat(hostKey.Type())
 		keyCallback = ssh.FixedHostKey(hostKey)
 	} else {
 		var u *user.User

--- a/internal/impl/sftp/config_test.go
+++ b/internal/impl/sftp/config_test.go
@@ -15,10 +15,12 @@
 package sftp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -87,6 +89,58 @@ credentials:
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestHostKeyAlgorithms covers CON-542: when a host public key is pinned via
+// "host_public_key"/"host_public_key_file", the resulting ssh.ClientConfig's
+// HostKeyAlgorithms must advertise the rsa-sha2-256/rsa-sha2-512 algorithms
+// (in addition to ssh-rsa) for RSA host keys, so that the client can
+// negotiate with modern OpenSSH servers that no longer offer the SHA-1 based
+// "ssh-rsa" signature algorithm. Non-RSA key types should keep exactly their
+// single reported algorithm.
+func TestHostKeyAlgorithms(t *testing.T) {
+	spec := service.NewConfigSpec().Fields(connectionFields()...)
+	env := service.NewEnvironment()
+
+	// A static, test-only 2048-bit RSA public key in authorized_keys format.
+	const rsaPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDet0eo6ERYCirrxjybU/R0p6dxfdX9OKaHQ8bgKMdkf0hVUoknXhCFP+QY56LMkzkLvRmavZEzgNUncmcHPpC25+vF1ToJqO4XyWZzE1Hq/pwSw4MNQ8Sf4wr1Iln+KCOHXFXfOAwa7i7djCSL+BxIqutfVEvSG/4ZQnwUIoHCG/XtvYSaChUm1IQokQYSczbemSTGeXmRRXDtrTKMlJyhJ3MwafoFH/nmNDO7ohcrj1a3OAI/TIwA4ASXEWvaQci8UrOBrsl7KXHjYZYeknq5tRhEKlQ2TUSwguj8RnS3gh8DN7Nj0eB875qdWOwrk3J91+tsLIGeFGJK8LX0DYFp test-key`
+
+	tests := []struct {
+		name             string
+		hostPublicKey    string
+		wantHostKeyAlgos []string
+	}{
+		{
+			name:             "rsa host key advertises rsa-sha2 algorithms",
+			hostPublicKey:    rsaPublicKey,
+			wantHostKeyAlgos: []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSA},
+		},
+		{
+			name:             "ed25519 host key advertises only its own algorithm",
+			hostPublicKey:    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDknETovnNcLdtMzYk3qj9qGmRh0NkS6i4uGc3jtBdmK",
+			wantHostKeyAlgos: []string{ssh.KeyAlgoED25519},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conf := fmt.Sprintf(`
+address: localhost:22
+credentials:
+  username: blobfish
+  password: secret
+  host_public_key: %s
+`, test.hostPublicKey)
+
+			pConf, err := spec.ParseYAML(conf, env)
+			require.NoError(t, err)
+
+			sshConf, err := sshAuthConfigFromParsed(pConf.Namespace(sFieldCredentials), service.MockResources())
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, test.wantHostKeyAlgos, sshConf.HostKeyAlgorithms)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

When `credentials.host_public_key` or `host_public_key_file` pins an RSA host key, the SFTP components set `ssh.ClientConfig.HostKeyAlgorithms` to the key's format string (`ssh-rsa`) — the SHA-1 signature algorithm that OpenSSH 8.8+ disables by default. Modern servers only offer `rsa-sha2-256`/`rsa-sha2-512`, so negotiation found no common host key algorithm and the handshake failed, even though both sides held the same RSA key.

Fixes [CON-542](https://redpandadata.atlassian.net/browse/CON-542).

## Solution

`HostKeyAlgorithms` takes signature algorithms, not key formats. A pinned RSA key (or RSA cert) now expands to all three of its signature algorithms — `rsa-sha2-256`, `rsa-sha2-512`, and legacy `ssh-rsa` — mirroring what x/crypto/ssh's internal `algorithmsForKeyFormat` does for the default (unpinned) path. Non-RSA key types keep exactly their single algorithm.

Security is unchanged: `ssh.FixedHostKey` still verifies the server presents exactly the pinned key; only the signature algorithms used to prove possession of that key are broadened. As a side effect this also restores connectivity to legacy servers that only support `ssh-rsa`.

## Testing

- New `TestHostKeyAlgorithms` unit test in `internal/impl/sftp/config_test.go`: confirmed failing before the fix (advertised only `["ssh-rsa"]`) and passing after; ed25519 case verifies non-RSA keys are untouched.
- Full sftp package unit tests, `go vet`, and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CON-542]: https://redpandadata.atlassian.net/browse/CON-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ