### PR TITLE
docker: point the Docker README and compose example at the published image

### DIFF
--- a/resources/docker/README.md
+++ b/resources/docker/README.md
@@ -7,10 +7,10 @@ The image has a [default config][default.config] but it's not particularly usefu
 
 ```shell
 # Using a config file
-docker run --rm -v /path/to/your/config.yaml:/connect.yaml ghcr.io/redpanda-data/connect
+docker run --rm -v /path/to/your/config.yaml:/connect.yaml docker.redpanda.com/redpandadata/connect
 
 # Using a series of -s flags
-docker run --rm -p 4195:4195 ghcr.io/redpanda-data/connect \
+docker run --rm -p 4195:4195 docker.redpanda.com/redpandadata/connect \
   -s "input.type=http_server" \
   -s "output.type=kafka" \
   -s "output.kafka.addresses=kafka-server:9092" \

--- a/resources/docker/schema_registry/docker-compose.yaml
+++ b/resources/docker/schema_registry/docker-compose.yaml
@@ -14,13 +14,13 @@ services:
       - '--advertise-pandaproxy-addr redpanda:8082'
 
   connect-in:
-    image: ghcr.io/redpanda-data/connect
+    image: docker.redpanda.com/redpandadata/connect
     command: [ '-w', '-c', '/connect.yaml' ]
     volumes:
       - ./in.yaml:/connect.yaml
 
   connect-out:
-    image: ghcr.io/redpanda-data/connect
+    image: docker.redpanda.com/redpandadata/connect
     command: [ '-w', '-c', '/connect.yaml' ]
     volumes:
       - ./out.yaml:/connect.yaml


### PR DESCRIPTION
The Docker README and the schema_registry compose example told users to pull ghcr.io/redpanda-data/connect. Nothing has published there for about two years: the release workflow pushes images to redpandadata/connect on Docker Hub and public.ecr.aws/l9j0i2e0/connect, and no workflow or goreleaser config targets GHCR at all.

The GHCR package is still public and still resolves, so following these docs silently gets 4.30.1 while the current release is 4.107.2 -- no error, just a two-year-old binary.

Both now use docker.redpanda.com/redpandadata/connect, matching what the product docs already tell users to pull.

The remaining ghcr.io references in the integration tests are third-party images (tigerbeetle, arc, opentelemetry, bigquery-emulator) and are unrelated.