### PR TITLE
sftp: advance to the next file without a reconnect

### DIFF
--- a/internal/impl/sftp/input.go
+++ b/internal/impl/sftp/input.go
@@ -309,43 +309,60 @@ func (s *sftpReader) Close(ctx context.Context) error {
 	return nil
 }
 
+// tryReadBatch reads the next batch from the current file. When the current
+// file is done it opens the next file and continues, so that a file boundary
+// is never reported to the caller as a lost connection. It returns
+// service.ErrEndOfInput when the path provider has no more files.
 func (s *sftpReader) tryReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
-	scanner, err := s.initScanner(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
+	for {
+		// A shutdown must interrupt the rotation between files.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 
-	parts, codecAckFn, err := scanner.NextBatch(ctx)
-	if err != nil {
+		scanner, err := s.initScanner(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		parts, codecAckFn, err := scanner.NextBatch(ctx)
+		if err == nil {
+			for _, part := range parts {
+				part.MetaSetMut("sftp_path", s.currentFileInfo.path)
+				part.MetaSetMut("sftp_mod_time", s.currentFileInfo.modTime)
+			}
+			return parts, codecAckFn, nil
+		}
+
 		if ctx.Err() != nil {
 			return nil, nil, ctx.Err()
 		}
-		s.stateLock.Lock()
-		scanner = s.scanner
-		s.stateLock.Unlock()
-
-		if scanner != nil {
-			if err := scanner.Close(ctx); err != nil {
-				s.log.With("error", err).Error("Failed to close scanner")
-			}
-
-			s.stateLock.Lock()
-			s.scanner = nil
-			s.stateLock.Unlock()
-		}
+		s.closeScanner(ctx)
 
 		if errors.Is(err, io.EOF) {
-			err = service.ErrNotConnected
+			// The current file is done. Move on to the next file.
+			continue
 		}
 		return nil, nil, err
 	}
+}
 
-	for _, part := range parts {
-		part.MetaSetMut("sftp_path", s.currentFileInfo.path)
-		part.MetaSetMut("sftp_mod_time", s.currentFileInfo.modTime)
+// closeScanner closes the current file scanner, if any, and clears it.
+func (s *sftpReader) closeScanner(ctx context.Context) {
+	s.stateLock.Lock()
+	scanner := s.scanner
+	s.stateLock.Unlock()
+
+	if scanner == nil {
+		return
+	}
+	if err := scanner.Close(ctx); err != nil {
+		s.log.With("error", err).Error("Failed to close scanner")
 	}
 
-	return parts, codecAckFn, nil
+	s.stateLock.Lock()
+	s.scanner = nil
+	s.stateLock.Unlock()
 }
 
 type sftpFile struct {

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -316,6 +316,221 @@ func writeSFTPFile(t *testing.T, client *sftp.Client, path, data string) {
 	file, err := client.Create(path)
 	require.NoError(t, err, "creating file")
 	defer file.Close()
-	_, err = fmt.Fprint(file, data, "writing file contents")
+	_, err = fmt.Fprint(file, data)
+	require.NoError(t, err, "writing file contents")
+}
+
+// readSFTPInput builds an sftp input for the emulator and connects it.
+func readSFTPInput(t *testing.T, emu emulator, path, scanner string, watcher bool) *sftpReader {
+	t.Helper()
+	conf := fmt.Sprintf(`
+address: %s
+paths:
+  - %s
+credentials:
+  username: %s
+  password: %s
+  host_public_key: %s
+scanner:
+  %s: {}
+watcher:
+  enabled: %t
+  minimum_age: 0s
+  poll_interval: 100ms
+  cache: files_memory
+`, emu.address, path, sftpUsername, sftpPassword, emu.hostKey, scanner, watcher)
+
+	parsed, err := sftpInputSpec().ParseYAML(conf, nil)
 	require.NoError(t, err)
+
+	reader, err := newSFTPReaderFromParsed(parsed, service.MockResources(service.MockResourcesOptAddCache("files_memory")))
+	require.NoError(t, err)
+	require.NoError(t, reader.Connect(t.Context()))
+	t.Cleanup(func() { require.NoError(t, reader.Close(context.Background())) })
+	return reader
+}
+
+// readOneFile reads one batch and fails the test if the input reports a lost
+// connection. A file boundary is not a lost connection.
+func readOneFile(t *testing.T, ctx context.Context, reader *sftpReader) string {
+	t.Helper()
+	batch, ackFn, err := reader.ReadBatch(ctx)
+	require.NotErrorIs(t, err, service.ErrNotConnected, "file boundary must not be reported as a lost connection")
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	content, err := batch[0].AsBytes()
+	require.NoError(t, err)
+	require.NoError(t, ackFn(ctx, nil))
+	return string(content)
+}
+
+func TestIntegrationSFTPReadBatchRotatesFiles(t *testing.T) {
+	integration.CheckSkip(t)
+
+	emu := runEmulator(t)
+	require.NoError(t, emu.client.MkdirAll("/upload"))
+
+	t.Run("static paths", func(t *testing.T) {
+		dir := "/upload/static"
+		require.NoError(t, emu.client.MkdirAll(dir))
+		writeSFTPFile(t, emu.client, dir+"/1.txt", "data-1")
+		writeSFTPFile(t, emu.client, dir+"/2.txt", "data-2")
+		writeSFTPFile(t, emu.client, dir+"/3.txt", "data-3")
+
+		reader := readSFTPInput(t, emu, dir+"/*.txt", "to_the_end", false)
+		ctx := t.Context()
+
+		// A cancelled context must stop the rotation before a file is opened.
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		_, _, err := reader.ReadBatch(cancelledCtx)
+		require.ErrorIs(t, err, context.Canceled)
+
+		var contents []string
+		for range 3 {
+			contents = append(contents, readOneFile(t, ctx, reader))
+		}
+		// The SFTP server does not sort glob results, so only the set is checked.
+		assert.ElementsMatch(t, []string{"data-1", "data-2", "data-3"}, contents)
+
+		_, _, err = reader.ReadBatch(ctx)
+		require.ErrorIs(t, err, service.ErrEndOfInput)
+	})
+
+	t.Run("empty files", func(t *testing.T) {
+		// With the lines scanner an empty file yields EOF at once. The reader
+		// must skip it inside one ReadBatch call, and an empty last file must
+		// end the input instead of returning an empty batch.
+		dir := "/upload/empty"
+		require.NoError(t, emu.client.MkdirAll(dir))
+		writeSFTPFile(t, emu.client, dir+"/1.txt", "data-1\n")
+		writeSFTPFile(t, emu.client, dir+"/2.txt", "")
+		writeSFTPFile(t, emu.client, dir+"/3.txt", "data-3\n")
+		writeSFTPFile(t, emu.client, dir+"/4.txt", "")
+
+		// Fix the order so the empty files sit where the test expects.
+		// Needed because we want to test that the reader skips empty files, so the order matters.
+		reader := readSFTPInput(t, emu, dir+"/*.txt", "lines", false)
+		reader.pathProvider = &staticPathProvider{expandedPaths: []string{
+			dir + "/1.txt", dir + "/2.txt", dir + "/3.txt", dir + "/4.txt",
+		}}
+		ctx := t.Context()
+
+		var contents []string
+		for {
+			batch, ackFn, err := reader.ReadBatch(ctx)
+			if errors.Is(err, service.ErrEndOfInput) {
+				break
+			}
+			require.NotErrorIs(t, err, service.ErrNotConnected)
+			require.NoError(t, err)
+			require.NotEmpty(t, batch, "ReadBatch must not return an empty batch")
+			for _, msg := range batch {
+				content, err := msg.AsBytes()
+				require.NoError(t, err)
+				contents = append(contents, string(content))
+			}
+			require.NoError(t, ackFn(ctx, nil))
+		}
+		assert.Equal(t, []string{"data-1", "data-3"}, contents)
+	})
+
+	t.Run("cancel mid rotation", func(t *testing.T) {
+		// A shutdown while the reader works through a run of empty files
+		// must stop the rotation at once, not drain the remaining files.
+		dir := "/upload/cancel"
+		require.NoError(t, emu.client.MkdirAll(dir))
+		writeSFTPFile(t, emu.client, dir+"/empty.txt", "")
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		const (
+			totalFiles   = 10
+			cancelAtFile = 3
+		)
+		provider := &countingPathProvider{path: dir + "/empty.txt", total: totalFiles}
+		provider.onNext = func(calls int) {
+			if calls == cancelAtFile {
+				cancel()
+			}
+		}
+
+		reader := readSFTPInput(t, emu, dir+"/*.txt", "lines", false)
+		reader.pathProvider = provider
+
+		_, _, err := reader.ReadBatch(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, cancelAtFile, provider.calls)
+	})
+
+	t.Run("watcher", func(t *testing.T) {
+		dir := "/upload/watcher"
+		require.NoError(t, emu.client.MkdirAll(dir))
+		writeSFTPFile(t, emu.client, dir+"/1.txt", "data-1")
+		writeSFTPFile(t, emu.client, dir+"/2.txt", "data-2")
+
+		reader := readSFTPInput(t, emu, dir+"/*.txt", "to_the_end", true)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var contents []string
+		for range 2 {
+			contents = append(contents, readOneFile(t, ctx, reader))
+		}
+		assert.ElementsMatch(t, []string{"data-1", "data-2"}, contents)
+
+		// The watcher waits for a new file. It must not end the input.
+		results := make(chan string, 1)
+		go func() { results <- readOneFile(t, ctx, reader) }()
+		select {
+		case content := <-results:
+			t.Fatalf("watcher returned %q before a new file was written", content)
+		case <-time.After(500 * time.Millisecond):
+		}
+
+		writeSFTPFile(t, emu.client, dir+"/3.txt", "data-3")
+		select {
+		case content := <-results:
+			assert.Equal(t, "data-3", content)
+		case <-time.After(5 * time.Second):
+			t.Fatal("watcher did not pick up the new file")
+		}
+
+		// A shutdown must unblock the waiting watcher.
+		errs := make(chan error, 1)
+		go func() {
+			_, _, err := reader.ReadBatch(ctx)
+			errs <- err
+		}()
+		cancel()
+		select {
+		case err := <-errs:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("watcher did not stop on context cancel")
+		}
+	})
+}
+
+// countingPathProvider returns the same path a fixed number of times and
+// counts the calls. It caps the run so a test cannot loop for ever.
+type countingPathProvider struct {
+	path   string
+	total  int
+	calls  int
+	onNext func(calls int)
+}
+
+func (c *countingPathProvider) Next(context.Context) (string, bool, error) {
+	if c.calls >= c.total {
+		return "", false, nil
+	}
+	c.calls++
+	c.onNext(c.calls)
+	return c.path, true, nil
+}
+
+func (*countingPathProvider) Ack(context.Context, string, error) error {
+	return nil
 }

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -350,18 +350,34 @@ watcher:
 	return reader
 }
 
-// readOneFile reads one batch and fails the test if the input reports a lost
-// connection. A file boundary is not a lost connection.
-func readOneFile(t *testing.T, ctx context.Context, reader *sftpReader) string {
-	t.Helper()
+// readOneFile reads one batch of exactly one message and acks it.
+// It has no testing.T, so it is safe to be called from the application code/goroutine.
+// Assert on the result from the test goroutine, or use mustReadOneFile.
+func readOneFile(ctx context.Context, reader *sftpReader) (string, error) {
 	batch, ackFn, err := reader.ReadBatch(ctx)
-	require.NotErrorIs(t, err, service.ErrNotConnected, "file boundary must not be reported as a lost connection")
-	require.NoError(t, err)
-	require.Len(t, batch, 1)
+	if err != nil {
+		return "", err
+	}
+	if len(batch) != 1 {
+		return "", fmt.Errorf("expected a batch of 1 message, got %d", len(batch))
+	}
 	content, err := batch[0].AsBytes()
-	require.NoError(t, err)
-	require.NoError(t, ackFn(ctx, nil))
-	return string(content)
+	if err != nil {
+		return "", err
+	}
+	if err := ackFn(ctx, nil); err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+// mustReadOneFile reads one file on the test goroutine and fails the test on
+// any error.
+func mustReadOneFile(t *testing.T, ctx context.Context, reader *sftpReader) string {
+	t.Helper()
+	content, err := readOneFile(ctx, reader)
+	require.NoError(t, err, "file boundary must not be reported as a lost connection")
+	return content
 }
 
 func TestIntegrationSFTPReadBatchRotatesFiles(t *testing.T) {
@@ -388,7 +404,7 @@ func TestIntegrationSFTPReadBatchRotatesFiles(t *testing.T) {
 
 		var contents []string
 		for range 3 {
-			contents = append(contents, readOneFile(t, ctx, reader))
+			contents = append(contents, mustReadOneFile(t, ctx, reader))
 		}
 		// The SFTP server does not sort glob results, so only the set is checked.
 		assert.ElementsMatch(t, []string{"data-1", "data-2", "data-3"}, contents)
@@ -476,23 +492,31 @@ func TestIntegrationSFTPReadBatchRotatesFiles(t *testing.T) {
 
 		var contents []string
 		for range 2 {
-			contents = append(contents, readOneFile(t, ctx, reader))
+			contents = append(contents, mustReadOneFile(t, ctx, reader))
 		}
 		assert.ElementsMatch(t, []string{"data-1", "data-2"}, contents)
 
 		// The watcher waits for a new file. It must not end the input.
-		results := make(chan string, 1)
-		go func() { results <- readOneFile(t, ctx, reader) }()
+		type readResult struct {
+			content string
+			err     error
+		}
+		results := make(chan readResult, 1)
+		go func() {
+			content, err := readOneFile(ctx, reader)
+			results <- readResult{content: content, err: err}
+		}()
 		select {
-		case content := <-results:
-			t.Fatalf("watcher returned %q before a new file was written", content)
+		case res := <-results:
+			t.Fatalf("watcher returned (%q, %v) before a new file was written", res.content, res.err)
 		case <-time.After(500 * time.Millisecond):
 		}
 
 		writeSFTPFile(t, emu.client, dir+"/3.txt", "data-3")
 		select {
-		case content := <-results:
-			assert.Equal(t, "data-3", content)
+		case res := <-results:
+			require.NoError(t, res.err, "file boundary must not be reported as a lost connection")
+			assert.Equal(t, "data-3", res.content)
 		case <-time.After(5 * time.Second):
 			t.Fatal("watcher did not pick up the new file")
 		}

--- a/internal/impl/sftp/integration_test.go
+++ b/internal/impl/sftp/integration_test.go
@@ -311,13 +311,18 @@ func runEmulator(t *testing.T) emulator {
 	}
 }
 
+// writeSFTPFile writes data to a temporary name and then renames it into place.
+// The file appears atomically at its full size, so a watcher poll can never
+// observe a partially written file.
 func writeSFTPFile(t *testing.T, client *sftp.Client, path, data string) {
 	t.Helper()
-	file, err := client.Create(path)
+	tmpPath := path + ".tmp"
+	file, err := client.Create(tmpPath)
 	require.NoError(t, err, "creating file")
-	defer file.Close()
 	_, err = fmt.Fprint(file, data)
 	require.NoError(t, err, "writing file contents")
+	require.NoError(t, file.Close(), "closing file")
+	require.NoError(t, client.Rename(tmpPath, path), "renaming file into place")
 }
 
 // readSFTPInput builds an sftp input for the emulator and connects it.


### PR DESCRIPTION
**The problem**

The sftp input returned `service.ErrNotConnected` when the current file reached `EOF`, to make the `AsyncReader` call `ReadBatch` again and open the next file (although no connection was actually lost).

Benthos adds a fixed wait before each reconnect (ticket VM-74, PR redpanda-data/benthos#496). With that change, the input would pay the wait once per file.

**The solution**

Move the file rotation into `tryReadBatch`. On `EOF` the reader closes the current scanner and opens the next file in the same call. It returns `service.ErrEndOfInput` only when the path provider has no more files. The watcher provider still blocks in `Next` until a new file appears or the context is cancelled.

The rotation loop checks the context at the top of each iteration so that a shutdown stops the input before it opens the next file. This was handled by the `AsyncReader` before, but now it's done directly in the reader.

Real connection loss still returns `service.ErrNotConnected`.

This mirrors the csv input fix in benthos (redpanda-data/benthos#497).