### PR TITLE
aws_dynamodb_cdc: settle acks by handle and isolate per-shard backpressure (INC-2974)

### DIFF
--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -70,13 +70,19 @@ type RecordBatcher struct {
 	reserved int
 	// perShardCap bounds one shard's in-flight (tracked + reserved) messages
 	// so a shard whose batches never settle downstream parks alone at its cap
-	// instead of pinning the global budget and every other reader. A shard
-	// with nothing in flight always admits one batch regardless, so progress
-	// is guaranteed for any cap/batch-size combination.
+	// instead of pinning the global budget and every other reader. The cap
+	// exists purely for that isolation, so it binds only while another shard
+	// is also active: a sole active shard may use the whole global budget (a
+	// one-partition table has a single active shard, and capping it would
+	// strand three quarters of the budget the pre-cap gate allowed it). A
+	// shard with nothing in flight always admits one batch regardless, so
+	// progress is guaranteed for any cap/batch-size combination.
 	perShardCap int
 	// throttledSince is when reservations last started failing on the global
-	// budget without a successful reserve in between; zero while not
-	// throttled. lastPinWarn rate-limits the pinned-throttle warning.
+	// budget without one passing the global check in between (a reservation
+	// the shard's own cap then refuses still proves the global budget has
+	// room); zero while not throttled. lastPinWarn rate-limits the
+	// pinned-throttle warning.
 	throttledSince time.Time
 	lastPinWarn    time.Time
 }
@@ -163,10 +169,10 @@ func NewRecordBatcher(maxTrackedShards, checkpointLimit int, log *service.Logger
 
 // TryReserve claims budget for a read of up to n messages on shardID. It
 // refuses when the global tracked+reserved budget or the shard's in-flight
-// cap has no room (the caller waits and retries), except that a shard with
-// nothing in flight always admits one batch so progress is never impossible.
-// Budget is consumed by AddMessages and any surplus must be returned via
-// Release.
+// cap has no room (the caller waits and retries). The per-shard cap binds
+// only while another shard is also active, and a shard with nothing in
+// flight always admits one batch, so progress is never impossible. Budget is
+// consumed by AddMessages and any surplus must be returned via Release.
 func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 	if b == nil {
 		// No batcher, no backpressure (mirrors ShouldThrottle's nil case).
@@ -189,9 +195,13 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 		}
 		return false
 	}
+	// The global budget can admit this reservation, so it is not pinned:
+	// clear its clock even if the shard's own cap refuses below, or the next
+	// global exhaustion would report a pin spanning the drained interval.
+	b.throttledSince = time.Time{}
 
 	st, ok := b.shards[shardID]
-	if ok && st.inflight+st.reserved > 0 && st.inflight+st.reserved+n > b.perShardCap {
+	if ok && st.inflight+st.reserved > 0 && st.inflight+st.reserved+n > b.perShardCap && b.otherShardActiveLocked(shardID) {
 		// The shard is pinned by its own unsettled messages; park it alone
 		// without touching the global throttle clock, but surface a
 		// continuous pin on the shard's own clock - in a topology with fewer
@@ -208,7 +218,6 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 		return false
 	}
 
-	b.throttledSince = time.Time{}
 	if !ok {
 		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string](), seqTimes: map[string]string{}}
 		b.shards[shardID] = st
@@ -217,6 +226,18 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 	st.reserved += n
 	b.reserved += n
 	return true
+}
+
+// otherShardActiveLocked reports whether any shard other than shardID has
+// in-flight or reserved messages - the per-shard cap only binds while one
+// does (see perShardCap doc). Callers must hold b.mu.
+func (b *RecordBatcher) otherShardActiveLocked(shardID string) bool {
+	for id, st := range b.shards {
+		if id != shardID && st.inflight+st.reserved > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // Release returns unused reservation for a shard (the read failed, returned

--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -250,14 +250,12 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 }
 
 // otherShardActiveLocked reports whether any shard other than shardID has
-// in-flight or reserved messages - the per-shard cap only binds while one
-// does (see perShardCap doc). Callers must hold b.mu.
+// unsettled (in-flight) messages - the per-shard cap only binds while one
+// does (see perShardCap doc). A transient read reservation is deliberately
+// not activity: idle shards hold one for every GetRecords round trip, and
+// counting those would intermittently engage the cap against a sole busy
+// shard. Callers must hold b.mu.
 func (b *RecordBatcher) otherShardActiveLocked(shardID string) bool {
-	for id := range b.reservedByShard {
-		if id != shardID {
-			return true
-		}
-	}
 	for id, st := range b.shards {
 		if id != shardID && st.inflight > 0 {
 			return true
@@ -326,7 +324,12 @@ func (b *RecordBatcher) topInflightShardsLocked(k int) string {
 // number is the batch's checkpoint payload. Must be called from the shard's
 // single reader goroutine so batches are tracked in dispatch order.
 func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) *trackedBatch {
-	if len(batch) == 0 {
+	// The nil guard matters at shutdown: Close() nils the input's batcher
+	// reference after timeouts that warn and proceed, and a straggler reader
+	// returning from a slow GetRecords must no-op (all other methods already
+	// tolerate nil; every caller tolerates a nil handle), not panic and kill
+	// the process.
+	if b == nil || len(batch) == 0 {
 		return nil
 	}
 

--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,11 +56,6 @@ type RecordBatcher struct {
 
 	mu sync.Mutex
 
-	// batches maps every message of a tracked batch to the batch's shared
-	// tracking state. The batch is the ack unit (each dispatched batch has
-	// exactly one ack callback), so resolving any of its messages resolves
-	// the whole batch.
-	batches map[*service.Message]*trackedBatch
 	// shards holds the per-shard ordered ack trackers. Entries are never
 	// removed; DynamoDB stream shards rotate within 24h so the map stays
 	// small, and maxTrackedShards guards against pathological growth.
@@ -66,19 +63,38 @@ type RecordBatcher struct {
 	// trackedMessages counts messages across all in-flight batches, used for
 	// backpressure via ShouldThrottle.
 	trackedMessages int
-	// throttledSince is when trackedMessages last crossed the throttle
-	// threshold without dipping back below it; zero while not throttled.
-	// lastPinWarn rate-limits the pinned-throttle warning.
+	// reserved counts budget handed out via TryReserve but not yet converted
+	// into tracked messages (reads in flight). trackedMessages + reserved is
+	// bounded by maxTrackedMessages, so concurrent readers can never
+	// collectively overshoot the budget on their first read wave.
+	reserved int
+	// perShardCap bounds one shard's in-flight (tracked + reserved) messages
+	// so a shard whose batches never settle downstream parks alone at its cap
+	// instead of pinning the global budget and every other reader. A shard
+	// with nothing in flight always admits one batch regardless, so progress
+	// is guaranteed for any cap/batch-size combination.
+	perShardCap int
+	// throttledSince is when reservations last started failing on the global
+	// budget without a successful reserve in between; zero while not
+	// throttled. lastPinWarn rate-limits the pinned-throttle warning.
 	throttledSince time.Time
 	lastPinWarn    time.Time
 }
 
+// trackedBatch is the settlement handle for one dispatched batch, returned by
+// AddMessages and captured by that batch's ack function. Settlement goes
+// through this handle - never through a lookup keyed by the batch's message
+// pointers - because wrappers between the input and the pipeline are free to
+// rewrite the batch slice: benthos's AutoRetryNacksBatched replaces every
+// element with a new *Message before the pipeline sees it, so a pointer-keyed
+// lookup silently misses, the tracker never drains, and every shard reader
+// parks in backpressure forever (INC-2974).
 type trackedBatch struct {
 	shardID string
 	size    int
-	// msgs holds the batch's messages so all map entries can be dropped when
-	// the batch settles.
-	msgs []*service.Message
+	// settled flips exactly once, whichever of ack/remove wins; repeat
+	// settles are no-ops. Guarded by the batcher's mu.
+	settled bool
 	// resolve marks the batch as acknowledged in the shard's ordered tracker
 	// and returns the new highest contiguous sequence, or nil if the frontier
 	// did not move (an earlier batch is still outstanding).
@@ -110,6 +126,11 @@ type shardAckTracker struct {
 	seqTimes map[string]string
 	// frontierTime is the ApproximateCreationDateTime of the current frontier.
 	frontierTime string
+	// inflight counts this shard's tracked (dispatched, unsettled) messages;
+	// reserved counts budget handed to this shard's reader ahead of a read.
+	// Together they are bounded by the batcher's perShardCap.
+	inflight int
+	reserved int
 }
 
 // NewRecordBatcher creates a new [RecordBatcher] for DynamoDB CDC.
@@ -123,20 +144,109 @@ func NewRecordBatcher(maxTrackedShards, checkpointLimit int, log *service.Logger
 	return &RecordBatcher{
 		maxTrackedShards:   maxTrackedShards,
 		maxTrackedMessages: maxTrackedMessages,
-		log:                log,
-		batches:            make(map[*service.Message]*trackedBatch),
-		shards:             make(map[string]*shardAckTracker),
+		// One never-settling shard may pin at most a quarter of the budget;
+		// the rest stays available to healthy shards (see perShardCap doc).
+		perShardCap: maxTrackedMessages / 4,
+		log:         log,
+		shards:      make(map[string]*shardAckTracker),
 	}
 }
 
+// TryReserve claims budget for a read of up to n messages on shardID. It
+// refuses when the global tracked+reserved budget or the shard's in-flight
+// cap has no room (the caller waits and retries), except that a shard with
+// nothing in flight always admits one batch so progress is never impossible.
+// Budget is consumed by AddMessages and any surplus must be returned via
+// Release.
+func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
+	if b == nil {
+		// No batcher, no backpressure (mirrors ShouldThrottle's nil case).
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.trackedMessages+b.reserved+n > b.maxTrackedMessages {
+		// Surface a continuously pinned budget: every shard reader parks on
+		// this check, so if in-flight messages never settle the input is
+		// stalled with no other signal.
+		now := time.Now()
+		if b.throttledSince.IsZero() {
+			b.throttledSince = now
+		} else if since := now.Sub(b.throttledSince); since >= throttlePinWarnAfter && now.Sub(b.lastPinWarn) >= throttlePinWarnInterval {
+			b.lastPinWarn = now
+			b.log.Warnf("Shard readers throttled for %v: %d/%d in-flight messages are still awaiting downstream acknowledgement (top shards: %s); no records are being read while this persists",
+				since.Round(time.Second), b.trackedMessages, b.maxTrackedMessages, b.topInflightShardsLocked(3))
+		}
+		return false
+	}
+
+	st, ok := b.shards[shardID]
+	if ok && st.inflight+st.reserved > 0 && st.inflight+st.reserved+n > b.perShardCap {
+		// The shard is pinned by its own unsettled messages; park it alone
+		// without touching the global throttle clock.
+		return false
+	}
+
+	b.throttledSince = time.Time{}
+	if !ok {
+		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string](), seqTimes: map[string]string{}}
+		b.shards[shardID] = st
+	}
+	st.reserved += n
+	b.reserved += n
+	return true
+}
+
+// Release returns unused reservation for a shard (the read failed, returned
+// fewer records than reserved, or every record was filtered out).
+func (b *RecordBatcher) Release(shardID string, n int) {
+	if b == nil || n <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if st, ok := b.shards[shardID]; ok {
+		released := min(n, st.reserved)
+		st.reserved -= released
+		b.reserved -= released
+	}
+}
+
+// topInflightShardsLocked renders the k shards holding the most unsettled
+// messages, for the pinned-throttle diagnostic. Callers must hold b.mu.
+func (b *RecordBatcher) topInflightShardsLocked(k int) string {
+	type entry struct {
+		id string
+		n  int
+	}
+	var entries []entry
+	for id, st := range b.shards {
+		if st.inflight > 0 {
+			entries = append(entries, entry{id, st.inflight})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].n > entries[j].n })
+	if len(entries) > k {
+		entries = entries[:k]
+	}
+	parts := make([]string, len(entries))
+	for i, e := range entries {
+		parts[i] = fmt.Sprintf("%s=%d", e.id, e.n)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // AddMessages tracks a batch of messages against a shard's ordered checkpoint
-// tracker. The batch must be in stream order (GetRecords returns records
-// ordered by sequence number), so the last message's sequence number is the
-// batch's checkpoint payload. Must be called from the shard's single reader
-// goroutine so batches are tracked in dispatch order.
-func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) service.MessageBatch {
+// tracker and returns the batch's settlement handle (nil for an empty batch),
+// which the ack function must capture (see trackedBatch for why the batch
+// itself cannot be the key). The batch must be in stream order (GetRecords
+// returns records ordered by sequence number), so the last message's sequence
+// number is the batch's checkpoint payload. Must be called from the shard's
+// single reader goroutine so batches are tracked in dispatch order.
+func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) *trackedBatch {
 	if len(batch) == 0 {
-		return batch
+		return nil
 	}
 
 	b.mu.Lock()
@@ -155,6 +265,12 @@ func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) 
 		b.shards[shardID] = st
 	}
 
+	// Convert the shard's outstanding reservation (if any) into tracked
+	// messages; readers reserve at least the batch size before reading.
+	consumed := min(st.reserved, len(batch))
+	st.reserved -= consumed
+	b.reserved -= consumed
+
 	last := batch[len(batch)-1]
 	seq, _ := last.MetaGet("dynamodb_sequence_number")
 	approxCreationTime, _ := last.MetaGet("dynamodb_approximate_creation_time")
@@ -162,40 +278,39 @@ func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) 
 	tb := &trackedBatch{
 		shardID: shardID,
 		size:    len(batch),
-		msgs:    batch,
 		resolve: st.tracker.Track(seq, int64(len(batch))),
 	}
-	for _, msg := range batch {
-		b.batches[msg] = tb
-	}
 	b.trackedMessages += len(batch)
+	st.inflight += len(batch)
 
-	return batch
+	return tb
 }
 
-// dropBatchLocked removes all of a batch's map entries and its message count.
-// Callers must hold b.mu.
-func (b *RecordBatcher) dropBatchLocked(tb *trackedBatch) {
-	for _, msg := range tb.msgs {
-		delete(b.batches, msg)
+// settleLocked marks a batch settled and removes its message count, returning
+// false if it had already settled. Callers must hold b.mu.
+func (b *RecordBatcher) settleLocked(tb *trackedBatch) bool {
+	if tb.settled {
+		return false
 	}
+	tb.settled = true
 	b.trackedMessages -= tb.size
+	if st, ok := b.shards[tb.shardID]; ok {
+		st.inflight -= tb.size
+	}
+	return true
 }
 
-// RemoveMessages drops a batch from tracking without resolving it (used when
-// messages are nacked, or acked after close). The shard's checkpoint frontier
-// stays pinned before this batch, so later acks cannot persist past it and a
-// restart redelivers the dropped records.
-func (b *RecordBatcher) RemoveMessages(batch service.MessageBatch) {
-	if b == nil || len(batch) == 0 {
+// RemoveBatch drops a tracked batch without resolving it (used when messages
+// are nacked, acked after close, or never dispatched). The shard's checkpoint
+// frontier stays pinned before this batch, so later acks cannot persist past
+// it and a restart redelivers the dropped records.
+func (b *RecordBatcher) RemoveBatch(tb *trackedBatch) {
+	if b == nil || tb == nil {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
-	if tb, ok := b.batches[batch[0]]; ok {
-		b.dropBatchLocked(tb)
-	}
+	b.settleLocked(tb)
 }
 
 type checkpointer interface {
@@ -215,29 +330,28 @@ func (st *shardAckTracker) advanceFrontier(frontier string) {
 	}
 }
 
-// AckMessages marks a batch as acknowledged, advances the shard's contiguous
-// frontier, and persists a checkpoint once enough messages have been acked
-// since the last persisted position.
-func (b *RecordBatcher) AckMessages(
+// AckBatch marks a tracked batch as acknowledged, advances the shard's
+// contiguous frontier, and persists a checkpoint once enough messages have
+// been acked since the last persisted position. Settlement goes through the
+// handle returned by AddMessages (see trackedBatch); repeat settles no-op.
+func (b *RecordBatcher) AckBatch(
 	ctx context.Context,
 	cp checkpointer,
-	batch service.MessageBatch,
+	tb *trackedBatch,
 ) error {
-	if b == nil || len(batch) == 0 {
+	if b == nil || tb == nil {
 		return nil
 	}
 
 	// Settle under b.mu only, never waiting on another ack's in-flight
-	// checkpoint write: batch settlement (and with it ShouldThrottle and
+	// checkpoint write: batch settlement (and with it TryReserve and
 	// AddMessages) stays wait-free even when the checkpoint store is slow.
 	b.mu.Lock()
-	tb, ok := b.batches[batch[0]]
-	if !ok {
-		// Already removed (nacked or double-acked); nothing to do.
+	if !b.settleLocked(tb) {
+		// Already settled (nacked or double-acked); nothing to do.
 		b.mu.Unlock()
 		return nil
 	}
-	b.dropBatchLocked(tb)
 	st := b.shards[tb.shardID]
 	if frontier := tb.resolve(); frontier != nil {
 		st.advanceFrontier(*frontier)
@@ -246,6 +360,11 @@ func (b *RecordBatcher) AckMessages(
 	shardsOverCap := len(b.shards) > b.maxTrackedShards
 	b.mu.Unlock()
 
+	if cp == nil {
+		// No checkpoint store: settlement still drains the tracker, there is
+		// just nothing to persist.
+		return nil
+	}
 	persistErr := b.maybePersist(ctx, cp, st, tb.shardID)
 	if shardsOverCap {
 		// The batch is settled and the frontier persisted above regardless:
@@ -345,24 +464,10 @@ func (b *RecordBatcher) ShouldThrottle() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Throttle at 90% capacity to leave some headroom
-	if b.trackedMessages < (b.maxTrackedMessages * 9 / 10) {
-		b.throttledSince = time.Time{}
-		return false
-	}
-
-	// Surface a continuously pinned throttle: every shard reader is parked
-	// on this check, so if the tracker never drains the input is stalled
-	// with no other signal.
-	now := time.Now()
-	if b.throttledSince.IsZero() {
-		b.throttledSince = now
-	} else if since := now.Sub(b.throttledSince); since >= throttlePinWarnAfter && now.Sub(b.lastPinWarn) >= throttlePinWarnInterval {
-		b.lastPinWarn = now
-		b.log.Warnf("Shard readers throttled for %v: %d/%d in-flight messages are still awaiting downstream acknowledgement; no records are being read while this persists",
-			since.Round(time.Second), b.trackedMessages, b.maxTrackedMessages)
-	}
-	return true
+	// Throttle at 90% capacity to leave some headroom. Readers use
+	// TryReserve (which also carries the pinned-throttle diagnostics); this
+	// remains for callers that only need a point-in-time pressure signal.
+	return b.trackedMessages >= (b.maxTrackedMessages * 9 / 10)
 }
 
 // PendingCount returns the count of acked-but-not-persisted messages for a

--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -131,6 +131,15 @@ type shardAckTracker struct {
 	// Together they are bounded by the batcher's perShardCap.
 	inflight int
 	reserved int
+	// throttledSince is when reservations last started failing on this
+	// shard's in-flight cap without a successful reserve in between; zero
+	// while not throttled. A shard pinned at its cap never reaches the
+	// global-budget branch (fewer than four pinned shards leave the global
+	// budget under 100%), so the per-shard refusal needs its own pin clock
+	// or a wedged shard parks in silence. lastPinWarn rate-limits the
+	// warning.
+	throttledSince time.Time
+	lastPinWarn    time.Time
 }
 
 // NewRecordBatcher creates a new [RecordBatcher] for DynamoDB CDC.
@@ -184,7 +193,18 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 	st, ok := b.shards[shardID]
 	if ok && st.inflight+st.reserved > 0 && st.inflight+st.reserved+n > b.perShardCap {
 		// The shard is pinned by its own unsettled messages; park it alone
-		// without touching the global throttle clock.
+		// without touching the global throttle clock, but surface a
+		// continuous pin on the shard's own clock - in a topology with fewer
+		// than four pinned shards the global branch above never trips, so
+		// this is the only place a wedged shard can become visible.
+		now := time.Now()
+		if st.throttledSince.IsZero() {
+			st.throttledSince = now
+		} else if since := now.Sub(st.throttledSince); since >= throttlePinWarnAfter && now.Sub(st.lastPinWarn) >= throttlePinWarnInterval {
+			st.lastPinWarn = now
+			b.log.Warnf("Shard %s reader throttled for %v: %d/%d in-flight messages on this shard are still awaiting downstream acknowledgement; no records are being read from it while this persists",
+				shardID, since.Round(time.Second), st.inflight+st.reserved, b.perShardCap)
+		}
 		return false
 	}
 
@@ -193,6 +213,7 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string](), seqTimes: map[string]string{}}
 		b.shards[shardID] = st
 	}
+	st.throttledSince = time.Time{}
 	st.reserved += n
 	b.reserved += n
 	return true

--- a/internal/impl/aws/dynamodb/batcher.go
+++ b/internal/impl/aws/dynamodb/batcher.go
@@ -68,6 +68,12 @@ type RecordBatcher struct {
 	// bounded by maxTrackedMessages, so concurrent readers can never
 	// collectively overshoot the budget on their first read wave.
 	reserved int
+	// reservedByShard breaks reserved down per shard, for the per-shard cap
+	// and so Release/AddMessages can return or consume the right shard's
+	// budget. Kept outside shards and pruned at zero: shards entries are
+	// never removed and count against maxTrackedShards, so a reader polling
+	// a shard that never yields records must not materialise tracker state.
+	reservedByShard map[string]int
 	// perShardCap bounds one shard's in-flight (tracked + reserved) messages
 	// so a shard whose batches never settle downstream parks alone at its cap
 	// instead of pinning the global budget and every other reader. The cap
@@ -132,11 +138,10 @@ type shardAckTracker struct {
 	seqTimes map[string]string
 	// frontierTime is the ApproximateCreationDateTime of the current frontier.
 	frontierTime string
-	// inflight counts this shard's tracked (dispatched, unsettled) messages;
-	// reserved counts budget handed to this shard's reader ahead of a read.
-	// Together they are bounded by the batcher's perShardCap.
+	// inflight counts this shard's tracked (dispatched, unsettled) messages.
+	// Together with the shard's entry in the batcher's reservedByShard it is
+	// bounded by perShardCap.
 	inflight int
-	reserved int
 	// throttledSince is when reservations last started failing on this
 	// shard's in-flight cap without a successful reserve in between; zero
 	// while not throttled. A shard pinned at its cap never reaches the
@@ -161,9 +166,10 @@ func NewRecordBatcher(maxTrackedShards, checkpointLimit int, log *service.Logger
 		maxTrackedMessages: maxTrackedMessages,
 		// One never-settling shard may pin at most a quarter of the budget;
 		// the rest stays available to healthy shards (see perShardCap doc).
-		perShardCap: maxTrackedMessages / 4,
-		log:         log,
-		shards:      make(map[string]*shardAckTracker),
+		perShardCap:     maxTrackedMessages / 4,
+		log:             log,
+		shards:          make(map[string]*shardAckTracker),
+		reservedByShard: make(map[string]int),
 	}
 }
 
@@ -181,7 +187,11 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.trackedMessages+b.reserved+n > b.maxTrackedMessages {
+	// A completely empty batcher admits one batch even above the global
+	// budget (mirroring the per-shard cap's idle escape): config validation
+	// bounds batch_size below the budget's floor, but a reservation that
+	// could never fit must hang the read loop under no circumstances.
+	if b.trackedMessages+b.reserved > 0 && b.trackedMessages+b.reserved+n > b.maxTrackedMessages {
 		// Surface a continuously pinned budget: every shard reader parks on
 		// this check, so if in-flight messages never settle the input is
 		// stalled with no other signal.
@@ -200,30 +210,41 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 	// global exhaustion would report a pin spanning the drained interval.
 	b.throttledSince = time.Time{}
 
-	st, ok := b.shards[shardID]
-	if ok && st.inflight+st.reserved > 0 && st.inflight+st.reserved+n > b.perShardCap && b.otherShardActiveLocked(shardID) {
+	// The shard-tracker entry may not exist yet - it is only materialised by
+	// AddMessages, so shards that never yield records don't count against
+	// maxTrackedShards - in which case the shard has nothing in flight.
+	st := b.shards[shardID]
+	inflight := 0
+	if st != nil {
+		inflight = st.inflight
+	}
+	resv := b.reservedByShard[shardID]
+	if inflight+resv > 0 && inflight+resv+n > b.perShardCap && b.otherShardActiveLocked(shardID) {
 		// The shard is pinned by its own unsettled messages; park it alone
 		// without touching the global throttle clock, but surface a
 		// continuous pin on the shard's own clock - in a topology with fewer
 		// than four pinned shards the global branch above never trips, so
-		// this is the only place a wedged shard can become visible.
-		now := time.Now()
-		if st.throttledSince.IsZero() {
-			st.throttledSince = now
-		} else if since := now.Sub(st.throttledSince); since >= throttlePinWarnAfter && now.Sub(st.lastPinWarn) >= throttlePinWarnInterval {
-			st.lastPinWarn = now
-			b.log.Warnf("Shard %s reader throttled for %v: %d/%d in-flight messages on this shard are still awaiting downstream acknowledgement; no records are being read from it while this persists",
-				shardID, since.Round(time.Second), st.inflight+st.reserved, b.perShardCap)
+		// this is the only place a wedged shard can become visible. A pinned
+		// shard always has tracked messages (its single reader never holds a
+		// reservation while reserving again), so st is non-nil here; the
+		// guard is belt and braces.
+		if st != nil {
+			now := time.Now()
+			if st.throttledSince.IsZero() {
+				st.throttledSince = now
+			} else if since := now.Sub(st.throttledSince); since >= throttlePinWarnAfter && now.Sub(st.lastPinWarn) >= throttlePinWarnInterval {
+				st.lastPinWarn = now
+				b.log.Warnf("Shard %s reader throttled for %v: %d/%d in-flight messages on this shard are still awaiting downstream acknowledgement; no records are being read from it while this persists",
+					shardID, since.Round(time.Second), inflight+resv, b.perShardCap)
+			}
 		}
 		return false
 	}
 
-	if !ok {
-		st = &shardAckTracker{tracker: checkpoint.NewUncapped[string](), seqTimes: map[string]string{}}
-		b.shards[shardID] = st
+	if st != nil {
+		st.throttledSince = time.Time{}
 	}
-	st.throttledSince = time.Time{}
-	st.reserved += n
+	b.reservedByShard[shardID] = resv + n
 	b.reserved += n
 	return true
 }
@@ -232,12 +253,34 @@ func (b *RecordBatcher) TryReserve(shardID string, n int) bool {
 // in-flight or reserved messages - the per-shard cap only binds while one
 // does (see perShardCap doc). Callers must hold b.mu.
 func (b *RecordBatcher) otherShardActiveLocked(shardID string) bool {
+	for id := range b.reservedByShard {
+		if id != shardID {
+			return true
+		}
+	}
 	for id, st := range b.shards {
-		if id != shardID && st.inflight+st.reserved > 0 {
+		if id != shardID && st.inflight > 0 {
 			return true
 		}
 	}
 	return false
+}
+
+// consumeReservationLocked removes up to n from a shard's outstanding
+// reservation, pruning the entry at zero, and returns how much was consumed.
+// Callers must hold b.mu.
+func (b *RecordBatcher) consumeReservationLocked(shardID string, n int) int {
+	consumed := min(n, b.reservedByShard[shardID])
+	if consumed == 0 {
+		return 0
+	}
+	if rem := b.reservedByShard[shardID] - consumed; rem > 0 {
+		b.reservedByShard[shardID] = rem
+	} else {
+		delete(b.reservedByShard, shardID)
+	}
+	b.reserved -= consumed
+	return consumed
 }
 
 // Release returns unused reservation for a shard (the read failed, returned
@@ -248,11 +291,7 @@ func (b *RecordBatcher) Release(shardID string, n int) {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if st, ok := b.shards[shardID]; ok {
-		released := min(n, st.reserved)
-		st.reserved -= released
-		b.reserved -= released
-	}
+	b.consumeReservationLocked(shardID, n)
 }
 
 // topInflightShardsLocked renders the k shards holding the most unsettled
@@ -309,9 +348,7 @@ func (b *RecordBatcher) AddMessages(batch service.MessageBatch, shardID string) 
 
 	// Convert the shard's outstanding reservation (if any) into tracked
 	// messages; readers reserve at least the batch size before reading.
-	consumed := min(st.reserved, len(batch))
-	st.reserved -= consumed
-	b.reserved -= consumed
+	b.consumeReservationLocked(shardID, len(batch))
 
 	last := batch[len(batch)-1]
 	seq, _ := last.MetaGet("dynamodb_sequence_number")

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -632,6 +632,44 @@ func TestBatcherWarnsWhenThrottlePinned(t *testing.T) {
 	assert.True(t, reset, "a successful reservation must reset the pin clock")
 }
 
+// TestBatcherWarnsWhenShardPinned: a shard parked at its per-shard cap never
+// reaches the global-budget branch (with fewer than four pinned shards the
+// global budget stays under 100%), so the per-shard refusal must drive its own
+// pin clock and warning or a single-shard wedge is completely silent.
+func TestBatcherWarnsWhenShardPinned(t *testing.T) {
+	// checkpointLimit 400 -> maxTrackedMessages 4000 -> per-shard cap 1000
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 1000))
+	tb := batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001")
+
+	require.False(t, batcher.TryReserve("shard-001", 100),
+		"the shard is at its in-flight cap")
+
+	// Backdate the shard's pin start beyond the warn threshold.
+	batcher.mu.Lock()
+	st := batcher.shards["shard-001"]
+	st.throttledSince = time.Now().Add(-2 * throttlePinWarnAfter)
+	batcher.mu.Unlock()
+
+	require.False(t, batcher.TryReserve("shard-001", 100))
+	batcher.mu.Lock()
+	warned := !st.lastPinWarn.IsZero()
+	globalUntouched := batcher.throttledSince.IsZero()
+	batcher.mu.Unlock()
+	assert.True(t, warned, "a continuously pinned shard must emit the stall warning")
+	assert.True(t, globalUntouched, "a per-shard refusal must not start the global pin clock")
+
+	// Settling the batch drains the shard; the next successful reservation
+	// resets its pin clock.
+	batcher.RemoveBatch(tb)
+	require.True(t, batcher.TryReserve("shard-001", 100))
+	batcher.mu.Lock()
+	reset := st.throttledSince.IsZero()
+	batcher.mu.Unlock()
+	assert.True(t, reset, "a successful reservation must reset the shard's pin clock")
+}
+
 // --- Reservation-based admission control (INC-2974 ack-path stall) ---
 
 // TestBatcherReserveBoundsGlobalBudget: readers must reserve tracker budget

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -750,6 +750,58 @@ func TestBatcherIdleReservationsDoNotMaterializeShardState(t *testing.T) {
 		"fully released reservations must be pruned")
 }
 
+// TestBatcherNilReceiverIsSafe: Close() nils the input's batcher reference
+// after shutdown timeouts that warn and proceed, so a straggler reader
+// returning from a slow GetRecords can call any batcher method on a nil
+// receiver. Every method must no-op instead of panicking (an unrecovered
+// panic in a reader goroutine kills the whole process).
+func TestBatcherNilReceiverIsSafe(t *testing.T) {
+	var b *RecordBatcher
+	require.True(t, b.TryReserve("shard-001", 100))
+	b.Release("shard-001", 100)
+	assert.Nil(t, b.AddMessages(createTestMessages(2, "shard-001", 1), "shard-001"),
+		"AddMessages on a nil batcher must return a nil handle, not panic")
+	b.RemoveBatch(nil)
+	require.NoError(t, b.AckBatch(t.Context(), nil, nil))
+	assert.False(t, b.ShouldThrottle())
+}
+
+// TestBatcherIdleReservationDoesNotEngageShardCap: "another shard is active"
+// must mean unsettled (in-flight) messages, not a transient read reservation.
+// Idle shards poll on every poll_interval and hold a reservation for the
+// GetRecords round trip; counting that as activity intermittently engages the
+// hot shard's cap and clamps a sole busy shard to a quarter of the budget the
+// sole-active-shard exemption promises it.
+func TestBatcherIdleReservationDoesNotEngageShardCap(t *testing.T) {
+	// checkpointLimit 400 -> maxTrackedMessages 4000 -> per-shard cap 1000
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	// Hot shard at its cap with unsettled messages.
+	require.True(t, batcher.TryReserve("shard-hot", 1000))
+	batcher.AddMessages(createTestMessages(1000, "shard-hot", 1), "shard-hot")
+
+	// An idle shard holds only a read reservation (poll in flight, no records
+	// tracked yet).
+	require.True(t, batcher.TryReserve("shard-idle", 100))
+
+	assert.True(t, batcher.TryReserve("shard-hot", 1000),
+		"a transient reservation on an idle shard must not engage the hot shard's cap")
+}
+
+// TestInputBatcherBudgetHoldsBatchSizedReads: readers reserve the full
+// batch_size before every read, so a checkpoint_limit below batch_size must
+// not shrink the budget below what batch-sized reads need - otherwise the
+// whole input serializes to one batch in flight globally.
+func TestInputBatcherBudgetHoldsBatchSizedReads(t *testing.T) {
+	conf := dynamoDBCDCConfig{maxTrackedShards: 100, checkpointLimit: 100, batchSize: 1000}
+	batcher := newInputRecordBatcher(conf, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 1000))
+	batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001")
+	assert.True(t, batcher.TryReserve("shard-002", 1000),
+		"a checkpoint_limit below batch_size must not serialize concurrent batch-sized reads")
+}
+
 // --- Reservation-based admission control (INC-2974 ack-path stall) ---
 
 // TestBatcherReserveBoundsGlobalBudget: readers must reserve tracker budget

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -98,8 +99,8 @@ func TestBatcher_PersistsApproxCreationTimeWithFrontier(t *testing.T) {
 	cp := &mockCheckpointer{checkpointLimit: 1}
 
 	batch := msgWithTime("shard-001", "00001", "2026-06-16T10:00:00Z")
-	b.AddMessages(batch, "shard-001")
-	require.NoError(t, b.AckMessages(context.Background(), cp, batch))
+	tbBatch := b.AddMessages(batch, "shard-001")
+	require.NoError(t, b.AckBatch(context.Background(), cp, tbBatch))
 
 	assert.Equal(t, "00001", cp.get("shard-001"))
 	assert.Equal(t, "2026-06-16T10:00:00Z", cp.timestamp("shard-001"))
@@ -114,17 +115,17 @@ func TestBatcher_FrontierTimestampFollowsContiguousSequence(t *testing.T) {
 
 	b1 := msgWithTime("shard-001", "00001", "2026-06-16T10:00:00Z")
 	b2 := msgWithTime("shard-001", "00002", "2026-06-16T10:01:00Z")
-	b.AddMessages(b1, "shard-001")
-	b.AddMessages(b2, "shard-001")
+	tbB1 := b.AddMessages(b1, "shard-001")
+	tbB2 := b.AddMessages(b2, "shard-001")
 
 	// Ack the second batch first: frontier is pinned (b1 still outstanding), so
 	// nothing is persisted yet.
-	require.NoError(t, b.AckMessages(context.Background(), cp, b2))
+	require.NoError(t, b.AckBatch(context.Background(), cp, tbB2))
 	assert.Equal(t, 0, cp.calls(), "frontier pinned until the earlier batch acks")
 
 	// Ack the first batch: frontier jumps to 00002, and the persisted timestamp
 	// must be 00002's (10:01), not b1's (10:00).
-	require.NoError(t, b.AckMessages(context.Background(), cp, b1))
+	require.NoError(t, b.AckBatch(context.Background(), cp, tbB1))
 	assert.Equal(t, "00002", cp.get("shard-001"))
 	assert.Equal(t, "2026-06-16T10:01:00Z", cp.timestamp("shard-001"))
 }
@@ -137,7 +138,7 @@ func TestBatcherAddMessages(t *testing.T) {
 	batch1 := createTestMessages(5, "shard-001", 0)
 	result1 := batcher.AddMessages(batch1, "shard-001")
 
-	assert.Len(t, result1, 5)
+	assert.Equal(t, 5, result1.size)
 	// pendingCount should be 0 until messages are acked
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 5, batcher.TrackedMessageCount())
@@ -146,7 +147,7 @@ func TestBatcherAddMessages(t *testing.T) {
 	batch2 := createTestMessages(3, "shard-001", 5)
 	result2 := batcher.AddMessages(batch2, "shard-001")
 
-	assert.Len(t, result2, 3)
+	assert.Equal(t, 3, result2.size)
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 8, batcher.TrackedMessageCount())
 
@@ -154,7 +155,7 @@ func TestBatcherAddMessages(t *testing.T) {
 	batch3 := createTestMessages(4, "shard-002", 0)
 	result3 := batcher.AddMessages(batch3, "shard-002")
 
-	assert.Len(t, result3, 4)
+	assert.Equal(t, 4, result3.size)
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 0, batcher.PendingCount("shard-002"))
 	assert.Equal(t, 12, batcher.TrackedMessageCount())
@@ -167,21 +168,21 @@ func TestBatcherRemoveMessages(t *testing.T) {
 	// Add two batches (the batch is the ack/removal unit)
 	batch1 := createTestMessages(5, "shard-001", 0)
 	batch2 := createTestMessages(5, "shard-001", 5)
-	batcher.AddMessages(batch1, "shard-001")
-	batcher.AddMessages(batch2, "shard-001")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-001")
 
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 10, batcher.TrackedMessageCount())
 
 	// Remove one batch (simulating nack)
-	batcher.RemoveMessages(batch1)
+	batcher.RemoveBatch(tbBatch1)
 
 	// pendingCount is still 0 since we never acked these messages
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 5, batcher.TrackedMessageCount())
 
 	// Remove the other batch
-	batcher.RemoveMessages(batch2)
+	batcher.RemoveBatch(tbBatch2)
 
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 0, batcher.TrackedMessageCount())
@@ -199,19 +200,19 @@ func TestBatcherAckMessagesWithCheckpointing(t *testing.T) {
 	batch1 := createTestMessages(3, "shard-001", 0) // 00000..00002
 	batch2 := createTestMessages(3, "shard-001", 3) // 00003..00005
 	batch3 := createTestMessages(4, "shard-001", 6) // 00006..00009
-	batcher.AddMessages(batch1, "shard-001")
-	batcher.AddMessages(batch2, "shard-001")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-001")
 	batcher.AddMessages(batch3, "shard-001")
 
 	// Ack batch 1 - pending count 3, no checkpoint yet (< 5)
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch1))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch1))
 	assert.Equal(t, 3, batcher.PendingCount("shard-001"), "Should have 3 pending after acking 3")
 	assert.Equal(t, 7, batcher.TrackedMessageCount())
 	assert.Equal(t, 0, checkpointer.calls(), "Should not checkpoint yet (3 < 5)")
 
 	// Ack batch 2 - pending count reaches 6 (>= 5), should checkpoint at the
 	// contiguous frontier: batch 2's last sequence.
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch2))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch2))
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"), "Should reset to 0 after checkpoint")
 	assert.Equal(t, 4, batcher.TrackedMessageCount())
 	assert.Equal(t, 1, checkpointer.calls(), "Should checkpoint once (6 >= 5)")
@@ -231,19 +232,19 @@ func TestBatcherOutOfOrderAckDoesNotSkipUnacked(t *testing.T) {
 
 	batchOld := createTestMessages(2, "shard-001", 100) // dispatched first
 	batchNew := createTestMessages(2, "shard-001", 200) // dispatched second
-	batcher.AddMessages(batchOld, "shard-001")
-	batcher.AddMessages(batchNew, "shard-001")
+	tbBatchold := batcher.AddMessages(batchOld, "shard-001")
+	tbBatchnew := batcher.AddMessages(batchNew, "shard-001")
 
 	// The NEWER batch acks first (out of order). Enough messages are acked
 	// to hit the checkpoint limit, but the frontier is pinned before the
 	// unacked older batch, so nothing may be persisted.
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batchNew))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatchnew))
 	assert.Equal(t, 0, checkpointer.calls(), "checkpoint must not advance past the unacked older batch")
 	assert.Empty(t, batcher.LastCheckpoint("shard-001"))
 
 	// Once the older batch acks, the frontier jumps to the newest contiguous
 	// sequence and the accumulated acks persist.
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batchOld))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatchold))
 	assert.Equal(t, 1, checkpointer.calls())
 	assert.Equal(t, "00201", checkpointer.get("shard-001"), "checkpoint should cover both batches once contiguous")
 }
@@ -260,18 +261,18 @@ func TestBatcherNackPinsCheckpointFrontier(t *testing.T) {
 	batch1 := createTestMessages(2, "shard-001", 0)
 	batch2 := createTestMessages(2, "shard-001", 2)
 	batch3 := createTestMessages(2, "shard-001", 4)
-	batcher.AddMessages(batch1, "shard-001")
-	batcher.AddMessages(batch2, "shard-001")
-	batcher.AddMessages(batch3, "shard-001")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-001")
+	tbBatch3 := batcher.AddMessages(batch3, "shard-001")
 
 	// Batch 1 acks and persists.
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch1))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch1))
 	assert.Equal(t, "00001", checkpointer.get("shard-001"))
 
 	// Batch 2 is nacked; batch 3 acks afterwards. The checkpoint must stay
 	// at batch 1's frontier.
-	batcher.RemoveMessages(batch2)
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch3))
+	batcher.RemoveBatch(tbBatch2)
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch3))
 	assert.Equal(t, "00001", checkpointer.get("shard-001"), "nacked batch must pin the checkpoint")
 	assert.Empty(t, batcher.PendingCheckpoints(), "no unpersisted frontier may exist past the nacked batch")
 }
@@ -284,16 +285,16 @@ func TestBatcherAckMessagesMultipleShards(t *testing.T) {
 	batch1 := createTestMessages(6, "shard-001", 0)
 	batch2 := createTestMessages(6, "shard-002", 0)
 
-	batcher.AddMessages(batch1, "shard-001")
-	batcher.AddMessages(batch2, "shard-002")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-002")
 
 	checkpointer := &mockCheckpointer{
 		checkpointLimit: 100, // High limit so we don't checkpoint
 	}
 
 	// Ack messages from both shards
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch1))
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch2))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch1))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch2))
 
 	assert.Equal(t, 6, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 6, batcher.PendingCount("shard-002"))
@@ -314,11 +315,11 @@ func TestBatcherPendingCountIncrementsOnAck(t *testing.T) {
 
 	// Add 10 messages
 	batch := createTestMessages(10, "shard-001", 0)
-	batcher.AddMessages(batch, "shard-001")
+	tbBatch := batcher.AddMessages(batch, "shard-001")
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"), "Should be 0 before ack")
 
 	// Ack messages - pending count should increment
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch))
 
 	// Pending count should be 10 after acking 10 messages
 	assert.Equal(t, 10, batcher.PendingCount("shard-001"))
@@ -335,10 +336,10 @@ func TestBatcherPendingCheckpointsFlush(t *testing.T) {
 
 	batch1 := createTestMessages(3, "shard-001", 0)
 	batch2 := createTestMessages(3, "shard-002", 0)
-	batcher.AddMessages(batch1, "shard-001")
-	batcher.AddMessages(batch2, "shard-002")
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch1))
-	require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch2))
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-002")
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch1))
+	require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch2))
 
 	pending := batcher.PendingCheckpoints()
 	assert.Equal(t, map[string]CheckpointValue{
@@ -350,8 +351,8 @@ func TestBatcherPendingCheckpointsFlush(t *testing.T) {
 	// for that shard.
 	lowLimit := &mockCheckpointer{checkpointLimit: 1}
 	batch3 := createTestMessages(2, "shard-001", 3)
-	batcher.AddMessages(batch3, "shard-001")
-	require.NoError(t, batcher.AckMessages(t.Context(), lowLimit, batch3))
+	tbBatch3 := batcher.AddMessages(batch3, "shard-001")
+	require.NoError(t, batcher.AckBatch(t.Context(), lowLimit, tbBatch3))
 	assert.Equal(t, "00004", lowLimit.get("shard-001"))
 
 	pending = batcher.PendingCheckpoints()
@@ -369,8 +370,8 @@ func TestBatcherConcurrentAccess(t *testing.T) {
 	go func() {
 		for i := range 10 {
 			batch := createTestMessages(5, "shard-001", i*5)
-			batcher.AddMessages(batch, "shard-001")
-			batcher.RemoveMessages(batch)
+			tbBatch := batcher.AddMessages(batch, "shard-001")
+			batcher.RemoveBatch(tbBatch)
 		}
 		done <- true
 	}()
@@ -378,8 +379,8 @@ func TestBatcherConcurrentAccess(t *testing.T) {
 	go func() {
 		for i := range 10 {
 			batch := createTestMessages(5, "shard-002", i*5)
-			batcher.AddMessages(batch, "shard-002")
-			batcher.RemoveMessages(batch)
+			tbBatch := batcher.AddMessages(batch, "shard-002")
+			batcher.RemoveBatch(tbBatch)
 		}
 		done <- true
 	}()
@@ -397,13 +398,13 @@ func TestBatcherNackAndReAdd(t *testing.T) {
 
 	// Add messages
 	batch := createTestMessages(5, "shard-001", 0)
-	batcher.AddMessages(batch, "shard-001")
+	tbBatch := batcher.AddMessages(batch, "shard-001")
 
 	// pendingCount should be 0 until ack
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 
 	// Simulate nack by removing messages
-	batcher.RemoveMessages(batch)
+	batcher.RemoveBatch(tbBatch)
 
 	assert.Equal(t, 0, batcher.PendingCount("shard-001"))
 	assert.Equal(t, 0, batcher.TrackedMessageCount())
@@ -429,8 +430,8 @@ func TestBatcherMaxTrackedShardsLimit(t *testing.T) {
 	for i := range 5 {
 		shardID := fmt.Sprintf("shard-%03d", i)
 		batch := createTestMessages(2, shardID, 0)
-		batcher.AddMessages(batch, shardID)
-		require.NoError(t, batcher.AckMessages(t.Context(), checkpointer, batch))
+		tbBatch := batcher.AddMessages(batch, shardID)
+		require.NoError(t, batcher.AckBatch(t.Context(), checkpointer, tbBatch))
 	}
 
 	// Verify we're tracking exactly 5 unpersisted shard frontiers
@@ -438,9 +439,9 @@ func TestBatcherMaxTrackedShardsLimit(t *testing.T) {
 
 	// Now try to add and ack a 6th shard (should exceed limit)
 	batch := createTestMessages(2, "shard-006", 0)
-	batcher.AddMessages(batch, "shard-006")
+	tbBatch := batcher.AddMessages(batch, "shard-006")
 
-	err := batcher.AckMessages(t.Context(), checkpointer, batch)
+	err := batcher.AckBatch(t.Context(), checkpointer, tbBatch)
 	assert.Error(t, err, "Should fail when exceeding max tracked shards")
 	assert.Contains(t, err.Error(), "exceeded maximum size")
 	assert.Contains(t, err.Error(), "5 shards")
@@ -511,10 +512,10 @@ func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
 	}
 
 	batch1 := createTestMessages(3, "shard-001", 1)
-	batcher.AddMessages(batch1, "shard-001")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
 
 	ackErr := make(chan error, 1)
-	go func() { ackErr <- batcher.AckMessages(t.Context(), cp, batch1) }()
+	go func() { ackErr <- batcher.AckBatch(t.Context(), cp, tbBatch1) }()
 
 	select {
 	case <-cp.entered:
@@ -536,13 +537,14 @@ func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
 
 	assertPrompt("ShouldThrottle", func() { batcher.ShouldThrottle() })
 	batch2 := createTestMessages(3, "shard-002", 1)
-	assertPrompt("AddMessages", func() { batcher.AddMessages(batch2, "shard-002") })
+	var tbBatch2 *trackedBatch
+	assertPrompt("AddMessages", func() { tbBatch2 = batcher.AddMessages(batch2, "shard-002") })
 	// Errors are captured and asserted from the test goroutine: require's
 	// FailNow inside assertPrompt's spawned goroutine would Goexit before
 	// close(done) and misreport the failure as a blocked call.
 	var otherShardErr error
 	assertPrompt("AckMessages(other shard)", func() {
-		otherShardErr = batcher.AckMessages(t.Context(), cp, batch2)
+		otherShardErr = batcher.AckBatch(t.Context(), cp, tbBatch2)
 	})
 	require.NoError(t, otherShardErr)
 	assert.Equal(t, "00003", cp.get("shard-002"),
@@ -552,10 +554,10 @@ func TestBatcherCheckpointWriteDoesNotBlockOtherShards(t *testing.T) {
 	// they skip the persist (single-flighted) and the in-flight writer's
 	// post-write re-check picks their progress up.
 	batch3 := createTestMessages(3, "shard-001", 4)
-	batcher.AddMessages(batch3, "shard-001")
+	tbBatch3 := batcher.AddMessages(batch3, "shard-001")
 	var sameShardErr error
 	assertPrompt("AckMessages(same shard)", func() {
-		sameShardErr = batcher.AckMessages(t.Context(), cp, batch3)
+		sameShardErr = batcher.AckBatch(t.Context(), cp, tbBatch3)
 	})
 	require.NoError(t, sameShardErr)
 
@@ -577,13 +579,13 @@ func TestBatcherAckOverShardCapStillDrainsTracker(t *testing.T) {
 	cp := &mockCheckpointer{checkpointLimit: 1}
 
 	batch1 := createTestMessages(2, "shard-001", 1)
-	batcher.AddMessages(batch1, "shard-001")
+	tbBatch1 := batcher.AddMessages(batch1, "shard-001")
 	batch2 := createTestMessages(2, "shard-002", 1)
-	batcher.AddMessages(batch2, "shard-002")
+	tbBatch2 := batcher.AddMessages(batch2, "shard-002")
 
-	require.Error(t, batcher.AckMessages(t.Context(), cp, batch1),
+	require.Error(t, batcher.AckBatch(t.Context(), cp, tbBatch1),
 		"the shard-cap guard should still surface an error")
-	require.Error(t, batcher.AckMessages(t.Context(), cp, batch2))
+	require.Error(t, batcher.AckBatch(t.Context(), cp, tbBatch2))
 	assert.Equal(t, 0, batcher.TrackedMessageCount(),
 		"acked batches must drain the tracker even when the shard-cap guard trips")
 	assert.Equal(t, "00002", cp.get("shard-001"),
@@ -598,26 +600,193 @@ func TestBatcherAckOverShardCapStillDrainsTracker(t *testing.T) {
 func TestBatcherWarnsWhenThrottlePinned(t *testing.T) {
 	batcher := NewRecordBatcher(100, 100, service.MockResources().Logger())
 
-	batch := createTestMessages(950, "shard-001", 0)
-	batcher.AddMessages(batch, "shard-001") // 950/1000 >= 90%
-	require.True(t, batcher.ShouldThrottle())
+	// Two shards fill the global budget with unsettled messages (each within
+	// its 250 per-shard cap would block first, so use larger holdings via the
+	// single-batch admission rule).
+	batchA := createTestMessages(500, "shard-001", 0)
+	tbBatcha := batcher.AddMessages(batchA, "shard-001")
+	batchB := createTestMessages(450, "shard-002", 0)
+	tbBatchb := batcher.AddMessages(batchB, "shard-002")
+
+	require.False(t, batcher.TryReserve("shard-003", 100),
+		"the global budget is exhausted")
 
 	// Backdate the pin start beyond the warn threshold.
 	batcher.mu.Lock()
 	batcher.throttledSince = time.Now().Add(-2 * throttlePinWarnAfter)
 	batcher.mu.Unlock()
 
-	require.True(t, batcher.ShouldThrottle())
+	require.False(t, batcher.TryReserve("shard-003", 100))
 	batcher.mu.Lock()
 	warned := !batcher.lastPinWarn.IsZero()
 	batcher.mu.Unlock()
-	assert.True(t, warned, "a continuously pinned throttle must emit the stall warning")
+	assert.True(t, warned, "a continuously pinned budget must emit the stall warning")
 
-	// Draining below the threshold resets the pin clock.
-	batcher.RemoveMessages(batch)
-	require.False(t, batcher.ShouldThrottle())
+	// Draining resets the pin clock on the next successful reservation.
+	batcher.RemoveBatch(tbBatcha)
+	batcher.RemoveBatch(tbBatchb)
+	require.True(t, batcher.TryReserve("shard-003", 100))
 	batcher.mu.Lock()
 	reset := batcher.throttledSince.IsZero()
 	batcher.mu.Unlock()
-	assert.True(t, reset, "releasing the throttle must reset the pin clock")
+	assert.True(t, reset, "a successful reservation must reset the pin clock")
+}
+
+// --- Reservation-based admission control (INC-2974 ack-path stall) ---
+
+// TestBatcherReserveBoundsGlobalBudget: readers must reserve tracker budget
+// BEFORE reading, so concurrent first reads can never overshoot the global
+// cap (the ~300k first-wave overshoot seen on the wedged pipelines).
+func TestBatcherReserveBoundsGlobalBudget(t *testing.T) {
+	// checkpointLimit 100 -> maxTrackedMessages 1000
+	batcher := NewRecordBatcher(100, 100, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 600))
+	assert.False(t, batcher.TryReserve("shard-002", 600),
+		"a reservation over the remaining global budget must be refused")
+	batcher.Release("shard-001", 600)
+	assert.True(t, batcher.TryReserve("shard-002", 600),
+		"released budget must become available again")
+}
+
+// TestBatcherReserveConsumedByAddMessages: AddMessages converts the shard's
+// outstanding reservation into tracked messages; the unused remainder must be
+// explicitly released by the reader.
+func TestBatcherReserveConsumedByAddMessages(t *testing.T) {
+	batcher := NewRecordBatcher(100, 100, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 600))
+	batcher.AddMessages(createTestMessages(400, "shard-001", 1), "shard-001")
+	assert.Equal(t, 400, batcher.TrackedMessageCount())
+
+	assert.False(t, batcher.TryReserve("shard-002", 500),
+		"tracked (400) + outstanding reservation (200) + 500 exceeds the 1000 budget")
+	batcher.Release("shard-001", 200)
+	assert.True(t, batcher.TryReserve("shard-002", 500))
+}
+
+// TestBatcherPerShardCapIsolatesPinnedShard: a shard whose batches never
+// settle downstream must park alone at its per-shard cap; other shards keep
+// reserving and reading. This is the isolation fix for the ack-path stall:
+// before it, one never-settling shard's messages pinned the global tracker
+// and parked every reader in the input.
+func TestBatcherPerShardCapIsolatesPinnedShard(t *testing.T) {
+	// checkpointLimit 400 -> maxTrackedMessages 4000 -> per-shard cap 1000
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	// Poison shard: fill to its per-shard cap with unsettled messages.
+	require.True(t, batcher.TryReserve("shard-poison", 1000))
+	poison := createTestMessages(1000, "shard-poison", 1)
+	tbPoison := batcher.AddMessages(poison, "shard-poison")
+
+	assert.False(t, batcher.TryReserve("shard-poison", 100),
+		"a shard at its in-flight cap must not reserve more")
+	assert.True(t, batcher.TryReserve("shard-healthy", 100),
+		"other shards must keep flowing while one shard is pinned")
+
+	// Settling the poison batch frees the shard again.
+	batcher.RemoveBatch(tbPoison)
+	assert.True(t, batcher.TryReserve("shard-poison", 100))
+}
+
+// TestBatcherReserveAlwaysAdmitsFirstBatch: when the derived per-shard cap is
+// smaller than a single read (small checkpoint_limit with the max batch
+// size), a shard with nothing in flight must still be allowed one batch, or
+// its reader could never make progress at all.
+func TestBatcherReserveAlwaysAdmitsFirstBatch(t *testing.T) {
+	// checkpointLimit 25 -> maxTrackedMessages 1000 -> per-shard cap 250
+	batcher := NewRecordBatcher(100, 25, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 1000),
+		"an idle shard must always admit a single full batch")
+	batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001")
+	assert.False(t, batcher.TryReserve("shard-001", 1),
+		"beyond the first in-flight batch the cap applies")
+}
+
+// TestBatcherConcurrentReservesNeverOvershoot: N readers racing to reserve
+// must collectively never exceed the global budget.
+func TestBatcherConcurrentReservesNeverOvershoot(t *testing.T) {
+	// checkpointLimit 100 -> maxTrackedMessages 1000
+	batcher := NewRecordBatcher(1000, 100, service.MockResources().Logger())
+
+	var granted atomic.Int64
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if batcher.TryReserve(fmt.Sprintf("shard-%03d", i), 100) {
+				granted.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, granted.Load(), int64(10),
+		"50 concurrent 100-message reservations must never exceed the 1000 budget")
+	assert.Positive(t, granted.Load())
+}
+
+// --- Ack settlement must survive the auto_replay_nacks wrapper (INC-2974) ---
+//
+// benthos's AutoRetryNacksBatched read hook REPLACES every element of the
+// batch slice returned by ReadBatch with a new *Message (tagging parts for
+// retry tracking) before the pipeline sees it. Any ack bookkeeping keyed by
+// the original message pointers silently no-ops afterwards: the ack "hits"
+// nothing, tracked messages never drain, and every shard reader parks in
+// backpressure forever. Settlement must therefore go through the handle
+// returned at tracking time, never through a pointer lookup.
+
+// wrapperMutate simulates the wrapper: same slice header, new pointers.
+func wrapperMutate(batch service.MessageBatch) {
+	for i := range batch {
+		batch[i] = batch[i].Copy()
+	}
+}
+
+func TestBatcherAckSurvivesWrapperPointerReplacement(t *testing.T) {
+	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
+	cp := &mockCheckpointer{checkpointLimit: 1}
+
+	batch := createTestMessages(3, "shard-001", 1)
+	tb := batcher.AddMessages(batch, "shard-001")
+	wrapperMutate(batch)
+
+	require.NoError(t, batcher.AckBatch(t.Context(), cp, tb))
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"settlement must not depend on the batch slice's message pointers")
+	assert.Equal(t, "00003", cp.get("shard-001"),
+		"the checkpoint must advance for an acked batch even after pointer replacement")
+}
+
+func TestBatcherNackSurvivesWrapperPointerReplacement(t *testing.T) {
+	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
+
+	batch := createTestMessages(3, "shard-001", 1)
+	tb := batcher.AddMessages(batch, "shard-001")
+	wrapperMutate(batch)
+
+	batcher.RemoveBatch(tb)
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"nack settlement must not depend on the batch slice's message pointers")
+}
+
+// TestBatcherSettleIsIdempotent: a batch settles exactly once - a double ack,
+// or an ack racing a nack, must not double-count.
+func TestBatcherSettleIsIdempotent(t *testing.T) {
+	batcher := NewRecordBatcher(100, 100, service.MockResources().Logger())
+	cp := &mockCheckpointer{checkpointLimit: 100}
+
+	batch := createTestMessages(3, "shard-001", 1)
+	tb := batcher.AddMessages(batch, "shard-001")
+
+	require.NoError(t, batcher.AckBatch(t.Context(), cp, tb))
+	require.NoError(t, batcher.AckBatch(t.Context(), cp, tb))
+	batcher.RemoveBatch(tb)
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"repeat settles must be no-ops, not double decrements")
+
+	other := createTestMessages(2, "shard-001", 4)
+	batcher.AddMessages(other, "shard-001")
+	assert.Equal(t, 2, batcher.TrackedMessageCount())
 }

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -708,6 +708,48 @@ func TestBatcherPerShardRefusalClearsGlobalClock(t *testing.T) {
 		"passing the global check must clear the global pin clock even when the per-shard cap refuses")
 }
 
+// TestBatcherEmptyTrackerAdmitsOversizedBatch: the global check must admit
+// one batch when nothing is tracked or reserved (the same idle escape the
+// per-shard cap has), or a reservation larger than the derived budget would
+// be refused forever on a completely empty batcher and the input would hang
+// from startup without ever issuing a read. Config validation bounds
+// batch_size to 1000 (the budget's floor), so this is defense in depth.
+func TestBatcherEmptyTrackerAdmitsOversizedBatch(t *testing.T) {
+	// checkpointLimit 25 -> maxTrackedMessages 1000
+	batcher := NewRecordBatcher(100, 25, service.MockResources().Logger())
+
+	require.True(t, batcher.TryReserve("shard-001", 2000),
+		"an empty batcher must admit one batch even above the global budget")
+	assert.False(t, batcher.TryReserve("shard-002", 100),
+		"the global budget binds again while the oversized batch is outstanding")
+	batcher.Release("shard-001", 2000)
+	assert.True(t, batcher.TryReserve("shard-002", 100))
+}
+
+// TestBatcherIdleReservationsDoNotMaterializeShardState: reserve/release
+// cycles from readers polling shards that never yield records must not
+// populate the shard-tracker map - entries there are never removed and count
+// against the maxTrackedShards guard, which poisons every ack once exceeded.
+// Only AddMessages (a shard actually producing records) may create state.
+func TestBatcherIdleReservationsDoNotMaterializeShardState(t *testing.T) {
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	for i := range 200 {
+		shard := fmt.Sprintf("shard-%03d", i)
+		require.True(t, batcher.TryReserve(shard, 100))
+		batcher.Release(shard, 100)
+	}
+
+	batcher.mu.Lock()
+	tracked := len(batcher.shards)
+	reservedEntries := len(batcher.reservedByShard)
+	batcher.mu.Unlock()
+	assert.Zero(t, tracked,
+		"idle reserve/release cycles must not create shard-tracker entries")
+	assert.Zero(t, reservedEntries,
+		"fully released reservations must be pruned")
+}
+
 // --- Reservation-based admission control (INC-2974 ack-path stall) ---
 
 // TestBatcherReserveBoundsGlobalBudget: readers must reserve tracker budget

--- a/internal/impl/aws/dynamodb/batcher_test.go
+++ b/internal/impl/aws/dynamodb/batcher_test.go
@@ -643,6 +643,10 @@ func TestBatcherWarnsWhenShardPinned(t *testing.T) {
 	require.True(t, batcher.TryReserve("shard-001", 1000))
 	tb := batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001")
 
+	// A second shard is active, so the isolation cap engages for shard-001.
+	require.True(t, batcher.TryReserve("shard-002", 100))
+	batcher.AddMessages(createTestMessages(100, "shard-002", 1), "shard-002")
+
 	require.False(t, batcher.TryReserve("shard-001", 100),
 		"the shard is at its in-flight cap")
 
@@ -668,6 +672,40 @@ func TestBatcherWarnsWhenShardPinned(t *testing.T) {
 	reset := st.throttledSince.IsZero()
 	batcher.mu.Unlock()
 	assert.True(t, reset, "a successful reservation must reset the shard's pin clock")
+}
+
+// TestBatcherPerShardRefusalClearsGlobalClock: a reservation that passes the
+// global check proves the global budget is NOT pinned, even when the shard's
+// own cap then refuses it. The per-shard refusal must clear the global pin
+// clock, or a later global exhaustion reports a pin duration spanning the
+// interval in which the budget had actually drained.
+func TestBatcherPerShardRefusalClearsGlobalClock(t *testing.T) {
+	// checkpointLimit 400 -> maxTrackedMessages 4000 -> per-shard cap 1000
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	// Two capped shards plus two more batches exhaust the global budget.
+	tbs := make([]*trackedBatch, 0, 4)
+	for i, shard := range []string{"shard-001", "shard-002", "shard-003", "shard-004"} {
+		require.True(t, batcher.TryReserve(shard, 1000), "batch %d", i)
+		tbs = append(tbs, batcher.AddMessages(createTestMessages(1000, shard, 1), shard))
+	}
+	require.False(t, batcher.TryReserve("shard-005", 100),
+		"the global budget is exhausted")
+	batcher.mu.Lock()
+	pinned := !batcher.throttledSince.IsZero()
+	batcher.mu.Unlock()
+	require.True(t, pinned)
+
+	// Drain one batch: the global budget has room again, but shard-001 is
+	// still at its own cap, so its reservation exits via the per-shard branch.
+	batcher.RemoveBatch(tbs[3])
+	require.False(t, batcher.TryReserve("shard-001", 1000),
+		"shard-001 is still at its per-shard cap")
+	batcher.mu.Lock()
+	cleared := batcher.throttledSince.IsZero()
+	batcher.mu.Unlock()
+	assert.True(t, cleared,
+		"passing the global check must clear the global pin clock even when the per-shard cap refuses")
 }
 
 // --- Reservation-based admission control (INC-2974 ack-path stall) ---
@@ -717,6 +755,10 @@ func TestBatcherPerShardCapIsolatesPinnedShard(t *testing.T) {
 	poison := createTestMessages(1000, "shard-poison", 1)
 	tbPoison := batcher.AddMessages(poison, "shard-poison")
 
+	// A healthy shard is also active, so the isolation cap engages.
+	require.True(t, batcher.TryReserve("shard-healthy", 100))
+	batcher.AddMessages(createTestMessages(100, "shard-healthy", 1), "shard-healthy")
+
 	assert.False(t, batcher.TryReserve("shard-poison", 100),
 		"a shard at its in-flight cap must not reserve more")
 	assert.True(t, batcher.TryReserve("shard-healthy", 100),
@@ -727,6 +769,36 @@ func TestBatcherPerShardCapIsolatesPinnedShard(t *testing.T) {
 	assert.True(t, batcher.TryReserve("shard-poison", 100))
 }
 
+// TestBatcherSoleActiveShardUsesGlobalBudget: the per-shard cap exists purely
+// to isolate a never-settling shard from OTHER shards, so it must not bind
+// while no other shard is active - a one-partition table has a single active
+// shard, and capping it would strand three quarters of the configured budget
+// (the pre-cap gate allowed ~90% of it). The cap re-engages as soon as a
+// second shard becomes active.
+func TestBatcherSoleActiveShardUsesGlobalBudget(t *testing.T) {
+	// checkpointLimit 400 -> maxTrackedMessages 4000 -> per-shard cap 1000
+	batcher := NewRecordBatcher(100, 400, service.MockResources().Logger())
+
+	// A sole active shard may fill the whole global budget, well past its cap.
+	tbs := make([]*trackedBatch, 0, 4)
+	for range 4 {
+		require.True(t, batcher.TryReserve("shard-001", 1000),
+			"a sole active shard must not be bound by the per-shard cap")
+		tbs = append(tbs, batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001"))
+	}
+	assert.False(t, batcher.TryReserve("shard-001", 1000),
+		"the global budget still binds a sole active shard")
+
+	// Drain below the global budget but keep the shard above its cap, then
+	// activate a second shard: the isolation cap must re-engage.
+	batcher.RemoveBatch(tbs[0])
+	batcher.RemoveBatch(tbs[1])
+	require.True(t, batcher.TryReserve("shard-002", 100))
+	batcher.AddMessages(createTestMessages(100, "shard-002", 1), "shard-002")
+	assert.False(t, batcher.TryReserve("shard-001", 1000),
+		"the per-shard cap must re-engage once another shard is active")
+}
+
 // TestBatcherReserveAlwaysAdmitsFirstBatch: when the derived per-shard cap is
 // smaller than a single read (small checkpoint_limit with the max batch
 // size), a shard with nothing in flight must still be allowed one batch, or
@@ -735,9 +807,14 @@ func TestBatcherReserveAlwaysAdmitsFirstBatch(t *testing.T) {
 	// checkpointLimit 25 -> maxTrackedMessages 1000 -> per-shard cap 250
 	batcher := NewRecordBatcher(100, 25, service.MockResources().Logger())
 
-	require.True(t, batcher.TryReserve("shard-001", 1000),
-		"an idle shard must always admit a single full batch")
-	batcher.AddMessages(createTestMessages(1000, "shard-001", 1), "shard-001")
+	require.True(t, batcher.TryReserve("shard-001", 500),
+		"an idle shard must always admit a single batch larger than its cap")
+	batcher.AddMessages(createTestMessages(500, "shard-001", 1), "shard-001")
+
+	// Activate a second shard so the isolation cap engages.
+	require.True(t, batcher.TryReserve("shard-002", 100))
+	batcher.AddMessages(createTestMessages(100, "shard-002", 1), "shard-002")
+
 	assert.False(t, batcher.TryReserve("shard-001", 1),
 		"beyond the first in-flight batch the cap applies")
 }

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -737,6 +737,16 @@ func parseTableTagFilter(filter string) (map[string][]string, error) {
 	return result, nil
 }
 
+// newInputRecordBatcher builds the input's record batcher. The budget scales
+// with the larger of checkpoint_limit and batch_size: readers reserve the
+// full batch_size before every read, so a checkpoint_limit below batch_size
+// must not shrink the budget below what batch-sized reads need - otherwise
+// TryReserve refuses whenever anything is in flight and the whole input
+// serializes to one batch in flight globally.
+func newInputRecordBatcher(conf dynamoDBCDCConfig, log *service.Logger) *RecordBatcher {
+	return NewRecordBatcher(conf.maxTrackedShards, max(conf.checkpointLimit, conf.batchSize), log)
+}
+
 // validateDynamoDBCDCConfig validates the configuration for consistency
 func validateDynamoDBCDCConfig(conf dynamoDBCDCConfig) error {
 	// Validate tag discovery mode requirements
@@ -1090,7 +1100,7 @@ func (d *dynamoDBCDCInput) connectSingleTable(ctx context.Context, tableName str
 	}
 
 	// Initialize record batcher
-	d.recordBatcher = NewRecordBatcher(d.conf.maxTrackedShards, d.conf.checkpointLimit, d.log)
+	d.recordBatcher = newInputRecordBatcher(d.conf, d.log)
 
 	// start_from only applies to a genuinely fresh pipeline: if any checkpoint
 	// state already exists, shards without checkpoints are rotation children
@@ -1212,7 +1222,7 @@ func (d *dynamoDBCDCInput) initializeTableStream(ctx context.Context, tableName 
 	}
 
 	// Initialize record batcher for this table
-	recordBatcher := NewRecordBatcher(d.conf.maxTrackedShards, d.conf.checkpointLimit, d.log)
+	recordBatcher := newInputRecordBatcher(d.conf, d.log)
 
 	// start_from only applies to a genuinely fresh pipeline: if any checkpoint
 	// state already exists for this table, shards without checkpoints are

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -2191,8 +2191,12 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 		default:
 		}
 
-		// Apply backpressure if too many messages are in flight
-		for ts.recordBatcher.ShouldThrottle() {
+		// Reserve tracker budget for this read BEFORE issuing it (see
+		// startShardReader): bounds the reader fleet to the global budget and
+		// parks a never-settling shard at its own cap without starving the
+		// rest.
+		reserve := d.conf.batchSize
+		for !ts.recordBatcher.TryReserve(shardID, reserve) {
 			d.log.Debugf("Throttling shard %s (table %s) due to too many in-flight messages", shardID, tableName)
 			throttleTimer.Reset(d.conf.throttleBackoff)
 			select {
@@ -2205,6 +2209,7 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 		// Get current reader state
 		iterator := ts.getShardIterator(shardID)
 		if iterator == nil {
+			ts.recordBatcher.Release(shardID, reserve)
 			return
 		}
 
@@ -2214,6 +2219,7 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 			Limit:         aws.Int32(int32(d.conf.batchSize)),
 		})
 		if err != nil {
+			ts.recordBatcher.Release(shardID, reserve)
 			if isThrottlingError(err) {
 				wait := boff.NextBackOff()
 				d.log.Debugf("Throttled on shard %s (table %s), backing off for %v", shardID, tableName, wait)
@@ -2319,6 +2325,7 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 				reader.exhausted = true
 				d.log.Infof("Shard %s (table %s) exhausted", shardID, tableName)
 				ts.mu.Unlock()
+				ts.recordBatcher.Release(shardID, reserve)
 				return
 			}
 			if seq := lastRecordSequenceNumber(getRecords.Records); seq != "" {
@@ -2329,6 +2336,7 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 
 		if len(getRecords.Records) == 0 {
 			// No records available: wait before polling again
+			ts.recordBatcher.Release(shardID, reserve)
 			idleTimer.Reset(d.conf.pollInterval)
 			select {
 			case <-ctx.Done():
@@ -2345,52 +2353,68 @@ func (d *dynamoDBCDCInput) startTableShardReader(ctx context.Context, tableName 
 		}
 		batch := convertTableRecordsToBatch(getRecords.Records, tableName, shardID, dedupeBuffer, ts.getShardCutoff(shardID), d.metrics.failoverSkipped)
 		if len(batch) == 0 {
+			ts.recordBatcher.Release(shardID, reserve)
 			continue
 		}
 
-		// Track messages in batcher
-		batch = ts.recordBatcher.AddMessages(batch, shardID)
+		// Track messages in batcher (consumes len(batch) of the reservation;
+		// return the surplus from records filtered out during conversion).
+		// Settlement goes through the returned handle: wrappers between this
+		// input and the pipeline (auto_replay_nacks) rewrite the batch
+		// slice's message pointers, so the batch itself cannot identify the
+		// tracked state afterwards.
+		tb := ts.recordBatcher.AddMessages(batch, shardID)
+		ts.recordBatcher.Release(shardID, reserve-len(batch))
 
 		// Track pending ack
 		d.pendingAcks.Add(1)
 
-		// Create ack function
-		checkpointer := ts.checkpointer
+		// Create ack function. The checkpointer interface value is built
+		// explicitly so a nil *Checkpointer stays a nil interface: AckBatch
+		// must still run to settle the batch (draining the tracker) even
+		// when there is no checkpoint store to persist to.
+		var cp checkpointer
+		if ts.checkpointer != nil {
+			cp = ts.checkpointer
+		}
 		recordBatcher := ts.recordBatcher
+		batchLen := len(batch)
 		ackFunc := func(ackCtx context.Context, err error) error {
 			defer d.pendingAcks.Done()
 
 			if d.closed.Load() {
 				d.log.Warn("Received ack after close, dropping")
 				if err == nil {
-					recordBatcher.RemoveMessages(batch)
+					recordBatcher.RemoveBatch(tb)
 				}
 				return nil
 			}
 
 			if err != nil {
 				d.log.Warnf("Batch nacked from shard %s (table %s): %v", shardID, tableName, err)
-				recordBatcher.RemoveMessages(batch)
+				recordBatcher.RemoveBatch(tb)
 				return err
 			}
 
 			// Mark messages as acked and checkpoint if needed
-			if checkpointer != nil {
-				if ackErr := recordBatcher.AckMessages(ackCtx, checkpointer, batch); ackErr != nil {
-					d.log.Errorf("Failed to checkpoint shard %s (table %s) after ack: %v", shardID, tableName, ackErr)
-					return ackErr
-				}
-				d.log.Debugf("Successfully checkpointed %d messages from shard %s (table %s)", len(batch), shardID, tableName)
+			if ackErr := recordBatcher.AckBatch(ackCtx, cp, tb); ackErr != nil {
+				d.log.Errorf("Failed to checkpoint shard %s (table %s) after ack: %v", shardID, tableName, ackErr)
+				return ackErr
 			}
+			d.log.Debugf("Successfully checkpointed %d messages from shard %s (table %s)", batchLen, shardID, tableName)
 			return nil
 		}
 
 		// Send to channel
 		select {
 		case <-ctx.Done():
+			// The batch was never dispatched: untrack it (and its pending
+			// ack) or its messages would pin the tracker budget forever.
+			recordBatcher.RemoveBatch(tb)
+			d.pendingAcks.Done()
 			return
 		case d.msgChan <- asyncMessage{msg: batch, ackFn: ackFunc}:
-			d.log.Debugf("Sent batch of %d records from shard %s (table %s)", len(batch), shardID, tableName)
+			d.log.Debugf("Sent batch of %d records from shard %s (table %s)", batchLen, shardID, tableName)
 		}
 	}
 }
@@ -2629,8 +2653,12 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 		default:
 		}
 
-		// Apply backpressure if too many messages are in flight
-		for d.recordBatcher.ShouldThrottle() {
+		// Reserve tracker budget for this read BEFORE issuing it: reserving
+		// up front bounds the whole fleet of readers to the global budget
+		// (no first-wave overshoot), and the per-shard cap parks a shard
+		// whose batches never settle downstream without starving the rest.
+		reserve := d.conf.batchSize
+		for !d.recordBatcher.TryReserve(shardID, reserve) {
 			d.log.Debugf("Throttling shard %s due to too many in-flight messages", shardID)
 			throttleTimer.Reset(d.conf.throttleBackoff)
 			select {
@@ -2643,6 +2671,7 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 		// Get current reader state
 		iterator := d.getShardIterator(shardID)
 		if iterator == nil {
+			d.recordBatcher.Release(shardID, reserve)
 			return
 		}
 
@@ -2652,6 +2681,7 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 			Limit:         aws.Int32(int32(d.conf.batchSize)),
 		})
 		if err != nil {
+			d.recordBatcher.Release(shardID, reserve)
 			if isThrottlingError(err) {
 				wait := boff.NextBackOff()
 				d.log.Debugf("Throttled on shard %s, backing off for %v", shardID, wait)
@@ -2757,6 +2787,7 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 				reader.exhausted = true
 				d.log.Infof("Shard %s exhausted", shardID)
 				d.mu.Unlock()
+				d.recordBatcher.Release(shardID, reserve)
 				return
 			}
 			if seq := lastRecordSequenceNumber(getRecords.Records); seq != "" {
@@ -2767,6 +2798,7 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 
 		if len(getRecords.Records) == 0 {
 			// No records available: wait before polling again
+			d.recordBatcher.Release(shardID, reserve)
 			idleTimer.Reset(d.conf.pollInterval)
 			select {
 			case <-ctx.Done():
@@ -2779,18 +2811,32 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 		// Convert records to messages
 		batch := d.convertRecordsToBatch(getRecords.Records, shardID, d.getShardCutoff(shardID))
 		if len(batch) == 0 {
+			d.recordBatcher.Release(shardID, reserve)
 			continue
 		}
 
-		// Track messages in batcher
-		batch = d.recordBatcher.AddMessages(batch, shardID)
+		// Track messages in batcher (consumes len(batch) of the reservation;
+		// return the surplus from records filtered out during conversion).
+		// Settlement goes through the returned handle: wrappers between this
+		// input and the pipeline (auto_replay_nacks) rewrite the batch
+		// slice's message pointers, so the batch itself cannot identify the
+		// tracked state afterwards.
+		tb := d.recordBatcher.AddMessages(batch, shardID)
+		d.recordBatcher.Release(shardID, reserve-len(batch))
 
 		// Track pending ack
 		d.pendingAcks.Add(1)
 
-		// Create ack function
-		checkpointer := d.checkpointer
+		// Create ack function. The checkpointer interface value is built
+		// explicitly so a nil *Checkpointer stays a nil interface: AckBatch
+		// must still run to settle the batch (draining the tracker) even
+		// when there is no checkpoint store to persist to.
+		var cp checkpointer
+		if d.checkpointer != nil {
+			cp = d.checkpointer
+		}
 		recordBatcher := d.recordBatcher
+		batchLen := len(batch)
 		ackFunc := func(ackCtx context.Context, err error) error {
 			defer d.pendingAcks.Done()
 
@@ -2798,34 +2844,36 @@ func (d *dynamoDBCDCInput) startShardReader(ctx context.Context, shardID string)
 			if d.closed.Load() {
 				d.log.Warn("Received ack after close, dropping")
 				if err == nil {
-					recordBatcher.RemoveMessages(batch)
+					recordBatcher.RemoveBatch(tb)
 				}
 				return nil
 			}
 
 			if err != nil {
 				d.log.Warnf("Batch nacked from shard %s: %v", shardID, err)
-				recordBatcher.RemoveMessages(batch)
+				recordBatcher.RemoveBatch(tb)
 				return err // Propagate nack error
 			}
 
 			// Mark messages as acked and checkpoint if needed
-			if checkpointer != nil {
-				if ackErr := recordBatcher.AckMessages(ackCtx, checkpointer, batch); ackErr != nil {
-					d.log.Errorf("Failed to checkpoint shard %s after ack: %v", shardID, ackErr)
-					return ackErr // Propagate checkpoint failure
-				}
-				d.log.Debugf("Successfully checkpointed %d messages from shard %s", len(batch), shardID)
+			if ackErr := recordBatcher.AckBatch(ackCtx, cp, tb); ackErr != nil {
+				d.log.Errorf("Failed to checkpoint shard %s after ack: %v", shardID, ackErr)
+				return ackErr // Propagate checkpoint failure
 			}
+			d.log.Debugf("Successfully checkpointed %d messages from shard %s", batchLen, shardID)
 			return nil
 		}
 
 		// Send to channel
 		select {
 		case <-ctx.Done():
+			// The batch was never dispatched: untrack it (and its pending
+			// ack) or its messages would pin the tracker budget forever.
+			recordBatcher.RemoveBatch(tb)
+			d.pendingAcks.Done()
 			return
 		case d.msgChan <- asyncMessage{msg: batch, ackFn: ackFunc}:
-			d.log.Debugf("Sent batch of %d records from shard %s", len(batch), shardID)
+			d.log.Debugf("Sent batch of %d records from shard %s", batchLen, shardID)
 		}
 	}
 }

--- a/internal/impl/aws/dynamodb/input_cdc.go
+++ b/internal/impl/aws/dynamodb/input_cdc.go
@@ -234,6 +234,7 @@ When `+"`global_table`"+` is enabled the principal additionally needs `+"`dynamo
 			service.NewIntField(dciFieldBatchSize).
 				Description("Maximum number of records to read per shard in a single request. Valid range: 1-1000.").
 				Default(defaultDynamoDBBatchSize).
+				LintRule(`root = if this < 1 || this > 1000 { ["batch_size must be between 1 and 1000"] }`).
 				Advanced(),
 			service.NewDurationField(dciFieldPollInterval).
 				Description("Time to wait between polling attempts when no records are available.").
@@ -756,6 +757,12 @@ func validateDynamoDBCDCConfig(conf dynamoDBCDCConfig) error {
 
 	if strings.Contains(conf.checkpointNamespace, "#") {
 		return errors.New("checkpoint_namespace must not contain '#'")
+	}
+
+	// The GetRecords Limit range; also keeps batch_size at or below the
+	// tracker budget's floor so a reservation can always eventually fit.
+	if conf.batchSize < 1 || conf.batchSize > 1000 {
+		return errors.New("batch_size must be between 1 and 1000")
 	}
 
 	// Validate snapshot configuration

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Jeffail/shutdown"
+
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
@@ -490,4 +492,67 @@ func TestStartShardReader_AckDrainsAfterWrapperPointerReplacement(t *testing.T) 
 	require.NoError(t, am.ackFn(t.Context(), nil))
 	assert.Equal(t, 0, batcher.TrackedMessageCount(),
 		"the ack must drain the tracker even after the wrapper replaced the batch's message pointers")
+}
+
+// TestStartShardReader_RealAutoRetryNacksWrapper runs the INC-2974 wedge
+// scenario through the REAL benthos AutoRetryNacksBatched wrapper (what
+// auto_replay_nacks: true, the default, installs) rather than a simulation:
+// reader -> msgChan -> ReadBatch -> wrapper (which rewrites the batch slice's
+// message pointers in place AND hands the pipeline a copy) -> ack chain.
+//
+// It also locks in the wrapper's nack contract: a nack is swallowed by the
+// wrapper (redelivered internally, the input's ack fn is NOT called), so the
+// batch must stay tracked until the retry finally succeeds, at which point
+// the inner ack fires exactly once and the tracker drains. The wedge this PR
+// fixes was the final ack silently missing the tracker because settlement was
+// keyed by the rewritten message pointers.
+func TestStartShardReader_RealAutoRetryNacksWrapper(t *testing.T) {
+	transport := &recordsStubTransport{
+		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
+		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}}]`,
+	}
+
+	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
+	d := &dynamoDBCDCInput{
+		conf: dynamoDBCDCConfig{
+			batchSize:       10,
+			pollInterval:    20 * time.Millisecond,
+			throttleBackoff: 20 * time.Millisecond,
+		},
+		log:           service.MockResources().Logger(),
+		streamsClient: newStubStreamsClient(transport),
+		streamArn:     aws.String(testStreamArn),
+		recordBatcher: batcher,
+		shardReaders: map[string]*dynamoDBShardReader{
+			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
+		},
+		msgChan: make(chan asyncMessage, 1),
+		shutSig: shutdown.NewSignaller(),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go d.startShardReader(ctx, "shard-001")
+
+	wrapped := service.AutoRetryNacksBatched(d)
+
+	batch, ackFn, err := wrapped.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch, 2)
+	require.Equal(t, 2, batcher.TrackedMessageCount())
+
+	// Nack through the wrapper: it owns the redelivery, the input's ack fn
+	// must not fire, and the batch must stay tracked (in flight).
+	require.NoError(t, ackFn(ctx, errors.New("downstream rejection")))
+	assert.Equal(t, 2, batcher.TrackedMessageCount(),
+		"a wrapper-owned nack must keep the batch tracked until the retry settles")
+
+	// The wrapper redelivers the batch; the final ack must reach the input's
+	// ack fn and drain the tracker despite the pointer rewrite.
+	retry, retryAckFn, err := wrapped.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, retry, 2)
+	require.NoError(t, retryAckFn(ctx, nil))
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"the final ack must drain the tracker through the real wrapper (the INC-2974 wedge)")
 }

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -397,15 +397,27 @@ func (s *recordsStubTransport) Do(req *http.Request) (*http.Response, error) {
 type readerHarness struct {
 	batcher *RecordBatcher
 	d       *dynamoDBCDCInput
-	start   func(ctx context.Context)
+	// shardReaders is the reader-state map the harnessed entry point consults
+	// (d.shardReaders for single-table, ts.shardReaders for multi-table).
+	shardReaders map[string]*dynamoDBShardReader
+	start        func(ctx context.Context)
 }
 
-// readerHarnesses returns one fresh harness factory per reader entry point.
-// Each factory builds its own stub transport and batcher so subtests stay
-// independent.
+// readerHarnesses returns one fresh harness factory per reader entry point,
+// serving the given records page. Each factory builds its own stub transport
+// and batcher so subtests stay independent.
 func readerHarnesses(records string, checkpointLimit, msgChanCap int) map[string]func() *readerHarness {
+	return readerHarnessesWithTransport(func() aws.HTTPClient {
+		return &recordsStubTransport{records: records}
+	}, checkpointLimit, msgChanCap)
+}
+
+// readerHarnessesWithTransport is readerHarnesses with a caller-supplied
+// transport factory, for tests that need error pages or other non-record
+// responses.
+func readerHarnessesWithTransport(mkTransport func() aws.HTTPClient, checkpointLimit, msgChanCap int) map[string]func() *readerHarness {
 	build := func(multiTable bool) *readerHarness {
-		transport := &recordsStubTransport{records: records}
+		transport := mkTransport()
 		batcher := NewRecordBatcher(100, checkpointLimit, service.MockResources().Logger())
 		shardReaders := map[string]*dynamoDBShardReader{
 			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
@@ -429,14 +441,14 @@ func readerHarnesses(records string, checkpointLimit, msgChanCap int) map[string
 				recordBatcher: batcher,
 				shardReaders:  shardReaders,
 			}
-			return &readerHarness{batcher: batcher, d: d, start: func(ctx context.Context) {
+			return &readerHarness{batcher: batcher, d: d, shardReaders: shardReaders, start: func(ctx context.Context) {
 				d.startTableShardReader(ctx, "table-a", ts, "shard-001")
 			}}
 		}
 		d.streamArn = aws.String(testStreamArn)
 		d.recordBatcher = batcher
 		d.shardReaders = shardReaders
-		return &readerHarness{batcher: batcher, d: d, start: func(ctx context.Context) {
+		return &readerHarness{batcher: batcher, d: d, shardReaders: shardReaders, start: func(ctx context.Context) {
 			d.startShardReader(ctx, "shard-001")
 		}}
 	}
@@ -561,6 +573,98 @@ func TestShardReader_RealAutoRetryNacksWrapper(t *testing.T) {
 			require.NoError(t, retryAckFn(ctx, nil))
 			assert.Equal(t, 0, h.batcher.TrackedMessageCount(),
 				"the final ack must drain the tracker through the real wrapper (the INC-2974 wedge)")
+		})
+	}
+}
+
+// TestShardReader_ReleasesReservationOnUnproductiveReads: TryReserve claims
+// batch_size of budget before every GetRecords, and each reader hands it back
+// on five hand-placed paths. A missed Release permanently consumes budget
+// with messages that were never tracked - the same silent wedge shape as the
+// INC-2974 ack stall. Each scenario drives one unproductive-read path on both
+// reader entry points, then cancels the reader and asserts every reservation
+// (and all tracker state) was returned.
+func TestShardReader_ReleasesReservationOnUnproductiveReads(t *testing.T) {
+	// Records stamped with an ancient ApproximateCreationDateTime so a future
+	// failover cutoff filters the whole page out after a successful read.
+	const staleRecordsPage = `[{"eventID":"1","eventName":"INSERT","dynamodb":{"ApproximateCreationDateTime":1000,"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}}]`
+
+	scenarios := map[string]struct {
+		mkTransport func() aws.HTTPClient
+		cutoff      time.Time
+		wantPages   func(t aws.HTTPClient) bool // reader has looped past the release at least once
+	}{
+		"get-records error": {
+			mkTransport: func() aws.HTTPClient {
+				return &stubStreamsTransport{getRecordsErrorType: "InternalServerError"}
+			},
+			wantPages: func(tr aws.HTTPClient) bool {
+				return tr.(*stubStreamsTransport).getRecordsCalls.Load() >= 2
+			},
+		},
+		"empty page": {
+			mkTransport: func() aws.HTTPClient { return &recordsStubTransport{records: "[]"} },
+			wantPages: func(tr aws.HTTPClient) bool {
+				return tr.(*recordsStubTransport).pages.Load() >= 2
+			},
+		},
+		"fully filtered page": {
+			mkTransport: func() aws.HTTPClient { return &recordsStubTransport{records: staleRecordsPage} },
+			cutoff:      time.Unix(2000, 0),
+			wantPages: func(tr aws.HTTPClient) bool {
+				return tr.(*recordsStubTransport).pages.Load() >= 2
+			},
+		},
+	}
+
+	for scenarioName, sc := range scenarios {
+		t.Run(scenarioName, func(t *testing.T) {
+			var transport aws.HTTPClient
+			mk := func() aws.HTTPClient {
+				transport = sc.mkTransport()
+				return transport
+			}
+			for name, mkHarness := range readerHarnessesWithTransport(mk, 100, 1) {
+				t.Run(name, func(t *testing.T) {
+					h := mkHarness()
+					h.shardReaders["shard-001"].failoverCutoff = sc.cutoff
+
+					ctx, cancel := context.WithCancel(t.Context())
+					defer cancel()
+					done := make(chan struct{})
+					go func() {
+						h.start(ctx)
+						close(done)
+					}()
+
+					tr := transport
+					require.Eventually(t, func() bool { return sc.wantPages(tr) },
+						5*time.Second, 5*time.Millisecond,
+						"the reader should loop past the release path at least once")
+
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(2 * time.Second):
+						t.Fatal("reader should exit promptly on cancellation")
+					}
+
+					assert.Equal(t, 0, h.batcher.TrackedMessageCount(),
+						"an unproductive read must not leave tracked messages behind")
+					b := h.batcher
+					b.mu.Lock()
+					reserved := b.reserved
+					reservedEntries := len(b.reservedByShard)
+					trackerEntries := len(b.shards)
+					b.mu.Unlock()
+					assert.Zero(t, reserved,
+						"every reservation must be returned on the unproductive-read paths")
+					assert.Zero(t, reservedEntries,
+						"released reservations must be pruned")
+					assert.Zero(t, trackerEntries,
+						"a shard that never yields a delivered record must not materialise tracker state")
+				})
+			}
 		})
 	}
 }

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -389,112 +389,138 @@ func (s *recordsStubTransport) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// TestStartShardReader_CancelledSendUntracksBatch: a reader cancelled while
+// readerHarness abstracts over the two hand-duplicated shard-reader entry
+// points (startShardReader for single-table, startTableShardReader for
+// multi-table) so every reader-level regression test runs against both:
+// the INC-2974 fixes were applied to each copy by hand, and a regression in
+// either one reproduces the wedge silently.
+type readerHarness struct {
+	batcher *RecordBatcher
+	d       *dynamoDBCDCInput
+	start   func(ctx context.Context)
+}
+
+// readerHarnesses returns one fresh harness factory per reader entry point.
+// Each factory builds its own stub transport and batcher so subtests stay
+// independent.
+func readerHarnesses(records string, checkpointLimit, msgChanCap int) map[string]func() *readerHarness {
+	build := func(multiTable bool) *readerHarness {
+		transport := &recordsStubTransport{records: records}
+		batcher := NewRecordBatcher(100, checkpointLimit, service.MockResources().Logger())
+		shardReaders := map[string]*dynamoDBShardReader{
+			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
+		}
+		d := &dynamoDBCDCInput{
+			conf: dynamoDBCDCConfig{
+				batchSize:       10,
+				pollInterval:    20 * time.Millisecond,
+				throttleBackoff: 20 * time.Millisecond,
+			},
+			log:           service.MockResources().Logger(),
+			streamsClient: newStubStreamsClient(transport),
+			metrics:       newDynamoDBCDCMetrics(service.MockResources().Metrics()),
+			msgChan:       make(chan asyncMessage, msgChanCap),
+			shutSig:       shutdown.NewSignaller(),
+		}
+		if multiTable {
+			ts := &tableStream{
+				tableName:     "table-a",
+				streamArn:     testStreamArn,
+				recordBatcher: batcher,
+				shardReaders:  shardReaders,
+			}
+			return &readerHarness{batcher: batcher, d: d, start: func(ctx context.Context) {
+				d.startTableShardReader(ctx, "table-a", ts, "shard-001")
+			}}
+		}
+		d.streamArn = aws.String(testStreamArn)
+		d.recordBatcher = batcher
+		d.shardReaders = shardReaders
+		return &readerHarness{batcher: batcher, d: d, start: func(ctx context.Context) {
+			d.startShardReader(ctx, "shard-001")
+		}}
+	}
+	return map[string]func() *readerHarness{
+		"single-table": func() *readerHarness { return build(false) },
+		"multi-table":  func() *readerHarness { return build(true) },
+	}
+}
+
+const twoRecordsPage = `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
+                         {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}}]`
+
+// TestShardReader_CancelledSendUntracksBatch: a reader cancelled while
 // blocked sending a batch to the message channel must untrack that batch.
 // Leaking it would permanently consume tracker budget: enough cancelled
 // readers (shard rotation over a slow downstream) pin the throttle with
 // messages that no longer exist anywhere.
-func TestStartShardReader_CancelledSendUntracksBatch(t *testing.T) {
-	transport := &recordsStubTransport{
-		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
-		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}},
-		           {"eventID":"3","eventName":"INSERT","dynamodb":{"SequenceNumber":"00003","Keys":{"pk":{"S":"c"}},"NewImage":{"pk":{"S":"c"}}}}]`,
+func TestShardReader_CancelledSendUntracksBatch(t *testing.T) {
+	for name, mk := range readerHarnesses(twoRecordsPage, 100, 0) { // unbuffered channel, never read: the send blocks
+		t.Run(name, func(t *testing.T) {
+			h := mk()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				h.start(ctx)
+				close(done)
+			}()
+
+			// Wait until the batch is tracked (the reader is now blocked on the send).
+			require.Eventually(t, func() bool {
+				return h.batcher.TrackedMessageCount() == 2
+			}, 5*time.Second, 5*time.Millisecond, "expected the read batch to be tracked before dispatch")
+
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("reader should exit promptly on cancellation")
+			}
+
+			assert.Equal(t, 0, h.batcher.TrackedMessageCount(),
+				"a batch never dispatched must be untracked on reader cancellation")
+		})
 	}
-
-	d := &dynamoDBCDCInput{
-		conf: dynamoDBCDCConfig{
-			batchSize:       10,
-			pollInterval:    20 * time.Millisecond,
-			throttleBackoff: 20 * time.Millisecond,
-		},
-		log:           service.MockResources().Logger(),
-		streamsClient: newStubStreamsClient(transport),
-		streamArn:     aws.String(testStreamArn),
-		recordBatcher: NewRecordBatcher(100, 100, service.MockResources().Logger()),
-		shardReaders: map[string]*dynamoDBShardReader{
-			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
-		},
-		msgChan: make(chan asyncMessage), // unbuffered and never read: the send blocks
-	}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		d.startShardReader(ctx, "shard-001")
-		close(done)
-	}()
-
-	// Wait until the batch is tracked (the reader is now blocked on the send).
-	require.Eventually(t, func() bool {
-		return d.recordBatcher.TrackedMessageCount() == 3
-	}, 5*time.Second, 5*time.Millisecond, "expected the read batch to be tracked before dispatch")
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("reader should exit promptly on cancellation")
-	}
-
-	assert.Equal(t, 0, d.recordBatcher.TrackedMessageCount(),
-		"a batch never dispatched must be untracked on reader cancellation")
 }
 
-// TestStartShardReader_AckDrainsAfterWrapperPointerReplacement is the
+// TestShardReader_AckDrainsAfterWrapperPointerReplacement is the
 // end-to-end regression test for the INC-2974 ack-path stall: benthos's
 // AutoRetryNacksBatched (auto_replay_nacks, default on) replaces every
 // element of the delivered batch slice with a new *Message before the
 // pipeline sees it. The dispatched ack function must still drain the
 // in-flight tracker afterwards - keying settlement off the batch's message
 // pointers silently no-ops instead, pinning every reader in backpressure.
-func TestStartShardReader_AckDrainsAfterWrapperPointerReplacement(t *testing.T) {
-	transport := &recordsStubTransport{
-		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
-		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}}]`,
+func TestShardReader_AckDrainsAfterWrapperPointerReplacement(t *testing.T) {
+	for name, mk := range readerHarnesses(twoRecordsPage, 1, 1) {
+		t.Run(name, func(t *testing.T) {
+			h := mk()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			go h.start(ctx)
+
+			var am asyncMessage
+			select {
+			case am = <-h.d.msgChan:
+			case <-time.After(5 * time.Second):
+				t.Fatal("expected a dispatched batch")
+			}
+			require.Equal(t, 2, h.batcher.TrackedMessageCount())
+
+			// Simulate the wrapper's read hook: same slice, new message pointers.
+			for i := range am.msg {
+				am.msg[i] = am.msg[i].Copy()
+			}
+
+			require.NoError(t, am.ackFn(t.Context(), nil))
+			assert.Equal(t, 0, h.batcher.TrackedMessageCount(),
+				"the ack must drain the tracker even after the wrapper replaced the batch's message pointers")
+		})
 	}
-
-	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
-	d := &dynamoDBCDCInput{
-		conf: dynamoDBCDCConfig{
-			batchSize:       10,
-			pollInterval:    20 * time.Millisecond,
-			throttleBackoff: 20 * time.Millisecond,
-		},
-		log:           service.MockResources().Logger(),
-		streamsClient: newStubStreamsClient(transport),
-		streamArn:     aws.String(testStreamArn),
-		recordBatcher: batcher,
-		shardReaders: map[string]*dynamoDBShardReader{
-			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
-		},
-		msgChan: make(chan asyncMessage, 1),
-	}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go d.startShardReader(ctx, "shard-001")
-
-	var am asyncMessage
-	select {
-	case am = <-d.msgChan:
-	case <-time.After(5 * time.Second):
-		t.Fatal("expected a dispatched batch")
-	}
-	require.Equal(t, 2, batcher.TrackedMessageCount())
-
-	// Simulate the wrapper's read hook: same slice, new message pointers.
-	for i := range am.msg {
-		am.msg[i] = am.msg[i].Copy()
-	}
-
-	require.NoError(t, am.ackFn(t.Context(), nil))
-	assert.Equal(t, 0, batcher.TrackedMessageCount(),
-		"the ack must drain the tracker even after the wrapper replaced the batch's message pointers")
 }
 
-// TestStartShardReader_RealAutoRetryNacksWrapper runs the INC-2974 wedge
+// TestShardReader_RealAutoRetryNacksWrapper runs the INC-2974 wedge
 // scenario through the REAL benthos AutoRetryNacksBatched wrapper (what
 // auto_replay_nacks: true, the default, installs) rather than a simulation:
 // reader -> msgChan -> ReadBatch -> wrapper (which rewrites the batch slice's
@@ -506,53 +532,35 @@ func TestStartShardReader_AckDrainsAfterWrapperPointerReplacement(t *testing.T) 
 // the inner ack fires exactly once and the tracker drains. The wedge this PR
 // fixes was the final ack silently missing the tracker because settlement was
 // keyed by the rewritten message pointers.
-func TestStartShardReader_RealAutoRetryNacksWrapper(t *testing.T) {
-	transport := &recordsStubTransport{
-		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
-		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}}]`,
+func TestShardReader_RealAutoRetryNacksWrapper(t *testing.T) {
+	for name, mk := range readerHarnesses(twoRecordsPage, 1, 1) {
+		t.Run(name, func(t *testing.T) {
+			h := mk()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			go h.start(ctx)
+
+			wrapped := service.AutoRetryNacksBatched(h.d)
+
+			batch, ackFn, err := wrapped.ReadBatch(ctx)
+			require.NoError(t, err)
+			require.Len(t, batch, 2)
+			require.Equal(t, 2, h.batcher.TrackedMessageCount())
+
+			// Nack through the wrapper: it owns the redelivery, the input's ack fn
+			// must not fire, and the batch must stay tracked (in flight).
+			require.NoError(t, ackFn(ctx, errors.New("downstream rejection")))
+			assert.Equal(t, 2, h.batcher.TrackedMessageCount(),
+				"a wrapper-owned nack must keep the batch tracked until the retry settles")
+
+			// The wrapper redelivers the batch; the final ack must reach the input's
+			// ack fn and drain the tracker despite the pointer rewrite.
+			retry, retryAckFn, err := wrapped.ReadBatch(ctx)
+			require.NoError(t, err)
+			require.Len(t, retry, 2)
+			require.NoError(t, retryAckFn(ctx, nil))
+			assert.Equal(t, 0, h.batcher.TrackedMessageCount(),
+				"the final ack must drain the tracker through the real wrapper (the INC-2974 wedge)")
+		})
 	}
-
-	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
-	d := &dynamoDBCDCInput{
-		conf: dynamoDBCDCConfig{
-			batchSize:       10,
-			pollInterval:    20 * time.Millisecond,
-			throttleBackoff: 20 * time.Millisecond,
-		},
-		log:           service.MockResources().Logger(),
-		streamsClient: newStubStreamsClient(transport),
-		streamArn:     aws.String(testStreamArn),
-		recordBatcher: batcher,
-		shardReaders: map[string]*dynamoDBShardReader{
-			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
-		},
-		msgChan: make(chan asyncMessage, 1),
-		shutSig: shutdown.NewSignaller(),
-	}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go d.startShardReader(ctx, "shard-001")
-
-	wrapped := service.AutoRetryNacksBatched(d)
-
-	batch, ackFn, err := wrapped.ReadBatch(ctx)
-	require.NoError(t, err)
-	require.Len(t, batch, 2)
-	require.Equal(t, 2, batcher.TrackedMessageCount())
-
-	// Nack through the wrapper: it owns the redelivery, the input's ack fn
-	// must not fire, and the batch must stay tracked (in flight).
-	require.NoError(t, ackFn(ctx, errors.New("downstream rejection")))
-	assert.Equal(t, 2, batcher.TrackedMessageCount(),
-		"a wrapper-owned nack must keep the batch tracked until the retry settles")
-
-	// The wrapper redelivers the batch; the final ack must reach the input's
-	// ack fn and drain the tracker despite the pointer rewrite.
-	retry, retryAckFn, err := wrapped.ReadBatch(ctx)
-	require.NoError(t, err)
-	require.Len(t, retry, 2)
-	require.NoError(t, retryAckFn(ctx, nil))
-	assert.Equal(t, 0, batcher.TrackedMessageCount(),
-		"the final ack must drain the tracker through the real wrapper (the INC-2974 wedge)")
 }

--- a/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_expired_iterator_test.go
@@ -358,3 +358,136 @@ func TestStartShardReader_ExpiredIteratorTransientRefreshFailure(t *testing.T) {
 	assert.False(t, exhausted, "a transient refresh failure must not mark the shard exhausted")
 	assert.Empty(t, d.shardRefreshCh, "a transient refresh failure must not signal the coordinator")
 }
+
+// recordsStubTransport serves GetRecords, standing in for a healthy shard:
+// the first page carries the configured records, every later page is empty
+// (with a live next iterator), so tests see exactly one tracked batch.
+type recordsStubTransport struct {
+	records string // JSON array body of the first page's Records field
+	pages   atomic.Int64
+}
+
+func (s *recordsStubTransport) Do(req *http.Request) (*http.Response, error) {
+	target := req.Header.Get("X-Amz-Target")
+	if !strings.HasSuffix(target, ".GetRecords") {
+		return nil, fmt.Errorf("recordsStubTransport: unexpected operation %q", target)
+	}
+	records := "[]"
+	if s.pages.Add(1) == 1 {
+		records = s.records
+	}
+	hdr := http.Header{}
+	hdr.Set("Content-Type", "application/x-amz-json-1.0")
+	body := fmt.Sprintf(`{"Records":%s,"NextShardIterator":"iter-next"}`, records)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     hdr,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+// TestStartShardReader_CancelledSendUntracksBatch: a reader cancelled while
+// blocked sending a batch to the message channel must untrack that batch.
+// Leaking it would permanently consume tracker budget: enough cancelled
+// readers (shard rotation over a slow downstream) pin the throttle with
+// messages that no longer exist anywhere.
+func TestStartShardReader_CancelledSendUntracksBatch(t *testing.T) {
+	transport := &recordsStubTransport{
+		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
+		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}},
+		           {"eventID":"3","eventName":"INSERT","dynamodb":{"SequenceNumber":"00003","Keys":{"pk":{"S":"c"}},"NewImage":{"pk":{"S":"c"}}}}]`,
+	}
+
+	d := &dynamoDBCDCInput{
+		conf: dynamoDBCDCConfig{
+			batchSize:       10,
+			pollInterval:    20 * time.Millisecond,
+			throttleBackoff: 20 * time.Millisecond,
+		},
+		log:           service.MockResources().Logger(),
+		streamsClient: newStubStreamsClient(transport),
+		streamArn:     aws.String(testStreamArn),
+		recordBatcher: NewRecordBatcher(100, 100, service.MockResources().Logger()),
+		shardReaders: map[string]*dynamoDBShardReader{
+			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
+		},
+		msgChan: make(chan asyncMessage), // unbuffered and never read: the send blocks
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		d.startShardReader(ctx, "shard-001")
+		close(done)
+	}()
+
+	// Wait until the batch is tracked (the reader is now blocked on the send).
+	require.Eventually(t, func() bool {
+		return d.recordBatcher.TrackedMessageCount() == 3
+	}, 5*time.Second, 5*time.Millisecond, "expected the read batch to be tracked before dispatch")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader should exit promptly on cancellation")
+	}
+
+	assert.Equal(t, 0, d.recordBatcher.TrackedMessageCount(),
+		"a batch never dispatched must be untracked on reader cancellation")
+}
+
+// TestStartShardReader_AckDrainsAfterWrapperPointerReplacement is the
+// end-to-end regression test for the INC-2974 ack-path stall: benthos's
+// AutoRetryNacksBatched (auto_replay_nacks, default on) replaces every
+// element of the delivered batch slice with a new *Message before the
+// pipeline sees it. The dispatched ack function must still drain the
+// in-flight tracker afterwards - keying settlement off the batch's message
+// pointers silently no-ops instead, pinning every reader in backpressure.
+func TestStartShardReader_AckDrainsAfterWrapperPointerReplacement(t *testing.T) {
+	transport := &recordsStubTransport{
+		records: `[{"eventID":"1","eventName":"INSERT","dynamodb":{"SequenceNumber":"00001","Keys":{"pk":{"S":"a"}},"NewImage":{"pk":{"S":"a"}}}},
+		           {"eventID":"2","eventName":"INSERT","dynamodb":{"SequenceNumber":"00002","Keys":{"pk":{"S":"b"}},"NewImage":{"pk":{"S":"b"}}}}]`,
+	}
+
+	batcher := NewRecordBatcher(100, 1, service.MockResources().Logger())
+	d := &dynamoDBCDCInput{
+		conf: dynamoDBCDCConfig{
+			batchSize:       10,
+			pollInterval:    20 * time.Millisecond,
+			throttleBackoff: 20 * time.Millisecond,
+		},
+		log:           service.MockResources().Logger(),
+		streamsClient: newStubStreamsClient(transport),
+		streamArn:     aws.String(testStreamArn),
+		recordBatcher: batcher,
+		shardReaders: map[string]*dynamoDBShardReader{
+			"shard-001": {shardID: "shard-001", iterator: aws.String("initial-iterator")},
+		},
+		msgChan: make(chan asyncMessage, 1),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go d.startShardReader(ctx, "shard-001")
+
+	var am asyncMessage
+	select {
+	case am = <-d.msgChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a dispatched batch")
+	}
+	require.Equal(t, 2, batcher.TrackedMessageCount())
+
+	// Simulate the wrapper's read hook: same slice, new message pointers.
+	for i := range am.msg {
+		am.msg[i] = am.msg[i].Copy()
+	}
+
+	require.NoError(t, am.ackFn(t.Context(), nil))
+	assert.Equal(t, 0, batcher.TrackedMessageCount(),
+		"the ack must drain the tracker even after the wrapper replaced the batch's message pointers")
+}

--- a/internal/impl/aws/dynamodb/input_cdc_test.go
+++ b/internal/impl/aws/dynamodb/input_cdc_test.go
@@ -591,3 +591,28 @@ func TestCheckpointNamespaceValidation_RejectsDelimiter(t *testing.T) {
 	conf.checkpointNamespace = "dev-alice"
 	require.NoError(t, validateDynamoDBCDCConfig(conf))
 }
+
+// TestBatchSizeValidation: batch_size is documented as 1-1000 (the DynamoDB
+// Streams GetRecords Limit range) but was previously unenforced. A value
+// above the tracker budget would make every TryReserve refuse even on an
+// empty batcher, silently hanging the input from startup.
+func TestBatchSizeValidation(t *testing.T) {
+	conf := dynamoDBCDCConfig{
+		tables:          []string{"t"},
+		checkpointTable: "cps",
+		startFrom:       "trim_horizon",
+		batchSize:       100,
+		snapshot:        snapshotConfig{mode: snapshotModeNone, segments: 1, batchSize: 100},
+	}
+	require.NoError(t, validateDynamoDBCDCConfig(conf))
+
+	for _, bad := range []int{0, -1, 1001, 2000} {
+		conf.batchSize = bad
+		err := validateDynamoDBCDCConfig(conf)
+		require.Error(t, err, "batch_size %d must be rejected", bad)
+		require.Contains(t, err.Error(), "batch_size must be between 1 and 1000")
+	}
+
+	conf.batchSize = 1000
+	require.NoError(t, validateDynamoDBCDCConfig(conf))
+}


### PR DESCRIPTION
## Root cause (the ack-path stall)

benthos's `AutoRetryNacksBatched` — the `auto_replay_nacks` wrapper, **default on** since this input adopted it in 4.106.0 — **replaces every element of the batch slice returned by `ReadBatch` with a new `*Message`** before the pipeline sees it (its read hook tags parts for retry tracking: `input_auto_retry_batched.go`, `t[i] = NewInternalMessage(p)`). The `RecordBatcher` keyed ack settlement by the original message pointers, so with the wrapper active every CDC ack looked up a pointer that no longer existed and **silently no-opped**: `trackedMessages` never drained, backpressure pinned, and every shard reader parked forever — zero errors logged.

The snapshot path settles through closure handles and was immune, which is why a 101M-record snapshot flowed to completion while CDC sat wedged at the handoff (prod), and why preprod re-wedged immediately after #4737 fixed shard discovery (300k records read, none ever settled). Field-confirmed: `auto_replay_nacks: false` (removing the wrapper) unwedges a stalled pipeline.

## The fix

Settlement now goes through the `*trackedBatch` handle returned by `AddMessages` and captured by the batch's ack function — `AckBatch`/`RemoveBatch` replace the pointer-keyed `AckMessages`/`RemoveMessages`, and the message-pointer map is deleted outright (under the wrapper it also leaked one entry per message, since misses meant nothing was ever removed). Settlement is idempotent (`settled` flag) and drains the tracker even with no checkpoint store. No wrapper rewriting the batch slice can break settlement again.

## Defense in depth (one poison shard can no longer freeze the input)

- **Reservation-based admission**: readers reserve tracker budget (`TryReserve`/`Release`) *before* each `GetRecords` call, so N readers' first wave is bounded by the global budget — previously all readers passed `ShouldThrottle` once and collectively overshot it (~300k tracked at startup against a 10k cap on the affected pipelines).
- **Per-shard in-flight cap** (quarter of the budget): a shard whose batches never settle parks alone; other shards keep flowing. An idle shard always admits one batch, so progress is never impossible.
- A reader cancelled while blocked dispatching a batch now untracks it instead of leaking its budget.
- The pinned-throttle warning moved into the reserve path and names the top shards holding unsettled messages.

## Testing

- Regression tests replay the wrapper's exact mutation at both the batcher level and end-to-end through `startShardReader`'s dispatched ack function.
- New coverage for reservation admission, per-shard isolation, idempotent settlement, first-batch admission, concurrent reserve bounds, and cancelled-send untracking.
- Full unit suite green under `-race`; `task fmt` / `task lint` / `task docs` clean.
- Integration: `TestIntegrationDynamoDBMultiTable` green locally; the remaining integration tests fail localstack container startup identically on unmodified main on the same machine (testcontainers/Docker environment issue, verified via a clean worktree) — CI is the gate for those.

## Follow-ups (not in this PR)

- Upstream benthos issue: `AutoRetryNacksBatched`'s read hook mutates the caller's slice; any input that retains its batch for ack bookkeeping is silently broken by it. Other inputs with pointer-keyed ack tracking should be audited.
- Interim workaround for wedged pipelines on ≤4.107.1: `auto_replay_nacks: false` (documented drop-on-nack trade-off).