### PR TITLE
rpcn: route input Ack to the correct batch instead of closing the component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- rpc plugins: Fixed `Ack` on an RPC (dynamic) input plugin closing the whole component instead of routing to the acked batch, which tore down any ack-dependent plugin input on its first ack. ([@Sirz3chs](https://github.com/Sirz3chs), [#TODO-fill-in-PR-number](https://github.com/redpanda-data/connect/pull/TODO))
+- rpc plugins: Fixed `Ack` on an RPC (dynamic) input plugin closing the whole component instead of routing to the acked batch, which tore down any ack-dependent plugin input on its first ack. ([@Sirz3chs](https://github.com/Sirz3chs), [#4772](https://github.com/redpanda-data/connect/pull/4772))
 
 ## 4.109.0 - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- rpc plugins: Fixed `Ack` on an RPC (dynamic) input plugin closing the whole component instead of routing to the acked batch, which tore down any ack-dependent plugin input on its first ack. ([@Sirz3chs](https://github.com/Sirz3chs), [#TODO-fill-in-PR-number](https://github.com/redpanda-data/connect/pull/TODO))
+
 ## 4.109.0 - 2026-09-10
 
 ### Added

--- a/public/plugin/go/rpcn/rpcn.go
+++ b/public/plugin/go/rpcn/rpcn.go
@@ -259,11 +259,19 @@ func (i *input) Close(ctx context.Context, _ *runtimepb.BatchInputCloseRequest) 
 }
 
 // Ack implements runtimepb.BatchInputServiceServer.
-func (i *input) Ack(ctx context.Context, _ *runtimepb.BatchInputAckRequest) (*runtimepb.BatchInputAckResponse, error) {
+func (i *input) Ack(ctx context.Context, req *runtimepb.BatchInputAckRequest) (*runtimepb.BatchInputAckResponse, error) {
 	if i.component == nil {
 		return &runtimepb.BatchInputAckResponse{Error: runtimepb.ErrorToProto(service.ErrNotConnected)}, nil
 	}
-	err := i.component.Close(ctx)
+	ackAny, ok := i.acks.LoadAndDelete(req.BatchId)
+	if !ok {
+		return &runtimepb.BatchInputAckResponse{Error: runtimepb.ErrorToProto(fmt.Errorf("unknown batch id: %d", req.BatchId))}, nil
+	}
+	ack, _ := ackAny.(service.AckFunc)
+	if ack == nil {
+		return &runtimepb.BatchInputAckResponse{Error: runtimepb.ErrorToProto(fmt.Errorf("batch id %d has no ack function", req.BatchId))}, nil
+	}
+	err := ack(ctx, runtimepb.ProtoToError(req.Error))
 	return &runtimepb.BatchInputAckResponse{Error: runtimepb.ErrorToProto(err)}, nil
 }
 
@@ -276,12 +284,18 @@ func (i *input) ReadBatch(ctx context.Context, _ *runtimepb.BatchInputReadReques
 	if err != nil {
 		return &runtimepb.BatchInputReadResponse{Error: runtimepb.ErrorToProto(err)}, nil
 	}
-	myID := i.batchIDGenerator.Add(1)
-	i.acks.Store(myID, ack)
 	proto, err := runtimepb.MessageBatchToProto(batch)
 	if err != nil {
+		// The batch can never reach the host from here, so settle it now
+		// instead of storing it under a BatchId the host will never
+		// receive and can therefore never ack.
+		if ack != nil {
+			_ = ack(ctx, err)
+		}
 		return &runtimepb.BatchInputReadResponse{Error: runtimepb.ErrorToProto(err)}, nil
 	}
+	myID := i.batchIDGenerator.Add(1)
+	i.acks.Store(myID, ack)
 	return &runtimepb.BatchInputReadResponse{BatchId: myID, Batch: proto}, nil
 }
 

--- a/public/plugin/go/rpcn/rpcn_test.go
+++ b/public/plugin/go/rpcn/rpcn_test.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/rpcplugin/runtimepb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBatchInput is a minimal service.BatchInput used only to give the
+// input server a non-nil component, since Ack no longer calls any of its
+// methods directly (that was the bug). closed tracks whether Close was
+// called, so tests can assert Ack never triggers it; readBatch lets a test
+// drive a real ReadBatch call when it needs a genuine BatchId rather than
+// one poked directly into i.acks.
+type fakeBatchInput struct {
+	closed    *bool
+	readBatch func(context.Context) (service.MessageBatch, service.AckFunc, error)
+}
+
+func (fakeBatchInput) Connect(context.Context) error { return nil }
+
+func (f fakeBatchInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	if f.readBatch != nil {
+		return f.readBatch(ctx)
+	}
+	return nil, nil, nil
+}
+
+func (f fakeBatchInput) Close(context.Context) error {
+	if f.closed != nil {
+		*f.closed = true
+	}
+	return nil
+}
+
+func TestInputAck_RoutesToTheAckedBatchByID(t *testing.T) {
+	i := &input{component: fakeBatchInput{}}
+
+	var (
+		ackCalled bool
+		gotErr    error
+	)
+	myID := i.batchIDGenerator.Add(1)
+	i.acks.Store(myID, service.AckFunc(func(_ context.Context, err error) error {
+		ackCalled = true
+		gotErr = err
+		return nil
+	}))
+
+	resp, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: myID})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Error)
+	assert.True(t, ackCalled, "the AckFunc stored for this batch ID should have been called")
+	assert.NoError(t, gotErr)
+}
+
+func TestInputAck_PropagatesTheNackErrorToTheCorrectBatch(t *testing.T) {
+	i := &input{component: fakeBatchInput{}}
+
+	nackErr := errors.New("downstream write failed")
+	var gotErr error
+	myID := i.batchIDGenerator.Add(1)
+	i.acks.Store(myID, service.AckFunc(func(_ context.Context, err error) error {
+		gotErr = err
+		return nil
+	}))
+
+	_, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{
+		BatchId: myID,
+		Error:   runtimepb.ErrorToProto(nackErr),
+	})
+	require.NoError(t, err)
+	require.Error(t, gotErr)
+	assert.Equal(t, nackErr.Error(), gotErr.Error())
+}
+
+func TestInputAck_DoesNotAffectOtherOutstandingBatches(t *testing.T) {
+	i := &input{component: fakeBatchInput{}}
+
+	var otherAcked bool
+	otherID := i.batchIDGenerator.Add(1)
+	i.acks.Store(otherID, service.AckFunc(func(context.Context, error) error {
+		otherAcked = true
+		return nil
+	}))
+
+	targetID := i.batchIDGenerator.Add(1)
+	i.acks.Store(targetID, service.AckFunc(func(context.Context, error) error { return nil }))
+
+	_, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: targetID})
+	require.NoError(t, err)
+	assert.False(t, otherAcked, "acking one batch must not ack a different outstanding batch")
+
+	// The other batch's ack should still be routable afterwards.
+	_, err = i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: otherID})
+	require.NoError(t, err)
+	assert.True(t, otherAcked)
+}
+
+func TestInputAck_UnknownBatchIDReturnsAnError(t *testing.T) {
+	i := &input{component: fakeBatchInput{}}
+
+	resp, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: 12345})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+}
+
+func TestInputAck_NeverClosesTheComponent(t *testing.T) {
+	// Regression test for the original bug: Ack used to call Close on the
+	// whole component instead of routing to the acked batch.
+	closed := false
+	i := &input{component: fakeBatchInput{closed: &closed}}
+
+	myID := i.batchIDGenerator.Add(1)
+	i.acks.Store(myID, service.AckFunc(func(context.Context, error) error { return nil }))
+
+	_, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: myID})
+	require.NoError(t, err)
+	assert.False(t, closed, "Ack must not close the component")
+}
+
+// TestInputAck_RoutesViaTheRealBatchIDFromReadBatch drives a real ReadBatch
+// call rather than poking a batch ID directly into i.acks: it's the
+// BatchId ReadBatch actually hands back that Ack must key off. It also
+// covers LoadAndDelete's deletion semantics (untested otherwise): acking
+// the same batch ID twice must fail the second time, not silently ack (or
+// re-ack) whatever AckFunc used to live there.
+func TestInputAck_RoutesViaTheRealBatchIDFromReadBatch(t *testing.T) {
+	var acked bool
+	i := &input{component: fakeBatchInput{
+		readBatch: func(context.Context) (service.MessageBatch, service.AckFunc, error) {
+			return service.MessageBatch{service.NewMessage([]byte("hello"))}, func(context.Context, error) error {
+				acked = true
+				return nil
+			}, nil
+		},
+	}}
+
+	readResp, err := i.ReadBatch(t.Context(), &runtimepb.BatchInputReadRequest{})
+	require.NoError(t, err)
+	require.Nil(t, readResp.Error)
+
+	ackResp, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: readResp.BatchId})
+	require.NoError(t, err)
+	assert.Nil(t, ackResp.Error)
+	assert.True(t, acked, "acking the BatchId ReadBatch actually returned should route to that batch's AckFunc")
+
+	ackResp, err = i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: readResp.BatchId})
+	require.NoError(t, err)
+	assert.NotNil(t, ackResp.Error, "acking an already-acked batch ID again must fail, not silently succeed")
+}
+
+// TestInputAck_NilAckFuncReturnsAnErrorInsteadOfPanicking guards against a
+// plugin author's ReadBatch returning a nil AckFunc alongside a nil error
+// (valid per the service.BatchInput contract, if unusual) — Ack must
+// report that cleanly rather than panicking the whole plugin subprocess
+// when it eventually tries to invoke a nil func value.
+func TestInputAck_NilAckFuncReturnsAnErrorInsteadOfPanicking(t *testing.T) {
+	i := &input{component: fakeBatchInput{
+		readBatch: func(context.Context) (service.MessageBatch, service.AckFunc, error) {
+			return service.MessageBatch{service.NewMessage([]byte("hello"))}, nil, nil
+		},
+	}}
+
+	readResp, err := i.ReadBatch(t.Context(), &runtimepb.BatchInputReadRequest{})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		ackResp, err := i.Ack(t.Context(), &runtimepb.BatchInputAckRequest{BatchId: readResp.BatchId})
+		require.NoError(t, err)
+		assert.NotNil(t, ackResp.Error, "a nil AckFunc should produce an error response, not a panic")
+	})
+}


### PR DESCRIPTION
Fixes #4771

## What

`input.Ack` in the RPC (dynamic) plugin bridge (`public/plugin/go/rpcn/rpcn.go`) discarded the incoming `BatchInputAckRequest` entirely and unconditionally called `Close` on the whole component on every ack, instead of looking up and invoking the `AckFunc` `ReadBatch` had stored for that specific batch ID under `i.acks`. The host side (`internal/rpcplugin/input.go`) already sends the correct `BatchId`/`Error` on every ack — the plugin side just never routed to it.

Consequence: any input relying on the ack/nack outcome (e.g. completing or abandoning a message-queue receive depending on whether the downstream write succeeded) would have its whole component torn down on the very first ack it ever received.

## The fix

- `Ack` now does `i.acks.LoadAndDelete(req.BatchId)` to find and remove the correct `AckFunc` (atomic, and bounds the map instead of leaking entries forever), converts `req.Error` via `runtimepb.ProtoToError` (nil = ack, non-nil = nack), and invokes it. An unknown batch ID or a nil `AckFunc` now returns a clean error instead of silently misbehaving or panicking the plugin subprocess.
- `ReadBatch` had a related leak: if proto conversion of the batch failed, the `AckFunc` was stored under a `BatchId` the host would never receive and could therefore never ack. It's now settled immediately (best-effort) instead of being orphaned.

## Tests

Added `rpcn_test.go` (7 tests, none existed before for this file):
- Routes to the acked batch by ID, and via a real `ReadBatch` call (not a hand-rolled ID) — also proves the `LoadAndDelete` deletion semantics by acking the same batch twice.
- Propagates the nack error to the correct batch.
- Doesn't affect other outstanding batches.
- Returns an error for an unknown batch ID.
- Never closes the component (regression test for the original bug).
- Returns an error rather than panicking on a nil `AckFunc`.

Confirmed all 7 fail against the pre-fix code and pass against the fix (verified via `git stash`). `golangci-lint run` (pinned v2.10.1, repo config) reports 0 issues; `go test -race -shuffle=on` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)