### PR TITLE
mssqlserver_cdc: reconnect when the flush loop dies poisoned (CON-504)

### DIFF
--- a/internal/impl/mssqlserver/batcher.go
+++ b/internal/impl/mssqlserver/batcher.go
@@ -346,6 +346,14 @@ func (p *batchPublisher) loop() {
 
 				return p.dispatch(closeAtLeisureCtx, ticket, sendBatch, checkpointLSN)
 			}(); err != nil {
+				// With period-only batching this loop is the ONLY flusher, so
+				// its death must be loud and recoverable: every live error
+				// path has already poisoned the publisher, and ReadBatch
+				// observes the stop below and returns ErrNotConnected so the
+				// framework reconnects and Connect rebuilds. Without that, a
+				// processor error here silently stalled the pipeline until
+				// SQL Server's CDC retention walked past the checkpoint LSN.
+				p.log.Errorf("Flush loop stopping after error; the session will reconnect and rebuild the publisher: %v", err)
 				return
 			}
 		case <-p.shutSig.SoftStopChan():

--- a/internal/impl/mssqlserver/batcher.go
+++ b/internal/impl/mssqlserver/batcher.go
@@ -337,8 +337,7 @@ func (p *batchPublisher) loop() {
 				}
 				p.batcherMu.Unlock()
 				if flushErr != nil {
-					p.log.Errorf("Flushing timed batch failed; the publisher is marked for rebuild and its rows re-read from the last durable LSN on reconnect: %v", flushErr)
-					return flushErr
+					return fmt.Errorf("flushing timed batch: %w", flushErr)
 				}
 				if len(sendBatch) == 0 {
 					return nil
@@ -346,6 +345,12 @@ func (p *batchPublisher) loop() {
 
 				return p.dispatch(closeAtLeisureCtx, ticket, sendBatch, checkpointLSN)
 			}(); err != nil {
+				if p.stopping.Load() || p.shutSig.IsSoftStopSignalled() {
+					// Expected when a shutdown cancels an in-flight flush:
+					// the session is being torn down for good, not rebuilt.
+					p.log.Debugf("Flush loop exiting during shutdown: %v", err)
+					return
+				}
 				// With period-only batching this loop is the ONLY flusher, so
 				// its death must be loud and recoverable: every live error
 				// path has already poisoned the publisher, and ReadBatch
@@ -353,7 +358,7 @@ func (p *batchPublisher) loop() {
 				// framework reconnects and Connect rebuilds. Without that, a
 				// processor error here silently stalled the pipeline until
 				// SQL Server's CDC retention walked past the checkpoint LSN.
-				p.log.Errorf("Flush loop stopping after error; the session will reconnect and rebuild the publisher: %v", err)
+				p.log.Errorf("Flush loop stopping after error; the session will reconnect, rebuild the publisher, and re-read from the last durable LSN: %v", err)
 				return
 			}
 		case <-p.shutSig.SoftStopChan():

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc.go
@@ -553,13 +553,40 @@ func (i *sqlServerCDCInput) cacheLSN(ctx context.Context, lsn replication.LSN) e
 }
 
 func (i *sqlServerCDCInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
-	select {
-	case m := <-i.publisher.Load().msgs():
-		return m.msg, m.ackFn, nil
-	case <-i.stopSig.HasStoppedChan():
-		return nil, nil, service.ErrNotConnected
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
+	pub := i.publisher.Load()
+	// Observed so a dead flush loop cannot silently stall the pipeline: with
+	// period-only batching that loop is the only flusher, and its error paths
+	// poison the publisher but cannot force a reconnect themselves.
+	pubStopped := pub.shutSig.HasStoppedChan()
+	for {
+		select {
+		case m := <-pub.msgs():
+			return m.msg, m.ackFn, nil
+		case <-pubStopped:
+			if pub.poisoned.Load() {
+				// Fatal flush-loop exit: tear the session down BEFORE handing
+				// control to Connect - the session goroutine may still be
+				// alive (Connect's still-active guard would otherwise turn
+				// this into a busy reconnect loop), and every session path
+				// escapes on the soft stop. The constructor leaves HasStopped
+				// triggered, so the wait is bounded; ctx stays the escape
+				// hatch regardless.
+				i.stopSig.TriggerSoftStop()
+				select {
+				case <-i.stopSig.HasStoppedChan():
+				case <-ctx.Done():
+					return nil, nil, ctx.Err()
+				}
+				return nil, nil, service.ErrNotConnected
+			}
+			// Deliberate stop (input Close): keep draining any batch still
+			// undelivered on msgs().
+			pubStopped = nil
+		case <-i.stopSig.HasStoppedChan():
+			return nil, nil, service.ErrNotConnected
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
 	}
 }
 

--- a/internal/impl/mssqlserver/input_mssqlserver_cdc_test.go
+++ b/internal/impl/mssqlserver/input_mssqlserver_cdc_test.go
@@ -136,3 +136,74 @@ func TestRebuildPublisherIfPoisoned(t *testing.T) {
 		require.NotEqual(t, "00000010", string(v), "the stale LSN must never have been persisted after the newer one")
 	}
 }
+
+// TestReadBatchReconnectsOnPoisonedLoopDeath encodes the silent-stall
+// finding: with period-only batching the timed-flush loop is the only
+// flusher, and when it dies after poisoning the publisher nothing else can
+// trigger the reconnect that rebuilds it - ReadBatch must observe the stop
+// and return ErrNotConnected. A DELIBERATE stop (input Close, publisher not
+// poisoned) must instead keep draining any batch still undelivered.
+func TestReadBatchReconnectsOnPoisonedLoopDeath(t *testing.T) {
+	t.Run("poisoned loop death reconnects", func(t *testing.T) {
+		i, _ := newTestInput(t)
+		// Model the mid-session state: Connect has armed the signaller and
+		// the session goroutine stops when soft-stopped, as in production.
+		go func() {
+			<-i.stopSig.SoftStopChan()
+			i.stopSig.TriggerHasStopped()
+		}()
+		pub := i.publisher.Load()
+		pub.poisoned.Store(true)
+		pub.shutSig.TriggerSoftStop()
+		require.Eventually(t, func() bool {
+			select {
+			case <-pub.shutSig.HasStoppedChan():
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		_, _, err := i.ReadBatch(ctx)
+		require.ErrorIs(t, err, service.ErrNotConnected,
+			"a poisoned publisher whose flush loop died must force a reconnect, not stall silently")
+	})
+
+	t.Run("deliberate stop keeps draining a parked batch", func(t *testing.T) {
+		i, _ := newTestInput(t)
+		pub := i.publisher.Load()
+
+		// A flusher parks in its send BEFORE the stop (the batcher teardown
+		// sets the closed flag, so nothing can flush after it): the batch is
+		// tracked, undelivered, and its owner's context is live.
+		flushed := make(chan error, 1)
+		go func() { flushed <- pub.Publish(t.Context(), streamingEvent("00000010", "00000010")) }()
+		require.Eventually(t, func() bool {
+			pub.batcherMu.Lock()
+			defer pub.batcherMu.Unlock()
+			return pub.nextTicket == 1
+		}, 5*time.Second, time.Millisecond)
+
+		// Deliberate, non-poisoned stop (input Close): the loop exits.
+		pub.shutSig.TriggerSoftStop()
+		require.Eventually(t, func() bool {
+			select {
+			case <-pub.shutSig.HasStoppedChan():
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, time.Millisecond)
+
+		// ReadBatch must drain the parked batch rather than bail out.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		batch, ackFn, err := i.ReadBatch(ctx)
+		require.NoError(t, err, "a deliberately stopped loop must not force a reconnect while a batch is undelivered")
+		require.Len(t, batch, 1)
+		require.NoError(t, ackFn(ctx, nil))
+		require.NoError(t, <-flushed)
+	})
+}


### PR DESCRIPTION
Part of CON-504. Backports the oracledb silent-stall fix from #4675 to the SQL Server CDC input, which shipped with the same defect in #4677.

## The defect

With period-only batching (`batching.period` set, no count/byte size), the timed flush loop is the *only* flusher. A dispatch error inside that loop — reachable in steady state by any config whose `batching.processors` occasionally error — exited the goroutine with no log and no signal. The publisher was poisoned, but the rebuild only runs from `Connect`, which the framework only calls after `ReadBatch` returns `ErrNotConnected` — and `ReadBatch` had no way to observe the loop's death, so that never happened. The pipeline stalled silently until SQL Server's CDC retention walked past the checkpoint LSN, converting the stall into data loss at the eventual restart.

## The fix

- The flush loop now logs its fatal exit at error level before returning.
- `ReadBatch` observes the publisher's stop channel:
  - **Poisoned stop** (fatal loop exit): tear the session down first — soft-stop and wait for the session goroutine, so `Connect`'s still-active guard can't busy-loop and the session's state isn't replaced under a live goroutine — then return `ErrNotConnected` so `Connect` rebuilds the publisher and resumes from the last durable LSN.
  - **Deliberate stop** (`FlushRemaining` at the snapshot-only handoff): keep draining, so a final batch still parked in the publisher's send is delivered.

Both behaviors are unit-tested (`TestReadBatchReconnectsOnPoisonedLoopDeath`); the poisoned case was proven red against the pre-fix `ReadBatch` shape on the oracledb side. Full mssqlserver integration suite green locally (10/10, sequential `-count=1`).