### PR TITLE
docs: repoint five dead links in component descriptions

### DIFF
--- a/docs/modules/components/pages/inputs/pulsar.adoc
+++ b/docs/modules/components/pages/inputs/pulsar.adoc
@@ -150,7 +150,7 @@ Specify the subscription name for this consumer.
 
 Specify the subscription type for this consumer.
 
-> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See https://pulsar.apache.org/docs/en/2.8.1/concepts-messaging/#negative-acknowledgement[Pulsar documentation^] and https://github.com/apache/pulsar/issues/12208[this Github issue^] for more details.
+> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See https://pulsar.apache.org/docs/concepts-messaging/#negative-acknowledgment[Pulsar documentation^] and https://github.com/apache/pulsar/issues/12208[this Github issue^] for more details.
 
 
 *Type*: `string`

--- a/docs/modules/components/pages/outputs/cassandra.adoc
+++ b/docs/modules/components/pages/outputs/cassandra.adoc
@@ -143,7 +143,7 @@ Insert JSON Documents::
 +
 --
 
-The following example inserts JSON documents into the table `footable` of the keyspace `foospace` using INSERT JSON (https://cassandra.apache.org/doc/latest/cql/json.html#insert-json).
+The following example inserts JSON documents into the table `footable` of the keyspace `foospace` using INSERT JSON (https://cassandra.apache.org/doc/latest/cassandra/developing/cql/json.html#insert-json).
 
 ```yaml
 output:

--- a/docs/modules/components/pages/outputs/gcp_pubsub.adoc
+++ b/docs/modules/components/pages/outputs/gcp_pubsub.adoc
@@ -96,7 +96,7 @@ For information on how to set up credentials, see https://cloud.google.com/docs/
 
 == Troubleshooting
 
-If you're consistently seeing `Failed to send message to gcp_pubsub: context deadline exceeded` error logs without any further information it is possible that you are encountering https://github.com/benthosdev/benthos/issues/1042, which occurs when metadata values contain characters that are not valid utf-8. This can frequently occur when consuming from Kafka as the key metadata field may be populated with an arbitrary binary value, but this issue is not exclusive to Kafka.
+If you're consistently seeing `Failed to send message to gcp_pubsub: context deadline exceeded` error logs without any further information it is possible that you are encountering https://github.com/redpanda-data/connect/issues/1042, which occurs when metadata values contain characters that are not valid utf-8. This can frequently occur when consuming from Kafka as the key metadata field may be populated with an arbitrary binary value, but this issue is not exclusive to Kafka.
 
 If you are blocked by this issue then a work around is to delete either the specific problematic keys:
 

--- a/docs/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/docs/modules/components/pages/processors/openai_chat_completion.adoc
@@ -375,7 +375,7 @@ Options:
 
 === `json_schema`
 
-The JSON schema to use when responding in `json_schema` format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs/supported-schemas[OpenAI documentation^].
+The JSON schema to use when responding in `json_schema` format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs[OpenAI documentation^].
 
 
 *Type*: `object`
@@ -407,7 +407,7 @@ The JSON schema for the LLM to use when generating the output.
 
 === `schema_registry`
 
-The schema registry to dynamically load schemas from when responding in `json_schema` format. Schemas themselves must be in JSON format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs/supported-schemas[OpenAI documentation^].
+The schema registry to dynamically load schemas from when responding in `json_schema` format. Schemas themselves must be in JSON format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs[OpenAI documentation^].
 
 
 *Type*: `object`

--- a/docs/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_decode.adoc
@@ -127,7 +127,7 @@ Avro, Protobuf and Json schemas are supported, all are capable of expanding from
 
 == Avro JSON format
 
-This processor creates documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -163,7 +163,7 @@ Configuration for how to decode schemas that are of type AVRO.
 
 === `avro.raw_unions`
 
-Whether avro messages should be decoded into normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[JSON as specified in the Avro Spec^].
+Whether avro messages should be decoded into normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/#json-encoding[JSON as specified in the Avro Spec^].
 
 For example, if there is a union schema `["null", "string", "Foo"]` where `Foo` is a record name, with raw_unions as false (the default) you get:
 - `null` as `null`;

--- a/docs/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/docs/modules/components/pages/processors/schema_registry_encode.adoc
@@ -105,7 +105,7 @@ Avro, Protobuf and JSON Schema formats are supported. In registry-pull mode all 
 
 == Avro JSON format
 
-By default this processor expects documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default this processor expects documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/docs/modules/components/pages/scanners/avro.adoc
+++ b/docs/modules/components/pages/scanners/avro.adoc
@@ -52,7 +52,7 @@ avro:
 
 == Avro JSON format
 
-This scanner yields documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This scanner yields documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -72,7 +72,7 @@ This scanner also emits the canonical Avro schema as `@avro_schema` metadata, al
 
 === `raw_json`
 
-Whether messages should be decoded into normal JSON rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {"type": value} wrappers).
+Whether messages should be decoded into normal JSON rather than https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {"type": value} wrappers).
 
 
 *Type*: `bool`

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -38,7 +38,7 @@ func avroScannerSpec() *service.ConfigSpec {
 		Description(`
 == Avro JSON format
 
-This scanner yields documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This scanner yields documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -55,7 +55,7 @@ This scanner also emits the canonical Avro schema as ` + "`@avro_schema`" + ` me
 `).
 		Fields(
 			service.NewBoolField(sFieldRawJSON).
-				Description("Whether messages should be decoded into normal JSON rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {\"type\": value} wrappers).").
+				Description("Whether messages should be decoded into normal JSON rather than https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {\"type\": value} wrappers).").
 				Advanced().
 				Default(false),
 		)

--- a/internal/impl/cassandra/output.go
+++ b/internal/impl/cassandra/output.go
@@ -67,7 +67,7 @@ output:
 		).
 		Example(
 			"Insert JSON Documents",
-			"The following example inserts JSON documents into the table `footable` of the keyspace `foospace` using INSERT JSON (https://cassandra.apache.org/doc/latest/cql/json.html#insert-json).",
+			"The following example inserts JSON documents into the table `footable` of the keyspace `foospace` using INSERT JSON (https://cassandra.apache.org/doc/latest/cassandra/developing/cql/json.html#insert-json).",
 			`
 output:
   cassandra:

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -45,7 +45,7 @@ Avro, Protobuf and Json schemas are supported, all are capable of expanding from
 
 == Avro JSON format
 
-This processor creates documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -69,13 +69,13 @@ This processor also adds the following metadata to each outgoing message:
 schema_id: the ID of the schema in the schema registry that was associated with the message.
 `).
 		Field(service.NewBoolField("avro_raw_json").
-			Description("Whether Avro messages should be decoded into normal JSON (\"json that meets the expectations of regular internet json\") rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {\"type\": value} wrappers).").
+			Description("Whether Avro messages should be decoded into normal JSON (\"json that meets the expectations of regular internet json\") rather than https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {\"type\": value} wrappers).").
 			ShortDescription("Decode Avro messages into plain JSON rather than Avro JSON, unwrapping union values.").
 			Advanced().Default(false).Deprecated()).
 		Fields(
 			service.NewObjectField(
 				"avro",
-				service.NewBoolField("raw_unions").Description(`Whether avro messages should be decoded into normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[JSON as specified in the Avro Spec^].
+				service.NewBoolField("raw_unions").Description(`Whether avro messages should be decoded into normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/#json-encoding[JSON as specified in the Avro Spec^].
 
 For example, if there is a union schema `+"`"+`["null", "string", "Foo"]`+"`"+` where `+"`Foo`"+` is a record name, with raw_unions as false (the default) you get:
 - `+"`null` as `null`"+`;

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -63,7 +63,7 @@ Avro, Protobuf and JSON Schema formats are supported. In registry-pull mode all 
 
 == Avro JSON format
 
-By default this processor expects documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default this processor expects documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -39,7 +39,7 @@ For information on how to set up credentials, see https://cloud.google.com/docs/
 
 == Troubleshooting
 
-If you're consistently seeing `+"`Failed to send message to gcp_pubsub: context deadline exceeded`"+` error logs without any further information it is possible that you are encountering https://github.com/benthosdev/benthos/issues/1042, which occurs when metadata values contain characters that are not valid utf-8. This can frequently occur when consuming from Kafka as the key metadata field may be populated with an arbitrary binary value, but this issue is not exclusive to Kafka.
+If you're consistently seeing `+"`Failed to send message to gcp_pubsub: context deadline exceeded`"+` error logs without any further information it is possible that you are encountering https://github.com/redpanda-data/connect/issues/1042, which occurs when metadata values contain characters that are not valid utf-8. This can frequently occur when consuming from Kafka as the key metadata field may be populated with an arbitrary binary value, but this issue is not exclusive to Kafka.
 
 If you are blocked by this issue then a work around is to delete either the specific problematic keys:
 

--- a/internal/impl/openai/chat_processor.go
+++ b/internal/impl/openai/chat_processor.go
@@ -141,7 +141,7 @@ We generally recommend altering this or top_p but not both.`).
 				service.NewStringField(ocpFieldJSONSchemaSchema).Description("The JSON schema for the LLM to use when generating the output."),
 			).
 				Optional().
-				Description("The JSON schema to use when responding in `json_schema` format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs/supported-schemas[OpenAI documentation^].").
+				Description("The JSON schema to use when responding in `json_schema` format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs[OpenAI documentation^].").
 				ShortDescription("The JSON schema to use when responding in json_schema format."),
 			service.NewObjectField(
 				ocpFieldSchemaRegistry,
@@ -161,7 +161,7 @@ We generally recommend altering this or top_p but not both.`).
 					service.NewHTTPRequestAuthSignerFields(),
 				)...,
 			).
-				Description("The schema registry to dynamically load schemas from when responding in `json_schema` format. Schemas themselves must be in JSON format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs/supported-schemas[OpenAI documentation^].").
+				Description("The schema registry to dynamically load schemas from when responding in `json_schema` format. Schemas themselves must be in JSON format. To learn more about what JSON schema is supported see the https://platform.openai.com/docs/guides/structured-outputs[OpenAI documentation^].").
 				ShortDescription("Schema registry to load schemas from when responding in json_schema format. Schemas must be JSON.").
 				Optional().
 				Advanced(),

--- a/internal/impl/pulsar/input.go
+++ b/internal/impl/pulsar/input.go
@@ -79,7 +79,7 @@ xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].
 		Field(service.NewStringField("subscription_name").
 			Description("Specify the subscription name for this consumer.")).
 		Field(service.NewStringEnumField("subscription_type", "shared", "key_shared", "failover", "exclusive").
-			Description("Specify the subscription type for this consumer.\n\n> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See https://pulsar.apache.org/docs/en/2.8.1/concepts-messaging/#negative-acknowledgement[Pulsar documentation^] and https://github.com/apache/pulsar/issues/12208[this Github issue^] for more details.").
+			Description("Specify the subscription type for this consumer.\n\n> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See https://pulsar.apache.org/docs/concepts-messaging/#negative-acknowledgment[Pulsar documentation^] and https://github.com/apache/pulsar/issues/12208[this Github issue^] for more details.").
 			ShortDescription("The subscription type for this consumer. key_shared allows out-of-order delivery.").
 			Default(defaultSubscriptionType)).
 		Field(service.NewStringEnumField("subscription_initial_position", "latest", "earliest").


### PR DESCRIPTION
Five dead links in component `Description` strings. All five turned up in the docs site's weekly link check ([redpanda-data/docs-site#211](https://github.com/redpanda-data/docs-site/issues/211)), which reads the published reference pages these strings generate.

Each old URL returns 404 and each replacement returns 200, verified with a live request. The two anchors were read off the target pages themselves rather than guessed.

| Component | Was | Now |
|---|---|---|
| `outputs/gcp_pubsub` | `github.com/benthosdev/benthos/issues/1042` | `github.com/redpanda-data/connect/issues/1042` |
| `outputs/cassandra` | `cassandra.apache.org/doc/latest/cql/json.html#insert-json` | `.../doc/latest/cassandra/developing/cql/json.html#insert-json` |
| `inputs/pulsar` | `pulsar.apache.org/docs/en/2.8.1/concepts-messaging/#negative-acknowledgement` | `pulsar.apache.org/docs/concepts-messaging/#negative-acknowledgment` |
| `processors/openai_chat_completion` (x2) | `platform.openai.com/docs/guides/structured-outputs/supported-schemas` | `platform.openai.com/docs/guides/structured-outputs` |
| `scanners/avro`, `processors/schema_registry_decode`, `processors/schema_registry_encode` | `avro.apache.org/docs/current/specification/_print/#json-encoding` | `avro.apache.org/docs/current/specification/#json-encoding` |

Two worth calling out:

- **gcp_pubsub**: the `benthosdev` org no longer exists. GitHub redirects the *repository root* `benthosdev/benthos` to `redpanda-data/connect`, but not the `/issues/N` path, so this one really is dead while looking like it should redirect. Checked three times to rule out rate limiting.
- **pulsar**: two problems, not one. The path lost its `/en/` segment and its `2.8.1` pin, and the heading anchor is the *American* spelling. I read the live page's heading ids: `negative-acknowledgment`, no middle "e". So the old link would have landed on the page but not the section even before the path broke.

For the Avro and Pulsar anchors I loaded the pages in a browser and read `document.getElementById(...)`, because both sites render headings client-side and a plain `curl` shows no ids at all.

## Generated docs

Regenerated. I confirmed `docs_gen` reproduces exactly the seven pages in this diff and changes nothing else: I snapshotted `docs/modules`, ran `go run ./cmd/tools/docs_gen`, and `diff -rq` against the snapshot came back empty. So `task docs` in CI has nothing left to do.

`gofmt` clean; `go build ./internal/impl/...` passes.

## Why here rather than in the docs repo

`rp-connect-docs` regenerates `modules/components/**` from this source, so a patch there is reverted on the next run. There is already a live example of that: `caches/ttlru.adoc` was hand-patched while its generated partial still carries the broken URL. (That particular one lives in `redpanda-data/benthos` and is fixed in [benthos#493](https://github.com/redpanda-data/benthos/pull/493).)
