### PR TITLE
Add pipeline_id to Connect telemetry payload

### DIFF
--- a/internal/cli/enterprise.go
+++ b/internal/cli/enterprise.go
@@ -60,6 +60,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 		disableTelemetry        bool
 		telemetryDeploymentType string
 		telemetryTenantID       string
+		telemetryPipelineID     string
 		authzResourceName       string
 		authzPolicyFile         string
 		authzPolicyEndpoint     string
@@ -158,7 +159,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 
 			// Kick off telemetry exporter
 			if !disableTelemetry {
-				telemetry.ActivateExporter(instanceID, version, telemetryDeploymentType, telemetryTenantID, fbLogger, schema, pConf)
+				telemetry.ActivateExporter(instanceID, version, telemetryDeploymentType, telemetryTenantID, telemetryPipelineID, fbLogger, schema, pConf)
 			}
 			return rpMgr.InitFromParsedConfig(pConf.Namespace("redpanda"))
 		}),
@@ -215,6 +216,7 @@ func InitEnterpriseCLI(binaryName, version, dateBuilt string, schema *service.Co
 				if err != nil {
 					return err
 				}
+				telemetryPipelineID = pipelineID
 
 				// Parse and resolve cloud auth flags
 				if authzResourceName, authzPolicyFile, authzPolicyEndpoint, err = parseCloudAuthFlags(c.Context, c, secretLookupFn); err != nil {

--- a/internal/telemetry/payload.go
+++ b/internal/telemetry/payload.go
@@ -67,16 +67,22 @@ type payload struct {
 	// TenantID identifies the owning tenant for cloud-managed deployments
 	// (typically the Redpanda Cloud organization ID). Empty for self-hosted.
 	TenantID string `json:"tenantId,omitempty"`
+
+	// PipelineID identifies the control-plane pipeline resource this
+	// Connect instance is running, for cloud-managed deployments. Empty
+	// for self-hosted.
+	PipelineID string `json:"pipelineId,omitempty"`
 }
 
 // All information sent during a telemetry export is extracted within this
 // function and stored within the payload.
-func extractPayload(identifier, deploymentType, tenantID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) (*payload, error) {
+func extractPayload(identifier, deploymentType, tenantID, pipelineID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) (*payload, error) {
 	p := payload{
 		ID:             identifier,
 		Uptime:         0,
 		DeploymentType: deploymentType,
 		TenantID:       tenantID,
+		PipelineID:     pipelineID,
 		HostInfo: hostInfo{
 			NumCPU:     runtime.NumCPU(),
 			GoMaxProcs: runtime.GOMAXPROCS(0), // using 0 means to just read the value

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -54,7 +54,7 @@ const (
 
 // ActivateExporter runs the telemetry exporter asynchronously, provided all
 // conditions for telemetry are satisfied.
-func ActivateExporter(identifier, version, deploymentType, tenantID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) {
+func ActivateExporter(identifier, version, deploymentType, tenantID, pipelineID string, logger *service.Logger, schema *service.ConfigSchema, conf *service.ParsedConfig) {
 	// If TLS information isn't present in the build then we do not send
 	// telemetry data.
 	if privateKey == "" {
@@ -82,7 +82,7 @@ func ActivateExporter(identifier, version, deploymentType, tenantID string, logg
 		exportHost = ExportHost
 	}
 
-	p, err := extractPayload(identifier, deploymentType, tenantID, logger, schema, conf)
+	p, err := extractPayload(identifier, deploymentType, tenantID, pipelineID, logger, schema, conf)
 	if err != nil {
 		logger.With("error", err).Debug("Failed to create telemetry payload")
 		return


### PR DESCRIPTION
## Summary
- Threads the control-plane pipeline ID into the anonymous telemetry payload's `pipelineId` field, so telemetry can be correlated with control-plane usage/billing data (`connect_usage_daily.pipeline_id` in the analytics warehouse).
- The pipeline ID is not new information: it's already parsed from the hidden `x-redpanda-pipeline-id` CLI flag the operator injects into every pipeline pod (dedicated, BYOC, and serverless alike) and used for log/status topic routing (`rpMgr.InitWithCustomDetails`). This just also passes it into `telemetry.ActivateExporter`.
- No new flags, no new data sources, no operator/control-plane changes required.
- Backward compatible: new field uses `omitempty`, so it's absent for self-hosted/OSS users where no pipeline ID exists.

## Context
Currently `connect_telemetry.source_identifier` (a self-generated instance ID) has no relationship to the control-plane-assigned `pipeline_id` used in usage/billing tables, so telemetry data can't be joined to usage data per-pipeline. This adds the missing key to telemetry so that join becomes possible once this ships and pipelines pick up the new binary.

## Test plan
- [x] `go build ./internal/telemetry/... ./internal/cli/...` passes
- [x] `go test ./internal/telemetry/... ./internal/cli/...` passes (no existing tests reference the changed function signatures)
- [ ] Owning team confirms the new `pipelineId` field is picked up correctly by the telemetry ingestion/analytics pipeline before relying on it in BigQuery