### PR TITLE
fix(mysql_cdc): accept unicode table names

### DIFF
--- a/internal/impl/mysql/validate.go
+++ b/internal/impl/mysql/validate.go
@@ -10,7 +10,6 @@ package mysql
 
 import (
 	"errors"
-	"regexp"
 	"unicode/utf8"
 )
 
@@ -21,10 +20,53 @@ var (
 	errInvalidTableName      = errors.New("invalid table name")
 )
 
+// isExtendedIdentifierRune reports whether r falls in the extended range MySQL
+// permits in unquoted identifiers, U+0080 to U+FFFF. Supplementary characters
+// (U+10000 and above) are not permitted.
+//
+// See https://dev.mysql.com/doc/refman/8.4/en/identifiers.html
+func isExtendedIdentifierRune(r rune) bool {
+	return r >= 0x80 && r <= 0xFFFF
+}
+
+// isIdentifierStartRune reports whether r may begin an unquoted table name.
+func isIdentifierStartRune(r rune) bool {
+	switch {
+	case r == '_':
+		return true
+	case 'a' <= r && r <= 'z':
+		return true
+	case 'A' <= r && r <= 'Z':
+		return true
+	default:
+		return isExtendedIdentifierRune(r)
+	}
+}
+
+// isIdentifierRune reports whether r may appear after the first character of an
+// unquoted table name.
+func isIdentifierRune(r rune) bool {
+	switch {
+	case '0' <= r && r <= '9':
+		return true
+	case r == '$':
+		return true
+	default:
+		return isIdentifierStartRune(r)
+	}
+}
+
 func validateTableName(tableName string) error {
 	// Check if empty
 	if tableName == "" {
 		return errEmptyTableName
+	}
+
+	// Reject malformed input up front. Ranging over a string yields
+	// utf8.RuneError for an invalid byte, which sits inside the extended range
+	// and would otherwise be accepted.
+	if !utf8.ValidString(tableName) {
+		return errInvalidTableName
 	}
 
 	// Check length
@@ -32,14 +74,20 @@ func validateTableName(tableName string) error {
 		return errInvalidTableLength
 	}
 
-	// Check if starts with a valid character
-	if matched, _ := regexp.MatchString(`^[a-zA-Z_]`, tableName); !matched {
-		return errInvalidTableStartChar
-	}
+	for i, r := range tableName {
+		// i is a byte offset, so it is only zero for the first rune.
+		if i == 0 {
+			// Check if starts with a valid character
+			if !isIdentifierStartRune(r) {
+				return errInvalidTableStartChar
+			}
+			continue
+		}
 
-	// Check if contains only valid characters
-	if matched, _ := regexp.MatchString(`^[a-zA-Z0-9_$]+$`, tableName); !matched {
-		return errInvalidTableName
+		// Check if contains only valid characters
+		if !isIdentifierRune(r) {
+			return errInvalidTableName
+		}
 	}
 
 	return nil

--- a/internal/impl/mysql/validate_test.go
+++ b/internal/impl/mysql/validate_test.go
@@ -45,6 +45,29 @@ func TestValidateTableName(t *testing.T) {
 			tableName:   "UserProfiles",
 			expectedErr: nil,
 		},
+		// MySQL permits the extended range U+0080..U+FFFF in unquoted
+		// identifiers, alongside the ASCII set.
+		// https://dev.mysql.com/doc/refman/8.4/en/identifiers.html
+		{
+			name:        "Valid table name with accented latin characters",
+			tableName:   "café",
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid table name starting with an extended character",
+			tableName:   "日本語テーブル",
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid table name with cyrillic characters",
+			tableName:   "Пользователи",
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid table name mixing ascii and extended characters",
+			tableName:   "orders_ñ_2024",
+			expectedErr: nil,
+		},
 
 		// Invalid cases
 		{
@@ -76,6 +99,21 @@ func TestValidateTableName(t *testing.T) {
 			name:        "Too long table name",
 			tableName:   strings.Repeat("a", 65),
 			expectedErr: errInvalidTableLength,
+		},
+		{
+			name:        "Too long table name counted in runes",
+			tableName:   strings.Repeat("é", 65),
+			expectedErr: errInvalidTableLength,
+		},
+		{
+			name:        "Supplementary characters are not permitted",
+			tableName:   "table_😀",
+			expectedErr: errInvalidTableName,
+		},
+		{
+			name:        "Invalid utf-8 is rejected",
+			tableName:   "table_" + string([]byte{0xff}),
+			expectedErr: errInvalidTableName,
 		},
 	}
 


### PR DESCRIPTION
## Problem

`mysql_cdc` rejects table names that MySQL itself accepts, so those tables cannot be captured at all.

MySQL permits two sets of characters in unquoted identifiers ([Schema Object Names](https://dev.mysql.com/doc/refman/8.4/en/identifiers.html)):

> - ASCII: `[0-9,a-z,A-Z$_]` (basic Latin letters, digits 0-9, dollar, underscore)
> - Extended: `U+0080 .. U+FFFF`

`validateTableName` implements only the first line:

```go
if matched, _ := regexp.MatchString(`^[a-zA-Z_]`, tableName); !matched {
    return errInvalidTableStartChar
}
if matched, _ := regexp.MatchString(`^[a-zA-Z0-9_$]+$`, tableName); !matched {
    return errInvalidTableName
}
```

Anything in the extended range fails one of the two checks. Every one of these is a legal MySQL table name:

| table | result before |
|---|---|
| `café` | `invalid table name` |
| `日本語テーブル` | `invalid start char in mysql table name` |
| `Пользователи` | `invalid start char in mysql table name` |
| `orders_ñ_2024` | `invalid table name` |

The check runs in `input_mysql_stream.go` while the input is being built, so this is not a per-row warning: the connector refuses to start and the table can never be streamed.

## Fix

Replace the two regexes with explicit rune checks covering both sets MySQL documents. Supplementary characters (U+10000 and above) stay rejected, since MySQL does not permit them in identifiers either, and malformed UTF-8 is now rejected up front, because ranging over a string yields `utf8.RuneError`, which sits inside the extended range and would otherwise be accepted.

Everything the existing tests assert is unchanged: empty names, names over 64 characters, `@`, spaces, and hyphens are all still rejected.

I deliberately did **not** change the leading-digit rule. MySQL does allow identifiers to begin with a digit ("unless quoted may not consist solely of digits"), so `2users` is arguably valid too, but `TestValidateTableName` explicitly asserts it is rejected. That looks like an intentional choice rather than an oversight, so I left it alone. Happy to relax it in this PR if you would rather the validator matched the spec on that point as well.

## Testing

Four cases added for the extended range (accented Latin, Japanese, Cyrillic, and a mixed ASCII/extended name), plus three for the boundaries: length counted in runes, supplementary characters rejected, and malformed UTF-8 rejected.

The four extended-range cases fail on current `main`:

```
--- FAIL: TestValidateTableName/Valid_table_name_with_accented_latin_characters
--- FAIL: TestValidateTableName/Valid_table_name_starting_with_an_extended_character
--- FAIL: TestValidateTableName/Valid_table_name_with_cyrillic_characters
--- FAIL: TestValidateTableName/Valid_table_name_mixing_ascii_and_extended_characters
```

and pass with this change. `go test ./internal/impl/mysql/` is green, `gofmt` and `go vet` are clean.
