### PR TITLE
bench: migrate tfstate locking to S3-native lockfile; document the cloud-nuke conflict

### DIFF
--- a/benchmarking/aws/SOAK.md
+++ b/benchmarking/aws/SOAK.md
@@ -86,10 +86,13 @@ files named below.
   2026-08-18 → 27): it deleted the tfstate lock table four times (why the
   backend now uses S3-native `use_lockfile` locking), disarmed the orphan
   reaper's schedule rule **every night**, and deleted the stall + backlog
-  alarms. Until the persistent stack gets a cloud-nuke exemption:
-  re-`task aws:persistent` after any gap to restore the rule/alarms, and do
-  NOT run a bench across 02:25 UTC (19:25 PT) — cloud-nuke terminates live
-  bench EC2 the same way. The exemption is the top operational follow-up.
+  alarms. The exemption is the `cloud-nuke-excluded = true` tag, applied via
+  `default_tags` in all three stacks — the persistent stack so the reaper
+  schedule and alarms survive, the session stacks so a live bench crossing
+  02:25 UTC isn't terminated mid-run. Our OWN reaper keys on `Project`, not
+  this tag, so bench cleanup at the 4h TTL is unaffected. Any new resource
+  created OUTSIDE these providers (e.g. the manually-bootstrapped tfstate
+  bucket) must carry the tag itself.
 
 - postgres_cdc IAM auth cannot work against vanilla RDS (replication-
   protocol connections reject IAM tokens — verified live 2026-08-12), so

--- a/benchmarking/aws/SOAK.md
+++ b/benchmarking/aws/SOAK.md
@@ -80,6 +80,17 @@ files named below.
 
 ## Known limitations
 
+- **An org-run `ci-cloud-nuke` sweeps this account nightly (~02:25 UTC)** and
+  deletes at least: DynamoDB tables, EventBridge rules, CloudWatch alarms
+  (untouched ~7 days), and EC2/VPC chains. Confirmed impact (CloudTrail,
+  2026-08-18 → 27): it deleted the tfstate lock table four times (why the
+  backend now uses S3-native `use_lockfile` locking), disarmed the orphan
+  reaper's schedule rule **every night**, and deleted the stall + backlog
+  alarms. Until the persistent stack gets a cloud-nuke exemption:
+  re-`task aws:persistent` after any gap to restore the rule/alarms, and do
+  NOT run a bench across 02:25 UTC (19:25 PT) — cloud-nuke terminates live
+  bench EC2 the same way. The exemption is the top operational follow-up.
+
 - postgres_cdc IAM auth cannot work against vanilla RDS (replication-
   protocol connections reject IAM tokens — verified live 2026-08-12), so
   the credential-rotation window is covered by a future mysql_cdc soak or

--- a/benchmarking/aws/Taskfile.yml
+++ b/benchmarking/aws/Taskfile.yml
@@ -56,7 +56,10 @@ tasks:
       # the zip is gitignored — build it here so a fresh checkout can apply
       # without knowing about the Makefile.
       - make -C cleanup-lambda zip
-      - terraform -chdir=terraform/persistent init -input=false -backend-config=../backend.hcl -backend-config=key=persistent
+      # -reconfigure: same reasoning as runner/terraform.go Init — the full
+      # backend config is on the command line, and without the flag a
+      # backend.hcl change strands every existing .terraform/ working dir.
+      - terraform -chdir=terraform/persistent init -input=false -reconfigure -backend-config=../backend.hcl -backend-config=key=persistent
       - terraform -chdir=terraform/persistent apply -input=false -auto-approve
 
   aws:cost-check:

--- a/benchmarking/aws/runner/terraform.go
+++ b/benchmarking/aws/runner/terraform.go
@@ -26,11 +26,18 @@ type Terraform struct {
 }
 
 // Init runs `terraform init` with the shared backend config.
+//
+// -reconfigure: the full backend config is passed explicitly on every init,
+// so the saved config in an existing .terraform/ carries no information —
+// but without the flag a backend.hcl change (e.g. the dynamodb_table →
+// use_lockfile migration) hard-fails every pre-existing working directory
+// with "Backend configuration changed" under -input=false.
 func (t *Terraform) Init() error {
 	args := []string{
 		"-chdir=" + t.Dir,
 		"init",
 		"-input=false",
+		"-reconfigure",
 		"-backend-config=" + t.BackendFile,
 		"-backend-config=key=" + t.StateKey + "/terraform.tfstate",
 	}

--- a/benchmarking/aws/terraform/backend.hcl
+++ b/benchmarking/aws/terraform/backend.hcl
@@ -2,7 +2,8 @@
 # Region and bucket below are the dedicated benchmarking AWS account; change in
 # a private fork if you run this in another account.
 #
-# Locking is S3-native (a .tflock object next to the state), NOT DynamoDB:
+# Locking is S3-native (a .tflock object next to the state, Terraform >=
+# 1.10 — the required_version floor in every root), NOT DynamoDB:
 # the old redpanda-connect-bench-tflocks table was deleted out from under us
 # four times (most recently failing the 2026-08-27 nightly soak before it
 # provisioned anything), and a lock that depends on a second service is a

--- a/benchmarking/aws/terraform/backend.hcl
+++ b/benchmarking/aws/terraform/backend.hcl
@@ -1,7 +1,13 @@
 # Shared S3 backend for all benchmarking/aws/terraform/{shared,stacks/*} state.
 # Region and bucket below are the dedicated benchmarking AWS account; change in
 # a private fork if you run this in another account.
-bucket         = "redpanda-connect-bench-tfstate"
-region         = "us-east-2"
-dynamodb_table = "redpanda-connect-bench-tflocks"
-encrypt        = true
+#
+# Locking is S3-native (a .tflock object next to the state), NOT DynamoDB:
+# the old redpanda-connect-bench-tflocks table was deleted out from under us
+# four times (most recently failing the 2026-08-27 nightly soak before it
+# provisioned anything), and a lock that depends on a second service is a
+# lock that fails when that service's resource vanishes.
+bucket       = "redpanda-connect-bench-tfstate"
+region       = "us-east-2"
+use_lockfile = true
+encrypt      = true

--- a/benchmarking/aws/terraform/modules/redpanda/main.tf
+++ b/benchmarking/aws/terraform/modules/redpanda/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10" # S3-native state locking (use_lockfile in backend.hcl)
   required_providers {
     aws = { source = "hashicorp/aws", version = "~> 5.70" }
   }

--- a/benchmarking/aws/terraform/persistent/main.tf
+++ b/benchmarking/aws/terraform/persistent/main.tf
@@ -11,7 +11,7 @@
 # -backend-config=key=persistent alongside backend.hcl).
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10" # S3-native state locking (use_lockfile in backend.hcl)
   required_providers {
     aws = { source = "hashicorp/aws", version = "~> 5.70" }
   }

--- a/benchmarking/aws/terraform/persistent/main.tf
+++ b/benchmarking/aws/terraform/persistent/main.tf
@@ -30,6 +30,10 @@ provider "aws" {
       Project   = "redpanda-connect-bench-persistent"
       Stack     = "persistent"
       ManagedBy = "terraform"
+      # Opts out of the org's nightly ci-cloud-nuke sweep (~02:25 UTC),
+      # which deleted the reaper's schedule rule every night 2026-08-18→27,
+      # two of the three soak alarms, and the old tfstate lock table 4x.
+      "cloud-nuke-excluded" = "true"
     }
   }
 }

--- a/benchmarking/aws/terraform/shared/main.tf
+++ b/benchmarking/aws/terraform/shared/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10" # S3-native state locking (use_lockfile in backend.hcl)
   required_providers {
     aws = { source = "hashicorp/aws", version = "~> 5.70" }
   }

--- a/benchmarking/aws/terraform/shared/main.tf
+++ b/benchmarking/aws/terraform/shared/main.tf
@@ -13,6 +13,10 @@ provider "aws" {
       Project            = "redpanda-connect-bench"
       "bench-session-id" = var.bench_session_id
       ManagedBy          = "terraform"
+      # A live bench crossing the org cloud-nuke's ~02:25 UTC sweep must
+      # not be terminated mid-run. OUR reaper still owns cleanup — it
+      # keys on Project, not this tag, so the 4h TTL is unaffected.
+      "cloud-nuke-excluded" = "true"
     }
   }
 }

--- a/benchmarking/aws/terraform/stacks/postgres/main.tf
+++ b/benchmarking/aws/terraform/stacks/postgres/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.10" # S3-native state locking (use_lockfile in backend.hcl)
   required_providers {
     aws    = { source = "hashicorp/aws", version = "~> 5.70" }
     random = { source = "hashicorp/random", version = "~> 3.6" }

--- a/benchmarking/aws/terraform/stacks/postgres/main.tf
+++ b/benchmarking/aws/terraform/stacks/postgres/main.tf
@@ -21,6 +21,9 @@ provider "aws" {
       # leaves this stack's groups unsweepable forever, and the surviving
       # security group blocks the shared VPC's deletion on every sweep.
       "bench-session-id" = var.bench_session_id
+      # See shared/main.tf: exempt from the org cloud-nuke sweep; our own
+      # reaper (keyed on Project) still reaps this stack at the 4h TTL.
+      "cloud-nuke-excluded" = "true"
     }
   }
 }


### PR DESCRIPTION
## What happened

The 2026-08-27 scheduled nightly soak failed in 90 seconds: terraform couldn't acquire the state lock because the `redpanda-connect-bench-tflocks` DynamoDB table had been deleted overnight — the **fourth** vanishing. Nothing was provisioned (teardown-verify green, zero spend); the failure email was the workflow being correctly loud.

## Root cause

CloudTrail attributes this deletion — and every previous one — to the org-run `ci-cloud-nuke` IAM user, which sweeps the bench account nightly at ~02:25 UTC. The same sweeps had been **disarming the orphan reaper's EventBridge rule every night since Aug 18** and deleted the stall + backlog CloudWatch alarms on Aug 26 — the account's safety net was off most of the time.

## Fixes

**1. State locking migrates to S3-native lockfiles** (`use_lockfile = true`, Terraform ≥ 1.10) — a lock that depends on a second service's nukable resource is not a lock. There is no lock table left to delete, and this also retires the `dynamodb_table` deprecation warning carried in every run log.

**2. Everything opts out of cloud-nuke via its exemption tag.** The cloud-nuke owner confirmed the self-service mechanism: `cloud-nuke-excluded = true`. Applied through `default_tags` in all three stacks — persistent (so the reaper schedule and alarms stop being deleted nightly) and the session stacks (so a live bench crossing 02:25 UTC isn't terminated mid-run). Our own reaper keys on the `Project` tag, not this one, so the 4h-TTL cleanup is unaffected. The manually-bootstrapped tfstate bucket and license secret were tagged directly in AWS (they live outside any Terraform provider).

**3. Hardening from review**: `required_version` raised to `>= 1.10` in every root (the old `>= 1.6` floor would have surfaced `use_lockfile` as an unrecognised-argument error on 1.6–1.9), and both automated init paths pass `-reconfigure` so this backend change — and any future one — lands cleanly on existing `.terraform/` working dirs instead of hard-failing under `-input=false`.

## Validation

- `init -reconfigure` succeeded against the real backend for all three states; plans and two full persistent applies acquired/released the S3 lockfile.
- The tagged persistent apply is live: all 11 persistent resources carry the exemption tag (verified on the reaper rule via the tagging API).
- SOAK.md documents the sweep, the tag mechanism, and the constraint that manually-created resources in this account must carry the tag.
- Definitive proof arrives nightly: the reaper rule surviving the 02:25 UTC sweep will be its first overnight survival since Aug 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)