### PR TITLE
migrator: update tests to accommodate new behaviour change in franz-go kadm

### DIFF
--- a/internal/impl/redpanda/migrator/integration_helpers_test.go
+++ b/internal/impl/redpanda/migrator/integration_helpers_test.go
@@ -331,7 +331,7 @@ func consume(cluster EmbeddedRedpandaCluster, topic, group string, numMessages i
 
 // ListTopics lists all topics.
 func (e *EmbeddedRedpandaCluster) ListTopics() []string {
-	metadata, err := e.Admin.Metadata(e.t.Context())
+	metadata, err := e.Admin.Metadata(kadm.WithAuthorizedOps(e.t.Context()))
 	require.NoError(e.t, err)
 
 	topics := make([]string, 0, len(metadata.Topics))

--- a/internal/impl/redpanda/migrator/migrator_groups_integration_test.go
+++ b/internal/impl/redpanda/migrator/migrator_groups_integration_test.go
@@ -78,6 +78,11 @@ func TestIntegrationListGroupOffsets(t *testing.T) {
 		defer cancel()
 		offsets, err := gm.ListGroupOffsets(ctx, topics)
 		require.NoError(t, err)
+
+		// TopicID populated by broker and is not deterministic so it's excluded from comparison.
+		for i := range offsets {
+			offsets[i].TopicID = kadm.TopicID{}
+		}
 		return offsets
 	}
 


### PR DESCRIPTION
A recent franz-go kadm v1.18.0 bump introduced two behaviour changes that impacted our tests.

1. Added a `TopicID` field to `kadm.Offset` (now populated from real broker responses). So had to update the test to zero this out as `assert.ElementsMatch` does full struct equality.
2. Metadata()'s "list all topics" path uses a client-side cache which was causing the test to fail as newly-created topics were invisible to the test for up to 5s. `WithAuthorizedOps` forces the direct, uncached broker request (so a bit of a workaround for the integration test, but feels better than waiting for the cache to expire).

### Proof of Work

Before:

<img width="1291" height="526" alt="image" src="https://github.com/user-attachments/assets/b5ce84a6-020b-477b-b6ac-736bcd540175" />

After:

<img width="1425" height="530" alt="image" src="https://github.com/user-attachments/assets/39ac1f01-3f1e-49d0-acf3-9dc1a6223e83" />