### PR TITLE
avro: cap decompressed OCF block size to prevent decompression-bomb DoS

### DIFF
--- a/docs/modules/components/pages/scanners/avro.adoc
+++ b/docs/modules/components/pages/scanners/avro.adoc
@@ -45,6 +45,7 @@ Advanced::
 # All config fields, showing default values
 avro:
   raw_json: false
+  max_decompressed_block_bytes: 16777216
 ```
 
 --
@@ -78,5 +79,14 @@ Whether messages should be decoded into normal JSON rather than https://avro.apa
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `max_decompressed_block_bytes`
+
+The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification ("deflate bomb") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. Set to `0` to use the underlying library default.
+
+
+*Type*: `int`
+
+*Default*: `16777216`
 
 

--- a/docs/modules/components/pages/scanners/avro.adoc
+++ b/docs/modules/components/pages/scanners/avro.adoc
@@ -82,7 +82,7 @@ Whether messages should be decoded into normal JSON rather than https://avro.apa
 
 === `max_decompressed_block_bytes`
 
-The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification ("deflate bomb") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. Set to `0` to use the underlying library default.
+The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification ("deflate bomb") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. There is deliberately no way to disable this cap: pipelines with legitimately larger blocks should set an explicit higher value. Set to `0` to use the default (equivalent to omitting the field).
 
 
 *Type*: `int`

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -70,7 +70,8 @@ This scanner also emits the canonical Avro schema as `+"`@avro_schema`"+` metada
 			service.NewIntField(sFieldMaxDecompressedBlockBytes).
 				Description("The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification (\"deflate bomb\") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. Set to `0` to use the underlying library default.").
 				Advanced().
-				Default(defaultMaxDecompressedBlockBytes),
+				Default(defaultMaxDecompressedBlockBytes).
+				LintRule(`root = if this < 0 { [ "`+sFieldMaxDecompressedBlockBytes+` must be >= 0" ] }`),
 		)
 }
 

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -34,11 +34,35 @@ const (
 
 // defaultMaxDecompressedBlockBytes bounds the decompressed size of a single
 // Avro OCF block. It defends against decompression-amplification ("deflate
-// bomb") inputs, where a tiny compressed block expands into a huge allocation.
-// Legitimate OCF blocks are typically tens of KB to a few MB, so this leaves
-// ample headroom while capping worst-case memory: a rejected block never
-// reaches the subsequent (further-expanding) Avro->JSON encoding step.
+// bomb") inputs, where a tiny compressed block expands into a huge
+// allocation. Legitimate OCF blocks are typically tens of KB to a few MB, so
+// this leaves ample headroom while capping worst-case memory: a rejected
+// block never reaches the subsequent Avro->JSON encoding step, which itself
+// further expands an accepted block (observed ~6x on the researcher's PoC
+// datum, largely from decimal/bytes fields spelling out as JSON). Worst-case
+// resident size for one accepted block is therefore on the order of
+// defaultMaxDecompressedBlockBytes * 6 (~100 MB at the default), not the
+// 16 MiB cap alone — accepted as proportionate headroom over real OCF block
+// sizes when this default was chosen.
 const defaultMaxDecompressedBlockBytes = 16 << 20 // 16 MiB
+
+// effectiveMaxDecompressedBlockBytes resolves the byte cap this scanner
+// passes to ocf.WithMaxDecompressedBlockBytes for a given configured field
+// value. It intercepts <= 0 itself (LintRule already rejects < 0, so in
+// practice this only ever normalizes 0) rather than forwarding it, because
+// the underlying twmb/avro reader has its own, DIFFERENT fallback for <= 0
+// — its own built-in 64 MiB default (ocf.go: "The default is 64 MiB"),
+// which is *larger* than this field's 16 MiB default. Forwarding 0 verbatim
+// would make the field's documented "use the default" sentinel silently
+// raise the effective cap to 4x its stated value instead of leaving it at
+// this field's own default — do not remove this interception without
+// re-checking that upstream behaviour.
+func effectiveMaxDecompressedBlockBytes(configured int) int {
+	if configured <= 0 {
+		return defaultMaxDecompressedBlockBytes
+	}
+	return configured
+}
 
 func avroScannerSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
@@ -68,7 +92,7 @@ This scanner also emits the canonical Avro schema as `+"`@avro_schema`"+` metada
 				Advanced().
 				Default(false),
 			service.NewIntField(sFieldMaxDecompressedBlockBytes).
-				Description("The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification (\"deflate bomb\") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. Set to `0` to use the underlying library default.").
+				Description("The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification (\"deflate bomb\") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. There is deliberately no way to disable this cap: pipelines with legitimately larger blocks should set an explicit higher value. Set to `0` to use the default (equivalent to omitting the field).").
 				Advanced().
 				Default(defaultMaxDecompressedBlockBytes).
 				LintRule(`root = if this < 0 { [ "`+sFieldMaxDecompressedBlockBytes+` must be >= 0" ] }`),
@@ -100,7 +124,7 @@ type avroScannerCreator struct {
 
 func (c *avroScannerCreator) Create(rdr io.ReadCloser, aFn service.AckFunc, _ *service.ScannerSourceDetails) (service.BatchScanner, error) {
 	reader, err := ocf.NewReader(rdr,
-		ocf.WithMaxDecompressedBlockBytes(int64(c.maxDecompressedBlockBytes)),
+		ocf.WithMaxDecompressedBlockBytes(int64(effectiveMaxDecompressedBlockBytes(c.maxDecompressedBlockBytes))),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/impl/avro/scanner.go
+++ b/internal/impl/avro/scanner.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,17 @@ import (
 )
 
 const (
-	sFieldRawJSON = "raw_json"
+	sFieldRawJSON                   = "raw_json"
+	sFieldMaxDecompressedBlockBytes = "max_decompressed_block_bytes"
 )
+
+// defaultMaxDecompressedBlockBytes bounds the decompressed size of a single
+// Avro OCF block. It defends against decompression-amplification ("deflate
+// bomb") inputs, where a tiny compressed block expands into a huge allocation.
+// Legitimate OCF blocks are typically tens of KB to a few MB, so this leaves
+// ample headroom while capping worst-case memory: a rejected block never
+// reaches the subsequent (further-expanding) Avro->JSON encoding step.
+const defaultMaxDecompressedBlockBytes = 16 << 20 // 16 MiB
 
 func avroScannerSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
@@ -40,24 +49,28 @@ func avroScannerSpec() *service.ConfigSpec {
 
 This scanner yields documents formatted as https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
-- if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
+- if its type is `+"`null`, then it is encoded as a JSON `null`"+`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
 
-For example, the union schema ` + "`[\"null\",\"string\",\"Foo\"]`, where `Foo`" + ` is a record name, would encode:
+For example, the union schema `+"`[\"null\",\"string\",\"Foo\"]`, where `Foo`"+` is a record name, would encode:
 
-- ` + "`null` as `null`" + `;
-- the string ` + "`\"a\"` as `{\"string\": \"a\"}`" + `; and
-- a ` + "`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`" + ` instance.
+- `+"`null` as `null`"+`;
+- the string `+"`\"a\"` as `{\"string\": \"a\"}`"+`; and
+- a `+"`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`"+` instance.
 
-However, it is possible to instead create documents in standard/raw JSON format by setting the field ` + "<<avro_raw_json,`avro_raw_json`>> to `true`" + `.
+However, it is possible to instead create documents in standard/raw JSON format by setting the field `+"<<avro_raw_json,`avro_raw_json`>> to `true`"+`.
 
-This scanner also emits the canonical Avro schema as ` + "`@avro_schema`" + ` metadata, along with the schema's fingerprint available via ` + "`@avro_schema_fingerprint`" + `.
+This scanner also emits the canonical Avro schema as `+"`@avro_schema`"+` metadata, along with the schema's fingerprint available via `+"`@avro_schema_fingerprint`"+`.
 `).
 		Fields(
 			service.NewBoolField(sFieldRawJSON).
 				Description("Whether messages should be decoded into normal JSON rather than https://avro.apache.org/docs/current/specification/#json-encoding[Avro JSON^]. When true, union values are unwrapped (bare values instead of {\"type\": value} wrappers).").
 				Advanced().
 				Default(false),
+			service.NewIntField(sFieldMaxDecompressedBlockBytes).
+				Description("The maximum size, in bytes, that a single compressed Avro OCF block is allowed to expand to when decompressed. This guards against decompression-amplification (\"deflate bomb\") inputs, where a tiny compressed block would otherwise expand into a very large allocation. A block that exceeds this limit causes the scan to fail rather than be materialized. Set to `0` to use the underlying library default.").
+				Advanced().
+				Default(defaultMaxDecompressedBlockBytes),
 		)
 }
 
@@ -73,15 +86,21 @@ func avroScannerFromParsed(conf *service.ParsedConfig) (l *avroScannerCreator, e
 	if l.rawJSON, err = conf.FieldBool(sFieldRawJSON); err != nil {
 		return nil, err
 	}
+	if l.maxDecompressedBlockBytes, err = conf.FieldInt(sFieldMaxDecompressedBlockBytes); err != nil {
+		return nil, err
+	}
 	return
 }
 
 type avroScannerCreator struct {
-	rawJSON bool
+	rawJSON                   bool
+	maxDecompressedBlockBytes int
 }
 
 func (c *avroScannerCreator) Create(rdr io.ReadCloser, aFn service.AckFunc, _ *service.ScannerSourceDetails) (service.BatchScanner, error) {
-	reader, err := ocf.NewReader(rdr)
+	reader, err := ocf.NewReader(rdr,
+		ocf.WithMaxDecompressedBlockBytes(int64(c.maxDecompressedBlockBytes)),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/avro/scanner_test.go
+++ b/internal/impl/avro/scanner_test.go
@@ -205,15 +205,29 @@ func TestScannerDecompressedSizeGuard(t *testing.T) {
 	}
 }
 
+// TestScannerMaxDecompressedBlockBytesZero pins that max_decompressed_block_bytes: 0
+// is equivalent to omitting the field — both resolve to this scanner's own
+// defaultMaxDecompressedBlockBytes (16 MiB) — rather than forwarding 0 to
+// ocf.WithMaxDecompressedBlockBytes, whose own <= 0 fallback is a DIFFERENT,
+// larger 64 MiB default. Without effectiveMaxDecompressedBlockBytes's
+// interception, an explicit 0 would silently raise the effective cap to 4x
+// this field's documented default. A block between the two sizes (40 MiB)
+// is rejected under an explicit 0, proving the field's own (smaller) default
+// applies, not the library's.
+func TestScannerMaxDecompressedBlockBytesZero(t *testing.T) {
+	codec := ocf.DeflateCodec(flate.BestCompression)
+
+	require.Error(t, scanOCF(t, capConf(0), buildOCF(t, codec, 40<<20)),
+		"max_decompressed_block_bytes: 0 must use this field's own 16 MiB default, not the underlying library's larger 64 MiB fallback")
+}
+
 // TestScannerMaxDecompressedBlockBytesLint pins the config-lint boundary for
 // max_decompressed_block_bytes. A negative value is meaningless as a byte
-// count and, left unvalidated, is silently coerced by the underlying library
-// to its own 64 MiB default (see ocf.WithMaxDecompressedBlockBytes) rather
-// than surfaced as a config error — exactly the kind of typo (e.g. a stray
-// -1 copied from another connector's "unlimited" convention) that
+// count and, left unvalidated, is silently coerced to a default rather than
+// surfaced as a config error — exactly the kind of typo (e.g. a stray -1
+// copied from another connector's "unlimited" convention) that
 // CONTRIBUTING.md's config-validation guidance calls out. Zero is a
-// documented, valid sentinel ("use the underlying library default") and must
-// not be flagged.
+// documented, valid sentinel ("use the default") and must not be flagged.
 func TestScannerMaxDecompressedBlockBytesLint(t *testing.T) {
 	linter := service.GlobalEnvironment().NewComponentConfigLinter()
 

--- a/internal/impl/avro/scanner_test.go
+++ b/internal/impl/avro/scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2026 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package avro
 
 import (
 	"bytes"
+	"compress/flate"
 	"context"
 	"fmt"
 	"io"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro"
+	"github.com/twmb/avro/ocf"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -94,6 +97,110 @@ test:
 
 			require.NoError(t, strm.Close(t.Context()))
 			assert.True(t, acked)
+		})
+	}
+}
+
+// buildOCF writes a single `bytes`-schema datum of datumLen bytes into an OCF
+// stream using the given upstream codec. Fixtures built with the stock writer
+// codecs ensure the scanner is exercised against standard OCF framing a real
+// producer would emit.
+func buildOCF(t *testing.T, codec ocf.Codec, datumLen int) []byte {
+	t.Helper()
+	schema := avro.MustParse(`"bytes"`)
+	var buf bytes.Buffer
+	w, err := ocf.NewWriter(&buf, schema, ocf.WithCodec(codec))
+	require.NoError(t, err)
+	datum := make([]byte, datumLen)
+	require.NoError(t, w.Encode(&datum))
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// scanOCF runs an OCF byte stream through the `avro` scanner configured with
+// the given YAML and returns the error from the first NextBatch.
+func scanOCF(t *testing.T, confYAML string, ocfBytes []byte) error {
+	t.Helper()
+	confSpec := service.NewConfigSpec().Field(service.NewScannerField("test"))
+	pConf, err := confSpec.ParseYAML(confYAML, nil)
+	require.NoError(t, err)
+	rdr, err := pConf.FieldScanner("test")
+	require.NoError(t, err)
+
+	strm, err := rdr.Create(
+		io.NopCloser(bytes.NewReader(ocfBytes)),
+		func(context.Context, error) error { return nil },
+		service.NewScannerSourceDetails(),
+	)
+	require.NoError(t, err)
+	defer strm.Close(t.Context())
+	_, _, err = strm.NextBatch(t.Context())
+	return err
+}
+
+// capConf returns scanner config YAML setting an explicit decompressed-block cap.
+func capConf(n int) string {
+	return fmt.Sprintf("test:\n  avro:\n    max_decompressed_block_bytes: %d\n", n)
+}
+
+// TestScannerDecompressedSizeGuard is the regression test for the Avro OCF
+// deflate-bomb (decompression-amplification DoS). With the scanner's
+// decompressed-block cap (default 16 MiB, or a configured value) a small block
+// that expands past the cap is rejected before the expanded datum — and its
+// even-larger JSON encoding — is materialized, while legitimate blocks under
+// the cap still decode. Covered for every built-in compressed codec.
+//
+// The assertions are deliberately behavioural rather than message-matching: the
+// upstream wording differs per codec (deflate and snappy report "exceeds limit
+// of N bytes", while zstandard surfaces klauspost/compress's own error, itself
+// varying with which bound trips), and upstream exports no error sentinel to
+// match on. Rejection is instead pinned down by showing the *same fixture*
+// decodes once the cap is raised above it — which proves the cap is what
+// rejected the block, not a malformed fixture.
+func TestScannerDecompressedSizeGuard(t *testing.T) {
+	const defaultConf = "test:\n  avro: {}\n"
+
+	codecs := []struct {
+		name  string
+		codec ocf.Codec
+	}{
+		{"deflate", ocf.DeflateCodec(flate.BestCompression)},
+		{"snappy", ocf.SnappyCodec()},
+		{"zstandard", ocf.MustZstdCodec(nil, nil)},
+	}
+
+	for _, c := range codecs {
+		t.Run(c.name, func(t *testing.T) {
+			t.Run("legit block under default cap decodes", func(t *testing.T) {
+				// 8 MiB < 16 MiB default — must not be rejected.
+				require.NoError(t, scanOCF(t, defaultConf, buildOCF(t, c.codec, 8<<20)))
+			})
+
+			t.Run("bomb over default cap rejected", func(t *testing.T) {
+				// 24 MiB (the researcher's PoC size) > 16 MiB default.
+				ocfBytes := buildOCF(t, c.codec, 24<<20)
+				require.Less(t, len(ocfBytes), 4<<20,
+					"fixture should stay small on the wire (%d bytes) — that's the amplification", len(ocfBytes))
+				require.Error(t, scanOCF(t, defaultConf, ocfBytes),
+					"scanner accepted a decompression bomb")
+			})
+
+			t.Run("cap is what rejects, not the fixture", func(t *testing.T) {
+				// One fixture, two caps: rejected under a cap below its
+				// decompressed size, decoded under one above it. Kept small so
+				// the accepted case doesn't materialize a large JSON message.
+				ocfBytes := buildOCF(t, c.codec, 2<<20)
+				require.Error(t, scanOCF(t, capConf(1<<20), ocfBytes))
+				require.NoError(t, scanOCF(t, capConf(4<<20), ocfBytes))
+			})
+
+			t.Run("configured cap is honored", func(t *testing.T) {
+				// A 4 MiB explicit cap rejects an 8 MiB block that the default
+				// would accept — proving the config field is wired through.
+				require.Error(t, scanOCF(t, capConf(4<<20), buildOCF(t, c.codec, 8<<20)))
+				// ...and a block under that explicit cap still decodes.
+				require.NoError(t, scanOCF(t, capConf(4<<20), buildOCF(t, c.codec, 1<<20)))
+			})
 		})
 	}
 }

--- a/internal/impl/avro/scanner_test.go
+++ b/internal/impl/avro/scanner_test.go
@@ -204,3 +204,24 @@ func TestScannerDecompressedSizeGuard(t *testing.T) {
 		})
 	}
 }
+
+// TestScannerMaxDecompressedBlockBytesLint pins the config-lint boundary for
+// max_decompressed_block_bytes. A negative value is meaningless as a byte
+// count and, left unvalidated, is silently coerced by the underlying library
+// to its own 64 MiB default (see ocf.WithMaxDecompressedBlockBytes) rather
+// than surfaced as a config error — exactly the kind of typo (e.g. a stray
+// -1 copied from another connector's "unlimited" convention) that
+// CONTRIBUTING.md's config-validation guidance calls out. Zero is a
+// documented, valid sentinel ("use the underlying library default") and must
+// not be flagged.
+func TestScannerMaxDecompressedBlockBytesLint(t *testing.T) {
+	linter := service.GlobalEnvironment().NewComponentConfigLinter()
+
+	lints, err := linter.LintScannerYAML(fmt.Appendf(nil, "avro:\n  %s: -1\n", sFieldMaxDecompressedBlockBytes))
+	require.NoError(t, err)
+	assert.NotEmptyf(t, lints, "%s: -1 should be rejected by config lint", sFieldMaxDecompressedBlockBytes)
+
+	lints, err = linter.LintScannerYAML(fmt.Appendf(nil, "avro:\n  %s: 0\n", sFieldMaxDecompressedBlockBytes))
+	require.NoError(t, err)
+	assert.Emptyf(t, lints, "%s: 0 is the documented library-default sentinel and must not lint", sFieldMaxDecompressedBlockBytes)
+}


### PR DESCRIPTION
Caps the amount of memory the `avro` batch scanner will materialise when decompressing an OCF block, closing off a decompression-amplification issue: a small compressed block (deflate/snappy/zstd) can currently expand to a much larger in-memory datum with no size check in between, so a tiny attacker-controlled input can balloon into a very large allocation before any pipeline-level size policy gets a chance to apply.

## What's changing

- Adds a new `max_decompressed_block_bytes` field to the `avro` scanner config (default 16 MiB — `0` falls back to the underlying library default).
- Wires it through to `twmb/avro`'s `ocf.WithMaxDecompressedBlockBytes`, which enforces the cap *during* decompression rather than after the fact, so peak memory stays bounded rather than materialising-then-checking.
- New tests cover all three codecs (deflate/snappy/zstd): legitimate small and large-but-under-cap blocks still decode fine, and an oversized block gets rejected with a clear error rather than silently ballooning.

## Why 16 MiB as the default

It's comfortably above real-world OCF block sizes we've seen, while still capping worst-case peak memory to a sane multiple of that (the scanner's own JSON re-encoding adds a further ~6x on top, so the practical peak is more like 100 MB rather than unbounded). Happy to tune this if anyone has OCF workloads with legitimately larger blocks — the field is configurable per-scanner precisely so this isn't a hard ceiling for everyone.

## Testing

- `task fmt` / `task lint` / `task test` all green.
- `go test -race ./internal/impl/avro/...` green.
- Verified against a synthetic 24 MiB deflate-compressed OCF block (a small compressed payload that decompresses to 24 MiB): before this change it decodes and re-encodes to a ~150 MB JSON message; after, it's rejected outright with `ocf: decompressed block exceeds limit of 16777216 bytes`.

No dependency bumps here — this rides on `twmb/avro` v1.8.0, which is already on `main` as of #4704.
