### PR TITLE
aws_dynamodb_cdc: fix shard-discovery convergence and checkpoint-write stalls (INC-2974)

### DIFF
--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -10,12 +10,23 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Jeffail/checkpoint"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// Throttle-pin visibility: a healthy backpressured input oscillates around
+// the throttle threshold as downstream acks drain the tracker. Staying
+// continuously at or above it means nothing is draining and every shard
+// reader is parked - a wedge that is otherwise completely silent.
+const (
+	throttlePinWarnAfter    = 5 * time.Minute
+	throttlePinWarnInterval = 5 * time.Minute
 )
 
 // RecordBatcher tracks in-flight message batches and persists shard
@@ -55,6 +66,11 @@ type RecordBatcher struct {
 	// trackedMessages counts messages across all in-flight batches, used for
 	// backpressure via ShouldThrottle.
 	trackedMessages int
+	// throttledSince is when trackedMessages last crossed the throttle
+	// threshold without dipping back below it; zero while not throttled.
+	// lastPinWarn rate-limits the pinned-throttle warning.
+	throttledSince time.Time
+	lastPinWarn    time.Time
 }
 
 type trackedBatch struct {
@@ -70,7 +86,14 @@ type trackedBatch struct {
 }
 
 type shardAckTracker struct {
-	tracker *checkpoint.Uncapped[string]
+	// persistMu single-flights checkpoint writes for one shard (see
+	// maybePersist): the holder computes each persist after its previous
+	// write finished, so the durable row only ever moves forward, and every
+	// other ack TryLocks past it - nothing queues behind a slow write, and
+	// b.mu is never held across the write itself, so a hung checkpoint
+	// PutItem cannot park ShouldThrottle/AddMessages and freeze the input.
+	persistMu sync.Mutex
+	tracker   *checkpoint.Uncapped[string]
 	// pending counts acked messages since the last persisted checkpoint.
 	pending int
 	// frontier is the highest contiguous acked sequence ("" until the first
@@ -203,40 +226,95 @@ func (b *RecordBatcher) AckMessages(
 	if b == nil || len(batch) == 0 {
 		return nil
 	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
 
+	// Settle under b.mu only, never waiting on another ack's in-flight
+	// checkpoint write: batch settlement (and with it ShouldThrottle and
+	// AddMessages) stays wait-free even when the checkpoint store is slow.
+	b.mu.Lock()
 	tb, ok := b.batches[batch[0]]
 	if !ok {
 		// Already removed (nacked or double-acked); nothing to do.
+		b.mu.Unlock()
 		return nil
 	}
-
-	if len(b.shards) > b.maxTrackedShards {
-		return fmt.Errorf("checkpoint map exceeded maximum size (%d shards) - possible memory leak", b.maxTrackedShards)
-	}
-
 	b.dropBatchLocked(tb)
-
 	st := b.shards[tb.shardID]
 	if frontier := tb.resolve(); frontier != nil {
 		st.advanceFrontier(*frontier)
 	}
 	st.pending += tb.size
+	shardsOverCap := len(b.shards) > b.maxTrackedShards
+	b.mu.Unlock()
 
-	// Persist once enough messages are acked AND the frontier has moved past
-	// the last persisted position. A pinned frontier (nacked batch ahead of
-	// us in stream order) accumulates pending acks without persisting.
-	if st.pending >= cp.CheckpointLimit() && st.frontier != "" && st.frontier != st.persisted {
-		if err := cp.Set(ctx, tb.shardID, st.frontier, st.frontierTime); err != nil {
+	persistErr := b.maybePersist(ctx, cp, st, tb.shardID)
+	if shardsOverCap {
+		// The batch is settled and the frontier persisted above regardless:
+		// swallowing the settle would leak tracked messages and permanently
+		// pin ShouldThrottle, and skipping persists would silently freeze
+		// durable checkpoints for as long as the guard trips.
+		return errors.Join(
+			fmt.Errorf("checkpoint map exceeded maximum size (%d shards) - possible memory leak", b.maxTrackedShards),
+			persistErr,
+		)
+	}
+	return persistErr
+}
+
+// maybePersist writes a shard's checkpoint once enough messages have been
+// acked since the last persisted position AND the contiguous frontier has
+// moved past it (a pinned frontier - nacked batch ahead in stream order -
+// accumulates pending acks without persisting).
+//
+// Writes are single-flighted per shard: whoever holds persistMu re-checks
+// after each successful write, so progress settled during the write is
+// picked up immediately, and every other ack skips past without blocking.
+// Anything left unpersisted when the writes stop is carried by the shard's
+// next ack or the shutdown flush (PendingCheckpoints/FlushCheckpoints).
+// b.mu is never held across the store write.
+func (b *RecordBatcher) maybePersist(ctx context.Context, cp checkpointer, st *shardAckTracker, shardID string) error {
+	if !st.persistMu.TryLock() {
+		return nil
+	}
+	defer st.persistMu.Unlock()
+
+	for {
+		b.mu.Lock()
+		due := st.pending >= cp.CheckpointLimit() && st.frontier != "" && st.frontier != st.persisted
+		persistSeq := st.frontier
+		persistTime := st.frontierTime
+		pendingAtCompute := st.pending
+		b.mu.Unlock()
+		if !due {
+			return nil
+		}
+
+		// Bound the write so a hung request surfaces as a retryable error
+		// (the ack context is typically deadline-free) instead of pinning
+		// the shard's persist slot indefinitely. An abandoned write can in
+		// principle still land server-side after a later one and step the
+		// durable row backwards (bounded redelivery after a crash inside
+		// that window, never loss). Stream sequence numbers are
+		// variable-length numeric strings, so a lexicographic
+		// ConditionExpression guarding forward-only movement could wrongly
+		// reject legitimate newer writes forever - a frozen checkpoint,
+		// strictly worse than the race it would close.
+		setCtx, cancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+		err := cp.Set(setCtx, shardID, persistSeq, persistTime)
+		cancel()
+		if err != nil {
+			// Bookkeeping untouched: pending keeps accumulating and the next
+			// ack on this shard retries the write from the newest frontier.
 			return err
 		}
-		st.persisted = st.frontier
-		st.pending = 0
-		b.log.Debugf("Checkpointed shard %s at sequence %s", tb.shardID, st.frontier)
-	}
 
-	return nil
+		b.mu.Lock()
+		st.persisted = persistSeq
+		// Subtract only what this write covered; acks settled while it was
+		// in flight keep counting toward the next persist.
+		st.pending -= pendingAtCompute
+		b.mu.Unlock()
+		b.log.Debugf("Checkpointed shard %s at sequence %s", shardID, persistSeq)
+	}
 }
 
 // PendingCheckpoints returns, per shard, the highest contiguous acked
@@ -268,7 +346,23 @@ func (b *RecordBatcher) ShouldThrottle() bool {
 	defer b.mu.Unlock()
 
 	// Throttle at 90% capacity to leave some headroom
-	return b.trackedMessages >= (b.maxTrackedMessages * 9 / 10)
+	if b.trackedMessages < (b.maxTrackedMessages * 9 / 10) {
+		b.throttledSince = time.Time{}
+		return false
+	}
+
+	// Surface a continuously pinned throttle: every shard reader is parked
+	// on this check, so if the tracker never drains the input is stalled
+	// with no other signal.
+	now := time.Now()
+	if b.throttledSince.IsZero() {
+		b.throttledSince = now
+	} else if since := now.Sub(b.throttledSince); since >= throttlePinWarnAfter && now.Sub(b.lastPinWarn) >= throttlePinWarnInterval {
+		b.lastPinWarn = now
+		b.log.Warnf("Shard readers throttled for %v: %d/%d in-flight messages are still awaiting downstream acknowledgement; no records are being read while this persists",
+			since.Round(time.Second), b.trackedMessages, b.maxTrackedMessages)
+	}
+	return true
 }
 
 // PendingCount returns the count of acked-but-not-persisted messages for a

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -537,9 +537,14 @@ func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
 	assertPrompt("ShouldThrottle", func() { batcher.ShouldThrottle() })
 	batch2 := createTestMessages(3, "shard-002", 1)
 	assertPrompt("AddMessages", func() { batcher.AddMessages(batch2, "shard-002") })
+	// Errors are captured and asserted from the test goroutine: require's
+	// FailNow inside assertPrompt's spawned goroutine would Goexit before
+	// close(done) and misreport the failure as a blocked call.
+	var otherShardErr error
 	assertPrompt("AckMessages(other shard)", func() {
-		require.NoError(t, batcher.AckMessages(t.Context(), cp, batch2))
+		otherShardErr = batcher.AckMessages(t.Context(), cp, batch2)
 	})
+	require.NoError(t, otherShardErr)
 	assert.Equal(t, "00003", cp.get("shard-002"),
 		"another shard's checkpoint must persist while shard-001's write is blocked")
 
@@ -548,9 +553,11 @@ func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
 	// post-write re-check picks their progress up.
 	batch3 := createTestMessages(3, "shard-001", 4)
 	batcher.AddMessages(batch3, "shard-001")
+	var sameShardErr error
 	assertPrompt("AckMessages(same shard)", func() {
-		require.NoError(t, batcher.AckMessages(t.Context(), cp, batch3))
+		sameShardErr = batcher.AckMessages(t.Context(), cp, batch3)
 	})
+	require.NoError(t, sameShardErr)
 
 	close(cp.release)
 	require.NoError(t, <-ackErr)

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -474,4 +475,142 @@ func TestBatcherShouldThrottle(t *testing.T) {
 		batcher.AddMessages(batch, "shard-001")
 	}
 	assert.True(t, batcher.ShouldThrottle(), "Should still throttle above 90% capacity")
+}
+
+// blockingCheckpointer blocks Set calls for one designated shard until
+// released, signalling entry exactly once. Other shards persist normally.
+type blockingCheckpointer struct {
+	mockCheckpointer
+	blockShard  string
+	entered     chan struct{}
+	enteredOnce sync.Once
+	release     chan struct{}
+}
+
+func (b *blockingCheckpointer) Set(ctx context.Context, shardID, sequenceNumber, approxCreationTime string) error {
+	if shardID == b.blockShard {
+		b.enteredOnce.Do(func() { close(b.entered) })
+		<-b.release
+	}
+	return b.mockCheckpointer.Set(ctx, shardID, sequenceNumber, approxCreationTime)
+}
+
+// TestBatcherCheckpointWriteDoesNotBlockOtherShards: a slow or hung
+// checkpoint write for one shard must not stall the whole input. While one
+// shard's persist is in flight, ShouldThrottle (polled by every shard
+// reader), AddMessages, and other shards' acks must all proceed. This is the
+// silent global-freeze hazard behind INC-2974's prod pipeline: holding the
+// batcher mutex across the PutItem parks every shard reader with no logs.
+func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
+	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
+	cp := &blockingCheckpointer{
+		mockCheckpointer: mockCheckpointer{checkpointLimit: 1},
+		blockShard:       "shard-001",
+		entered:          make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+
+	batch1 := createTestMessages(3, "shard-001", 1)
+	batcher.AddMessages(batch1, "shard-001")
+
+	ackErr := make(chan error, 1)
+	go func() { ackErr <- batcher.AckMessages(t.Context(), cp, batch1) }()
+
+	select {
+	case <-cp.entered:
+		// shard-001's checkpoint write is now in flight and blocked
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the ack to reach the checkpoint write")
+	}
+
+	assertPrompt := func(name string, fn func()) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() { fn(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s blocked behind an in-flight checkpoint write for another shard", name)
+		}
+	}
+
+	assertPrompt("ShouldThrottle", func() { batcher.ShouldThrottle() })
+	batch2 := createTestMessages(3, "shard-002", 1)
+	assertPrompt("AddMessages", func() { batcher.AddMessages(batch2, "shard-002") })
+	assertPrompt("AckMessages(other shard)", func() {
+		require.NoError(t, batcher.AckMessages(t.Context(), cp, batch2))
+	})
+	assert.Equal(t, "00003", cp.get("shard-002"),
+		"another shard's checkpoint must persist while shard-001's write is blocked")
+
+	// Even the SAME shard's acks settle without queueing behind the write:
+	// they skip the persist (single-flighted) and the in-flight writer's
+	// post-write re-check picks their progress up.
+	batch3 := createTestMessages(3, "shard-001", 4)
+	batcher.AddMessages(batch3, "shard-001")
+	assertPrompt("AckMessages(same shard)", func() {
+		require.NoError(t, batcher.AckMessages(t.Context(), cp, batch3))
+	})
+
+	close(cp.release)
+	require.NoError(t, <-ackErr)
+	assert.Equal(t, "00006", cp.get("shard-001"),
+		"the writer's post-write re-check must persist progress settled during the write")
+	assert.Equal(t, 0, batcher.TrackedMessageCount())
+}
+
+// TestBatcherAckOverShardCapStillDrainsTracker: the tracked-shards safety
+// guard must still settle the acked batch AND persist its checkpoint.
+// Returning the guard error without dropping the batch leaks tracked
+// messages forever (permanently pinning ShouldThrottle once enough acks have
+// been swallowed), and skipping the persist would silently freeze durable
+// checkpoints pipeline-wide for as long as the guard trips.
+func TestBatcherAckOverShardCapStillDrainsTracker(t *testing.T) {
+	batcher := NewRecordBatcher(1, 1, service.MockResources().Logger())
+	cp := &mockCheckpointer{checkpointLimit: 1}
+
+	batch1 := createTestMessages(2, "shard-001", 1)
+	batcher.AddMessages(batch1, "shard-001")
+	batch2 := createTestMessages(2, "shard-002", 1)
+	batcher.AddMessages(batch2, "shard-002")
+
+	require.Error(t, batcher.AckMessages(t.Context(), cp, batch1),
+		"the shard-cap guard should still surface an error")
+	require.Error(t, batcher.AckMessages(t.Context(), cp, batch2))
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"acked batches must drain the tracker even when the shard-cap guard trips")
+	assert.Equal(t, "00002", cp.get("shard-001"),
+		"checkpoints must keep persisting even when the shard-cap guard trips")
+	assert.Equal(t, "00002", cp.get("shard-002"))
+}
+
+// TestBatcherWarnsWhenThrottlePinned: a throttle that never releases is an
+// otherwise-silent stall, so ShouldThrottle must surface it once the tracker
+// has been pinned past the warn threshold, and dropping below the threshold
+// must reset the pin clock.
+func TestBatcherWarnsWhenThrottlePinned(t *testing.T) {
+	batcher := NewRecordBatcher(100, 100, service.MockResources().Logger())
+
+	batch := createTestMessages(950, "shard-001", 0)
+	batcher.AddMessages(batch, "shard-001") // 950/1000 >= 90%
+	require.True(t, batcher.ShouldThrottle())
+
+	// Backdate the pin start beyond the warn threshold.
+	batcher.mu.Lock()
+	batcher.throttledSince = time.Now().Add(-2 * throttlePinWarnAfter)
+	batcher.mu.Unlock()
+
+	require.True(t, batcher.ShouldThrottle())
+	batcher.mu.Lock()
+	warned := !batcher.lastPinWarn.IsZero()
+	batcher.mu.Unlock()
+	assert.True(t, warned, "a continuously pinned throttle must emit the stall warning")
+
+	// Draining below the threshold resets the pin clock.
+	batcher.RemoveMessages(batch)
+	require.False(t, batcher.ShouldThrottle())
+	batcher.mu.Lock()
+	reset := batcher.throttledSince.IsZero()
+	batcher.mu.Unlock()
+	assert.True(t, reset, "releasing the throttle must reset the pin clock")
 }

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -1553,10 +1553,16 @@ func describeStreamAllShards(ctx context.Context, client describeStreamPager, st
 		startID *string
 	)
 	for page := range maxDescribeStreamPages {
-		out, err := client.DescribeStream(ctx, &dynamodbstreams.DescribeStreamInput{
+		// Bound each page like every other AWS call in a discovery cycle:
+		// the SDK's default HTTP client has no overall response timeout, and
+		// an unbounded hang here would otherwise consume the caller's whole
+		// cycle budget before a single shard could be prepared.
+		pageCtx, cancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+		out, err := client.DescribeStream(pageCtx, &dynamodbstreams.DescribeStreamInput{
 			StreamArn:             streamArn,
 			ExclusiveStartShardId: startID,
 		})
+		cancel()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -48,6 +48,13 @@ const (
 	defaultAPICallTimeout          = 30 * time.Second // Timeout for AWS API calls
 	shardRefreshInterval           = 30 * time.Second // Interval for refreshing shard list
 	shardCleanupInterval           = 5 * time.Minute  // Interval for cleaning up exhausted shards
+	// shardRefreshCycleBudget bounds one shard-discovery refresh cycle. Each
+	// AWS call inside the cycle carries its own defaultAPICallTimeout, so the
+	// cycle budget must be a multiple of it - otherwise a single hung call
+	// consumes the whole cycle and a large shard backlog converges one
+	// truncated pass at a time (INC-2974). Progress made inside an expired
+	// budget is still committed; the next tick continues where it stopped.
+	shardRefreshCycleBudget = 4 * defaultAPICallTimeout
 
 	// Metrics
 	metricShardsTracked           = "dynamodb_cdc_shards_tracked"
@@ -475,6 +482,22 @@ type dynamoDBCDCMetrics struct {
 	failoverSkipped         *service.MetricCounter // Counts records skipped during global-table failover replay
 }
 
+// newDynamoDBCDCMetrics builds the input's metric set (shared with tests so
+// the field list cannot drift and leave nil gauges behind).
+func newDynamoDBCDCMetrics(m *service.Metrics) dynamoDBCDCMetrics {
+	return dynamoDBCDCMetrics{
+		shardsTracked:           m.NewGauge(metricShardsTracked),
+		shardsActive:            m.NewGauge(metricShardsActive),
+		snapshotState:           m.NewGauge(metricSnapshotState),
+		snapshotRecordsRead:     m.NewCounter(metricSnapshotRecordsRead),
+		snapshotSegmentsActive:  m.NewGauge(metricSnapshotSegmentsActive),
+		snapshotBufferOverflow:  m.NewCounter(metricSnapshotBufferOverflow),
+		snapshotSegmentDuration: m.NewTimer(metricSnapshotSegmentDuration),
+		checkpointFailures:      m.NewCounter(metricCheckpointFailures),
+		failoverSkipped:         m.NewCounter(metricFailoverSkipped),
+	}
+}
+
 type dynamoDBShardReader struct {
 	shardID   string
 	iterator  *string
@@ -856,17 +879,7 @@ func newDynamoDBCDCInputFromConfig(pConf *service.ParsedConfig, mgr *service.Res
 		tableStreams: make(map[string]*tableStream),
 		shutSig:      shutdown.NewSignaller(),
 		log:          mgr.Logger(),
-		metrics: dynamoDBCDCMetrics{
-			shardsTracked:           mgr.Metrics().NewGauge(metricShardsTracked),
-			shardsActive:            mgr.Metrics().NewGauge(metricShardsActive),
-			snapshotState:           mgr.Metrics().NewGauge(metricSnapshotState),
-			snapshotRecordsRead:     mgr.Metrics().NewCounter(metricSnapshotRecordsRead),
-			snapshotSegmentsActive:  mgr.Metrics().NewGauge(metricSnapshotSegmentsActive),
-			snapshotBufferOverflow:  mgr.Metrics().NewCounter(metricSnapshotBufferOverflow),
-			snapshotSegmentDuration: mgr.Metrics().NewTimer(metricSnapshotSegmentDuration),
-			checkpointFailures:      mgr.Metrics().NewCounter(metricCheckpointFailures),
-			failoverSkipped:         mgr.Metrics().NewCounter(metricFailoverSkipped),
-		},
+		metrics:      newDynamoDBCDCMetrics(mgr.Metrics()),
 	}
 
 	// Always initialize snapshot state (needed for state tracking and metrics)
@@ -1330,6 +1343,17 @@ func (d *dynamoDBCDCInput) connectWithSnapshot(ctx context.Context, tableName st
 			return fmt.Errorf("initializing shards: %w", err)
 		}
 
+		// The snapshot's data-loss guarantee depends on CDC readers running
+		// first, so committing zero shards must fail the connection attempt
+		// (per-shard preparation failures are non-fatal inside refreshShards)
+		// rather than silently snapshotting without CDC coverage.
+		d.mu.RLock()
+		activeCount := len(d.shardReaders)
+		d.mu.RUnlock()
+		if activeCount == 0 {
+			return errors.New("initializing shard readers: no active shards available")
+		}
+
 		// Start shard coordinator in background
 		coordinatorCtx, coordinatorCancel := d.shutSig.SoftStopCtx(context.Background())
 		d.backgroundWorkers.Add(1)
@@ -1624,76 +1648,117 @@ func cdcCheckpointProbeNeeded(mode resumeMode) bool {
 	return mode == resumeExact
 }
 
+// preparedShard is a discovered shard resolved to a start position with its
+// iterator acquired, ready to be committed as a shard reader.
+type preparedShard struct {
+	shardID  string
+	iterator *string
+	cutoff   time.Time
+}
+
+// prepareShardReader resolves where a shard should start (global-table
+// aware) and acquires its iterator. Each AWS call carries its own timeout so
+// one hung call cannot stall an entire discovery cycle. tableSuffix is
+// appended to log lines on the multi-table path (e.g. " (table foo)").
+func (d *dynamoDBCDCInput) prepareShardReader(ctx context.Context, cp *Checkpointer, streamArn *string, shardID, tableSuffix string, honorStartFrom bool) (preparedShard, error) {
+	resolveCtx, cancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+	decision, err := cp.ResolveResume(resolveCtx, shardID)
+	cancel()
+	if err != nil {
+		return preparedShard{}, fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
+	}
+
+	var (
+		iteratorType   types.ShardIteratorType
+		sequenceNumber *string
+		cutoff         time.Time
+	)
+	switch decision.Mode {
+	case resumeExact:
+		iteratorType = types.ShardIteratorTypeAfterSequenceNumber
+		seq := decision.SequenceNumber
+		sequenceNumber = &seq
+		d.log.Infof("Resuming shard %s%s from checkpoint: %s", shardID, tableSuffix, seq)
+	case resumeFailover:
+		iteratorType = types.ShardIteratorTypeTrimHorizon
+		cutoff = decision.Cutoff
+		d.log.Infof("Failover resume for shard %s%s from trim horizon, skipping records at/before %s", shardID, tableSuffix, cutoff.Format(time.RFC3339))
+	default:
+		iteratorType = initialIteratorType(d.conf.startFrom, honorStartFrom)
+		d.log.Infof("Starting shard %s%s from %s", shardID, tableSuffix, iteratorType)
+	}
+
+	iterCtx, cancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+	iter, err := d.streamsClient.GetShardIterator(iterCtx, &dynamodbstreams.GetShardIteratorInput{
+		StreamArn:         streamArn,
+		ShardId:           &shardID,
+		ShardIteratorType: iteratorType,
+		SequenceNumber:    sequenceNumber,
+	})
+	cancel()
+	if err != nil {
+		return preparedShard{}, fmt.Errorf("getting iterator for shard %s: %w", shardID, err)
+	}
+
+	return preparedShard{shardID: shardID, iterator: iter.ShardIterator, cutoff: cutoff}, nil
+}
+
+// prepareNewShards resolves and acquires iterators for every discovered shard
+// not already registered (per isRegistered). A shard that fails to prepare is
+// skipped, counted, and retried on a later cycle rather than aborting the
+// batch, and the loop stops early once ctx's budget is exhausted so the
+// shards prepared so far can still be committed by the caller: an
+// all-or-nothing cycle can never converge on a large shard backlog, because
+// a single error each pass discards every prepared shard and the next pass
+// starts over from zero (INC-2974). Truncation and per-shard failures are
+// logged here, not returned - the caller commits whatever came back.
+func (d *dynamoDBCDCInput) prepareNewShards(ctx context.Context, cp *Checkpointer, streamArn *string, shards []types.Shard, isRegistered func(string) bool, tableSuffix string, honorStartFrom bool) []preparedShard {
+	var (
+		prepared     []preparedShard
+		failedShards int
+		firstErr     error
+	)
+	for _, shard := range shards {
+		if ctx.Err() != nil {
+			d.log.Infof("Shard discovery budget expired after preparing %d shards%s; the remaining shards will be discovered on the next refresh cycle", len(prepared), tableSuffix)
+			break
+		}
+		shardID := *shard.ShardId
+		if isRegistered(shardID) {
+			continue
+		}
+
+		p, err := d.prepareShardReader(ctx, cp, streamArn, shardID, tableSuffix, honorStartFrom)
+		if err != nil {
+			failedShards++
+			if firstErr == nil {
+				firstErr = err
+			}
+			d.log.Debugf("Failed to prepare shard %s%s, will retry on the next refresh cycle: %v", shardID, tableSuffix, err)
+			continue
+		}
+		prepared = append(prepared, p)
+	}
+
+	if failedShards > 0 {
+		d.log.Warnf("Failed to prepare %d of %d discovered shards this refresh cycle%s; they will be retried on the next cycle (first error: %v)",
+			failedShards, len(shards), tableSuffix, firstErr)
+	}
+	return prepared
+}
+
 func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 	shards, err := describeStreamAllShards(ctx, d.streamsClient, d.streamArn)
 	if err != nil {
 		return err
 	}
 
-	// Collect new shards to add without holding locks during I/O operations
-	type shardToAdd struct {
-		shardID  string
-		iterator *string
-		cutoff   time.Time
-	}
-	var newShards []shardToAdd
-
-	for _, shard := range shards {
-		shardID := *shard.ShardId
-
-		// Check if shard already exists (minimize lock hold time)
+	newShards := d.prepareNewShards(ctx, d.checkpointer, d.streamArn, shards, func(shardID string) bool {
 		d.mu.RLock()
+		defer d.mu.RUnlock()
 		_, exists := d.shardReaders[shardID]
-		d.mu.RUnlock()
-
-		if exists {
-			continue
-		}
-
-		// Decide how to resume this shard (global-table aware).
-		decision, err := d.checkpointer.ResolveResume(ctx, shardID)
-		if err != nil {
-			return fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
-		}
-
-		var (
-			iteratorType   types.ShardIteratorType
-			sequenceNumber *string
-			cutoff         time.Time
-		)
-
-		switch decision.Mode {
-		case resumeExact:
-			iteratorType = types.ShardIteratorTypeAfterSequenceNumber
-			seq := decision.SequenceNumber
-			sequenceNumber = &seq
-			d.log.Infof("Resuming shard %s from checkpoint: %s", shardID, seq)
-		case resumeFailover:
-			iteratorType = types.ShardIteratorTypeTrimHorizon
-			cutoff = decision.Cutoff
-			d.log.Infof("Failover resume for shard %s from trim horizon, skipping records at/before %s", shardID, cutoff.Format(time.RFC3339))
-		default:
-			iteratorType = initialIteratorType(d.conf.startFrom, d.honorStartFrom.Load())
-			d.log.Infof("Starting shard %s from %s", shardID, iteratorType)
-		}
-
-		// Get shard iterator (I/O operation - do not hold lock)
-		iter, err := d.streamsClient.GetShardIterator(ctx, &dynamodbstreams.GetShardIteratorInput{
-			StreamArn:         d.streamArn,
-			ShardId:           shard.ShardId,
-			ShardIteratorType: iteratorType,
-			SequenceNumber:    sequenceNumber,
-		})
-		if err != nil {
-			return fmt.Errorf("getting iterator for shard %s: %w", shardID, err)
-		}
-
-		newShards = append(newShards, shardToAdd{
-			shardID:  shardID,
-			iterator: iter.ShardIterator,
-			cutoff:   cutoff,
-		})
-	}
+		return exists
+	}, "", d.honorStartFrom.Load())
 
 	// Add all new shard readers in a single critical section
 	if len(newShards) > 0 {
@@ -1714,11 +1779,15 @@ func (d *dynamoDBCDCInput) refreshShards(ctx context.Context) error {
 
 		d.log.Infof("Tracking %d shards", totalShards)
 		d.metrics.shardsTracked.Set(int64(totalShards))
-	}
 
-	// The first successful discovery has positioned the fresh pipeline's
-	// initial shards; anything discovered from here on is a rotation child.
-	d.honorStartFrom.Store(false)
+		// The first discovery to commit shards has positioned the fresh
+		// pipeline; anything discovered from here on (including retries of
+		// shards that failed to prepare above) starts at TRIM_HORIZON -
+		// at-least-once delivery takes precedence over start_from: latest. A
+		// cycle that committed nothing keeps the flag so start_from still
+		// applies once discovery first succeeds.
+		d.honorStartFrom.Store(false)
+	}
 
 	return nil
 }
@@ -1775,14 +1844,14 @@ func (d *dynamoDBCDCInput) startShardCoordinator(ctx context.Context) {
 			return
 		case <-d.shardRefreshCh:
 			// Immediate refresh triggered by a shard reader (e.g. TrimmedDataAccessException)
-			refreshCtx, refreshCancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+			refreshCtx, refreshCancel := context.WithTimeout(ctx, shardRefreshCycleBudget)
 			if err := d.refreshShards(refreshCtx); err != nil && !errors.Is(err, context.Canceled) {
 				d.log.Warnf("Failed to refresh shards: %v", err)
 			}
 			refreshCancel()
 		case <-refreshTicker.C:
 			// Refresh shards periodically to discover new shards
-			refreshCtx, refreshCancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+			refreshCtx, refreshCancel := context.WithTimeout(ctx, shardRefreshCycleBudget)
 			if err := d.refreshShards(refreshCtx); err != nil && !errors.Is(err, context.Canceled) {
 				d.log.Warnf("Failed to refresh shards: %v", err)
 			}
@@ -1906,14 +1975,14 @@ func (d *dynamoDBCDCInput) startTableStreamCoordinator(ctx context.Context, tabl
 			return
 		case <-ts.shardRefreshCh:
 			// Immediate refresh triggered by a shard reader (e.g. TrimmedDataAccessException)
-			refreshCtx, refreshCancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+			refreshCtx, refreshCancel := context.WithTimeout(ctx, shardRefreshCycleBudget)
 			if err := d.refreshTableShards(refreshCtx, tableName, ts); err != nil && !errors.Is(err, context.Canceled) {
 				d.log.Warnf("Failed to refresh shards for table %s: %v", tableName, err)
 			}
 			refreshCancel()
 		case <-refreshTicker.C:
 			// Refresh shards periodically to discover new shards
-			refreshCtx, refreshCancel := context.WithTimeout(ctx, defaultAPICallTimeout)
+			refreshCtx, refreshCancel := context.WithTimeout(ctx, shardRefreshCycleBudget)
 			if err := d.refreshTableShards(refreshCtx, tableName, ts); err != nil && !errors.Is(err, context.Canceled) {
 				d.log.Warnf("Failed to refresh shards for table %s: %v", tableName, err)
 			}
@@ -1932,69 +2001,12 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 		return err
 	}
 
-	// Collect new shards to add
-	type shardToAdd struct {
-		shardID  string
-		iterator *string
-		cutoff   time.Time
-	}
-	var newShards []shardToAdd
-
-	for _, shard := range shards {
-		shardID := *shard.ShardId
-
-		// Check if shard already exists
+	newShards := d.prepareNewShards(ctx, ts.checkpointer, &ts.streamArn, shards, func(shardID string) bool {
 		ts.mu.RLock()
+		defer ts.mu.RUnlock()
 		_, exists := ts.shardReaders[shardID]
-		ts.mu.RUnlock()
-		if exists {
-			continue
-		}
-
-		// Decide how to resume this shard (global-table aware).
-		decision, err := ts.checkpointer.ResolveResume(ctx, shardID)
-		if err != nil {
-			return fmt.Errorf("resolving resume for shard %s: %w", shardID, err)
-		}
-
-		var (
-			iteratorType   types.ShardIteratorType
-			sequenceNumber *string
-			cutoff         time.Time
-		)
-
-		switch decision.Mode {
-		case resumeExact:
-			iteratorType = types.ShardIteratorTypeAfterSequenceNumber
-			seq := decision.SequenceNumber
-			sequenceNumber = &seq
-			d.log.Infof("Resuming shard %s (table %s) from checkpoint: %s", shardID, tableName, seq)
-		case resumeFailover:
-			iteratorType = types.ShardIteratorTypeTrimHorizon
-			cutoff = decision.Cutoff
-			d.log.Infof("Failover resume for shard %s (table %s) from trim horizon, skipping records at/before %s", shardID, tableName, cutoff.Format(time.RFC3339))
-		default:
-			iteratorType = initialIteratorType(d.conf.startFrom, ts.honorStartFrom.Load())
-			d.log.Infof("Starting shard %s (table %s) from %s", shardID, tableName, iteratorType)
-		}
-
-		// Get shard iterator
-		iter, err := d.streamsClient.GetShardIterator(ctx, &dynamodbstreams.GetShardIteratorInput{
-			StreamArn:         &ts.streamArn,
-			ShardId:           shard.ShardId,
-			ShardIteratorType: iteratorType,
-			SequenceNumber:    sequenceNumber,
-		})
-		if err != nil {
-			return fmt.Errorf("getting iterator for shard %s: %w", shardID, err)
-		}
-
-		newShards = append(newShards, shardToAdd{
-			shardID:  shardID,
-			iterator: iter.ShardIterator,
-			cutoff:   cutoff,
-		})
-	}
+		return exists
+	}, " (table "+tableName+")", ts.honorStartFrom.Load())
 
 	// Add all new shard readers
 	if len(newShards) > 0 {
@@ -2014,11 +2026,15 @@ func (d *dynamoDBCDCInput) refreshTableShards(ctx context.Context, tableName str
 
 		d.log.Infof("Table %s: tracking %d shards", tableName, shardCount)
 		d.updateTotalShardsMetric()
-	}
 
-	// The first successful discovery has positioned the fresh pipeline's
-	// initial shards; anything discovered from here on is a rotation child.
-	ts.honorStartFrom.Store(false)
+		// The first discovery to commit shards has positioned the fresh
+		// pipeline; anything discovered from here on (including retries of
+		// shards that failed to prepare above) starts at TRIM_HORIZON -
+		// at-least-once delivery takes precedence over start_from: latest. A
+		// cycle that committed nothing keeps the flag so start_from still
+		// applies once discovery first succeeds.
+		ts.honorStartFrom.Store(false)
+	}
 
 	return nil
 }

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -170,7 +170,7 @@ func (s *stubStreamsTransport) Do(req *http.Request) (*http.Response, error) {
 // newStubStreamsClient builds a real *dynamodbstreams.Client whose transport
 // is entirely local (no network, no AWS account) so it deserializes responses
 // exactly the way the production client would.
-func newStubStreamsClient(t *stubStreamsTransport) *dynamodbstreams.Client {
+func newStubStreamsClient(t aws.HTTPClient) *dynamodbstreams.Client {
 	cfg := aws.Config{
 		Region:      "us-east-1",
 		Credentials: aws.AnonymousCredentials{},

--- a/internal/impl/aws/dynamodb/input_cdc_refresh_shards_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_refresh_shards_test.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package dynamodb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// newTestCheckpointer builds a Checkpointer for a pipeline with no prior
+// checkpoint state: every resume lookup misses.
+func newTestCheckpointer(t *testing.T) *Checkpointer {
+	t.Helper()
+	return &Checkpointer{
+		tableName:       "checkpoints",
+		sourceTable:     "test",
+		streamArn:       testStreamArn,
+		checkpointLimit: 1000,
+		svc: &fakeCheckpointAPI{
+			getItem: func(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{}, nil
+			},
+		},
+		log: service.MockResources().Logger(),
+	}
+}
+
+// refreshStubTransport fakes the DynamoDB Streams endpoint for shard
+// discovery: DescribeStream returns a fixed shard list, and GetShardIterator
+// succeeds or fails per shard. onGetShardIterator, when set, runs before each
+// GetShardIterator response is built (used to cancel contexts mid-cycle).
+type refreshStubTransport struct {
+	mu                 sync.Mutex
+	shardIDs           []string
+	failShards         map[string]bool
+	iteratorCalls      []string
+	onGetShardIterator func(shardID string)
+}
+
+func (s *refreshStubTransport) setFailShards(shards ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failShards = map[string]bool{}
+	for _, id := range shards {
+		s.failShards[id] = true
+	}
+}
+
+func (s *refreshStubTransport) iteratorCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.iteratorCalls)
+}
+
+func jsonResponse(req *http.Request, status int, body string) *http.Response {
+	hdr := http.Header{}
+	hdr.Set("Content-Type", "application/x-amz-json-1.0")
+	return &http.Response{
+		StatusCode: status,
+		Header:     hdr,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func (s *refreshStubTransport) Do(req *http.Request) (*http.Response, error) {
+	target := req.Header.Get("X-Amz-Target")
+	switch {
+	case strings.HasSuffix(target, ".DescribeStream"):
+		s.mu.Lock()
+		shards := make([]map[string]any, 0, len(s.shardIDs))
+		for _, id := range s.shardIDs {
+			shards = append(shards, map[string]any{"ShardId": id})
+		}
+		s.mu.Unlock()
+		desc, err := json.Marshal(map[string]any{
+			"StreamDescription": map[string]any{
+				"StreamArn":    testStreamArn,
+				"StreamStatus": "ENABLED",
+				"Shards":       shards,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(req, 200, string(desc)), nil
+
+	case strings.HasSuffix(target, ".GetShardIterator"):
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var in struct{ ShardId string }
+		if err := json.Unmarshal(payload, &in); err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		s.iteratorCalls = append(s.iteratorCalls, in.ShardId)
+		fail := s.failShards[in.ShardId]
+		hook := s.onGetShardIterator
+		s.mu.Unlock()
+		if hook != nil {
+			hook(in.ShardId)
+		}
+		if fail {
+			resp := jsonResponse(req, 400, `{"__type":"LimitExceededException","message":"stubbed for test"}`)
+			resp.Header.Set("X-Amzn-ErrorType", "LimitExceededException")
+			return resp, nil
+		}
+		return jsonResponse(req, 200, fmt.Sprintf(`{"ShardIterator":"iter-%s"}`, in.ShardId)), nil
+
+	default:
+		return nil, fmt.Errorf("refreshStubTransport: unexpected operation %q", target)
+	}
+}
+
+func newRefreshTestInput(t *testing.T, transport *refreshStubTransport) *dynamoDBCDCInput {
+	t.Helper()
+	return &dynamoDBCDCInput{
+		conf:           dynamoDBCDCConfig{startFrom: "trim_horizon"},
+		log:            service.MockResources().Logger(),
+		metrics:        newDynamoDBCDCMetrics(service.MockResources().Metrics()),
+		streamsClient:  newStubStreamsClient(transport),
+		streamArn:      aws.String(testStreamArn),
+		checkpointer:   newTestCheckpointer(t),
+		shardReaders:   map[string]*dynamoDBShardReader{},
+		shardRefreshCh: make(chan struct{}, 1),
+	}
+}
+
+func registeredShards(d *dynamoDBCDCInput) []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	ids := make([]string, 0, len(d.shardReaders))
+	for id := range d.shardReaders {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// TestRefreshShards_SkipsFailedShardAndCommitsRest: one shard failing to
+// resolve must not discard the whole discovery cycle. Healthy shards are
+// registered (partial progress commits), the failed shard is retried on the
+// next cycle, and per-shard failures are not fatal. This is the
+// non-convergence wedge behind INC-2974's preprod pipeline: with the
+// all-or-nothing cycle, a single error meant zero readers ever started.
+func TestRefreshShards_SkipsFailedShardAndCommitsRest(t *testing.T) {
+	transport := &refreshStubTransport{shardIDs: []string{"shard-001", "shard-002", "shard-003"}}
+	transport.setFailShards("shard-002")
+
+	d := newRefreshTestInput(t, transport)
+	d.honorStartFrom.Store(true)
+
+	require.NoError(t, d.refreshShards(t.Context()),
+		"a per-shard failure must not fail the whole refresh cycle")
+	assert.ElementsMatch(t, []string{"shard-001", "shard-003"}, registeredShards(d),
+		"healthy shards must be registered even when another shard fails")
+	assert.False(t, d.honorStartFrom.Load(),
+		"the first committed discovery positions the pipeline; later retries of failed shards must use TRIM_HORIZON so no backlog is skipped")
+
+	// The failed shard recovers on the next cycle.
+	transport.setFailShards()
+	require.NoError(t, d.refreshShards(t.Context()))
+	assert.ElementsMatch(t, []string{"shard-001", "shard-002", "shard-003"}, registeredShards(d),
+		"a previously failed shard must be picked up by the next refresh cycle")
+}
+
+// TestRefreshShards_ZeroCommitKeepsStartFrom: a discovery cycle that commits
+// no shards has not positioned anything, so it must not consume the
+// once-only start_from window - otherwise a transient full-cycle failure on
+// a fresh pipeline silently converts start_from: latest into a 24h backlog
+// replay.
+func TestRefreshShards_ZeroCommitKeepsStartFrom(t *testing.T) {
+	transport := &refreshStubTransport{shardIDs: []string{"shard-001", "shard-002"}}
+	transport.setFailShards("shard-001", "shard-002")
+
+	d := newRefreshTestInput(t, transport)
+	d.honorStartFrom.Store(true)
+
+	require.NoError(t, d.refreshShards(t.Context()))
+	assert.Empty(t, registeredShards(d))
+	assert.True(t, d.honorStartFrom.Load(),
+		"a cycle that committed nothing must keep honoring start_from for the first real discovery")
+
+	transport.setFailShards()
+	require.NoError(t, d.refreshShards(t.Context()))
+	assert.ElementsMatch(t, []string{"shard-001", "shard-002"}, registeredShards(d))
+	assert.False(t, d.honorStartFrom.Load())
+}
+
+// TestRefreshShards_BudgetExhaustedCommitsProgress: when the refresh budget
+// (the caller's context deadline) expires mid-cycle, the shards already
+// resolved must still be committed - and the truncation is not an error, so
+// successive cycles converge on a large backlog instead of restarting from
+// zero every time.
+func TestRefreshShards_BudgetExhaustedCommitsProgress(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	transport := &refreshStubTransport{shardIDs: []string{"shard-001", "shard-002", "shard-003"}}
+	transport.setFailShards("shard-002")
+	// The budget dies while shard-002's call is in flight: the cycle must
+	// stop (no call for shard-003) but keep shard-001.
+	transport.onGetShardIterator = func(shardID string) {
+		if shardID == "shard-002" {
+			cancel()
+		}
+	}
+
+	d := newRefreshTestInput(t, transport)
+
+	require.NoError(t, d.refreshShards(ctx),
+		"a truncated-but-progressing cycle is not a failure")
+	assert.ElementsMatch(t, []string{"shard-001"}, registeredShards(d),
+		"shards resolved before the budget expired must be committed")
+	assert.Equal(t, 2, transport.iteratorCallCount(),
+		"the cycle must stop iterating once the budget is exhausted")
+}
+
+// TestRefreshTableShards_SkipsFailedShardAndCommitsRest mirrors the partial
+// progress contract on the multi-table path.
+func TestRefreshTableShards_SkipsFailedShardAndCommitsRest(t *testing.T) {
+	transport := &refreshStubTransport{shardIDs: []string{"shard-001", "shard-002", "shard-003"}}
+	transport.setFailShards("shard-002")
+
+	d := &dynamoDBCDCInput{
+		conf:          dynamoDBCDCConfig{startFrom: "trim_horizon"},
+		log:           service.MockResources().Logger(),
+		metrics:       newDynamoDBCDCMetrics(service.MockResources().Metrics()),
+		streamsClient: newStubStreamsClient(transport),
+	}
+	ts := &tableStream{
+		tableName:      "test",
+		streamArn:      testStreamArn,
+		checkpointer:   newTestCheckpointer(t),
+		shardReaders:   map[string]*dynamoDBShardReader{},
+		shardRefreshCh: make(chan struct{}, 1),
+	}
+	ts.honorStartFrom.Store(true)
+
+	require.NoError(t, d.refreshTableShards(t.Context(), "test", ts),
+		"a per-shard failure must not fail the whole refresh cycle")
+
+	ts.mu.RLock()
+	ids := make([]string, 0, len(ts.shardReaders))
+	for id := range ts.shardReaders {
+		ids = append(ids, id)
+	}
+	ts.mu.RUnlock()
+	assert.ElementsMatch(t, []string{"shard-001", "shard-003"}, ids,
+		"healthy shards must be registered even when another shard fails")
+	assert.False(t, ts.honorStartFrom.Load())
+}

--- a/internal/impl/aws/dynamodb/input_cdc_refresh_shards_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_refresh_shards_test.go
@@ -54,6 +54,16 @@ type refreshStubTransport struct {
 	failShards         map[string]bool
 	iteratorCalls      []string
 	onGetShardIterator func(shardID string)
+	// missingDeadlines records operations whose request context carried no
+	// deadline: every AWS call in a discovery cycle must be individually
+	// bounded, or a single hung call consumes the whole cycle budget.
+	missingDeadlines []string
+}
+
+func (s *refreshStubTransport) deadlineViolations() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.missingDeadlines...)
 }
 
 func (s *refreshStubTransport) setFailShards(shards ...string) {
@@ -84,6 +94,11 @@ func jsonResponse(req *http.Request, status int, body string) *http.Response {
 
 func (s *refreshStubTransport) Do(req *http.Request) (*http.Response, error) {
 	target := req.Header.Get("X-Amz-Target")
+	if _, hasDeadline := req.Context().Deadline(); !hasDeadline {
+		s.mu.Lock()
+		s.missingDeadlines = append(s.missingDeadlines, target)
+		s.mu.Unlock()
+	}
 	switch {
 	case strings.HasSuffix(target, ".DescribeStream"):
 		s.mu.Lock()
@@ -182,6 +197,9 @@ func TestRefreshShards_SkipsFailedShardAndCommitsRest(t *testing.T) {
 	require.NoError(t, d.refreshShards(t.Context()))
 	assert.ElementsMatch(t, []string{"shard-001", "shard-002", "shard-003"}, registeredShards(d),
 		"a previously failed shard must be picked up by the next refresh cycle")
+
+	assert.Empty(t, transport.deadlineViolations(),
+		"every AWS call in a discovery cycle must carry its own deadline, or one hung call consumes the whole cycle budget")
 }
 
 // TestRefreshShards_ZeroCommitKeepsStartFrom: a discovery cycle that commits


### PR DESCRIPTION
## Context

INC-2974: two managed `aws_dynamodb_cdc` pipelines (prod + preprod) reported `STATE_RUNNING` with completely dead data paths for days. Investigation against the pipeline logs and the v4.106.0 source identified two independent stall mechanisms in this connector, both present since at least v4.105.0 (neither is fixed by #4727 / v4.107.0).

## Fix 1 — converge shard discovery under partial failure

`refreshShards`/`refreshTableShards` were all-or-nothing: the first per-shard error (checkpoint `GetItem` or `GetShardIterator`) aborted the whole cycle, discarding every shard already resolved, and the coordinator retried the entire batch under a single 30s budget every 30s. With a large shard backlog (~684 retained shards on the affected preprod pipeline) a cycle could never finish inside the budget, so no reader ever started: the pipeline logged `Starting shard ... from TRIM_HORIZON` for the full list every 30s forever and read nothing.

Discovery now commits whatever it managed to prepare:
- a shard that fails to prepare is skipped, logged, and retried next cycle;
- a cycle truncated by its budget still registers the shards prepared so far — truncation is progress, not an error — so successive cycles converge on any backlog size;
- each AWS call carries its own `defaultAPICallTimeout`, and the coordinator cycle budget is `4x` that, so one hung call cannot consume a whole cycle;
- the single- and multi-table paths share one `prepareNewShards`/`prepareShardReader` implementation.

Contract details preserved deliberately: `honorStartFrom` latches only after the first discovery that actually **commits** shards (a zero-commit cycle keeps `start_from: latest` armed; shards that failed on a committed first cycle retry at TRIM_HORIZON — replay, never skip). `connectWithSnapshot` now fails the connection attempt when zero shards committed, matching `connectCDCOnly`, since the snapshot's data-loss guarantee depends on CDC readers running first.

## Fix 2 — keep the batcher mutex off the checkpoint write path

`RecordBatcher.AckMessages` held `b.mu` across the checkpoint `PutItem`. Every shard reader polls `ShouldThrottle()` (and calls `AddMessages`) under the same mutex, so a single slow or hung checkpoint write silently froze every shard reader — no errors, no reads — while the snapshot path (separate tracker) kept flowing. The ack context is typically deadline-free, so a hung request could pin the input indefinitely.

Now: settlement (drop/resolve/pending) happens under `b.mu` alone, so acks are wait-free; checkpoint writes are single-flighted per shard (`persistMu.TryLock` + post-write re-check loop, so progress settled during a write is picked up immediately and the durable row only moves forward); the write is bounded by `defaultAPICallTimeout`.

Two adjacent stall hazards fixed in the same code:
- the `maxTrackedShards` guard returned before settling the acked batch (leaking tracked messages until `ShouldThrottle` pinned permanently) and would have frozen all checkpoint persists for as long as it tripped; it now settles and persists first, then surfaces the guard error;
- a continuously pinned throttle was invisible: `ShouldThrottle` now emits a rate-limited warning once the tracker has been saturated for 5 minutes, naming the in-flight count, so a stalled data path is diagnosable from logs.

## Testing

- 8 new unit tests, each written first and confirmed failing against the old code (per-shard skip + partial commit on both paths, budget-truncation commit, zero-commit `start_from` latch, blocked-write non-blocking settlement + same-shard single-flighting, over-cap drain + persist, pinned-throttle warning).
- Full `internal/impl/aws/dynamodb` suite green under `-race`; `task fmt` / `task lint` / `task docs` clean.

## Not addressed here (follow-ups)

- Batcher shard-entry eviction (entries are never removed; the `maxTrackedShards` guard now degrades gracefully instead of freezing, but retirement is the real fix).
- Parallel shard preparation (sequential under the larger budget converges acceptably).
- The prod pipeline's root cause is not yet conclusively pinned between the two mechanisms Fix 2 addresses/mitigates; a goroutine dump from the wedged pod is requested on the incident before restart.