### PR TITLE
postgres_cdc: support incremental snapshot

### DIFF
--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -100,6 +100,13 @@ input:
       role_external_id: "" # No default (optional)
       roles: [] # No default (optional)
     signal_table_name: ""
+    incremental_snapshot:
+      enabled: false
+      tables: [] # No default (optional)
+      chunk_size: 1024
+      heartbeat_interval: 1s
+      checkpoint_cache: "" # No default (optional)
+      checkpoint_cache_key: postgres_cdc_incremental_snapshot
     auto_replay_nacks: true
     batching:
       count: 0
@@ -270,7 +277,9 @@ pg_wal_monitor_interval: 6s
 
 === `max_parallel_snapshot_tables`
 
-Int specifies a number of tables that will be processed in parallel during the snapshot processing stage
+Int specifies a number of tables that will be processed in parallel during the snapshot processing stage.
+
+Applies to the `stream_snapshot` snapshot only.
 
 
 *Type*: `int`
@@ -295,6 +304,8 @@ unchanged_toast_value: __redpanda_connect_unchanged_toast_value__
 === `heartbeat_interval`
 
 The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.
+
+Heartbeats also pace `incremental_snapshot`: on a quiet table they are the only thing advancing the snapshot. This interval just keeps the slot current, so `incremental_snapshot.heartbeat_interval` applies alongside it and the more frequent wins for the life of the input. A non-zero value is still required here.
 
 
 *Type*: `string`
@@ -617,6 +628,76 @@ INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message"
 
 signal_table_name: rpcn_signal_table
 ```
+
+=== `incremental_snapshot`
+
+Configures chunked snapshotting that runs alongside replication streaming.
+
+
+*Type*: `object`
+
+
+=== `incremental_snapshot.enabled`
+
+Snapshots the configured tables in chunks, starting as soon as replication begins. Unlike `stream_snapshot` it needs no up-front snapshot phase, does not delay replication. The two are mutually exclusive: both read the same rows, so enabling either alongside the other would deliver everything twice.
+
+Progress is driven by the replication stream: each streamed transaction releases a buffered chunk, and several more follow immediately if the database was idle during the read. Quiet tables therefore advance in bursts on each heartbeat, paced by `heartbeat_interval`.
+
+A row can arrive twice, once from replication and once from the backfill: when a primary key reuses or fills a gap below the table's current maximum, or -- whatever the key type -- when a row is inserted after replication starts but before the snapshot reaches its table. Treat rows as idempotent upserts keyed by primary key, as is standard CDC practice.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `incremental_snapshot.tables`
+
+The tables to incrementally snapshot. If omitted, the tables configured in `tables` are used instead, so at least one of the two must be set. Each entry must be replicated, so it must appear in `tables` unless that list is empty, which replicates everything.
+
+Only read when a snapshot starts from scratch. Once a checkpoint exists the table set comes from it, so edits here are silently ignored: added tables are not backfilled, and removed tables still are. Change `checkpoint_cache_key`, or clear the existing key, to pick up an edited list.
+
+
+*Type*: `array`
+
+
+=== `incremental_snapshot.chunk_size`
+
+The number of rows to read per chunk while incrementally snapshotting a table.
+
+
+*Type*: `int`
+
+*Default*: `1024`
+
+=== `incremental_snapshot.heartbeat_interval`
+
+How often to heartbeat while `enabled` is `true`. The snapshot only advances on a streamed transaction, so on quiet tables this paces it. Raise it to reduce write load at the cost of a slower backfill.
+
+Whichever of this and the top-level `heartbeat_interval` is more frequent wins, and applies for the life of the input -- it is fixed at startup, not reverted when the backfill completes. Heartbeats are transactional while this is enabled, so each consumes a transaction id.
+
+
+*Type*: `string`
+
+*Default*: `"1s"`
+
+=== `incremental_snapshot.checkpoint_cache`
+
+A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] storing the snapshot's progress, so a restart resumes instead of starting over. Required when `enabled` is `true`.
+
+
+*Type*: `string`
+
+
+=== `incremental_snapshot.checkpoint_cache_key`
+
+The key used to store the incremental snapshot progress in `checkpoint_cache`. Use a different key if multiple incremental snapshots share the same cache.
+
+Changing or clearing this key starts a fresh snapshot of the configured tables -- currently the only way to re-run a backfill.
+
+
+*Type*: `string`
+
+*Default*: `"postgres_cdc_incremental_snapshot"`
 
 === `auto_replay_nacks`
 

--- a/docs/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/docs/modules/components/pages/inputs/postgres_cdc.adoc
@@ -654,7 +654,7 @@ A row can arrive twice, once from replication and once from the backfill: when a
 
 The tables to incrementally snapshot. If omitted, the tables configured in `tables` are used instead, so at least one of the two must be set. Each entry must be replicated, so it must appear in `tables` unless that list is empty, which replicates everything.
 
-Only read when a snapshot starts from scratch. Once a checkpoint exists the table set comes from it, so edits here are silently ignored: added tables are not backfilled, and removed tables still are. Change `checkpoint_cache_key`, or clear the existing key, to pick up an edited list.
+This list is reconciled against the checkpoint on every restart. Adding a table backfills it, even once the snapshot has finished. Removing one drops it, and a table that was part-read stops where it is, leaving it incomplete downstream -- both are logged. Change `checkpoint_cache_key`, or clear the existing key, to start over from this list.
 
 
 *Type*: `array`

--- a/internal/impl/postgresql/checkpoint_tracker_test.go
+++ b/internal/impl/postgresql/checkpoint_tracker_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
+	replincsnapshot "github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+// TestCheckpointTrackerPreventsClobberFromRowlessSentinel reproduces the
+// deadlock/data-loss scenario in commitIncrementalSnapshotCheckpoint: a
+// row-less incremental snapshot checkpoint (LSN=nil) is tracked right after
+// a real batch and resolved synchronously, without waiting on that batch's
+// own ack. Without checkpointTracker's merge, the sentinel's nil LSN would
+// wipe out the still-pending batch's real LSN.
+func TestCheckpointTrackerPreventsClobberFromRowlessSentinel(t *testing.T) {
+	lsn := "1/AAAA"
+	state := []byte("snapshot-state")
+
+	tracker := newCheckpointTracker(10, new(atomic.Uint64))
+
+	resolveBatch, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{LSN: &lsn}, 1)
+	require.NoError(t, err)
+
+	resolveSentinel, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{IncSnapshotState: state}, 0)
+	require.NoError(t, err)
+
+	// The sentinel resolves immediately, ahead of the still-pending batch;
+	// nothing is visible yet since the batch hasn't resolved.
+	assert.Nil(t, resolveSentinel())
+
+	// The batch resolving afterward must still carry its own LSN *and* the
+	// snapshot state spliced onto it - neither field lost.
+	maxOffset := resolveBatch()
+	require.NotNil(t, maxOffset)
+	assert.Equal(t, &lsn, maxOffset.LSN)
+	assert.Equal(t, state, maxOffset.IncSnapshotState)
+}
+
+// TestCheckpointTrackerPreservesPendingStateAcrossLaterBatch is the mirror
+// scenario: a later batch with no new snapshot state (because
+// pendingIncrementalState was already consumed by the earlier batch)
+// resolves before its still-pending predecessor, which is still carrying
+// unflushed snapshot state.
+func TestCheckpointTrackerPreservesPendingStateAcrossLaterBatch(t *testing.T) {
+	lsnA := "1/AAAA"
+	lsnB := "1/BBBB"
+	stateA := []byte("state-a")
+
+	tracker := newCheckpointTracker(10, new(atomic.Uint64))
+
+	resolveA, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{LSN: &lsnA, IncSnapshotState: stateA}, 1)
+	require.NoError(t, err)
+
+	resolveB, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{LSN: &lsnB}, 1)
+	require.NoError(t, err)
+
+	// B resolves first, while A is still pending; nothing visible yet.
+	assert.Nil(t, resolveB())
+
+	maxOffset := resolveA()
+	require.NotNil(t, maxOffset)
+	assert.Equal(t, &lsnB, maxOffset.LSN, "B's own LSN must still surface once A resolves")
+	assert.Equal(t, stateA, maxOffset.IncSnapshotState, "A's pending snapshot state must not be lost even though B resolved first")
+}
+
+// TestCommitCheckpointSkipsRedundantStatePersist verifies commitCheckpoint
+// only writes to the checkpoint cache when the incremental snapshot state
+// actually changed, since checkpointTracker.Track now carries the
+// last-known state forward onto every checkpoint (including ones that
+// didn't themselves advance it) to prevent the clobber above.
+func TestCommitCheckpointSkipsRedundantStatePersist(t *testing.T) {
+	const cacheName = "inc_snapshot_cache"
+	mgr := service.MockResources(service.MockResourcesOptAddCache(cacheName))
+
+	p := &pgStreamInput{
+		mgr:                           mgr,
+		incSnapshotCheckpointCache:    cacheName,
+		incSnapshotCheckpointCacheKey: "key",
+	}
+
+	ctx := t.Context()
+	stateA := []byte("state-a")
+
+	// offset.LSN is nil throughout this test, so commitCheckpoint never
+	// touches pgStream - passing nil is safe.
+	require.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{IncSnapshotState: stateA, Seq: 1}))
+
+	got, err := p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, stateA, got)
+
+	// Delete the cache entry directly, bypassing commitCheckpoint, so a
+	// re-write would be observable.
+	require.NoError(t, mgr.AccessCache(ctx, cacheName, func(c service.Cache) {
+		require.NoError(t, c.Delete(ctx, "key"))
+	}))
+
+	// Re-committing the *same* state must be a no-op: checkpointTracker
+	// would carry stateA forward onto every later checkpoint even when
+	// nothing new happened, so commitCheckpoint must recognise it's
+	// unchanged and skip the redundant cache write.
+	require.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{IncSnapshotState: stateA, Seq: 2}))
+	_, err = p.loadCachedIncSnapshotStateBytes(ctx)
+	require.ErrorIs(t, err, service.ErrKeyNotFound, "unchanged state must not be re-persisted")
+
+	// A genuinely new state must still be persisted.
+	stateB := []byte("state-b")
+	require.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{IncSnapshotState: stateB, Seq: 3}))
+	got, err = p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, stateB, got)
+}
+
+// loadCachedIncSnapshotStateBytes is a small test helper reading the raw
+// cache bytes directly, sidestepping loadCachedIncSnapshotState's JSON
+// unmarshal (which requires a valid incrementalsnapshot.State payload).
+func (p *pgStreamInput) loadCachedIncSnapshotStateBytes(ctx context.Context) ([]byte, error) {
+	var (
+		val  []byte
+		cErr error
+	)
+	if err := p.mgr.AccessCache(ctx, p.incSnapshotCheckpointCache, func(c service.Cache) {
+		val, cErr = c.Get(ctx, p.incSnapshotCheckpointCacheKey)
+	}); err != nil {
+		return nil, err
+	}
+	return val, cErr
+}
+
+// TestTrackAssignsIncreasingSeq checks that each tracked offset gets the
+// next Seq.
+func TestTrackAssignsIncreasingSeq(t *testing.T) {
+	lsnA := "1/AAAA"
+	lsnB := "1/BBBB"
+
+	tracker := newCheckpointTracker(10, new(atomic.Uint64))
+
+	resolveA, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{LSN: &lsnA}, 1)
+	require.NoError(t, err)
+	offsetA := resolveA()
+	require.NotNil(t, offsetA)
+	assert.Equal(t, uint64(1), offsetA.Seq)
+
+	resolveB, err := tracker.Track(t.Context(), incrementalsnapshot.CheckpointOffset{LSN: &lsnB}, 1)
+	require.NoError(t, err)
+	offsetB := resolveB()
+	require.NotNil(t, offsetB)
+	assert.Equal(t, uint64(2), offsetB.Seq)
+}
+
+// TestCommitCheckpointRejectsOlderState covers the race between concurrent
+// acknowledgements: their writes can land in either order, and an older one
+// landing last makes a restart re-deliver chunks. A lock alone does not fix
+// this, because the calls can take it in either order.
+func TestCommitCheckpointRejectsOlderState(t *testing.T) {
+	const cacheName = "inc_snapshot_cache"
+	mgr := service.MockResources(service.MockResourcesOptAddCache(cacheName))
+
+	p := &pgStreamInput{
+		mgr:                           mgr,
+		incSnapshotCheckpointCache:    cacheName,
+		incSnapshotCheckpointCacheKey: "key",
+	}
+
+	ctx := t.Context()
+	older := []byte("state-1")
+	newer := []byte("state-2")
+
+	// Newer acknowledgement lands first.
+	require.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{IncSnapshotState: newer, Seq: 2}))
+
+	// Older one arrives after, and must not write.
+	require.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{IncSnapshotState: older, Seq: 1}))
+
+	got, err := p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, newer, got, "an older checkpoint must not replace a newer one")
+}
+
+// TestCommitCheckpointConcurrentAcksNeverRegress runs many acknowledgements
+// concurrently. The cache must end on the newest state. Run with -race.
+func TestCommitCheckpointConcurrentAcksNeverRegress(t *testing.T) {
+	const (
+		cacheName = "inc_snapshot_cache"
+		acks      = 64
+	)
+	mgr := service.MockResources(service.MockResourcesOptAddCache(cacheName))
+
+	p := &pgStreamInput{
+		mgr:                           mgr,
+		incSnapshotCheckpointCache:    cacheName,
+		incSnapshotCheckpointCacheKey: "key",
+	}
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for i := 1; i <= acks; i++ {
+		wg.Add(1)
+		go func(seq uint64) {
+			defer wg.Done()
+			state := fmt.Appendf(nil, "state-%03d", seq)
+			assert.NoError(t, p.commitCheckpoint(ctx, nil, incrementalsnapshot.CheckpointOffset{
+				IncSnapshotState: state,
+				Seq:              seq,
+			}))
+		}(uint64(i))
+	}
+	wg.Wait()
+
+	got, err := p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Appendf(nil, "state-%03d", acks), got)
+}
+
+// TestCheckpointsPersistAcrossTrackerReplacement covers the reconnect path.
+// Connect builds a fresh checkpointTracker each time, but the
+// lastPersisted fields live on the input. A Seq counter owned by the tracker
+// would restart at 0, fail the "not newer" guard against the pre-reconnect
+// high-water mark, and silently stop persisting for the life of the process.
+func TestCheckpointsPersistAcrossTrackerReplacement(t *testing.T) {
+	const cacheName = "inc_snapshot_cache"
+	mgr := service.MockResources(service.MockResourcesOptAddCache(cacheName))
+
+	p := &pgStreamInput{
+		mgr:                           mgr,
+		incSnapshotCheckpointCache:    cacheName,
+		incSnapshotCheckpointCacheKey: "key",
+	}
+
+	// offset.LSN stays nil throughout, so commitCheckpoint never touches
+	// pgStream and passing nil for it is safe.
+	ctx := t.Context()
+
+	// First connection: track and commit a few checkpoints.
+	first := newCheckpointTracker(10, &p.incSnapshotSeq)
+	for i := range 5 {
+		state := fmt.Appendf(nil, "state-a-%d", i)
+		resolve, err := first.Track(ctx, incrementalsnapshot.CheckpointOffset{IncSnapshotState: state}, 1)
+		require.NoError(t, err)
+		offset := resolve()
+		require.NotNil(t, offset)
+		require.NoError(t, p.commitCheckpoint(ctx, nil, *offset))
+	}
+
+	got, err := p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []byte("state-a-4"), got)
+
+	// Reconnect: a new tracker, the same input.
+	second := newCheckpointTracker(10, &p.incSnapshotSeq)
+	state := []byte("state-b-0")
+	resolve, err := second.Track(ctx, incrementalsnapshot.CheckpointOffset{IncSnapshotState: state}, 1)
+	require.NoError(t, err)
+	offset := resolve()
+	require.NotNil(t, offset)
+	assert.Greater(t, offset.Seq, uint64(5), "Seq must continue past the first connection")
+	require.NoError(t, p.commitCheckpoint(ctx, nil, *offset))
+
+	got, err = p.loadCachedIncSnapshotStateBytes(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, state, got, "checkpoints must keep persisting after a reconnect")
+}
+
+func TestLoadCachedIncSnapshotStateRejectsForeignVersion(t *testing.T) {
+	// A checkpoint this build cannot interpret must fail loudly, and the
+	// error must name the way out.
+	const cacheName = "inc_snapshot_cache"
+	mgr := service.MockResources(service.MockResourcesOptAddCache(cacheName))
+
+	p := &pgStreamInput{
+		mgr:                           mgr,
+		incSnapshotCheckpointCache:    cacheName,
+		incSnapshotCheckpointCacheKey: "key",
+	}
+
+	require.NoError(t, p.saveIncrementalSnapshotState(t.Context(), []byte(`{"version":99,"last_sent_pk":[42]}`)))
+
+	_, err := p.loadCachedIncSnapshotState(t.Context())
+	require.ErrorIs(t, err, replincsnapshot.ErrUnsupportedStateVersion)
+	assert.ErrorContains(t, err, "checkpoint_cache_key")
+}

--- a/internal/impl/postgresql/config.go
+++ b/internal/impl/postgresql/config.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+)
+
+type incSnapshotCfg struct {
+	cfg      *incrementalsnapshot.Cfg
+	cache    string
+	cacheKey string
+}
+
+func newDefaultIncSnapshotCfg() *incSnapshotCfg {
+	return &incSnapshotCfg{
+		cacheKey: incrementalsnapshot.DefaultIncSnapshotCheckpointKey,
+	}
+}
+
+func parseIncrementalSnapshotCfg(conf *service.ParsedConfig, heartbeatInterval time.Duration, replicatedTables []string, streamSnapshot bool) (*incSnapshotCfg, error) {
+	out := newDefaultIncSnapshotCfg()
+	if conf.Contains(fieldIncSnapshot) {
+		var (
+			snapConf = conf.Namespace(fieldIncSnapshot)
+			cfg      = &incrementalsnapshot.Cfg{}
+			err      error
+		)
+
+		if cfg.Enabled, err = snapConf.FieldBool(fieldIncSnapshotEnabled); err != nil {
+			return nil, err
+		}
+		if snapConf.Contains(fieldIncrementalSnapshotTables) {
+			if cfg.Tables, err = snapConf.FieldStringList(fieldIncrementalSnapshotTables); err != nil {
+				return nil, err
+			}
+		}
+
+		if cfg.HeartbeatInterval, err = snapConf.FieldDuration(fieldIncSnapshotHeartbeatInterval); err != nil {
+			return nil, err
+		}
+		if cfg.Enabled && cfg.HeartbeatInterval <= 0 {
+			return nil, fmt.Errorf("%s.%s must be > 0, got %s", fieldIncSnapshot, fieldIncSnapshotHeartbeatInterval, cfg.HeartbeatInterval)
+		}
+
+		if cfg.ChunkSize, err = snapConf.FieldInt(fieldIncrementalSnapshotChunkSize); err != nil {
+			return nil, err
+		} else if cfg.ChunkSize <= 0 {
+			return nil, fmt.Errorf("%s.%s must be > 0, got %d", fieldIncSnapshot, fieldIncrementalSnapshotChunkSize, cfg.ChunkSize)
+		}
+
+		if cfg.Enabled && streamSnapshot {
+			return nil, fmt.Errorf(
+				"%s and %s.%s are mutually exclusive snapshot modes, only one can be enabled",
+				fieldStreamSnapshot, fieldIncSnapshot, fieldIncSnapshotEnabled,
+			)
+		}
+
+		// Both lists empty: no table names to read, so the coordinator would
+		// report itself complete without emitting a row.
+		if cfg.Enabled && len(cfg.Tables) == 0 && len(replicatedTables) == 0 {
+			return nil, fmt.Errorf(
+				"%s.%s is true but no tables are listed: set %s.%s, or %s to inherit from",
+				fieldIncSnapshot, fieldIncSnapshotEnabled,
+				fieldIncSnapshot, fieldIncrementalSnapshotTables, fieldTables,
+			)
+		}
+
+		// An unreplicated table is backfilled with no live changes to dedup
+		// against, so writes after its chunk is read are lost. Only an
+		// explicit list needs checking: an empty one inherits the replicated
+		// set, and an empty replicatedTables means FOR ALL TABLES.
+		if cfg.Enabled && len(cfg.Tables) > 0 && len(replicatedTables) > 0 {
+			replicated := make(map[string]struct{}, len(replicatedTables))
+			for _, table := range replicatedTables {
+				normalized, err := sanitize.NormalizePostgresIdentifier(table)
+				if err != nil {
+					return nil, fmt.Errorf("invalid table name %q: %w", table, err)
+				}
+				replicated[normalized] = struct{}{}
+			}
+			for _, table := range cfg.Tables {
+				normalized, err := sanitize.NormalizePostgresIdentifier(table)
+				if err != nil {
+					return nil, fmt.Errorf("invalid %s.%s entry %q: %w", fieldIncSnapshot, fieldIncrementalSnapshotTables, table, err)
+				}
+				if _, ok := replicated[normalized]; !ok {
+					return nil, fmt.Errorf(
+						"%s.%s entry %q is not listed in %s, so it would not be replicated: no live change could be deduplicated against its backfill",
+						fieldIncSnapshot, fieldIncrementalSnapshotTables, table, fieldTables,
+					)
+				}
+			}
+		}
+
+		// The snapshot moves forward only on a streamed commit. On a table
+		// with no writes the heartbeat makes the only such commit. Without a
+		// heartbeat the snapshot reads the first chunk and then stops for
+		// ever, and it reports no error. Refuse this configuration.
+		if cfg.Enabled && heartbeatInterval <= 0 {
+			return nil, fmt.Errorf(
+				"%s.%s is true but %s is disabled: incremental snapshot progress is paced by streamed commits, so a quiet table would never advance. Set %s to a non-zero interval",
+				fieldIncSnapshot, fieldIncSnapshotEnabled, fieldHeartbeatInterval, fieldHeartbeatInterval,
+			)
+		}
+		if snapConf.Contains(fieldIncSnapshotCheckpointCache) {
+			if out.cache, err = snapConf.FieldString(fieldIncSnapshotCheckpointCache); err != nil {
+				return nil, err
+			}
+		}
+		if out.cacheKey, err = snapConf.FieldString(fieldIncSnapshotCheckpointCacheKey); err != nil {
+			return nil, err
+		}
+		if cfg.Enabled && out.cache == "" {
+			return nil, fmt.Errorf("%s.%s is required when %s.%s is true", fieldIncSnapshot, fieldIncSnapshotCheckpointCache, fieldIncSnapshot, fieldIncSnapshotEnabled)
+		}
+		if cfg.Enabled && !conf.Resources().HasCache(out.cache) {
+			return nil, fmt.Errorf("unknown cache resource: %s", out.cache)
+		}
+		if cfg.Enabled {
+			out.cfg = cfg
+		}
+	}
+
+	return out, nil
+}

--- a/internal/impl/postgresql/config.go
+++ b/internal/impl/postgresql/config.go
@@ -32,106 +32,109 @@ func newDefaultIncSnapshotCfg() *incSnapshotCfg {
 
 func parseIncrementalSnapshotCfg(conf *service.ParsedConfig, heartbeatInterval time.Duration, replicatedTables []string, streamSnapshot bool) (*incSnapshotCfg, error) {
 	out := newDefaultIncSnapshotCfg()
-	if conf.Contains(fieldIncSnapshot) {
-		var (
-			snapConf = conf.Namespace(fieldIncSnapshot)
-			cfg      = &incrementalsnapshot.Cfg{}
-			err      error
+	// No config block: the snapshot is off and out holds the defaults.
+	if !conf.Contains(fieldIncSnapshot) {
+		return out, nil
+	}
+
+	var (
+		snapConf = conf.Namespace(fieldIncSnapshot)
+		cfg      = &incrementalsnapshot.Cfg{}
+		err      error
+	)
+
+	if cfg.Enabled, err = snapConf.FieldBool(fieldIncSnapshotEnabled); err != nil {
+		return nil, err
+	}
+	if snapConf.Contains(fieldIncrementalSnapshotTables) {
+		if cfg.Tables, err = snapConf.FieldStringList(fieldIncrementalSnapshotTables); err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.HeartbeatInterval, err = snapConf.FieldDuration(fieldIncSnapshotHeartbeatInterval); err != nil {
+		return nil, err
+	}
+	if cfg.Enabled && cfg.HeartbeatInterval <= 0 {
+		return nil, fmt.Errorf("%s.%s must be > 0, got %s", fieldIncSnapshot, fieldIncSnapshotHeartbeatInterval, cfg.HeartbeatInterval)
+	}
+
+	if cfg.ChunkSize, err = snapConf.FieldInt(fieldIncrementalSnapshotChunkSize); err != nil {
+		return nil, err
+	} else if cfg.ChunkSize <= 0 {
+		return nil, fmt.Errorf("%s.%s must be > 0, got %d", fieldIncSnapshot, fieldIncrementalSnapshotChunkSize, cfg.ChunkSize)
+	}
+
+	if cfg.Enabled && streamSnapshot {
+		return nil, fmt.Errorf(
+			"%s and %s.%s are mutually exclusive snapshot modes, only one can be enabled",
+			fieldStreamSnapshot, fieldIncSnapshot, fieldIncSnapshotEnabled,
 		)
+	}
 
-		if cfg.Enabled, err = snapConf.FieldBool(fieldIncSnapshotEnabled); err != nil {
-			return nil, err
+	// Both lists empty: no table names to read, so the coordinator would
+	// report itself complete without emitting a row.
+	if cfg.Enabled && len(cfg.Tables) == 0 && len(replicatedTables) == 0 {
+		return nil, fmt.Errorf(
+			"%s.%s is true but no tables are listed: set %s.%s, or %s to inherit from",
+			fieldIncSnapshot, fieldIncSnapshotEnabled,
+			fieldIncSnapshot, fieldIncrementalSnapshotTables, fieldTables,
+		)
+	}
+
+	// An unreplicated table is backfilled with no live changes to dedup
+	// against, so writes after its chunk is read are lost. Only an
+	// explicit list needs checking: an empty one inherits the replicated
+	// set, and an empty replicatedTables means FOR ALL TABLES.
+	if cfg.Enabled && len(cfg.Tables) > 0 && len(replicatedTables) > 0 {
+		replicated := make(map[string]struct{}, len(replicatedTables))
+		for _, table := range replicatedTables {
+			normalized, err := sanitize.NormalizePostgresIdentifier(table)
+			if err != nil {
+				return nil, fmt.Errorf("invalid table name %q: %w", table, err)
+			}
+			replicated[normalized] = struct{}{}
 		}
-		if snapConf.Contains(fieldIncrementalSnapshotTables) {
-			if cfg.Tables, err = snapConf.FieldStringList(fieldIncrementalSnapshotTables); err != nil {
-				return nil, err
+		for _, table := range cfg.Tables {
+			normalized, err := sanitize.NormalizePostgresIdentifier(table)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s.%s entry %q: %w", fieldIncSnapshot, fieldIncrementalSnapshotTables, table, err)
+			}
+			if _, ok := replicated[normalized]; !ok {
+				return nil, fmt.Errorf(
+					"%s.%s entry %q is not listed in %s, so it would not be replicated: no live change could be deduplicated against its backfill",
+					fieldIncSnapshot, fieldIncrementalSnapshotTables, table, fieldTables,
+				)
 			}
 		}
+	}
 
-		if cfg.HeartbeatInterval, err = snapConf.FieldDuration(fieldIncSnapshotHeartbeatInterval); err != nil {
+	// The snapshot moves forward only on a streamed commit. On a table
+	// with no writes the heartbeat makes the only such commit. Without a
+	// heartbeat the snapshot reads the first chunk and then stops for
+	// ever, and it reports no error. Refuse this configuration.
+	if cfg.Enabled && heartbeatInterval <= 0 {
+		return nil, fmt.Errorf(
+			"%s.%s is true but %s is disabled: incremental snapshot progress is paced by streamed commits, so a quiet table would never advance. Set %s to a non-zero interval",
+			fieldIncSnapshot, fieldIncSnapshotEnabled, fieldHeartbeatInterval, fieldHeartbeatInterval,
+		)
+	}
+	if snapConf.Contains(fieldIncSnapshotCheckpointCache) {
+		if out.cache, err = snapConf.FieldString(fieldIncSnapshotCheckpointCache); err != nil {
 			return nil, err
 		}
-		if cfg.Enabled && cfg.HeartbeatInterval <= 0 {
-			return nil, fmt.Errorf("%s.%s must be > 0, got %s", fieldIncSnapshot, fieldIncSnapshotHeartbeatInterval, cfg.HeartbeatInterval)
-		}
-
-		if cfg.ChunkSize, err = snapConf.FieldInt(fieldIncrementalSnapshotChunkSize); err != nil {
-			return nil, err
-		} else if cfg.ChunkSize <= 0 {
-			return nil, fmt.Errorf("%s.%s must be > 0, got %d", fieldIncSnapshot, fieldIncrementalSnapshotChunkSize, cfg.ChunkSize)
-		}
-
-		if cfg.Enabled && streamSnapshot {
-			return nil, fmt.Errorf(
-				"%s and %s.%s are mutually exclusive snapshot modes, only one can be enabled",
-				fieldStreamSnapshot, fieldIncSnapshot, fieldIncSnapshotEnabled,
-			)
-		}
-
-		// Both lists empty: no table names to read, so the coordinator would
-		// report itself complete without emitting a row.
-		if cfg.Enabled && len(cfg.Tables) == 0 && len(replicatedTables) == 0 {
-			return nil, fmt.Errorf(
-				"%s.%s is true but no tables are listed: set %s.%s, or %s to inherit from",
-				fieldIncSnapshot, fieldIncSnapshotEnabled,
-				fieldIncSnapshot, fieldIncrementalSnapshotTables, fieldTables,
-			)
-		}
-
-		// An unreplicated table is backfilled with no live changes to dedup
-		// against, so writes after its chunk is read are lost. Only an
-		// explicit list needs checking: an empty one inherits the replicated
-		// set, and an empty replicatedTables means FOR ALL TABLES.
-		if cfg.Enabled && len(cfg.Tables) > 0 && len(replicatedTables) > 0 {
-			replicated := make(map[string]struct{}, len(replicatedTables))
-			for _, table := range replicatedTables {
-				normalized, err := sanitize.NormalizePostgresIdentifier(table)
-				if err != nil {
-					return nil, fmt.Errorf("invalid table name %q: %w", table, err)
-				}
-				replicated[normalized] = struct{}{}
-			}
-			for _, table := range cfg.Tables {
-				normalized, err := sanitize.NormalizePostgresIdentifier(table)
-				if err != nil {
-					return nil, fmt.Errorf("invalid %s.%s entry %q: %w", fieldIncSnapshot, fieldIncrementalSnapshotTables, table, err)
-				}
-				if _, ok := replicated[normalized]; !ok {
-					return nil, fmt.Errorf(
-						"%s.%s entry %q is not listed in %s, so it would not be replicated: no live change could be deduplicated against its backfill",
-						fieldIncSnapshot, fieldIncrementalSnapshotTables, table, fieldTables,
-					)
-				}
-			}
-		}
-
-		// The snapshot moves forward only on a streamed commit. On a table
-		// with no writes the heartbeat makes the only such commit. Without a
-		// heartbeat the snapshot reads the first chunk and then stops for
-		// ever, and it reports no error. Refuse this configuration.
-		if cfg.Enabled && heartbeatInterval <= 0 {
-			return nil, fmt.Errorf(
-				"%s.%s is true but %s is disabled: incremental snapshot progress is paced by streamed commits, so a quiet table would never advance. Set %s to a non-zero interval",
-				fieldIncSnapshot, fieldIncSnapshotEnabled, fieldHeartbeatInterval, fieldHeartbeatInterval,
-			)
-		}
-		if snapConf.Contains(fieldIncSnapshotCheckpointCache) {
-			if out.cache, err = snapConf.FieldString(fieldIncSnapshotCheckpointCache); err != nil {
-				return nil, err
-			}
-		}
-		if out.cacheKey, err = snapConf.FieldString(fieldIncSnapshotCheckpointCacheKey); err != nil {
-			return nil, err
-		}
-		if cfg.Enabled && out.cache == "" {
-			return nil, fmt.Errorf("%s.%s is required when %s.%s is true", fieldIncSnapshot, fieldIncSnapshotCheckpointCache, fieldIncSnapshot, fieldIncSnapshotEnabled)
-		}
-		if cfg.Enabled && !conf.Resources().HasCache(out.cache) {
-			return nil, fmt.Errorf("unknown cache resource: %s", out.cache)
-		}
-		if cfg.Enabled {
-			out.cfg = cfg
-		}
+	}
+	if out.cacheKey, err = snapConf.FieldString(fieldIncSnapshotCheckpointCacheKey); err != nil {
+		return nil, err
+	}
+	if cfg.Enabled && out.cache == "" {
+		return nil, fmt.Errorf("%s.%s is required when %s.%s is true", fieldIncSnapshot, fieldIncSnapshotCheckpointCache, fieldIncSnapshot, fieldIncSnapshotEnabled)
+	}
+	if cfg.Enabled && !conf.Resources().HasCache(out.cache) {
+		return nil, fmt.Errorf("unknown cache resource: %s", out.cache)
+	}
+	if cfg.Enabled {
+		out.cfg = cfg
 	}
 
 	return out, nil

--- a/internal/impl/postgresql/config_test.go
+++ b/internal/impl/postgresql/config_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
+
+package pgstream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestParseIncrementalSnapshotCfgDisabled(t *testing.T) {
+	const base = `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+`
+
+	// A configuration with no incremental_snapshot block returns before the
+	// parse. It must still give the default values, which are no
+	// configuration and the default checkpoint key.
+	tests := []struct {
+		name string
+		conf string
+	}{
+		{
+			name: "block omitted",
+			conf: base,
+		},
+		{
+			name: "block present but disabled",
+			conf: base + `
+incremental_snapshot:
+  enabled: false
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := newPostgresCDCConfig().ParseYAML(test.conf, service.NewEnvironment())
+			require.NoError(t, err)
+
+			got, err := parseIncrementalSnapshotCfg(pConf, time.Hour, nil, false)
+			require.NoError(t, err)
+			require.NotNil(t, got, "callers read the returned fields unconditionally")
+
+			assert.Nil(t, got.cfg, "pglogicalstream branches on a nil cfg when disabled")
+			assert.Equal(t, newDefaultIncSnapshotCfg(), got)
+		})
+	}
+}

--- a/internal/impl/postgresql/incrementalsnapshot/chunk_query.go
+++ b/internal/impl/postgresql/incrementalsnapshot/chunk_query.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+// rowTuple renders a PrimaryKey as a Postgres ROW constructor, e.g.
+// "ROW(?, ?)", enabling row-wise comparisons such as
+// ROW(pk1, pk2) > ROW(?, ?) for composite keys.
+type rowTuple struct {
+	values []any
+}
+
+//nolint:stylecheck // This is implementing the squirrel.Sqlizer interface.
+func (t rowTuple) ToSql() (sql string, args []any, err error) {
+	placeholders := strings.TrimSuffix(strings.Repeat("?, ", len(t.values)), ", ")
+	return "ROW(" + placeholders + ")", t.values, nil
+}
+
+var _ squirrel.Sqlizer = rowTuple{}
+
+func quotedColumns(colsUnquoted []string) []string {
+	quoted := make([]string, len(colsUnquoted))
+	for i, c := range colsUnquoted {
+		quoted[i] = sanitize.QuotePostgresIdentifier(c)
+	}
+	return quoted
+}
+
+// quotedRowExpr renders the key columns as a ROW constructor, e.g.
+// ROW("id", "tenant_id"), for the left side of a row-wise comparison.
+func quotedRowExpr(pkColsUnquoted []string) string {
+	return "ROW(" + strings.Join(quotedColumns(pkColsUnquoted), ", ") + ")"
+}
+
+func quotedTableName(table incrementalsnapshot.TableID) string {
+	return sanitize.QuotePostgresIdentifier(table.Schema) + "." + sanitize.QuotePostgresIdentifier(table.Table)
+}
+
+// BuildChunkQuery builds the paginated chunk SELECT behind
+// incrementalsnapshot.Deps.FetchChunk. A nil lower omits the lower bound, for
+// a table's first chunk; upper is the table's fixed max-key bound and must
+// not be nil. Selects "*" since the column list is unknown here -- callers
+// decode whatever comes back.
+func BuildChunkQuery(table incrementalsnapshot.TableID, pkColsUnquoted []string, lower, upper incrementalsnapshot.PrimaryKey, limit int) (query string, args []any, err error) {
+	if len(pkColsUnquoted) == 0 {
+		return "", nil, errors.New("BuildChunkQuery: no primary key columns provided")
+	}
+	if upper == nil {
+		return "", nil, fmt.Errorf("BuildChunkQuery: upper bound must not be nil for table %s", table)
+	}
+
+	rowExpr := quotedRowExpr(pkColsUnquoted)
+
+	pred := squirrel.And{}
+	if lower != nil {
+		pred = append(pred, squirrel.ConcatExpr(rowExpr, " > ", rowTuple{values: lower}))
+	}
+	pred = append(pred, squirrel.ConcatExpr(rowExpr, " <= ", rowTuple{values: upper}))
+
+	orderBy := make([]string, len(pkColsUnquoted))
+	for i, c := range quotedColumns(pkColsUnquoted) {
+		orderBy[i] = c + " ASC"
+	}
+
+	query, args, err = squirrel.Select("*").
+		From(quotedTableName(table)).
+		Where(pred).
+		OrderBy(orderBy...).
+		Limit(uint64(limit)).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("building chunk query for table %s: %w", table, err)
+	}
+	return query, args, nil
+}
+
+// BuildMaxKeyQuery builds the query behind
+// incrementalsnapshot.Deps.ResolveMaxKey, reading the table's current largest
+// key.
+func BuildMaxKeyQuery(table incrementalsnapshot.TableID, pkColsUnquoted []string) (query string, err error) {
+	if len(pkColsUnquoted) == 0 {
+		return "", errors.New("BuildMaxKeyQuery: no primary key columns provided")
+	}
+
+	quotedCols := quotedColumns(pkColsUnquoted)
+	orderBy := make([]string, len(quotedCols))
+	for i, c := range quotedCols {
+		orderBy[i] = c + " DESC"
+	}
+
+	const maxKeyLimit = 1
+	query, _, err = squirrel.Select(quotedCols...).
+		From(quotedTableName(table)).
+		OrderBy(orderBy...).
+		Limit(maxKeyLimit).
+		PlaceholderFormat(squirrel.Dollar).
+		ToSql()
+	if err != nil {
+		return "", fmt.Errorf("building max key query for table %s: %w", table, err)
+	}
+	return query, nil
+}

--- a/internal/impl/postgresql/incrementalsnapshot/chunk_query_test.go
+++ b/internal/impl/postgresql/incrementalsnapshot/chunk_query_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+func TestBuildChunkQueryFirstChunkSingleColumnPK(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	query, args, err := BuildChunkQuery(table, []string{"id"}, nil, incrementalsnapshot.PrimaryKey{100}, 500)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		`SELECT * FROM "public"."orders" WHERE (ROW("id") <= ROW($1)) ORDER BY "id" ASC LIMIT 500`,
+		query,
+	)
+	assert.Equal(t, []any{100}, args)
+}
+
+func TestBuildChunkQuerySubsequentChunkCompositePK(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "line_items"}
+
+	query, args, err := BuildChunkQuery(
+		table,
+		[]string{"order_id", "line_no"},
+		incrementalsnapshot.PrimaryKey{5, 2},
+		incrementalsnapshot.PrimaryKey{50, 9},
+		250,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		`SELECT * FROM "public"."line_items" WHERE (ROW("order_id", "line_no") > ROW($1, $2) AND ROW("order_id", "line_no") <= ROW($3, $4)) ORDER BY "order_id" ASC, "line_no" ASC LIMIT 250`,
+		query,
+	)
+	assert.Equal(t, []any{5, 2, 50, 9}, args)
+}
+
+func TestBuildChunkQueryNilUpperIsError(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	_, _, err := BuildChunkQuery(table, []string{"id"}, nil, nil, 500)
+	require.Error(t, err)
+}
+
+func TestBuildChunkQueryNoPKColumnsIsError(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	_, _, err := BuildChunkQuery(table, nil, nil, incrementalsnapshot.PrimaryKey{1}, 500)
+	require.Error(t, err)
+}
+
+func TestBuildMaxKeyQuery(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	query, err := BuildMaxKeyQuery(table, []string{"id"})
+	require.NoError(t, err)
+	assert.Equal(t, `SELECT "id" FROM "public"."orders" ORDER BY "id" DESC LIMIT 1`, query)
+}
+
+func TestBuildMaxKeyQueryCompositePK(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "line_items"}
+
+	query, err := BuildMaxKeyQuery(table, []string{"order_id", "line_no"})
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		`SELECT "order_id", "line_no" FROM "public"."line_items" ORDER BY "order_id" DESC, "line_no" DESC LIMIT 1`,
+		query,
+	)
+}
+
+func TestBuildMaxKeyQueryNoPKColumnsIsError(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	_, err := BuildMaxKeyQuery(table, nil)
+	require.Error(t, err)
+}

--- a/internal/impl/postgresql/incrementalsnapshot/config.go
+++ b/internal/impl/postgresql/incrementalsnapshot/config.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"time"
+
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+var (
+	// DefaultIncSnapshotEnabled is the default for enabling the snapshot.
+	DefaultIncSnapshotEnabled = false
+
+	// DefaultIncSnapshotChunkSize is the default row count per chunk.
+	DefaultIncSnapshotChunkSize = 1024
+
+	// DefaultIncSnapshotCheckpointKey is the default checkpoint cache key.
+	DefaultIncSnapshotCheckpointKey = "postgres_cdc_incremental_snapshot"
+
+	// DefaultIncSnapshotHeartbeatInterval is frequent enough that the
+	// backfill is bound by chunk reads rather than by the heartbeat.
+	DefaultIncSnapshotHeartbeatInterval = time.Second
+)
+
+// Cfg holds the incremental snapshot configuration.
+type Cfg struct {
+	Enabled   bool
+	Tables    []string
+	ChunkSize int
+	// HeartbeatInterval is how often the snapshot needs a commit to advance
+	// on, separate from Config.HeartbeatInterval, which only keeps the
+	// replication slot current.
+	HeartbeatInterval time.Duration
+	ResumeState       *incrementalsnapshot.State
+}
+
+// IsEnabled reports whether the snapshot is enabled.
+func (c *Cfg) IsEnabled() bool {
+	return c != nil && c.Enabled
+}
+
+// CheckpointOffset is the per-batch payload the LSN checkpointer tracks.
+// IncSnapshotState is non-nil when the batch carries a checkpoint, giving it
+// the same ack ordering as the LSN.
+type CheckpointOffset struct {
+	LSN              *string
+	IncSnapshotState []byte
+	// Seq orders the checkpoints; the tracker assigns it. Acknowledgements
+	// run concurrently and IncSnapshotState does not reveal which state is
+	// newer, so the writer compares this instead.
+	Seq uint64
+}
+
+// Merge overlays each non-nil field of other onto a copy of o.
+//
+// Resolving a node out of order assigns its whole payload onto its unresolved
+// predecessor, so a nil field would wipe whatever the predecessor held.
+// Callers must therefore merge against the last tracked payload before
+// calling Track.
+func (o CheckpointOffset) Merge(other CheckpointOffset) CheckpointOffset {
+	merged := o
+	if other.LSN != nil {
+		merged.LSN = other.LSN
+	}
+	if other.IncSnapshotState != nil {
+		merged.IncSnapshotState = other.IncSnapshotState
+	}
+	if other.Seq > merged.Seq {
+		merged.Seq = other.Seq
+	}
+	return merged
+}

--- a/internal/impl/postgresql/incrementalsnapshot/config_test.go
+++ b/internal/impl/postgresql/incrementalsnapshot/config_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointOffsetMerge(t *testing.T) {
+	lsn1 := "1/AAAA"
+	lsn2 := "1/BBBB"
+	state1 := []byte("state-1")
+	state2 := []byte("state-2")
+
+	t.Run("nil fields on other never clobber non-nil fields on the receiver", func(t *testing.T) {
+		// This is the exact scenario that used to lose data: a row-less
+		// incremental snapshot checkpoint (LSN=nil) resolving out of order
+		// must not erase a pending real batch's LSN, and a real batch with
+		// no new snapshot state must not erase pending snapshot progress.
+		receiver := CheckpointOffset{LSN: &lsn1, IncSnapshotState: state1}
+
+		merged := receiver.Merge(CheckpointOffset{})
+		assert.Equal(t, &lsn1, merged.LSN)
+		assert.Equal(t, state1, merged.IncSnapshotState)
+	})
+
+	t.Run("non-nil fields on other overwrite the receiver", func(t *testing.T) {
+		receiver := CheckpointOffset{LSN: &lsn1, IncSnapshotState: state1}
+
+		merged := receiver.Merge(CheckpointOffset{LSN: &lsn2, IncSnapshotState: state2})
+		assert.Equal(t, &lsn2, merged.LSN)
+		assert.Equal(t, state2, merged.IncSnapshotState)
+	})
+
+	t.Run("merge is independent per field", func(t *testing.T) {
+		receiver := CheckpointOffset{LSN: &lsn1, IncSnapshotState: nil}
+
+		merged := receiver.Merge(CheckpointOffset{LSN: nil, IncSnapshotState: state2})
+		assert.Equal(t, &lsn1, merged.LSN, "LSN must carry forward from the receiver, unaffected by other's state advancing")
+		assert.Equal(t, state2, merged.IncSnapshotState)
+	})
+
+	t.Run("merging two zero values stays zero", func(t *testing.T) {
+		merged := CheckpointOffset{}.Merge(CheckpointOffset{})
+		assert.Nil(t, merged.LSN)
+		assert.Nil(t, merged.IncSnapshotState)
+	})
+}

--- a/internal/impl/postgresql/incrementalsnapshot/coordinator.go
+++ b/internal/impl/postgresql/incrementalsnapshot/coordinator.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import "github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+
+// The coordinator itself is database-agnostic and lives in
+// internal/replication/incrementalsnapshot. These aliases pin it to Postgres'
+// position type and watermark, keeping the type arguments out of call sites.
+//
+// The position is a uint32 because pgoutput reports a raw 32-bit xid on
+// BEGIN; naming that in the type stops an epoch-extended id being passed by
+// mistake. Watermark handles the widening.
+type (
+	// Coordinator is the incremental snapshot coordinator for Postgres.
+	Coordinator = incrementalsnapshot.Coordinator[uint32, Watermark]
+	// CoordinatorConfig configures a Postgres incremental snapshot Coordinator.
+	CoordinatorConfig = incrementalsnapshot.CoordinatorConfig[uint32, Watermark]
+	// Deps supplies the side-effecting operations.
+	Deps = incrementalsnapshot.Deps[Watermark]
+	// EmitFunc receives each chunk of rows the Coordinator releases.
+	EmitFunc = incrementalsnapshot.EmitFunc
+)
+
+// NewCoordinator builds a Postgres Coordinator. A non-nil resume makes Start
+// continue from that state; otherwise it starts fresh from cfg.Tables.
+func NewCoordinator(cfg CoordinatorConfig, resume *incrementalsnapshot.State) (*Coordinator, error) {
+	return incrementalsnapshot.NewCoordinator(cfg, resume)
+}

--- a/internal/impl/postgresql/incrementalsnapshot/watermark.go
+++ b/internal/impl/postgresql/incrementalsnapshot/watermark.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Watermark holds the xmin/xmax bounds of a Postgres snapshot, which the
+// coordinator compares against streamed transactions.
+//
+// It satisfies the shared package's Watermark[uint32] constraint, checked
+// where CoordinatorConfig is instantiated. The position is a raw transaction
+// id as pgoutput reports it on BEGIN, while the bounds here are
+// epoch-extended, so every comparison goes through normalizeXID.
+type Watermark struct {
+	Xmin uint64
+	Xmax uint64
+}
+
+// OpensAt reports whether xid started at or after this watermark. Xmin is
+// the oldest transaction then in flight, so anything at or above it began
+// late enough that the stream has passed everything this watermark could not
+// see.
+func (w Watermark) OpensAt(xid uint32) bool {
+	return normalizeXID(xid, w.Xmin) >= w.Xmin
+}
+
+// ClosesAt reports whether xid follows every transaction in flight at this
+// watermark. Xmax is the first id not yet assigned, so anything above it
+// started later.
+func (w Watermark) ClosesAt(xid uint32) bool {
+	return normalizeXID(xid, w.Xmax) > w.Xmax
+}
+
+// Quiesced reports whether nothing was in flight. Xmin is the oldest
+// transaction still running and Xmax the first id not yet assigned, so equal
+// values mean nothing was running at all.
+func (w Watermark) Quiesced() bool {
+	return w.Xmin == w.Xmax
+}
+
+const (
+	xidEpoch     = 1 << 32
+	xidHalfEpoch = 1 << 31
+)
+
+// normalizeXID lifts a raw 32-bit WAL xid into ref's epoch so the two become
+// comparable.
+//
+// Snapshot bounds are epoch-extended to 64 bits, but pgoutput's BEGIN carries
+// only the low 32 bits, which wrap every ~4.3 billion transactions. Comparing
+// them directly fails after the first wrap: every bound then exceeds every
+// possible xid, so the window never opens and the snapshot stalls silently.
+//
+// Watermarks are read either side of a chunk and compared against commits
+// arriving moments later, so the true xid is always within half an epoch of
+// ref. Splicing ref's epoch onto xid therefore lands within one epoch, and
+// whichever neighbouring epoch falls inside that half-epoch window is right.
+func normalizeXID(xid uint32, ref uint64) uint64 {
+	full := (ref & ^uint64(math.MaxUint32)) | uint64(xid)
+	switch {
+	case full > ref && full-ref > xidHalfEpoch && full >= xidEpoch:
+		// xid wrapped ahead of ref, so it belongs to the previous epoch.
+		// The last test guards underflow: epoch 0 has no predecessor.
+		return full - xidEpoch
+	case ref > full && ref-full > xidHalfEpoch:
+		// ref wrapped ahead of xid, so xid belongs to the next epoch.
+		return full + xidEpoch
+	default:
+		return full
+	}
+}
+
+// ParseSnapshot reads a Postgres snapshot's text form, e.g. "100:104:101,103"
+// (xmin:xmax:xip_list, where the xip list may be empty). Both
+// pg_current_snapshot (PG 13+) and the obsolete txid_current_snapshot render
+// this way with epoch-extended ids, so either result parses.
+//
+// The xip list is validated but discarded: the window comparisons need only
+// the bounds.
+func ParseSnapshot(raw string) (Watermark, error) {
+	parts := strings.Split(raw, ":")
+	const expectedParts = 3
+	if len(parts) != expectedParts {
+		return Watermark{}, fmt.Errorf("invalid snapshot format %q: expected 3 colon-separated parts, got %d", raw, len(parts))
+	}
+
+	xmin, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Watermark{}, fmt.Errorf("invalid snapshot format %q: xmin %q is not a valid uint64: %w", raw, parts[0], err)
+	}
+
+	xmax, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Watermark{}, fmt.Errorf("invalid snapshot format %q: xmax %q is not a valid uint64: %w", raw, parts[1], err)
+	}
+
+	if xip := parts[2]; xip != "" {
+		for id := range strings.SplitSeq(xip, ",") {
+			if _, err := strconv.ParseUint(id, 10, 64); err != nil {
+				return Watermark{}, fmt.Errorf("invalid snapshot format %q: xip entry %q is not a valid uint64: %w", raw, id, err)
+			}
+		}
+	}
+
+	return Watermark{Xmin: xmin, Xmax: xmax}, nil
+}

--- a/internal/impl/postgresql/incrementalsnapshot/watermark_test.go
+++ b/internal/impl/postgresql/incrementalsnapshot/watermark_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSnapshotValid(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want Watermark
+	}{
+		{
+			name: "with xip list",
+			raw:  "100:104:101,103",
+			want: Watermark{Xmin: 100, Xmax: 104},
+		},
+		{
+			name: "without xip list",
+			raw:  "100:104:",
+			want: Watermark{Xmin: 100, Xmax: 104},
+		},
+		{
+			name: "equal xmin and xmax",
+			raw:  "50:50:",
+			want: Watermark{Xmin: 50, Xmax: 50},
+		},
+		{
+			name: "single xip entry",
+			raw:  "10:20:15",
+			want: Watermark{Xmin: 10, Xmax: 20},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSnapshot(tc.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseSnapshotMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty string", raw: ""},
+		{name: "missing colon", raw: "100104"},
+		{name: "only one colon", raw: "100:104"},
+		{name: "too many colons", raw: "100:104:101:extra"},
+		{name: "non-numeric xmin", raw: "abc:104:"},
+		{name: "non-numeric xmax", raw: "100:abc:"},
+		{name: "non-numeric xip entry", raw: "100:104:abc"},
+		{name: "negative xmin", raw: "-1:104:"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseSnapshot(tc.raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestWatermarkOpensAt(t *testing.T) {
+	// Xmin is the oldest transaction that is in flight. Each value that is
+	// equal to xmin or larger started late enough to open the window.
+	wm := Watermark{Xmin: 100, Xmax: 105}
+
+	assert.False(t, wm.OpensAt(99))
+	assert.True(t, wm.OpensAt(100), "xmin itself must open the window")
+	assert.True(t, wm.OpensAt(101))
+}
+
+func TestWatermarkClosesAt(t *testing.T) {
+	// Xmax is the first id that Postgres had not given out. Only a larger
+	// id started after the watermark.
+	wm := Watermark{Xmin: 100, Xmax: 105}
+
+	assert.False(t, wm.ClosesAt(104))
+	assert.False(t, wm.ClosesAt(105), "xmax itself must not close the window")
+	assert.True(t, wm.ClosesAt(106))
+}
+
+func TestWatermarkZeroValueDoesNotClose(t *testing.T) {
+	// The coordinator holds a zero Watermark until it plans the first chunk.
+	// Until then it must not report a closed window.
+	var wm Watermark
+
+	assert.False(t, wm.ClosesAt(0))
+	assert.True(t, wm.OpensAt(0))
+}
+
+func TestNormalizeXID(t *testing.T) {
+	const epoch = uint64(1) << 32
+
+	tests := []struct {
+		name string
+		xid  uint32
+		ref  uint64
+		want uint64
+	}{
+		{
+			name: "epoch 0 passes through",
+			xid:  100,
+			ref:  120,
+			want: 100,
+		},
+		{
+			// This case is the reason for the function. The watermark is in
+			// epoch 1, and the xid has no epoch.
+			name: "lifted into ref's epoch",
+			xid:  100,
+			ref:  epoch + 120,
+			want: epoch + 100,
+		},
+		{
+			name: "equal to ref within an epoch",
+			xid:  100,
+			ref:  epoch + 100,
+			want: epoch + 100,
+		},
+		{
+			// The xid is a little larger than ref. This case is usual for
+			// a commit that arrives a short time after the watermark.
+			name: "just ahead of ref",
+			xid:  121,
+			ref:  epoch + 120,
+			want: epoch + 121,
+		},
+		{
+			// ref is a little after a return to zero, and xid is a little
+			// before it. The epoch of ref would put xid one full epoch too
+			// late.
+			name: "xid before a wrap that ref is after",
+			xid:  math.MaxUint32 - 10,
+			ref:  epoch + 5,
+			want: epoch - 11,
+		},
+		{
+			// This case is the opposite. ref is before a return to zero and
+			// xid is after it.
+			name: "xid after a wrap that ref is before",
+			xid:  5,
+			ref:  epoch - 11,
+			want: epoch + 5,
+		},
+		{
+			// Epoch 0 has no earlier epoch. A much larger xid must not
+			// cause an underflow to a very large uint64.
+			name: "no underflow below epoch 0",
+			xid:  math.MaxUint32 - 10,
+			ref:  5,
+			want: uint64(math.MaxUint32) - 10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, normalizeXID(test.xid, test.ref))
+		})
+	}
+}
+
+func TestWatermarkComparisonsSurviveEpochWraparound(t *testing.T) {
+	// Regression test. The bounds are 64-bit values that include an epoch,
+	// and the streamed xid is a 32-bit value. A direct comparison makes each
+	// bound in epoch 1 or later larger than each possible xid. The window
+	// then never opens and the snapshot stops without a message.
+	const epoch = uint64(1) << 32
+	wm := Watermark{Xmin: epoch + 100, Xmax: epoch + 105}
+
+	assert.False(t, wm.OpensAt(99))
+	assert.True(t, wm.OpensAt(100), "xmin itself must open the window")
+	assert.True(t, wm.OpensAt(101))
+
+	assert.False(t, wm.ClosesAt(105), "xmax itself must not close the window")
+	assert.True(t, wm.ClosesAt(106))
+}

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -884,10 +884,10 @@ func (p *pgStreamInput) commitCheckpoint(ctx context.Context, pgStream *pglogica
 
 // persistIncSnapshotState writes offset's snapshot state to the cache.
 //
-// Acknowledgements run concurrently, so it holds incStateMu across the test
-// and the write to keep the pair atomic. The lock alone is not enough: the
-// calls can take it in either order, so it also rejects any offset that is
-// not newer than the one already written.
+// Acknowledgements run concurrently, so it holds lastPersistedMu across the
+// test and the write to keep the pair atomic. The lock alone is not enough:
+// the calls can take it in either order, so it also rejects any offset that
+// is not newer than the one already written.
 func (p *pgStreamInput) persistIncSnapshotState(ctx context.Context, offset incsnapshot.CheckpointOffset) error {
 	p.lastPersistedMu.Lock()
 	defer p.lastPersistedMu.Unlock()

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -9,6 +9,7 @@
 package pgstream
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Jeffail/checkpoint"
@@ -25,9 +27,11 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	incsnapshot "github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
 	"github.com/redpanda-data/connect/v4/internal/license"
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
 )
 
 const (
@@ -52,6 +56,14 @@ const (
 	// FieldAWSIAMAuthEnabled enabled field.
 	FieldAWSIAMAuthEnabled = "enabled"
 	shutdownTimeout        = 5 * time.Second
+
+	fieldIncSnapshot                   = "incremental_snapshot"
+	fieldIncSnapshotEnabled            = "enabled"
+	fieldIncrementalSnapshotTables     = "tables"
+	fieldIncrementalSnapshotChunkSize  = "chunk_size"
+	fieldIncSnapshotCheckpointCache    = "checkpoint_cache"
+	fieldIncSnapshotCheckpointCacheKey = "checkpoint_cache_key"
+	fieldIncSnapshotHeartbeatInterval  = "heartbeat_interval"
 )
 
 func notImportedAWSOptFn(_ context.Context, awsConf *service.ParsedConfig, _ *pgconn.Config, _ *service.Logger) (TokenBuilder, error) {
@@ -151,7 +163,8 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Example("6s").
 			Default("3s")).
 		Field(service.NewIntField(fieldMaxParallelSnapshotTables).
-			Description("Int specifies a number of tables that will be processed in parallel during the snapshot processing stage").
+			Description("Int specifies a number of tables that will be processed in parallel during the snapshot processing stage.\n\nApplies to the `" + fieldStreamSnapshot + "` snapshot only.").
+			ShortDescription("Number of tables to snapshot in parallel. Applies to `" + fieldStreamSnapshot + "` only.").
 			Default(1)).
 		Field(service.NewAnyField(fieldUnchangedToastValue).
 			Description("The value to emit when there are unchanged TOAST values in the stream. This occurs for updates and deletes where REPLICA IDENTITY is not FULL.").
@@ -161,7 +174,7 @@ This connector uses the naming pattern ` + "`pglog_stream_<replication_slot_name
 			Optional().
 			Advanced()).
 		Field(service.NewDurationField(fieldHeartbeatInterval).
-			Description("The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.").
+			Description("The interval at which to write heartbeat messages. Heartbeat messages are needed in scenarios when the subscribed tables are low frequency, but there are other high frequency tables writing. Due to the checkpointing mechanism for replication slots, not having new messages to acknowledge will prevent postgres from reclaiming the write ahead log, which can exhaust the local disk. Having heartbeats allows Redpanda Connect to safely acknowledge data periodically and move forward the committed point in the log so it can be reclaimed. Setting the duration to 0s will disable heartbeats entirely. Heartbeats are created by periodically writing logical messages to the write ahead log using `pg_logical_emit_message`.\n\nHeartbeats also pace `incremental_snapshot`: on a quiet table they are the only thing advancing the snapshot. This interval just keeps the slot current, so `" + fieldIncSnapshot + "." + fieldIncSnapshotHeartbeatInterval + "` applies alongside it and the more frequent wins for the life of the input. A non-zero value is still required here.").
 			ShortDescription("Interval at which to write heartbeat messages, keeping the replication slot current on low-traffic tables.").
 			Default("1h").
 			Example("0s").
@@ -258,6 +271,34 @@ INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message"
 			Example("rpcn_signal_table").
 			Default("").
 			Advanced()).
+		// incremental snapshot config
+		Field(service.NewObjectField(fieldIncSnapshot,
+			service.NewBoolField(fieldIncSnapshotEnabled).
+				Description("Snapshots the configured tables in chunks, starting as soon as replication begins. Unlike `"+fieldStreamSnapshot+"` it needs no up-front snapshot phase, does not delay replication. The two are mutually exclusive: both read the same rows, so enabling either alongside the other would deliver everything twice.\n\nProgress is driven by the replication stream: each streamed transaction releases a buffered chunk, and several more follow immediately if the database was idle during the read. Quiet tables therefore advance in bursts on each heartbeat, paced by `"+fieldIncSnapshotHeartbeatInterval+"`.\n\nA row can arrive twice, once from replication and once from the backfill: when a primary key reuses or fills a gap below the table's current maximum, or -- whatever the key type -- when a row is inserted after replication starts but before the snapshot reaches its table. Treat rows as idempotent upserts keyed by primary key, as is standard CDC practice.").
+				ShortDescription("Snapshot the configured tables in chunks, alongside replication streaming.").
+				Default(incsnapshot.DefaultIncSnapshotEnabled),
+			service.NewStringListField(fieldIncrementalSnapshotTables).
+				Description("The tables to incrementally snapshot. If omitted, the tables configured in `"+fieldTables+"` are used instead, so at least one of the two must be set. Each entry must be replicated, so it must appear in `"+fieldTables+"` unless that list is empty, which replicates everything.\n\nOnly read when a snapshot starts from scratch. Once a checkpoint exists the table set comes from it, so edits here are silently ignored: added tables are not backfilled, and removed tables still are. Change `"+fieldIncSnapshotCheckpointCacheKey+"`, or clear the existing key, to pick up an edited list.").
+				Optional(),
+			service.NewIntField(fieldIncrementalSnapshotChunkSize).
+				Description("The number of rows to read per chunk while incrementally snapshotting a table.").
+				Default(incsnapshot.DefaultIncSnapshotChunkSize),
+			service.NewDurationField(fieldIncSnapshotHeartbeatInterval).
+				Description("How often to heartbeat while `"+fieldIncSnapshotEnabled+"` is `true`. The snapshot only advances on a streamed transaction, so on quiet tables this paces it. Raise it to reduce write load at the cost of a slower backfill.\n\nWhichever of this and the top-level `"+fieldHeartbeatInterval+"` is more frequent wins, and applies for the life of the input -- it is fixed at startup, not reverted when the backfill completes. Heartbeats are transactional while this is enabled, so each consumes a transaction id.").
+				ShortDescription("How often to heartbeat while incremental snapshotting is enabled, which paces it on quiet tables.").
+				Default(incsnapshot.DefaultIncSnapshotHeartbeatInterval.String()),
+			service.NewStringField(fieldIncSnapshotCheckpointCache).
+				Description("A https://www.docs.redpanda.com/redpanda-connect/components/caches/about[cache resource^] storing the snapshot's progress, so a restart resumes instead of starting over. Required when `"+fieldIncSnapshotEnabled+"` is `true`.").
+				ShortDescription("Cache resource storing incremental snapshot progress, so restarts resume instead of starting over. Required when enabled.").
+				Optional(),
+			service.NewStringField(fieldIncSnapshotCheckpointCacheKey).
+				Description("The key used to store the incremental snapshot progress in `"+fieldIncSnapshotCheckpointCache+"`. Use a different key if multiple incremental snapshots share the same cache.\n\nChanging or clearing this key starts a fresh snapshot of the configured tables -- currently the only way to re-run a backfill.").
+				Default(incsnapshot.DefaultIncSnapshotCheckpointKey),
+		).
+			Description("Configures chunked snapshotting that runs alongside replication streaming.").
+			ShortDescription("Configures chunked snapshotting that runs alongside replication streaming.").
+			Advanced().
+			Optional()).
 		Field(service.NewAutoRetryNacksToggleField()).
 		Field(service.NewBatchPolicyField(fieldBatching))
 }
@@ -379,6 +420,11 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 	awsConf := conf.Namespace(fieldAWSIAMAuth)
 	iamAuthEnabled, _ = awsConf.FieldBool(FieldAWSIAMAuthEnabled)
 
+	incSnapshot, err := parseIncrementalSnapshotCfg(conf, heartbeatInterval, tables, streamSnapshot)
+	if err != nil {
+		return nil, err
+	}
+
 	pgConnConfig, err := pgconn.ParseConfigWithOptions(dsn, pgconn.ParseConfigOptions{
 		// Don't support dynamic reading of password
 		GetSSLPassword: func(context.Context) string { return "" },
@@ -428,6 +474,7 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 			UnchangedToastValue:      unchangedToastValue,
 			HeartbeatInterval:        heartbeatInterval,
 			SignalTableName:          signalTableName,
+			IncrementalSnapshot:      incSnapshot.cfg,
 		},
 		batching:        batching,
 		checkpointLimit: checkpointLimit,
@@ -440,6 +487,9 @@ func newPgStreamInput(conf *service.ParsedConfig, mgr *service.Resources) (s ser
 		stopSig:         shutdown.NewSignaller(),
 
 		iamAuthEnabled: iamAuthEnabled,
+
+		incSnapshotCheckpointCache:    incSnapshot.cache,
+		incSnapshotCheckpointCacheKey: incSnapshot.cacheKey,
 	}
 
 	if i.controlSig, err = newControlSignaller(schema, signalTableName, logger); err != nil {
@@ -498,6 +548,22 @@ type pgStreamInput struct {
 
 	// IAM authentication fields
 	iamAuthEnabled bool
+
+	// only applies to incremental snapshot when enabled
+	incSnapshotCheckpointCache    string
+	incSnapshotCheckpointCacheKey string
+	incSnapshotSeq                atomic.Uint64
+
+	// lastPersistedMu protects the lastPersisted fields below, which
+	// commitCheckpoint touches from concurrent acknowledgements.
+	lastPersistedMu sync.Mutex
+	// lastPersistedIncSnapshotState avoids needless cache writes.
+	// checkpointTracker copies the last state onto every later checkpoint,
+	// so most acknowledgements carry an unchanged value.
+	lastPersistedIncSnapshotState []byte
+	// lastPersistedIncSnapshotSeq is the Seq of the state in the cache.
+	// persistIncSnapshotState uses it to reject an older state.
+	lastPersistedIncSnapshotSeq uint64
 }
 
 func (p *pgStreamInput) Connect(ctx context.Context) error {
@@ -505,6 +571,19 @@ func (p *pgStreamInput) Connect(ctx context.Context) error {
 	if p.iamAuthEnabled && p.streamConfig.RefreshAuthToken != nil {
 		if err := p.streamConfig.RefreshAuthToken(ctx); err != nil {
 			return fmt.Errorf("unable to generate IAM auth token: %w", err)
+		}
+	}
+
+	if p.streamConfig.IncrementalSnapshotCfg().IsEnabled() {
+		state, err := p.loadCachedIncSnapshotState(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to load incremental snapshot checkpoint: %w", err)
+		}
+		p.streamConfig.IncrementalSnapshot.ResumeState = state
+		if state == nil {
+			p.logger.Debugf("Incremental snapshot: no checkpoint found, will start fresh")
+		} else {
+			p.logger.Debugf("Incremental snapshot: loaded checkpoint (done=%v, current_table=%v, remaining=%d)", state.Done, state.CurrentTable, len(state.RemainingTables))
 		}
 	}
 
@@ -551,7 +630,25 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 	var nextTimedBatchChan <-chan time.Time
 
 	// offsets are nilable since we don't provide offset tracking during the snapshot phase
-	cp := checkpoint.NewCapped[*string](int64(p.checkpointLimit))
+	cp := newCheckpointTracker(int64(p.checkpointLimit), &p.incSnapshotSeq)
+
+	// blockingSnapshotComplete gates the isSnapshot/snapshotAckWG barrier to
+	// the one-shot stream_snapshot phase, never to incremental snapshot's
+	// nil-LSN batches. See WillEmitBlockingSnapshot.
+	blockingSnapshotComplete := !pgStream.BlockingSnapshot
+
+	// pendingIncrementalState holds the newest checkpoint state until the
+	// next flush sends it. The "lsn" metadata of a message moves in the same
+	// way.
+	var pendingIncrementalState []byte
+
+	// batcherBuffered is the number of messages in the batcher that the
+	// input has not given to checkpointTracker. The tracker cannot order
+	// those rows. Therefore a checkpoint with no rows must not resolve while
+	// this number is not zero. Refer to the
+	// IncrementalSnapshotCheckpointOpType case.
+	batcherBuffered := 0
+
 	for !p.stopSig.IsSoftStopSignalled() {
 		select {
 		case <-nextTimedBatchChan:
@@ -561,9 +658,15 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				p.logger.Debugf("timed flush batch error: %s", err)
 				break
 			}
-			if err := p.flushBatch(ctx, pgStream, cp, flushedBatch); err != nil {
+			batcherBuffered = 0
+			if err := p.flushBatch(ctx, pgStream, cp, flushedBatch, pendingIncrementalState, blockingSnapshotComplete); err != nil {
 				p.logger.Debugf("failed to flush batch: %s", err)
 				break
+			}
+			// Clear the state only when flushBatch tracked a batch. An empty
+			// flush tracks nothing, and a clear here loses the checkpoint.
+			if len(flushedBatch) > 0 {
+				pendingIncrementalState = nil
 			}
 		case batch := <-pgStream.Messages():
 			if len(batch) == 1 && batch[0].Operation == pglogicalstream.SnapshotCompleteOpType {
@@ -581,10 +684,17 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 					p.stopSig.TriggerSoftStop()
 					break
 				}
-				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch); err != nil {
+				batcherBuffered = 0
+				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch, pendingIncrementalState, blockingSnapshotComplete); err != nil {
 					p.logger.Debugf("failed to flush snapshot completion batch: %s", err)
 					p.stopSig.TriggerSoftStop()
 					break
+				}
+				// Clear the state only when flushBatch tracked a batch. An
+				// empty flush tracks nothing, and a clear here loses the
+				// checkpoint.
+				if len(flushedBatch) > 0 {
+					pendingIncrementalState = nil
 				}
 				drained := make(chan struct{})
 				go func() {
@@ -596,8 +706,31 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				select {
 				case <-drained:
 					pgStream.MarkSnapshotAcknowledged()
+					blockingSnapshotComplete = true
 				case <-p.stopSig.SoftStopChan():
 				}
+				break
+			}
+			if len(batch) == 1 && batch[0].Operation == pglogicalstream.IncrementalSnapshotCheckpointOpType {
+				// State advanced with no rows emitted, so no message can
+				// carry it. Hold it pending -- state only advances, so the
+				// newest wins and anything left pending rides out on the
+				// next flush.
+				pendingIncrementalState = batch[0].IncrementalSnapshotState
+				if batcherBuffered > 0 {
+					// The tracker cannot see the rows still in the batcher,
+					// so committing now would checkpoint past them.
+					break
+				}
+				// Nothing untracked is buffered, so this still resolves
+				// behind any unresolved earlier batch.
+				if err := p.commitIncrementalSnapshotCheckpoint(ctx, pgStream, cp, batch[0].IncrementalSnapshotState); err != nil {
+					// Stays pending for the next flush. Until one succeeds
+					// the stored checkpoint is stale.
+					p.logger.Warnf("unable to commit incremental snapshot checkpoint, retrying on the next flush: %s", err)
+					break
+				}
+				pendingIncrementalState = nil
 				break
 			}
 			var (
@@ -609,6 +742,15 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				if _, err := p.controlSig.listen(&msg); err != nil {
 					// Log it and fall through to the normal emit path below.
 					p.logger.Errorf("failed to detect control signal in change event: %s", err)
+				}
+
+				if msg.IncrementalSnapshotState != nil {
+					pendingIncrementalState = msg.IncrementalSnapshotState
+				}
+				if msg.Operation == pglogicalstream.IncrementalSnapshotCheckpointOpType {
+					// Defensive: this sentinel never shares a batch with other
+					// messages today, but never forward it if that changes.
+					continue
 				}
 
 				var marshalErr error
@@ -647,6 +789,7 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 				if msg.BeforeData != nil {
 					batchMsg.MetaSetImmut("before", service.ImmutableAny{V: msg.BeforeData})
 				}
+				batcherBuffered++
 				if batcher.Add(batchMsg) {
 					flush = true
 				}
@@ -658,9 +801,16 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 					p.logger.Debugf("error flushing batch: %s", err)
 					break
 				}
-				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch); err != nil {
+				batcherBuffered = 0
+				if err := p.flushBatch(ctx, pgStream, cp, flushedBatch, pendingIncrementalState, blockingSnapshotComplete); err != nil {
 					p.logger.Debugf("failed to flush batch: %s", err)
 					break
+				}
+				// Clear the state only when flushBatch tracked a batch. An
+				// empty flush tracks nothing, and a clear here loses the
+				// checkpoint.
+				if len(flushedBatch) > 0 {
+					pendingIncrementalState = nil
 				}
 			} else {
 				d, ok := batcher.UntilNext()
@@ -678,31 +828,147 @@ func (p *pgStreamInput) processStream(pgStream *pglogicalstream.Stream, batcher 
 	}
 }
 
+// checkpointTracker tracks CheckpointOffset values. It resolves
+// acknowledgements in order, also when they arrive out of order. It merges
+// each offset with the last offset before it tracks the offset. A
+// resolution with a nil LSN or a nil IncSnapshotState therefore does not
+// remove the value of the field that it does not hold.
+//
+// Call Track only from the processStream goroutine. The functions that Track
+// returns are safe to call from other goroutines at the same time. The
+// acknowledgement functions do this.
+type checkpointTracker struct {
+	cp   *checkpoint.Capped[incsnapshot.CheckpointOffset]
+	last incsnapshot.CheckpointOffset
+	// seq is owned by the input, not this tracker, so it survives a
+	// reconnect. See pgStreamInput.incSnapshotSeq.
+	seq *atomic.Uint64
+}
+
+func newCheckpointTracker(limit int64, seq *atomic.Uint64) *checkpointTracker {
+	return &checkpointTracker{
+		cp:  checkpoint.NewCapped[incsnapshot.CheckpointOffset](limit),
+		seq: seq,
+	}
+}
+
+func (t *checkpointTracker) Track(ctx context.Context, offset incsnapshot.CheckpointOffset, batchSize int64) (func() *incsnapshot.CheckpointOffset, error) {
+	// Orders the offsets for commitCheckpoint. Monotonic for the life of the
+	// input, across any number of trackers.
+	offset.Seq = t.seq.Add(1)
+	t.last = t.last.Merge(offset)
+	return t.cp.Track(ctx, t.last, batchSize)
+}
+
+// commitCheckpoint applies a resolved CheckpointOffset. It writes
+// IncSnapshotState even when the LSN acknowledgement fails. A temporary
+// AckLSN error must not stop the input from saving snapshot progress.
+//
+// The opposite order is worse. If the input acknowledges the LSN first and
+// then writes the state, a failure between the two steps leaves an
+// acknowledged LSN with no state.
+func (p *pgStreamInput) commitCheckpoint(ctx context.Context, pgStream *pglogicalstream.Stream, offset incsnapshot.CheckpointOffset) error {
+	var errs []error
+	if offset.IncSnapshotState != nil {
+		if err := p.persistIncSnapshotState(ctx, offset); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if offset.LSN != nil {
+		if err := pgStream.AckLSN(ctx, *offset.LSN); err != nil {
+			errs = append(errs, fmt.Errorf("unable to ack LSN to postgres: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// persistIncSnapshotState writes offset's snapshot state to the cache.
+//
+// Acknowledgements run concurrently, so it holds incStateMu across the test
+// and the write to keep the pair atomic. The lock alone is not enough: the
+// calls can take it in either order, so it also rejects any offset that is
+// not newer than the one already written.
+func (p *pgStreamInput) persistIncSnapshotState(ctx context.Context, offset incsnapshot.CheckpointOffset) error {
+	p.lastPersistedMu.Lock()
+	defer p.lastPersistedMu.Unlock()
+
+	if offset.Seq <= p.lastPersistedIncSnapshotSeq {
+		// A newer state is already in the cache.
+		return nil
+	}
+
+	// Unchanged state: record the new Seq but skip the write.
+	if bytes.Equal(offset.IncSnapshotState, p.lastPersistedIncSnapshotState) {
+		p.lastPersistedIncSnapshotSeq = offset.Seq
+		return nil
+	}
+
+	if err := p.saveIncrementalSnapshotState(ctx, offset.IncSnapshotState); err != nil {
+		return fmt.Errorf("unable to persist incremental snapshot checkpoint: %w", err)
+	}
+	p.lastPersistedIncSnapshotState = offset.IncSnapshotState
+	p.lastPersistedIncSnapshotSeq = offset.Seq
+	return nil
+}
+
+// commitIncrementalSnapshotCheckpoint tracks a checkpoint that has no rows
+// and then resolves it. It tracks the checkpoint and does not write it
+// directly. The checkpoint then still comes after each earlier tracked
+// batch and cannot pass rows that the pipeline has not acknowledged.
+//
+// Call this function only when the batcher holds no rows that the tracker
+// does not have. The tracker orders only the batches that it has. It cannot
+// see rows in the batcher, and this function would then resolve past those
+// rows.
+func (p *pgStreamInput) commitIncrementalSnapshotCheckpoint(ctx context.Context, pgStream *pglogicalstream.Stream, checkpointer *checkpointTracker, state []byte) error {
+	resolveFn, err := checkpointer.Track(ctx, incsnapshot.CheckpointOffset{IncSnapshotState: state}, 0)
+	if err != nil {
+		return fmt.Errorf("unable to checkpoint incremental snapshot state: %w", err)
+	}
+	maxOffset := resolveFn()
+	if maxOffset == nil {
+		return nil
+	}
+	return p.commitCheckpoint(ctx, pgStream, *maxOffset)
+}
+
 func (p *pgStreamInput) flushBatch(
 	ctx context.Context,
 	pgStream *pglogicalstream.Stream,
-	checkpointer *checkpoint.Capped[*string],
+	checkpointer *checkpointTracker,
 	batch service.MessageBatch,
+	incSnapshotState []byte,
+	blockingSnapshotComplete bool,
 ) error {
 	if len(batch) == 0 {
 		return nil
 	}
 
+	// Snapshot rows have no LSN, and they share this batcher with change
+	// rows that have an LSN. Therefore a batch can end with a snapshot row.
+	// Search backwards for the last message that has an LSN. Do not use the
+	// last message of the batch.
 	var lsn *string
-	lastMsg := batch[len(batch)-1]
-	lsnStr, ok := lastMsg.MetaGet("lsn")
-	if ok {
-		lsn = &lsnStr
+	for i := len(batch) - 1; i >= 0; i-- {
+		if lsnStr, ok := batch[i].MetaGet("lsn"); ok {
+			lsn = &lsnStr
+			break
+		}
 	}
-	resolveFn, err := checkpointer.Track(ctx, lsn, int64(len(batch)))
+	offset := incsnapshot.CheckpointOffset{LSN: lsn, IncSnapshotState: incSnapshotState}
+	resolveFn, err := checkpointer.Track(ctx, offset, int64(len(batch)))
 	if err != nil {
 		return fmt.Errorf("unable to checkpoint: %w", err)
 	}
 
-	// Snapshot batches carry no LSN. Track them so the snapshot->stream handoff
-	// can block until they are acknowledged downstream (see the sentinel handling
-	// in the read loop).
-	isSnapshot := lsn == nil
+	// The single stream_snapshot phase also has no LSN. Track those batches,
+	// and the change from snapshot to stream can then wait for their
+	// acknowledgement. Refer to the message handling in the read loop.
+	//
+	// Incremental snapshot batches also have no LSN, but they continue for
+	// the life of the stream. Therefore blockingSnapshotComplete removes
+	// them from that wait after the first phase is complete.
+	isSnapshot := lsn == nil && !blockingSnapshotComplete
 
 	ackFn := func(ctx context.Context, _ error) error {
 		if isSnapshot {
@@ -712,14 +978,7 @@ func (p *pgStreamInput) flushBatch(
 		if maxOffset == nil {
 			return nil
 		}
-		maxLSN := *maxOffset
-		if maxLSN == nil {
-			return nil
-		}
-		if err = pgStream.AckLSN(ctx, *maxLSN); err != nil {
-			return fmt.Errorf("unable to ack LSN to postgres: %w", err)
-		}
-		return nil
+		return p.commitCheckpoint(ctx, pgStream, *maxOffset)
 	}
 	if isSnapshot {
 		p.snapshotAckWG.Add(1)
@@ -731,6 +990,51 @@ func (p *pgStreamInput) flushBatch(
 			p.snapshotAckWG.Done()
 		}
 		return ctx.Err()
+	}
+	return nil
+}
+
+// loadCachedIncSnapshotState reads the incremental snapshot checkpoint from
+// the cache. A key that does not exist shows that there is no checkpoint and
+// that the snapshot starts new. This result is not an error.
+func (p *pgStreamInput) loadCachedIncSnapshotState(ctx context.Context) (*incrementalsnapshot.State, error) {
+	var (
+		cacheVal []byte
+		cErr     error
+	)
+	if err := p.mgr.AccessCache(ctx, p.incSnapshotCheckpointCache, func(c service.Cache) {
+		cacheVal, cErr = c.Get(ctx, p.incSnapshotCheckpointCacheKey)
+	}); err != nil {
+		return nil, fmt.Errorf("unable to access cache for reading: %w", err)
+	}
+	if errors.Is(cErr, service.ErrKeyNotFound) {
+		return nil, nil
+	} else if cErr != nil {
+		return nil, fmt.Errorf("unable to read checkpoint from cache: %w", cErr)
+	} else if cacheVal == nil {
+		return nil, nil
+	}
+	state := new(incrementalsnapshot.State)
+	if err := json.Unmarshal(cacheVal, state); err != nil {
+		if errors.Is(err, incrementalsnapshot.ErrUnsupportedStateVersion) {
+			return nil, fmt.Errorf("%w: change %s.%s, or clear that key, to start a fresh snapshot", err, fieldIncSnapshot, fieldIncSnapshotCheckpointCacheKey)
+		}
+		return nil, fmt.Errorf("unable to unmarshal incremental snapshot checkpoint: %w", err)
+	}
+	return state, nil
+}
+
+// saveIncrementalSnapshotState writes an incremental snapshot checkpoint to
+// the cache. The caller supplies the checkpoint as bytes.
+func (p *pgStreamInput) saveIncrementalSnapshotState(ctx context.Context, state []byte) error {
+	var cErr error
+	if err := p.mgr.AccessCache(ctx, p.incSnapshotCheckpointCache, func(c service.Cache) {
+		cErr = c.Set(ctx, p.incSnapshotCheckpointCacheKey, state, nil)
+	}); err != nil {
+		return fmt.Errorf("unable to access cache for writing: %w", err)
+	}
+	if cErr != nil {
+		return fmt.Errorf("unable to persist checkpoint to cache: %w", cErr)
 	}
 	return nil
 }

--- a/internal/impl/postgresql/input_pg_stream.go
+++ b/internal/impl/postgresql/input_pg_stream.go
@@ -278,7 +278,7 @@ INSERT INTO <schema>.<signal_table_name> (type, data) VALUES ('log', '{"message"
 				ShortDescription("Snapshot the configured tables in chunks, alongside replication streaming.").
 				Default(incsnapshot.DefaultIncSnapshotEnabled),
 			service.NewStringListField(fieldIncrementalSnapshotTables).
-				Description("The tables to incrementally snapshot. If omitted, the tables configured in `"+fieldTables+"` are used instead, so at least one of the two must be set. Each entry must be replicated, so it must appear in `"+fieldTables+"` unless that list is empty, which replicates everything.\n\nOnly read when a snapshot starts from scratch. Once a checkpoint exists the table set comes from it, so edits here are silently ignored: added tables are not backfilled, and removed tables still are. Change `"+fieldIncSnapshotCheckpointCacheKey+"`, or clear the existing key, to pick up an edited list.").
+				Description("The tables to incrementally snapshot. If omitted, the tables configured in `"+fieldTables+"` are used instead, so at least one of the two must be set. Each entry must be replicated, so it must appear in `"+fieldTables+"` unless that list is empty, which replicates everything.\n\nThis list is reconciled against the checkpoint on every restart. Adding a table backfills it, even once the snapshot has finished. Removing one drops it, and a table that was part-read stops where it is, leaving it incomplete downstream -- both are logged. Change `"+fieldIncSnapshotCheckpointCacheKey+"`, or clear the existing key, to start over from this list.").
 				Optional(),
 			service.NewIntField(fieldIncrementalSnapshotChunkSize).
 				Description("The number of rows to read per chunk while incrementally snapshotting a table.").

--- a/internal/impl/postgresql/input_pg_stream_test.go
+++ b/internal/impl/postgresql/input_pg_stream_test.go
@@ -10,6 +10,7 @@ package pgstream
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -92,4 +93,169 @@ signal_table_name: rpcn_signal_table
 			}
 		})
 	}
+}
+
+func TestNewPgStreamInputIncSnapshotHeartbeat(t *testing.T) {
+	env := service.NewEnvironment()
+	spec := newPostgresCDCConfig()
+
+	const base = `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+`
+
+	// ParseYAML cannot add a cache resource. The checkpoint_cache tests also
+	// run after the heartbeat tests. Therefore the cases that pass look for
+	// the cache error. That error shows that the checks passed the heartbeat
+	// test.
+	const pastHeartbeatCheck = "checkpoint_cache is required"
+
+	tests := []struct {
+		name        string
+		conf        string
+		errContains string
+	}{
+		{
+			// An unreplicated table would lose writes: no live changes to
+			// dedup its backfill against.
+			name: "incremental snapshot table not replicated",
+			conf: base + `
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+  tables:
+    - events
+    - customers
+`,
+			errContains: `"customers" is not listed in tables`,
+		},
+		{
+			// Case-folding must match how Postgres resolves the names.
+			name: "incremental snapshot table matches under case folding",
+			conf: base + `
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+  tables:
+    - EVENTS
+`,
+			errContains: pastHeartbeatCheck,
+		},
+		{
+			// Both modes read the same rows, so together they double-deliver.
+			name: "both snapshot modes enabled",
+			conf: base + `
+stream_snapshot: true
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: "mutually exclusive",
+		},
+		{
+			name: "blocking snapshot alone",
+			conf: base + `
+stream_snapshot: true
+`,
+		},
+		{
+			// Both lists empty: no table names to read, so the snapshot
+			// would silently do nothing.
+			name: "incremental snapshot enabled with no tables anywhere",
+			conf: `
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: "no tables are listed",
+		},
+		{
+			// An omitted list inherits the replicated tables.
+			name: "incremental snapshot enabled without tables",
+			conf: base + `
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: pastHeartbeatCheck,
+		},
+		{
+			// The incremental snapshot moves forward only on a streamed
+			// commit. Without a heartbeat a quiet table stops for ever.
+			name: "incremental snapshot enabled with heartbeats disabled",
+			conf: base + `
+heartbeat_interval: 0s
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: "heartbeat_interval is disabled",
+		},
+		{
+			name: "incremental snapshot enabled with a heartbeat interval",
+			conf: base + `
+heartbeat_interval: 5s
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: pastHeartbeatCheck,
+		},
+		{
+			// A long interval makes the snapshot slow but does not stop
+			// it. Therefore the input warns and does not fail.
+			name: "incremental snapshot enabled at the default heartbeat interval",
+			conf: base + `
+incremental_snapshot:
+  enabled: true
+`,
+			errContains: pastHeartbeatCheck,
+		},
+		{
+			// This condition applies only while the snapshot runs.
+			name: "heartbeats disabled with incremental snapshot disabled",
+			conf: base + `
+heartbeat_interval: 0s
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pConf, err := spec.ParseYAML(test.conf, env)
+			require.NoError(t, err)
+
+			mgr := service.MockResources()
+			license.InjectTestService(mgr)
+
+			_, err = newPgStreamInput(pConf, mgr)
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIncSnapshotHeartbeatIntervalRejectsZero(t *testing.T) {
+	// The snapshot cannot advance without commits to compare against.
+	pConf, err := newPostgresCDCConfig().ParseYAML(`
+dsn: postgres://user:pass@localhost:5432/db
+slot_name: my_slot
+schema: dbo
+tables:
+  - events
+incremental_snapshot:
+  enabled: true
+  heartbeat_interval: 0s
+`, service.NewEnvironment())
+	require.NoError(t, err)
+
+	_, err = parseIncrementalSnapshotCfg(pConf, time.Hour, []string{"events"}, false)
+	require.ErrorContains(t, err, "incremental_snapshot.heartbeat_interval must be > 0")
 }

--- a/internal/impl/postgresql/integration_test.go
+++ b/internal/impl/postgresql/integration_test.go
@@ -1717,3 +1717,663 @@ postgres_cdc:
 	}
 	assert.Equal(t, "STRING", byName["extra"], "new 'extra' column should have type STRING")
 }
+
+func TestIntegrationIncrementalSnapshot(t *testing.T) {
+	integration.CheckSkip(t)
+
+	type incrementalSnapshotRow struct {
+		id        int64
+		operation string
+	}
+
+	t.Run("Concurrent Writes", func(t *testing.T) {
+		databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+		require.NoError(t, err)
+
+		// Pre-existing rows: only ever observable via the incremental snapshot
+		// backfill, since the replication slot is created after these commits.
+		const numPreExisting = 1000
+		for range numPreExisting {
+			_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ('pre', NOW())`)
+			require.NoError(t, err)
+		}
+
+		template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_incremental_concurrent
+    schema: public
+    heartbeat_interval: 500ms
+    tables:
+      - flights
+    incremental_snapshot:
+        enabled: true
+        chunk_size: 20
+        checkpoint_cache: snap_cache
+`, databaseURL)
+
+		builder := service.NewStreamBuilder()
+		require.NoError(t, builder.SetLoggerYAML(`level: DEBUG`))
+		require.NoError(t, builder.AddInputYAML(template))
+		require.NoError(t, builder.AddCacheYAML(`
+label: snap_cache
+memory: {}`))
+
+		var (
+			mu   sync.Mutex
+			rows []incrementalSnapshotRow
+		)
+		require.NoError(t, builder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, msg := range batch {
+				data, err := msg.AsStructured()
+				if err != nil {
+					return err
+				}
+				id, err := data.(map[string]any)["id"].(json.Number).Int64()
+				if err != nil {
+					return err
+				}
+				op, _ := msg.MetaGet("operation")
+				rows = append(rows, incrementalSnapshotRow{id: id, operation: op})
+			}
+			return nil
+		}))
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		streamStopped := make(chan struct{})
+		go func() {
+			defer close(streamStopped)
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		// Wait for at least one backfill row before writing concurrently: it
+		// proves the coordinator's max-PK bound is already frozen, so every
+		// subsequent insert gets a serial PK above it -- immune to the
+		// double-delivery race documented on Coordinator.OnStreamedRow.
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(rows) >= 1
+		}, 30*time.Second, 50*time.Millisecond, "did not observe any snapshot backfill rows before starting the concurrent writer")
+
+		// Write new rows while the backfill is still running, racing chunk
+		// reads against live inserts on the same table.
+		const numConcurrent = 1000
+		writerDone := make(chan struct{})
+		// require calls FailNow, which is invalid off the test goroutine: it
+		// would stop the writer early and surface as a missing-rows failure
+		// instead of the insert error. Carry the error out and assert it
+		// here, where closing writerDone orders the write before this read.
+		var writerErr error
+		go func() {
+			defer close(writerDone)
+			for range numConcurrent {
+				if _, err := db.Exec(`INSERT INTO flights (name, created_at) VALUES ('concurrent', NOW())`); err != nil {
+					writerErr = err
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+		<-writerDone
+		require.NoError(t, writerErr, "concurrent writer failed")
+
+		var totalRows int64
+		require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM flights`).Scan(&totalRows))
+		require.EqualValues(t, numPreExisting+numConcurrent, totalRows)
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return int64(len(rows)) >= totalRows
+		}, 60*time.Second, 100*time.Millisecond, "did not observe every row from the pre-existing backfill and the concurrent writes")
+
+		require.NoError(t, stream.StopWithin(10*time.Second))
+		select {
+		case <-streamStopped:
+		case <-time.After(30 * time.Second):
+			require.Fail(t, "stream did not stop in time")
+		}
+
+		// Every row, backfill or live, must be observed exactly once: dedup must
+		// neither drop nor double-deliver.
+		mu.Lock()
+		defer mu.Unlock()
+		counts := make(map[int64]int, len(rows))
+		for _, r := range rows {
+			counts[r.id]++
+		}
+		assert.Len(t, counts, int(totalRows), "expected exactly %d distinct rows to be observed", totalRows)
+		for id, count := range counts {
+			assert.Equal(t, 1, count, "row id %d observed %d times, expected exactly once", id, count)
+		}
+	})
+
+	// Non-integer keys, run through the real decoders. The window keys rows
+	// by the formatted key, so if the snapshot and streaming paths disagree
+	// on a type no live row evicts its buffered copy and the stale snapshot
+	// row lands after the update that superseded it.
+	for _, keyed := range []struct {
+		name    string
+		table   string
+		ddl     string
+		insert  string
+		keyCols []string
+	}{
+		{
+			name:    "UUIDKey",
+			table:   "uuid_keyed",
+			ddl:     `CREATE TABLE uuid_keyed (id uuid PRIMARY KEY, name TEXT)`,
+			insert:  `INSERT INTO uuid_keyed (id, name) VALUES (gen_random_uuid(), 'orig')`,
+			keyCols: []string{"id"},
+		},
+		{
+			name:    "CompositeUUIDTextKey",
+			table:   "uuid_text_keyed",
+			ddl:     `CREATE TABLE uuid_text_keyed (id uuid, tenant TEXT, name TEXT, PRIMARY KEY (id, tenant))`,
+			insert:  `INSERT INTO uuid_text_keyed (id, tenant, name) VALUES (gen_random_uuid(), 'tenant-a', 'orig')`,
+			keyCols: []string{"id", "tenant"},
+		},
+	} {
+		t.Run("Concurrent Updates/"+keyed.name, func(t *testing.T) {
+			databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+			require.NoError(t, err)
+
+			_, err = db.Exec(keyed.ddl)
+			require.NoError(t, err)
+
+			// Inserted before the slot exists, so only the snapshot can
+			// deliver them.
+			const numPreExisting = 400
+			for range numPreExisting {
+				_, err = db.Exec(keyed.insert)
+				require.NoError(t, err)
+			}
+
+			template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_inc_%s
+    schema: public
+    heartbeat_interval: 500ms
+    tables:
+      - %s
+    incremental_snapshot:
+        enabled: true
+        chunk_size: 50
+        checkpoint_cache: snap_cache
+`, databaseURL, keyed.table, keyed.table)
+
+			builder := service.NewStreamBuilder()
+			require.NoError(t, builder.SetLoggerYAML(`level: DEBUG`))
+			require.NoError(t, builder.AddInputYAML(template))
+			require.NoError(t, builder.AddCacheYAML(`
+label: snap_cache
+memory: {}`))
+
+			// Key on the formatted primary key, mirroring how the dedup window
+			// keys rows, so a decode mismatch shows up as extra keys as well
+			// as a stale value.
+			var (
+				mu      sync.Mutex
+				latest  = map[string]string{}
+				updates int
+				reads   int
+			)
+			require.NoError(t, builder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, msg := range batch {
+					data, err := msg.AsStructured()
+					if err != nil {
+						return err
+					}
+					fields, ok := data.(map[string]any)
+					if !ok {
+						return fmt.Errorf("unexpected payload shape %T", data)
+					}
+					key := make([]string, 0, len(keyed.keyCols))
+					for _, col := range keyed.keyCols {
+						key = append(key, fmt.Sprint(fields[col]))
+					}
+					op, _ := msg.MetaGet("operation")
+					switch op {
+					case "read":
+						reads++
+					case "update":
+						updates++
+					}
+					name, _ := fields["name"].(string)
+					latest[strings.Join(key, "|")] = name
+				}
+				return nil
+			}))
+
+			stream, err := builder.Build()
+			require.NoError(t, err)
+			license.InjectTestService(stream.Resources())
+
+			streamStopped := make(chan struct{})
+			go func() {
+				defer close(streamStopped)
+				if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
+			}()
+
+			require.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				return reads >= 1
+			}, 30*time.Second, 50*time.Millisecond, "did not observe any backfill rows before updating")
+
+			// Update every row repeatedly while the backfill runs, so updates
+			// land on chunks already read, currently buffered, and not yet
+			// reached.
+			const updatePasses = 3
+			for pass := range updatePasses {
+				_, err := db.Exec(`UPDATE `+keyed.table+` SET name = $1`, fmt.Sprintf("updated-%d", pass))
+				require.NoError(t, err)
+			}
+			finalName := fmt.Sprintf("updated-%d", updatePasses-1)
+
+			var totalRows int64
+			require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM `+keyed.table).Scan(&totalRows))
+			require.EqualValues(t, numPreExisting, totalRows)
+
+			require.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				if int64(len(latest)) < totalRows {
+					return false
+				}
+				for _, name := range latest {
+					if name != finalName {
+						return false
+					}
+				}
+				return true
+			}, 90*time.Second, 100*time.Millisecond,
+				"a row never settled on its updated value, so the snapshot and streaming decoders disagreed on the primary key")
+
+			require.NoError(t, stream.StopWithin(10*time.Second))
+			<-streamStopped
+
+			mu.Lock()
+			defer mu.Unlock()
+			// One key per row: a decode mismatch would produce two.
+			require.Len(t, latest, int(totalRows))
+			require.NotZero(t, updates, "no updates streamed, so dedup was not exercised")
+		})
+	}
+
+	t.Run("Concurrent Updates", func(t *testing.T) {
+		// Whichever order the two occur in, the consumer must end on the updated
+		// value: an update committing before its chunk is read is already in the
+		// snapshot's result, and one committing after must evict the buffered
+		// row.
+
+		databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+		require.NoError(t, err)
+
+		// Not a multiple of chunk_size, so the last chunk is a partial one.
+		const numPreExisting = 605 // 12 full chunks of 50, then 5
+		for range numPreExisting {
+			_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ('orig', NOW())`)
+			require.NoError(t, err)
+		}
+
+		var minID, maxID int64
+		require.NoError(t, db.QueryRow(`SELECT MIN(id), MAX(id) FROM flights`).Scan(&minID, &maxID))
+
+		template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_incremental_collision
+    schema: public
+    heartbeat_interval: 500ms
+    tables:
+      - flights
+    incremental_snapshot:
+        enabled: true
+        chunk_size: 50
+        checkpoint_cache: snap_cache
+`, databaseURL)
+
+		builder := service.NewStreamBuilder()
+		require.NoError(t, builder.SetLoggerYAML(`level: DEBUG`))
+		require.NoError(t, builder.AddInputYAML(template))
+		require.NoError(t, builder.AddCacheYAML(`
+label: snap_cache
+memory: {}`))
+
+		// Keep the last operation and value seen per id, plus the arrival
+		// order, so a stale read landing after an update is detectable.
+		type observation struct {
+			operation string
+			name      string
+		}
+		var (
+			mu      sync.Mutex
+			latest  = map[int64]observation{}
+			updates int
+			reads   int
+		)
+		require.NoError(t, builder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, msg := range batch {
+				data, err := msg.AsStructured()
+				if err != nil {
+					return err
+				}
+				fields, ok := data.(map[string]any)
+				if !ok {
+					return fmt.Errorf("unexpected payload shape %T", data)
+				}
+				id, err := fields["id"].(json.Number).Int64()
+				if err != nil {
+					return err
+				}
+				name, _ := fields["name"].(string)
+				op, _ := msg.MetaGet("operation")
+				switch op {
+				case "read":
+					reads++
+				case "update":
+					updates++
+				}
+				latest[id] = observation{operation: op, name: name}
+			}
+			return nil
+		}))
+
+		stream, err := builder.Build()
+		require.NoError(t, err)
+		license.InjectTestService(stream.Resources())
+
+		streamStopped := make(chan struct{})
+		go func() {
+			defer close(streamStopped)
+			if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+				t.Error(err)
+			}
+		}()
+
+		// Wait for the backfill to start, so the max-key bound is frozen and
+		// the updates below genuinely race chunk reads.
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return reads >= 1
+		}, 30*time.Second, 50*time.Millisecond, "did not observe any backfill rows before updating")
+
+		// Update every row repeatedly while the backfill is mid-flight. Each
+		// pass walks the key range, so updates land on chunks already read,
+		// currently buffered, and not yet reached. Several passes widen the
+		// window in which an update can collide with a buffered chunk.
+		const updatePasses = 3
+		for pass := range updatePasses {
+			name := fmt.Sprintf("updated-%d", pass)
+			for id := minID; id <= maxID; id++ {
+				_, err := db.Exec(`UPDATE flights SET name = $1 WHERE id = $2`, name, id)
+				require.NoError(t, err)
+			}
+		}
+		finalName := fmt.Sprintf("updated-%d", updatePasses-1)
+
+		var totalRows int64
+		require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM flights`).Scan(&totalRows))
+		require.EqualValues(t, numPreExisting, totalRows)
+
+		// Every row must be accounted for, and settle on the updated value.
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			if int64(len(latest)) < totalRows {
+				return false
+			}
+			for _, obs := range latest {
+				if obs.name != finalName {
+					return false
+				}
+			}
+			return true
+		}, 90*time.Second, 100*time.Millisecond,
+			"a row never settled on its updated value, so a stale snapshot read overwrote a streamed change")
+
+		require.NoError(t, stream.StopWithin(10*time.Second))
+		<-streamStopped
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, latest, int(totalRows))
+		// Sanity check on the race itself: if every update had been folded
+		// into the snapshot reads, no update would have streamed and the
+		// assertion above would pass without exercising dedup at all.
+		require.NotZero(t, updates, "no updates streamed as change events; the test did not exercise deduplication")
+		for id, obs := range latest {
+			assert.Equal(t, finalName, obs.name, "row %d settled on %q via %q", id, obs.name, obs.operation)
+		}
+	})
+
+	for _, version := range []string{"17", "16", "15", "14", "13"} {
+		// On a quiet table only the heartbeat produces the COMMIT that advances
+		// the snapshot, and pgoutput decodes the heartbeat message on PostgreSQL
+		// 15 and later only. Run on each version, because a change to the plugin
+		// options or to the heartbeat can stop the snapshot without an error.
+		t.Run("QuietTable/PG"+version, func(t *testing.T) {
+			t.Parallel()
+
+			databaseURL, db, err := ResourceWithPostgreSQLVersion(t, version)
+			require.NoError(t, err)
+
+			// Inserted before the slot exists, so only the snapshot can
+			// deliver them.
+			const numPreExisting = 200
+			for range numPreExisting {
+				_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ('quiet', NOW())`)
+				require.NoError(t, err)
+			}
+
+			template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_inc_quiet_pg%s
+    schema: public
+    heartbeat_interval: 200ms
+    tables:
+      - flights
+    incremental_snapshot:
+        enabled: true
+        chunk_size: 20
+        checkpoint_cache: snap_cache
+`, databaseURL, version)
+
+			builder := service.NewStreamBuilder()
+			require.NoError(t, builder.SetLoggerYAML(`level: DEBUG`))
+			require.NoError(t, builder.AddInputYAML(template))
+			require.NoError(t, builder.AddCacheYAML(`
+label: snap_cache
+memory: {}`))
+
+			var (
+				mu   sync.Mutex
+				rows []incrementalSnapshotRow
+			)
+			require.NoError(t, builder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, msg := range batch {
+					data, err := msg.AsStructured()
+					if err != nil {
+						return err
+					}
+					id, err := data.(map[string]any)["id"].(json.Number).Int64()
+					if err != nil {
+						return err
+					}
+					op, _ := msg.MetaGet("operation")
+					rows = append(rows, incrementalSnapshotRow{id: id, operation: op})
+				}
+				return nil
+			}))
+
+			stream, err := builder.Build()
+			require.NoError(t, err)
+			license.InjectTestService(stream.Resources())
+
+			streamStopped := make(chan struct{})
+			go func() {
+				defer close(streamStopped)
+				if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
+			}()
+
+			// No writes from here, so only the heartbeat advances the
+			// snapshot.
+			require.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				return len(rows) >= numPreExisting
+			}, 90*time.Second, 100*time.Millisecond,
+				"the snapshot did not deliver each row of a quiet table on PostgreSQL "+version)
+
+			require.NoError(t, stream.StopWithin(10*time.Second))
+			<-streamStopped
+		})
+	}
+
+	t.Run("Resume", func(t *testing.T) {
+		databaseURL, db, err := ResourceWithPostgreSQLVersion(t, "16")
+		require.NoError(t, err)
+
+		const numRows = 1000
+		for range numRows {
+			_, err = db.Exec(`INSERT INTO flights (name, created_at) VALUES ('pre', NOW())`)
+			require.NoError(t, err)
+		}
+
+		// A file cache, not memory, so the checkpoint survives across the two
+		// independent stream instances below, like an actual restart.
+		cacheDir := t.TempDir()
+		template := fmt.Sprintf(`
+postgres_cdc:
+    dsn: %s
+    slot_name: test_slot_incremental_resume
+    schema: public
+    heartbeat_interval: 100ms
+    tables:
+      - flights
+    incremental_snapshot:
+        enabled: true
+        chunk_size: 20
+        checkpoint_cache: snap_cache_resume
+`, databaseURL)
+		cacheTemplate := fmt.Sprintf(`
+label: snap_cache_resume
+file:
+  directory: '%s'`, cacheDir)
+
+		runPartial := func(minRows int) []incrementalSnapshotRow {
+			builder := service.NewStreamBuilder()
+			require.NoError(t, builder.SetLoggerYAML(`level: DEBUG`))
+			require.NoError(t, builder.AddInputYAML(template))
+			require.NoError(t, builder.AddCacheYAML(cacheTemplate))
+
+			var (
+				mu   sync.Mutex
+				rows []incrementalSnapshotRow
+			)
+			require.NoError(t, builder.AddBatchConsumerFunc(func(_ context.Context, batch service.MessageBatch) error {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, msg := range batch {
+					data, err := msg.AsStructured()
+					if err != nil {
+						return err
+					}
+					id, err := data.(map[string]any)["id"].(json.Number).Int64()
+					if err != nil {
+						return err
+					}
+					op, _ := msg.MetaGet("operation")
+					rows = append(rows, incrementalSnapshotRow{id: id, operation: op})
+				}
+				return nil
+			}))
+
+			stream, err := builder.Build()
+			require.NoError(t, err)
+			license.InjectTestService(stream.Resources())
+
+			streamStopped := make(chan struct{})
+			go func() {
+				defer close(streamStopped)
+				if err := stream.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Error(err)
+				}
+			}()
+
+			require.Eventually(t, func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				return len(rows) >= minRows
+			}, 60*time.Second, 20*time.Millisecond, "did not observe the minimum number of rows before stopping")
+
+			require.NoError(t, stream.StopWithin(10*time.Second))
+			select {
+			case <-streamStopped:
+			case <-time.After(30 * time.Second):
+				require.Fail(t, "stream did not stop in time")
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]incrementalSnapshotRow(nil), rows...)
+		}
+
+		// Stop early, leaving the backfill (and its checkpoint) partway through.
+		firstRun := runPartial(10)
+		require.NotEmpty(t, firstRun)
+		require.Less(t, len(firstRun), numRows, "first run should not have completed the entire backfill; the test can't exercise resume otherwise")
+
+		// Reuses the same slot and cache directory: a correct resume picks up
+		// from the checkpoint, so none of the first run's rows should reappear.
+		secondRun := runPartial(numRows - len(firstRun))
+
+		firstIDs := make(map[int64]struct{}, len(firstRun))
+		for _, r := range firstRun {
+			firstIDs[r.id] = struct{}{}
+		}
+		for _, r := range secondRun {
+			_, seenBefore := firstIDs[r.id]
+			assert.False(t, seenBefore, "row id %d observed in both the first and second run; resume should not re-deliver already-observed rows", r.id)
+		}
+
+		allCounts := make(map[int64]int, numRows)
+		for _, r := range firstRun {
+			allCounts[r.id]++
+		}
+		for _, r := range secondRun {
+			allCounts[r.id]++
+		}
+
+		var totalRows int64
+		require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM flights`).Scan(&totalRows))
+		require.EqualValues(t, numRows, totalRows)
+
+		assert.Len(t, allCounts, int(totalRows), "expected exactly %d distinct rows across both runs combined", totalRows)
+		for id, count := range allCounts {
+			assert.Equal(t, 1, count, "row id %d observed %d times across both runs, expected exactly once", id, count)
+		}
+	})
+}

--- a/internal/impl/postgresql/pglogicalstream/config.go
+++ b/internal/impl/postgresql/pglogicalstream/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
 )
 
 // Config is the configuration for the pglogicalstream plugin
@@ -54,4 +55,16 @@ type Config struct {
 	UnchangedToastValue any
 	// The interval to send logical messages
 	HeartbeatInterval time.Duration
+
+	// IncrementalSnapshot holds the incremental snapshot configuration.
+	IncrementalSnapshot *incrementalsnapshot.Cfg
+}
+
+// IncrementalSnapshotCfg returns the incremental snapshot configuration. It
+// returns nil when the snapshot is disabled.
+func (c *Config) IncrementalSnapshotCfg() *incrementalsnapshot.Cfg {
+	if c != nil && c.IncrementalSnapshot != nil {
+		return c.IncrementalSnapshot
+	}
+	return nil
 }

--- a/internal/impl/postgresql/pglogicalstream/heartbeat.go
+++ b/internal/impl/postgresql/pglogicalstream/heartbeat.go
@@ -11,6 +11,9 @@ package pglogicalstream
 import (
 	"context"
 	"database/sql"
+	"time"
+
+	incsnapshot "github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
@@ -22,15 +25,32 @@ type heartbeat struct {
 	task          *asyncroutine.Periodic
 	logger        *service.Logger
 	prefix, value string
+	// transactional selects a transactional heartbeat message. It must be
+	// true during an incremental snapshot. OnCommit gets a transaction id
+	// from a transactional message only. On a quiet table the heartbeat can
+	// also be the only write.
+	transactional bool
 }
 
-func newHeartbeat(config *Config, prefix, value string) (*heartbeat, error) {
+// EffectiveHeartbeatInterval returns how often to heartbeat: the more
+// frequent of the two intervals while a snapshot is enabled, since a snapshot
+// needs commits far more often than slot retention does, and heartbeating
+// faster serves both.
+func EffectiveHeartbeatInterval(configured time.Duration, incSnapshot *incsnapshot.Cfg) time.Duration {
+	if !incSnapshot.IsEnabled() || incSnapshot.HeartbeatInterval <= 0 {
+		return configured
+	}
+	return min(configured, incSnapshot.HeartbeatInterval)
+}
+
+func newHeartbeat(config *Config, interval time.Duration, prefix, value string) (*heartbeat, error) {
 	dbConn, err := openPgConnectionFromConfig(config)
 	if err != nil {
 		return nil, err
 	}
-	h := &heartbeat{db: dbConn, task: nil, logger: config.Logger, prefix: prefix, value: value}
-	h.task = asyncroutine.NewPeriodicWithContext(config.HeartbeatInterval, h.run)
+	enabled := config.IncrementalSnapshotCfg().IsEnabled()
+	h := &heartbeat{db: dbConn, task: nil, logger: config.Logger, prefix: prefix, value: value, transactional: enabled}
+	h.task = asyncroutine.NewPeriodicWithContext(interval, h.run)
 	return h, nil
 }
 
@@ -39,7 +59,12 @@ func (h *heartbeat) Start() {
 }
 
 func (h *heartbeat) run(ctx context.Context) {
-	_, err := h.db.ExecContext(ctx, "SELECT pg_logical_emit_message(false, $1, $2)", h.prefix, h.value)
+	var err error
+	if h.transactional {
+		_, err = h.db.ExecContext(ctx, "SELECT pg_logical_emit_message(true, $1, $2)", h.prefix, h.value)
+	} else {
+		_, err = h.db.ExecContext(ctx, "SELECT pg_logical_emit_message(false, $1, $2)", h.prefix, h.value)
+	}
 	if err != nil {
 		h.logger.Warnf("unable to write heartbeat message: %v", err)
 	}

--- a/internal/impl/postgresql/pglogicalstream/incremental_snapshot.go
+++ b/internal/impl/postgresql/pglogicalstream/incremental_snapshot.go
@@ -523,3 +523,18 @@ func (s *Stream) deduplicateStreamedRow(ctx context.Context, message *StreamMess
 	}
 	return nil
 }
+
+// reportResumeReconciliation logs what Start made of a resumed checkpoint
+// whose table set no longer matches the config. It logs nothing when the two
+// agree, which is the normal case.
+func (s *Stream) reportResumeReconciliation() {
+	if added := s.incSnapshotCoordinator.AddedOnResume(); len(added) > 0 {
+		s.logger.Infof("Incremental snapshot: %d table(s) added to the config since the checkpoint, queued for backfill: %v", len(added), added)
+	}
+	if removed := s.incSnapshotCoordinator.RemovedOnResume(); len(removed) > 0 {
+		s.logger.Warnf(
+			"Incremental snapshot: dropped %d table(s) the checkpoint covers but the config no longer lists: %v. A table that was part-read stops there, so its remaining rows are not backfilled",
+			len(removed), removed,
+		)
+	}
+}

--- a/internal/impl/postgresql/pglogicalstream/incremental_snapshot.go
+++ b/internal/impl/postgresql/pglogicalstream/incremental_snapshot.go
@@ -1,0 +1,525 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+
+	incsnapshot "github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
+	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+// setupIncrementalSnapshot adds a Coordinator to the stream. It does nothing
+// when the snapshot is disabled, and leaves the coordinator and the
+// connection nil.
+func (s *Stream) setupIncrementalSnapshot(ctx context.Context, config *Config) error {
+	incSnapshotCfg := config.IncrementalSnapshotCfg()
+	if !incSnapshotCfg.IsEnabled() {
+		return nil
+	}
+
+	db, err := openPgConnectionFromConfig(config)
+	if err != nil {
+		return fmt.Errorf("opening incremental snapshot connection: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("pinging incremental snapshot connection: %w", err)
+	}
+
+	tableNames := incSnapshotCfg.Tables
+	if len(tableNames) == 0 {
+		tableNames = config.DBTables
+	}
+
+	tables := make([]incrementalsnapshot.TableID, 0, len(tableNames))
+	tableSet := make(map[incrementalsnapshot.TableID]struct{}, len(tableNames))
+	for _, name := range tableNames {
+		table, err := normalizeTableID(config.DBSchema, name)
+		if err != nil {
+			_ = db.Close()
+			return fmt.Errorf("resolving incremental snapshot table %q: %w", name, err)
+		}
+		tables = append(tables, table)
+		tableSet[table] = struct{}{}
+	}
+
+	s.incSnapshotConn = db
+	s.incSnapshotPKCache = make(map[string][]string)
+	s.incSnapshotTables = tableSet
+
+	coordinator, err := incsnapshot.NewCoordinator(incsnapshot.CoordinatorConfig{
+		Tables:    tables,
+		ChunkSize: incSnapshotCfg.ChunkSize,
+		Deps:      incrementalSnapshotDeps{stream: s},
+	}, incSnapshotCfg.ResumeState)
+	if err != nil {
+		_ = db.Close()
+		s.incSnapshotConn = nil
+		s.incSnapshotPKCache = nil
+		s.incSnapshotTables = nil
+		return fmt.Errorf("constructing incremental snapshot coordinator: %w", err)
+	}
+	s.incSnapshotCoordinator = coordinator
+	s.logger.Debugf("Incremental snapshot: enabled for %d table(s) %v, chunk_size=%d", len(tables), tables, incSnapshotCfg.ChunkSize)
+	return nil
+}
+
+// normalizeTableID makes a TableID from a schema name and a table name. It
+// uses the same rules as NewPgStream, then removes the quotation marks: a
+// TableID must hold unquoted names, because Postgres reports them in this
+// form in replication messages.
+func normalizeTableID(schemaRaw, tableRaw string) (incrementalsnapshot.TableID, error) {
+	schemaNorm, err := sanitize.NormalizePostgresIdentifier(schemaRaw)
+	if err != nil {
+		return incrementalsnapshot.TableID{}, fmt.Errorf("invalid schema name %q: %w", schemaRaw, err)
+	}
+	tableNorm, err := sanitize.NormalizePostgresIdentifier(tableRaw)
+	if err != nil {
+		return incrementalsnapshot.TableID{}, fmt.Errorf("invalid table name %q: %w", tableRaw, err)
+	}
+	schema, err := sanitize.UnquotePostgresIdentifier(schemaNorm)
+	if err != nil {
+		return incrementalsnapshot.TableID{}, fmt.Errorf("unquoting normalized schema name %q: %w", schemaNorm, err)
+	}
+	table, err := sanitize.UnquotePostgresIdentifier(tableNorm)
+	if err != nil {
+		return incrementalsnapshot.TableID{}, fmt.Errorf("unquoting normalized table name %q: %w", tableNorm, err)
+	}
+	return incrementalsnapshot.TableID{Schema: schema, Table: table}, nil
+}
+
+// incrementalPKColumns reads the unquoted primary key columns of the table
+// and keeps them in a cache. ResolvePrimaryKey and incrementalStreamedRowPK
+// both need the same columns to make a PrimaryKey that OnStreamedRow matches.
+func (s *Stream) incrementalPKColumns(ctx context.Context, table incrementalsnapshot.TableID) ([]string, error) {
+	key := table.String()
+	if cols, exists := s.incSnapshotPKCache[key]; exists {
+		return cols, nil
+	}
+
+	quoted, err := s.resolveIncrementalPKColumns(ctx, TableFQN{
+		Schema: sanitize.QuotePostgresIdentifier(table.Schema),
+		Table:  sanitize.QuotePostgresIdentifier(table.Table),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cols := make([]string, len(quoted))
+	for i, c := range quoted {
+		unquoted, err := sanitize.UnquotePostgresIdentifier(c)
+		if err != nil {
+			return nil, fmt.Errorf("unquoting primary key column %q for table %s: %w", c, table, err)
+		}
+		cols[i] = unquoted
+	}
+
+	s.incSnapshotPKCache[key] = cols
+	return cols, nil
+}
+
+// resolveIncrementalPKColumns reads the primary key columns of the table. It
+// must use s.incSnapshotConn and never s.pgConn: after the stream starts,
+// s.pgConn is in COPY BOTH for the replication protocol, and a normal query
+// on it at the same time stops or damages the stream.
+//
+// Its only caller, incrementalPKColumns, can run at any time during the
+// stream - from Deps.ResolvePrimaryKey when planning a chunk, and from
+// incrementalStreamedRowPK on each insert, update or delete.
+func (s *Stream) resolveIncrementalPKColumns(ctx context.Context, table TableFQN) ([]string, error) {
+	q, err := primaryKeyColumnsQuery(table.String())
+	if err != nil {
+		return nil, fmt.Errorf("sanitizing query: %w", err)
+	}
+
+	rows, err := s.incSnapshotConn.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("querying primary key columns for table %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	var pkColumns []string
+	for rows.Next() {
+		var col string
+		if err := rows.Scan(&col); err != nil {
+			return nil, fmt.Errorf("scanning primary key column for table %s: %w", table, err)
+		}
+		// Postgres gives the names in normal form, so quote them.
+		pkColumns = append(pkColumns, sanitize.QuotePostgresIdentifier(col))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating primary key columns for table %s: %w", table, err)
+	}
+
+	if len(pkColumns) == 0 {
+		return nil, fmt.Errorf("no primary key found for table %s", table)
+	}
+
+	return pkColumns, nil
+}
+
+// incrementalSnapshotDeps makes *Stream satisfy incrementalsnapshot.Deps,
+// keeping these general method names out of the API of Stream.
+type incrementalSnapshotDeps struct {
+	stream *Stream
+}
+
+var _ incsnapshot.Deps = incrementalSnapshotDeps{}
+
+func (d incrementalSnapshotDeps) ResolvePrimaryKey(ctx context.Context, table incrementalsnapshot.TableID) ([]string, error) {
+	return d.stream.resolveIncrementalPK(ctx, table)
+}
+
+func (d incrementalSnapshotDeps) ResolveMaxKey(ctx context.Context, table incrementalsnapshot.TableID, pkColumnsUnquoted []string) (incrementalsnapshot.PrimaryKey, error) {
+	query, err := incsnapshot.BuildMaxKeyQuery(table, pkColumnsUnquoted)
+	if err != nil {
+		return nil, err
+	}
+	return d.stream.resolveIncrementalMaxKey(ctx, table, pkColumnsUnquoted, query)
+}
+
+func (d incrementalSnapshotDeps) ResolveWatermark(ctx context.Context) (incsnapshot.Watermark, error) {
+	return d.stream.resolveIncrementalWatermark(ctx)
+}
+
+func (d incrementalSnapshotDeps) ForceFreshTransaction(ctx context.Context) error {
+	return d.stream.forceFreshIncrementalTransaction(ctx)
+}
+
+func (d incrementalSnapshotDeps) FetchChunk(ctx context.Context, table incrementalsnapshot.TableID, pkColumnsUnquoted []string, lower, upper incrementalsnapshot.PrimaryKey, limit int) ([]incrementalsnapshot.Row, error) {
+	query, args, err := incsnapshot.BuildChunkQuery(table, pkColumnsUnquoted, lower, upper, limit)
+	if err != nil {
+		return nil, err
+	}
+	return d.stream.fetchIncrementalChunk(ctx, table, pkColumnsUnquoted, query, args)
+}
+
+// resolveIncrementalPK backs Deps.ResolvePrimaryKey.
+func (s *Stream) resolveIncrementalPK(ctx context.Context, table incrementalsnapshot.TableID) ([]string, error) {
+	return s.incrementalPKColumns(ctx, table)
+}
+
+// incrementalStreamedRowPK makes the PrimaryKey that OnStreamedRow matches
+// from the data of a streamed row.
+func (s *Stream) incrementalStreamedRowPK(ctx context.Context, table incrementalsnapshot.TableID, data any) (incrementalsnapshot.PrimaryKey, error) {
+	pkCols, err := s.incrementalPKColumns(ctx, table)
+	if err != nil {
+		return nil, err
+	}
+
+	values, _ := data.(map[string]any)
+	pk := make(incrementalsnapshot.PrimaryKey, len(pkCols))
+	for i, col := range pkCols {
+		pk[i] = canonicalizePKValue(values[col])
+	}
+	return pk, nil
+}
+
+// canonicalizePKValue changes a decoded primary key value to one stable
+// form. The window buffer keys rows on the text form of each PrimaryKey
+// element - refer to newWindowKey in the shared package - so one value must
+// give one key on both decode paths.
+//
+// The paths disagree: the stream uses decodeTextColumnData and the snapshot
+// uses prepareScannersAndGetters, so one Postgres type can arrive as two Go
+// types. A UUID can come as 16 bytes or as text. The buffer would then hold
+// both rows and remove neither.
+func canonicalizePKValue(v any) any {
+	switch val := v.(type) {
+	case [16]byte:
+		return uuid.UUID(val).String()
+	case []byte:
+		return string(val)
+	default:
+		return val
+	}
+}
+
+// resolveIncrementalMaxKey backs Deps.ResolveMaxKey.
+func (s *Stream) resolveIncrementalMaxKey(ctx context.Context, table incrementalsnapshot.TableID, pkCols []string, query string) (incrementalsnapshot.PrimaryKey, error) {
+	rows, err := s.incSnapshotConn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("querying max key for table %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("getting column types for table %s max key query: %w", table, err)
+	}
+	scanArgs, valueGetters := prepareScannersAndGetters(columnTypes)
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("resolving max key for table %s: %w", table, err)
+		}
+		// An empty table has no rows to read. Return nil and no error, so
+		// the coordinator moves to the next table instead of stopping the
+		// replication of every table.
+		s.logger.Debugf("Incremental snapshot: table %s is empty, skipping", table)
+		return nil, nil
+	}
+
+	if err := rows.Scan(scanArgs...); err != nil {
+		return nil, fmt.Errorf("scanning max key row for table %s: %w", table, err)
+	}
+
+	pk := make(incrementalsnapshot.PrimaryKey, len(pkCols))
+	for i, getter := range valueGetters {
+		val, err := getter(scanArgs[i])
+		if err != nil {
+			return nil, fmt.Errorf("decoding max key column %s for table %s: %w", pkCols[i], table, err)
+		}
+		pk[i] = canonicalizePKValue(val)
+	}
+	s.logger.Debugf("Incremental snapshot: table %s upper bound resolved to pk=%v", table, pk)
+	return pk, nil
+}
+
+func currentSnapshotQuery(pgVersion int) string {
+	// pg_current_snapshot replaces the obsolete txid_current_snapshot from
+	// PostgreSQL 13. Both give the same text form.
+	if pgVersion >= 13 {
+		return "SELECT pg_current_snapshot()"
+	}
+	return "SELECT txid_current_snapshot()"
+}
+
+// resolveIncrementalWatermark backs Deps.ResolveWatermark.
+func (s *Stream) resolveIncrementalWatermark(ctx context.Context) (incsnapshot.Watermark, error) {
+	query := currentSnapshotQuery(s.pgVersion)
+	var raw string
+	if err := s.incSnapshotConn.QueryRowContext(ctx, query).Scan(&raw); err != nil {
+		return incsnapshot.Watermark{}, fmt.Errorf("querying current snapshot with %q: %w", query, err)
+	}
+	wm, err := incsnapshot.ParseSnapshot(raw)
+	if err != nil {
+		return incsnapshot.Watermark{}, fmt.Errorf("parsing current snapshot result %q: %w", raw, err)
+	}
+	return wm, nil
+}
+
+// forceFreshIncrementalTransaction backs Deps.ForceFreshTransaction.
+func (s *Stream) forceFreshIncrementalTransaction(ctx context.Context) error {
+	var txid uint64
+	if err := s.incSnapshotConn.QueryRowContext(ctx, "SELECT txid_current()").Scan(&txid); err != nil {
+		return fmt.Errorf("querying txid_current: %w", err)
+	}
+	return nil
+}
+
+// fetchIncrementalChunk backs Deps.FetchChunk.
+func (s *Stream) fetchIncrementalChunk(ctx context.Context, table incrementalsnapshot.TableID, pkCols []string, query string, args []any) ([]incrementalsnapshot.Row, error) {
+	rows, err := s.incSnapshotConn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("fetching chunk for table %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, fmt.Errorf("getting column types for table %s: %w", table, err)
+	}
+	scanArgs, valueGetters := prepareScannersAndGetters(columnTypes)
+
+	columnNames, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("getting column names for table %s: %w", table, err)
+	}
+	tableSchema := columnTypesToSchema(table.Table, columnNames, columnTypes)
+
+	pkPositions := make([]int, len(pkCols))
+	for i, pkCol := range pkCols {
+		pkPositions[i] = slices.Index(columnNames, pkCol)
+		if pkPositions[i] == -1 {
+			return nil, fmt.Errorf("primary key column %s not found in chunk result for table %s", pkCol, table)
+		}
+	}
+
+	var result []incrementalsnapshot.Row
+	for rows.Next() {
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, fmt.Errorf("scanning row for table %s: %w", table, err)
+		}
+
+		data := make(map[string]any, len(valueGetters))
+		for i, getter := range valueGetters {
+			val, err := getter(scanArgs[i])
+			if err != nil {
+				return nil, fmt.Errorf("decoding column %s for table %s: %w", columnNames[i], table, err)
+			}
+			data[columnNames[i]] = val
+		}
+
+		pk := make(incrementalsnapshot.PrimaryKey, len(pkCols))
+		for i, pos := range pkPositions {
+			pk[i] = canonicalizePKValue(data[columnNames[pos]])
+		}
+
+		result = append(result, incrementalsnapshot.Row{
+			Table:        table,
+			PK:           pk,
+			Data:         data,
+			ColumnSchema: tableSchema,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating chunk rows for table %s: %w", table, err)
+	}
+	if len(result) == 0 {
+		s.logger.Debugf("Incremental snapshot: fetched 0 rows for table %s, table exhausted", table)
+	} else {
+		s.logger.Debugf("Incremental snapshot: fetched %d row(s) for table %s (pk %v..%v)", len(result), table, result[0].PK, result[len(result)-1].PK)
+	}
+	return result, nil
+}
+
+// buildIncrementalSnapshotMessages makes StreamMessage values from the rows
+// and puts the state on the last one. With no rows it makes one message that
+// holds the state only, because the state can move forward with no rows - for
+// example when the stream has already delivered each buffered row.
+func buildIncrementalSnapshotMessages(emitted []incrementalsnapshot.Row, state []byte) []StreamMessage {
+	if len(emitted) == 0 {
+		return []StreamMessage{{
+			Operation:                IncrementalSnapshotCheckpointOpType,
+			IncrementalSnapshotState: state,
+		}}
+	}
+
+	msgs := make([]StreamMessage, len(emitted))
+	for i, row := range emitted {
+		msgs[i] = StreamMessage{
+			Operation:    ReadOpType,
+			Schema:       row.Table.Schema,
+			Table:        row.Table.Table,
+			Data:         row.Data,
+			ColumnSchema: row.ColumnSchema,
+		}
+	}
+	msgs[len(msgs)-1].IncrementalSnapshotState = state
+	return msgs
+}
+
+// advanceIncrementalSnapshot reports a committed transaction to the snapshot,
+// sending whatever it releases before the commit reaches the consumer, so the
+// consumer never sees progress past changes it cannot yet read.
+//
+// A no-op when the snapshot is disabled, or when xid is zero: no BEGIN
+// supplied one, and zero sorts below every watermark, so it would open or
+// close the window spuriously.
+func (s *Stream) advanceIncrementalSnapshot(ctx context.Context, xid uint32) error {
+	if s.incSnapshotCoordinator == nil || xid == 0 {
+		return nil
+	}
+
+	// One commit can release several chunks, when the database is quiet
+	// enough to need no deduplication. emit runs once per chunk, and its send
+	// to s.messages paces the drain.
+	emit := func(rows []incrementalsnapshot.Row) error {
+		if len(rows) > 0 {
+			s.logger.Debugf("Incremental snapshot: flushed %d row(s) for table %s", len(rows), rows[0].Table)
+			s.monitor.UpdateSnapshotProgressForTable(tableFQN(rows[0].Table), len(rows))
+		} else {
+			s.logger.Debugf("Incremental snapshot: checkpoint advanced with no rows to flush (fully deduplicated)")
+		}
+		checkpoint := s.incSnapshotCoordinator.State()
+		s.reportTableTransition(checkpoint.CurrentTable)
+
+		state, err := json.Marshal(checkpoint)
+		if err != nil {
+			return fmt.Errorf("serializing incremental snapshot state: %w", err)
+		}
+		select {
+		case s.messages <- buildIncrementalSnapshotMessages(rows, state):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	changed, err := s.incSnapshotCoordinator.OnCommit(ctx, xid, emit)
+	if err != nil {
+		return fmt.Errorf("advancing incremental snapshot: %w", err)
+	}
+	if changed && s.incSnapshotCoordinator.Done() {
+		// The last table never sees a following checkpoint, so report it here.
+		s.reportTableTransition(nil)
+		s.logger.Info("Incremental snapshot: complete")
+		for table := range s.incSnapshotTables {
+			s.monitor.MarkSnapshotComplete(tableFQN(table))
+		}
+	}
+	return nil
+}
+
+func (s *Stream) reportTableTransition(current *incrementalsnapshot.TableID) {
+	previous := s.incSnapshotLastTable
+	s.incSnapshotLastTable = current
+	if sameTable(previous, current) {
+		return
+	}
+	if previous != nil {
+		s.logger.Infof("Incremental snapshot: finished table %s", *previous)
+		s.monitor.MarkSnapshotComplete(tableFQN(*previous))
+	}
+	if current != nil {
+		s.logger.Infof("Incremental snapshot: starting table %s", *current)
+	}
+}
+
+func sameTable(a, b *incrementalsnapshot.TableID) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func tableFQN(table incrementalsnapshot.TableID) TableFQN {
+	return TableFQN{
+		Schema: sanitize.QuotePostgresIdentifier(table.Schema),
+		Table:  sanitize.QuotePostgresIdentifier(table.Table),
+	}
+}
+
+// deduplicateStreamedRow tells the coordinator that the stream carries this
+// row, which drops any copy the window buffer holds for the same key. That
+// copy is stale or redundant, and this message gives the current value.
+//
+// A no-op unless the snapshot runs and the table is one it snapshots.
+func (s *Stream) deduplicateStreamedRow(ctx context.Context, message *StreamMessage) error {
+	if s.incSnapshotCoordinator == nil {
+		return nil
+	}
+	switch message.Operation {
+	case InsertOpType, UpdateOpType, DeleteOpType:
+	default:
+		return nil
+	}
+
+	table := incrementalsnapshot.TableID{Schema: message.Schema, Table: message.Table}
+	if _, tracked := s.incSnapshotTables[table]; !tracked {
+		return nil
+	}
+
+	pk, err := s.incrementalStreamedRowPK(ctx, table, message.Data)
+	if err != nil {
+		return fmt.Errorf("resolving primary key for incremental snapshot deduplication on table %s: %w", table, err)
+	}
+	if s.incSnapshotCoordinator.OnStreamedRow(table, pk) {
+		s.logger.Debugf("Incremental snapshot: deduplicated live row for table %s pk=%v", table, pk)
+	}
+	return nil
+}

--- a/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
+++ b/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package pglogicalstream
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
+)
+
+// fakeQueryDriver is a minimal database/sql driver that ignores whatever SQL
+// text it's given and always returns the canned rows/columns it was
+// constructed with. It exists so tests can exercise code that queries
+// *sql.DB (i.e. Stream.incrementalDB) without a real Postgres connection.
+type fakeQueryDriver struct {
+	columns []string
+	rows    [][]driver.Value
+	queries *int
+}
+
+func (d *fakeQueryDriver) Open(string) (driver.Conn, error) {
+	return &fakeQueryConn{driver: d}, nil
+}
+
+type fakeQueryConn struct{ driver *fakeQueryDriver }
+
+func (c *fakeQueryConn) Prepare(string) (driver.Stmt, error) {
+	return &fakeQueryStmt{conn: c}, nil
+}
+func (*fakeQueryConn) Close() error              { return nil }
+func (*fakeQueryConn) Begin() (driver.Tx, error) { return nil, fmt.Errorf("not implemented") }
+
+type fakeQueryStmt struct{ conn *fakeQueryConn }
+
+func (*fakeQueryStmt) Close() error  { return nil }
+func (*fakeQueryStmt) NumInput() int { return -1 }
+func (*fakeQueryStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *fakeQueryStmt) Query([]driver.Value) (driver.Rows, error) {
+	if s.conn.driver.queries != nil {
+		*s.conn.driver.queries++
+	}
+	return &fakeQueryRows{columns: s.conn.driver.columns, rows: s.conn.driver.rows}, nil
+}
+
+type fakeQueryRows struct {
+	columns []string
+	rows    [][]driver.Value
+	idx     int
+}
+
+func (r *fakeQueryRows) Columns() []string { return r.columns }
+func (*fakeQueryRows) Close() error        { return nil }
+func (r *fakeQueryRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.idx])
+	r.idx++
+	return nil
+}
+
+var fakeQueryDriverSeq atomic.Int64
+
+// newFakeQueryDB registers a fresh fakeQueryDriver under a unique name (since
+// sql.Register panics on reuse) and opens a *sql.DB backed by it. If queries
+// is non-nil it's incremented once per Query call, letting tests assert on
+// query counts (e.g. to prove caching avoids a repeat round trip).
+func newFakeQueryDB(t *testing.T, columns []string, rows [][]driver.Value, queries *int) *sql.DB {
+	t.Helper()
+	name := fmt.Sprintf("fake_pglog_test_%d", fakeQueryDriverSeq.Add(1))
+	sql.Register(name, &fakeQueryDriver{columns: columns, rows: rows, queries: queries})
+	db, err := sql.Open(name, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestResolveIncrementalPKColumnsUsesIncrementalDB(t *testing.T) {
+	// pgConn is deliberately left nil: if resolveIncrementalPKColumns (or
+	// anything it calls) touched s.pgConn instead of s.incrementalDB, this
+	// would panic with a nil pointer dereference rather than returning a
+	// result -- this is precisely the deadlock/crash bug being guarded
+	// against, since s.pgConn is occupied by the replication protocol once
+	// streaming has started.
+	db := newFakeQueryDB(t, []string{"attname"}, [][]driver.Value{{"tenant_id"}, {"id"}}, nil)
+	s := &Stream{incSnapshotConn: db}
+
+	cols, err := s.resolveIncrementalPKColumns(t.Context(), TableFQN{Schema: `"public"`, Table: `"orders"`})
+	require.NoError(t, err)
+	assert.Equal(t, []string{`"tenant_id"`, `"id"`}, cols)
+}
+
+func TestResolveIncrementalPKColumnsNoPrimaryKey(t *testing.T) {
+	db := newFakeQueryDB(t, []string{"attname"}, nil, nil)
+	s := &Stream{incSnapshotConn: db}
+
+	_, err := s.resolveIncrementalPKColumns(t.Context(), TableFQN{Schema: `"public"`, Table: `"orders"`})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no primary key found")
+}
+
+func TestIncrementalPKColumnsCachesAndUnquotes(t *testing.T) {
+	queries := 0
+	// pgConn is left nil for the same reason as above: incrementalPKColumns
+	// backs both the coordinator's PK resolution and live DML dedup lookups,
+	// either of which may run concurrently with replication streaming.
+	db := newFakeQueryDB(t, []string{"attname"}, [][]driver.Value{{"id"}}, &queries)
+	s := &Stream{
+		incSnapshotConn:    db,
+		incSnapshotPKCache: make(map[string][]string),
+	}
+
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+
+	cols, err := s.incrementalPKColumns(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, cols, "cached columns must be unquoted")
+	assert.Equal(t, 1, queries)
+
+	// Second call for the same table must be served from the cache, not
+	// issue a second query.
+	cols, err = s.incrementalPKColumns(t.Context(), table)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, cols)
+	assert.Equal(t, 1, queries, "second lookup for the same table must be cached")
+}
+
+func TestResolveIncrementalMaxKeyEmptyTableIsNotAnError(t *testing.T) {
+	// Zero rows means the table currently has nothing to backfill; this must
+	// be reported as (nil, nil), not an error that aborts the whole stream.
+	db := newFakeQueryDB(t, []string{"id"}, nil, nil)
+	s := &Stream{incSnapshotConn: db}
+
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "orders"}
+	pk, err := s.resolveIncrementalMaxKey(t.Context(), table, []string{"id"}, "SELECT id FROM orders")
+	require.NoError(t, err)
+	assert.Nil(t, pk)
+}
+
+func TestCanonicalizePKValue(t *testing.T) {
+	id := uuid.New()
+
+	t.Run("binary uuid normalizes to canonical string", func(t *testing.T) {
+		assert.Equal(t, id.String(), canonicalizePKValue([16]byte(id)))
+	})
+
+	t.Run("byte slice normalizes to string", func(t *testing.T) {
+		assert.Equal(t, "hello", canonicalizePKValue([]byte("hello")))
+	})
+
+	t.Run("other types pass through unchanged", func(t *testing.T) {
+		assert.Equal(t, int32(5), canonicalizePKValue(int32(5)))
+		assert.Nil(t, canonicalizePKValue(nil))
+	})
+}
+
+// TestCanonicalizePKValueDedupsAcrossDecodePaths proves the fix end-to-end
+// against the dedup window: without canonicalizing PK values before they
+// reach incrementalsnapshot.PrimaryKey, a UUID primary key decoded as a raw
+// [16]byte on one path and a canonical string on the other would never
+// dedup, since the window's key is built by directly formatting each
+// PrimaryKey element.
+func TestCanonicalizePKValueDedupsAcrossDecodePaths(t *testing.T) {
+	table := incrementalsnapshot.TableID{Schema: "public", Table: "widgets"}
+	id := uuid.New()
+
+	window := incrementalsnapshot.NewWindowBuffer()
+
+	// Simulates a row buffered by the incrementalDB backfill path.
+	backfillPK := incrementalsnapshot.PrimaryKey{canonicalizePKValue([16]byte(id))}
+	window.Add(incrementalsnapshot.Row{Table: table, PK: backfillPK, Data: map[string]any{"id": id.String()}})
+	require.Equal(t, 1, window.Len())
+
+	// Simulates the same row arriving via the live streaming decode path.
+	streamedPK := incrementalsnapshot.PrimaryKey{canonicalizePKValue(id.String())}
+	removed := window.Remove(table, streamedPK)
+	assert.True(t, removed, "the same uuid decoded via either path must dedup to the same window key")
+	assert.Equal(t, 0, window.Len())
+}

--- a/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
+++ b/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
@@ -26,7 +26,7 @@ import (
 // fakeQueryDriver is a minimal database/sql driver that ignores whatever SQL
 // text it's given and always returns the canned rows/columns it was
 // constructed with. It exists so tests can exercise code that queries
-// *sql.DB (i.e. Stream.incrementalDB) without a real Postgres connection.
+// *sql.DB (i.e. Stream.incSnapshotConn) without a real Postgres connection.
 type fakeQueryDriver struct {
 	columns []string
 	rows    [][]driver.Value
@@ -93,9 +93,9 @@ func newFakeQueryDB(t *testing.T, columns []string, rows [][]driver.Value, queri
 	return db
 }
 
-func TestResolveIncrementalPKColumnsUsesIncrementalDB(t *testing.T) {
+func TestResolveIncrementalPKColumnsUsesSnapshotConn(t *testing.T) {
 	// pgConn is deliberately left nil: if resolveIncrementalPKColumns (or
-	// anything it calls) touched s.pgConn instead of s.incrementalDB, this
+	// anything it calls) touched s.pgConn instead of s.incSnapshotConn, this
 	// would panic with a nil pointer dereference rather than returning a
 	// result -- this is precisely the deadlock/crash bug being guarded
 	// against, since s.pgConn is occupied by the replication protocol once
@@ -184,7 +184,7 @@ func TestCanonicalizePKValueDedupsAcrossDecodePaths(t *testing.T) {
 
 	window := incrementalsnapshot.NewWindowBuffer()
 
-	// Simulates a row buffered by the incrementalDB backfill path.
+	// Simulates a row buffered by the snapshot backfill path.
 	backfillPK := incrementalsnapshot.PrimaryKey{canonicalizePKValue([16]byte(id))}
 	window.Add(incrementalsnapshot.Row{Table: table, PK: backfillPK, Data: map[string]any{"id": id.String()}})
 	require.Equal(t, 1, window.Len())

--- a/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
+++ b/internal/impl/postgresql/pglogicalstream/incremental_snapshot_test.go
@@ -13,12 +13,18 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
 
 	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
 )
@@ -194,4 +200,138 @@ func TestCanonicalizePKValueDedupsAcrossDecodePaths(t *testing.T) {
 	removed := window.Remove(table, streamedPK)
 	assert.True(t, removed, "the same uuid decoded via either path must dedup to the same window key")
 	assert.Equal(t, 0, window.Len())
+}
+
+func TestIntegrationSnapshotStreamPKParity(t *testing.T) {
+	integration.CheckSkip(t)
+
+	cleanup, replURL := createDockerInstance(t)
+	defer cleanup()
+
+	// createDockerInstance hands back a replication DSN; plain queries need
+	// one without it. Use the driver the snapshot connection uses.
+	queryDSN := strings.ReplaceAll(replURL, " replication=database", "")
+	pcfg, err := pgxpool.ParseConfig(queryDSN)
+	require.NoError(t, err)
+	db := stdlib.OpenDB(*pcfg.ConnConfig)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+
+	cases := []struct {
+		name    string
+		colType string
+		value   string
+	}{
+		{"int4", "integer", "42"},
+		{"int8", "bigint", "9007199254740993"},
+		{"int2", "smallint", "32767"},
+		{"text", "text", "'abc'"},
+		{"varchar", "varchar(10)", "'xy'"},
+		// char(n) is blank-padded by its output function.
+		{"bpchar", "char(5)", "'ab'"},
+		{"uuid", "uuid", "'0b7f2e1e-4a5b-4c3d-8e9f-0a1b2c3d4e5f'::uuid"},
+		// numeric reaches the snapshot decoder's default branch as raw text
+		// while the stream canonicalises it, so it is the type most likely
+		// to drift apart.
+		{"numeric", "numeric", "1.50"},
+		{"numeric_scaled", "numeric(10,2)", "1.5"},
+		{"numeric_nan", "numeric", "'NaN'::numeric"},
+		// bytea arrives as []byte from the stream and as a string from the
+		// snapshot, which is what canonicalizePKValue reconciles.
+		{"bytea", "bytea", "'\\x0102ff'::bytea"},
+		{"timestamptz", "timestamptz", "'2026-01-02 03:04:05.678+00'::timestamptz"},
+		{"timestamp", "timestamp", "'2026-01-02 03:04:05.678'::timestamp"},
+		{"date", "date", "'2026-01-02'::date"},
+		{"float8", "double precision", "0.1"},
+		{"bool", "boolean", "true"},
+		{"inet", "inet", "'192.168.0.1/24'::inet"},
+	}
+	// Excluded: numeric with a negative scale, e.g. numeric(5,-2). The
+	// streaming decoder rejects it outright because
+	// pgNumericModFromAtttypmod misreads the scale. That is a pre-existing
+	// fault in replication_message_decoders.go, unrelated to key parity.
+
+	for _, tc := range cases {
+		_, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id %s PRIMARY KEY)", tc.name, tc.colType))
+		require.NoError(t, err, "creating table for %s", tc.name)
+	}
+
+	_, err = db.Exec("CREATE PUBLICATION parity_pub FOR ALL TABLES")
+	require.NoError(t, err)
+	_, err = db.Exec("SELECT pg_create_logical_replication_slot('parity_slot', 'pgoutput')")
+	require.NoError(t, err)
+
+	for _, tc := range cases {
+		_, err := db.Exec(fmt.Sprintf("INSERT INTO %s (id) VALUES (%s)", tc.name, tc.value))
+		require.NoError(t, err, "inserting into %s", tc.name)
+	}
+
+	streamed := streamedPKValues(t, db)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			streamVal, decoded := streamed[tc.name]
+			require.True(t, decoded, "no streamed insert decoded for %s", tc.name)
+
+			rows, err := db.Query(fmt.Sprintf("SELECT id FROM %s", tc.name))
+			require.NoError(t, err)
+			defer rows.Close()
+			columnTypes, err := rows.ColumnTypes()
+			require.NoError(t, err)
+			scanArgs, getters := prepareScannersAndGetters(columnTypes)
+			require.True(t, rows.Next())
+			require.NoError(t, rows.Scan(scanArgs...))
+			snapshotVal, err := getters[0](scanArgs[0])
+			require.NoError(t, err)
+			require.NoError(t, rows.Err())
+
+			snapshotKey := fmt.Sprintf("%v", canonicalizePKValue(snapshotVal))
+			streamKey := fmt.Sprintf("%v", canonicalizePKValue(streamVal))
+			assert.Equal(t, snapshotKey, streamKey,
+				"snapshot and stream must reduce a %s key to the same window key", tc.colType)
+		})
+	}
+}
+
+// streamedPKValues drains the pgoutput slot and returns, per table, the
+// decoded primary key of its insert -- the value OnStreamedRow would key on.
+func streamedPKValues(t *testing.T, db *sql.DB) map[string]any {
+	t.Helper()
+
+	rows, err := db.Query(`SELECT data FROM pg_logical_slot_get_binary_changes(
+		'parity_slot', NULL, NULL, 'proto_version', '1', 'publication_names', 'parity_pub')`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	typeMap := pgtype.NewMap()
+	relations := map[uint32]*RelationMessage{}
+	out := map[string]any{}
+
+	for rows.Next() {
+		var data []byte
+		require.NoError(t, rows.Scan(&data))
+
+		msg, err := Parse(data)
+		require.NoError(t, err)
+
+		switch m := msg.(type) {
+		case *RelationMessage:
+			relations[m.RelationID] = m
+		case *InsertMessage:
+			rel, found := relations[m.RelationID]
+			require.True(t, found, "insert for unknown relation %d", m.RelationID)
+
+			for i, col := range rel.Columns {
+				// Flag 1 marks the column as part of the key.
+				if col.Flags != 1 {
+					continue
+				}
+				val, err := decodeTextColumnData(typeMap, m.Tuple.Columns[i].Data, col.DataType, col.TypeModifier)
+				require.NoError(t, err, "decoding streamed key for %s", rel.RelationName)
+				out[rel.RelationName] = val
+			}
+		}
+	}
+	require.NoError(t, rows.Err())
+	return out
 }

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -10,6 +10,7 @@ package pglogicalstream
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"slices"
@@ -26,7 +27,9 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/redpanda-data/connect/v4/internal/asyncroutine"
+	incsnapshot "github.com/redpanda-data/connect/v4/internal/impl/postgresql/incrementalsnapshot"
 	"github.com/redpanda-data/connect/v4/internal/impl/postgresql/pglogicalstream/sanitize"
+	"github.com/redpanda-data/connect/v4/internal/replication/incrementalsnapshot"
 )
 
 const decodingPlugin = "pgoutput"
@@ -62,6 +65,20 @@ type Stream struct {
 	heartbeat               *heartbeat
 	maxSnapshotWorkers      int
 	unchangedToastValue     any
+	pgVersion               int
+
+	// incremental snapshot
+	incSnapshotCoordinator *incsnapshot.Coordinator
+	incSnapshotConn        *sql.DB
+	incSnapshotPKCache     map[string][]string
+	incSnapshotTables      map[incrementalsnapshot.TableID]struct{}
+	incSnapshotLastTable   *incrementalsnapshot.TableID // used for logging
+
+	// BlockingSnapshot is true only when this session runs the one-shot
+	// stream_snapshot backfill, which also emits a SnapshotCompleteOpType
+	// sentinel. False when the slot already existed, since that backfill only
+	// runs against a fresh slot.
+	BlockingSnapshot bool
 }
 
 // NewPgStream creates a new instance of the Stream struct.
@@ -145,6 +162,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	if config.HeartbeatInterval > 0 {
 		stream.heartbeat, err = newHeartbeat(
 			config,
+			EffectiveHeartbeatInterval(config.HeartbeatInterval, config.IncrementalSnapshotCfg()),
 			"redpanda_connect_"+stream.slotName,
 			`{"type":"heartbeat"}`,
 		)
@@ -159,8 +177,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		})
 	}
 
-	var version int
-	if version, err = getPostgresVersion(config); err != nil {
+	if stream.pgVersion, err = getPostgresVersion(config); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +187,13 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		fmt.Sprintf("publication_names 'pglog_stream_%s'", config.ReplicationSlotName),
 	}
 
-	if version > 14 {
+	// The incremental snapshot advances only on a
+	// decoded COMMIT, which on a quiet table only the heartbeat produces.
+	// PostgreSQL 13 has no "messages" option and refuses the slot. From
+	// PostgreSQL 15 an empty transaction is dropped, so without the decoded
+	// message no BEGIN or COMMIT arrives. Earlier versions still send the
+	// empty transaction, and its BEGIN carries a real xid.
+	if stream.pgVersion > 14 {
 		pluginArguments = append(pluginArguments, "messages 'true'")
 	}
 
@@ -198,6 +221,19 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 	cleanups = append(cleanups, func() {
 		// TODO: Drop publication if it was created (meaning it's not existing state we might want to keep).
 	})
+
+	if err := stream.setupIncrementalSnapshot(ctx, config); err != nil {
+		return nil, fmt.Errorf("setting up incremental snapshot: %w", err)
+	}
+	if stream.incSnapshotConn != nil {
+		cleanups = append(cleanups, func() {
+			if stream != nil && stream.incSnapshotConn != nil {
+				if err := stream.incSnapshotConn.Close(); err != nil {
+					config.Logger.Warnf("unable to properly cleanup incremental snapshot connection on stream creation failure: %s", err)
+				}
+			}
+		})
+	}
 
 	query, err := sanitize.SQLQuery("SELECT confirmed_flush_lsn, plugin FROM pg_replication_slots WHERE slot_name = $1", config.ReplicationSlotName)
 	if err != nil {
@@ -230,6 +266,12 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 			}
 		}
 		stream.logger.Debugf("starting stream from LSN %s", confirmedLSNFromDB.String())
+		if stream.incSnapshotCoordinator != nil {
+			if err := stream.incSnapshotCoordinator.Start(ctx); err != nil {
+				return nil, fmt.Errorf("starting incremental snapshot: %w", err)
+			}
+			stream.logger.Debugf("Incremental snapshot: coordinator started")
+		}
 		if err = stream.startLr(ctx, confirmedLSNFromDB); err != nil {
 			return nil, err
 		}
@@ -245,6 +287,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 
 	var snapshotter *snapshotter
 	if config.StreamOldData {
+		stream.BlockingSnapshot = true
 		// A crash between snapshot completion and slot promotion leaves <slot>_tmp
 		// behind, owned by the dead session. We only get here when no permanent
 		// slot exists, so any leftover _tmp slot is necessarily stale - drop it
@@ -345,6 +388,13 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 		stream.ackedLSNMu.Lock()
 		stream.ackedLSN = startLSN
 		stream.ackedLSNMu.Unlock()
+		if stream.incSnapshotCoordinator != nil {
+			if err := stream.incSnapshotCoordinator.Start(ctx); err != nil {
+				stream.errors <- fmt.Errorf("starting incremental snapshot: %w", err)
+				return
+			}
+			stream.logger.Debugf("Incremental snapshot: coordinator started")
+		}
 		if err := stream.startLr(ctx, startLSN); err != nil {
 			stream.errors <- fmt.Errorf("starting logical replication: %w", err)
 			return
@@ -434,6 +484,7 @@ func (s *Stream) streamMessages(currentLSN LSN) error {
 		lastEmittedLSN       = currentLSN
 		lastEmittedCommitLSN = currentLSN
 		currentTxnCommitTime time.Time
+		currentTxnXid        uint32
 	)
 
 	commitLSN := func(force bool) (committed bool, err error) {
@@ -511,7 +562,7 @@ func (s *Stream) streamMessages(currentLSN LSN) error {
 				return fmt.Errorf("parsing XLogData: %w", err)
 			}
 			msgLSN := xld.WALStart + LSN(len(xld.WALData))
-			result, err := s.processChange(ctx, msgLSN, xld, relations, typeMap, schemaCache, &currentTxnCommitTime)
+			result, err := s.processChange(ctx, msgLSN, xld, relations, typeMap, schemaCache, &currentTxnCommitTime, &currentTxnXid)
 			if err != nil {
 				return fmt.Errorf("decoding postgres changes failed: %w", err)
 			}
@@ -542,7 +593,7 @@ const (
 )
 
 // Handle handles the pgoutput output.
-func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, schemaCache map[uint32]any, currentTxnCommitTime *time.Time) (processChangeResult, error) {
+func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, relations map[uint32]*RelationMessage, typeMap *pgtype.Map, schemaCache map[uint32]any, currentTxnCommitTime *time.Time, currentTxnXid *uint32) (processChangeResult, error) {
 	logicalMsg, err := Parse(xld.WALData)
 	if err != nil {
 		return changeResultNoMessage, err
@@ -555,11 +606,16 @@ func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, re
 		delete(schemaCache, rel.RelationID)
 	}
 
-	// capture transaction commit time for insert, update and delete events
+	// capture transaction commit time and xid for insert, update and delete events
 	if begin, ok := logicalMsg.(*BeginMessage); ok {
 		*currentTxnCommitTime = begin.CommitTime
+		*currentTxnXid = begin.Xid
 	} else if _, ok := logicalMsg.(*CommitMessage); ok {
+		if err := s.advanceIncrementalSnapshot(ctx, *currentTxnXid); err != nil {
+			return changeResultNoMessage, err
+		}
 		*currentTxnCommitTime = time.Time{}
+		*currentTxnXid = 0
 	}
 
 	// parse changes inside the transaction
@@ -605,6 +661,10 @@ func (s *Stream) processChange(ctx context.Context, msgLSN LSN, xld XLogData, re
 			schemaCache[relID] = schema
 			message.ColumnSchema = schema
 		}
+	}
+
+	if err := s.deduplicateStreamedRow(ctx, message); err != nil {
+		return changeResultNoMessage, err
 	}
 
 	message.CommitTime = *currentTxnCommitTime
@@ -834,9 +894,10 @@ func (s *Stream) Errors() chan error {
 	return s.errors
 }
 
-func (s *Stream) getPrimaryKeyColumn(ctx context.Context, table TableFQN) ([]string, error) {
-	/// Query to get all primary key columns in their correct order
-	q, err := sanitize.SQLQuery(`
+// primaryKeyColumnsQuery returns the query used to resolve table's primary
+// key columns, in index order.
+func primaryKeyColumnsQuery(table string) (string, error) {
+	return sanitize.SQLQuery(`
         SELECT a.attname
         FROM   pg_index i
         JOIN   pg_attribute a ON a.attrelid = i.indrelid
@@ -844,7 +905,18 @@ func (s *Stream) getPrimaryKeyColumn(ctx context.Context, table TableFQN) ([]str
         WHERE  i.indrelid = $1::regclass
         AND    i.indisprimary
         ORDER BY array_position(i.indkey, a.attnum);
-    `, table.String())
+    `, table)
+}
+
+// getPrimaryKeyColumn resolves table's primary key columns over s.pgConn.
+// Only safe to call before logical replication starts (COPY BOTH mode) --
+// s.pgConn is the dedicated replication protocol connection from that point
+// on, and issuing a plain Exec on it concurrently corrupts/deadlocks the
+// stream. Callers that may run once streaming has started (e.g. incremental
+// snapshot's PK resolution) must instead use resolveIncrementalPKColumns,
+// which queries over s.incrementalDB.
+func (s *Stream) getPrimaryKeyColumn(ctx context.Context, table TableFQN) ([]string, error) {
+	q, err := primaryKeyColumnsQuery(table.String())
 	if err != nil {
 		return nil, fmt.Errorf("sanitizing query: %w", err)
 	}
@@ -876,13 +948,24 @@ func (s *Stream) Stop(ctx context.Context) error {
 	stopNowCtx, done := s.shutSig.HardStopCtx(ctx)
 	defer done()
 	wg.Go(func() error {
-		// Wait for streamMessages to finish using pgConn before closing it,
-		// otherwise we race on pgconn internal state (lock field, write buffer).
+		// Wait for streamMessages to finish using pgConn (and, if incremental
+		// snapshotting is enabled, incrementalDB) before closing them,
+		// otherwise we race on pgconn internal state (lock field, write buffer)
+		// or on a connection that's mid-query.
 		select {
 		case <-s.shutSig.HasStoppedChan():
 		case <-stopNowCtx.Done():
 		}
-		return s.pgConn.Close(stopNowCtx)
+		var errs []error
+		if err := s.pgConn.Close(stopNowCtx); err != nil {
+			errs = append(errs, err)
+		}
+		if s.incSnapshotConn != nil {
+			if err := s.incSnapshotConn.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
 	})
 	wg.Go(func() error {
 		return s.monitor.Stop()

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -270,7 +270,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 			if err := stream.incSnapshotCoordinator.Start(ctx); err != nil {
 				return nil, fmt.Errorf("starting incremental snapshot: %w", err)
 			}
-			stream.logger.Debugf("Incremental snapshot: coordinator started")
+			stream.reportResumeReconciliation()
 		}
 		if err = stream.startLr(ctx, confirmedLSNFromDB); err != nil {
 			return nil, err
@@ -393,7 +393,7 @@ func NewPgStream(ctx context.Context, config *Config) (*Stream, error) {
 				stream.errors <- fmt.Errorf("starting incremental snapshot: %w", err)
 				return
 			}
-			stream.logger.Debugf("Incremental snapshot: coordinator started")
+			stream.reportResumeReconciliation()
 		}
 		if err := stream.startLr(ctx, startLSN); err != nil {
 			stream.errors <- fmt.Errorf("starting logical replication: %w", err)

--- a/internal/impl/postgresql/pglogicalstream/logical_stream.go
+++ b/internal/impl/postgresql/pglogicalstream/logical_stream.go
@@ -914,7 +914,7 @@ func primaryKeyColumnsQuery(table string) (string, error) {
 // on, and issuing a plain Exec on it concurrently corrupts/deadlocks the
 // stream. Callers that may run once streaming has started (e.g. incremental
 // snapshot's PK resolution) must instead use resolveIncrementalPKColumns,
-// which queries over s.incrementalDB.
+// which queries over s.incSnapshotConn.
 func (s *Stream) getPrimaryKeyColumn(ctx context.Context, table TableFQN) ([]string, error) {
 	q, err := primaryKeyColumnsQuery(table.String())
 	if err != nil {
@@ -949,7 +949,7 @@ func (s *Stream) Stop(ctx context.Context) error {
 	defer done()
 	wg.Go(func() error {
 		// Wait for streamMessages to finish using pgConn (and, if incremental
-		// snapshotting is enabled, incrementalDB) before closing them,
+		// snapshotting is enabled, incSnapshotConn) before closing them,
 		// otherwise we race on pgconn internal state (lock field, write buffer)
 		// or on a connection that's mid-query.
 		select {

--- a/internal/impl/postgresql/pglogicalstream/monitor.go
+++ b/internal/impl/postgresql/pglogicalstream/monitor.go
@@ -81,12 +81,16 @@ func NewMonitor(
 
 // UpdateSnapshotProgressForTable updates the snapshot ingestion progress for a given table.
 func (m *Monitor) UpdateSnapshotProgressForTable(table TableFQN, read int) {
-	m.snapshotProgress[table].Add(int64(read))
+	if progress, ok := m.snapshotProgress[table]; ok {
+		progress.Add(int64(read))
+	}
 }
 
 // MarkSnapshotComplete means that we finished snapshotting.
 func (m *Monitor) MarkSnapshotComplete(table TableFQN) {
-	m.snapshotProgress[table].Store(int64(m.tableStat[table]))
+	if progress, ok := m.snapshotProgress[table]; ok {
+		progress.Store(int64(m.tableStat[table]))
+	}
 }
 
 // we need to read the tables stat to calculate the snapshot ingestion progress.

--- a/internal/impl/postgresql/pglogicalstream/stream_message.go
+++ b/internal/impl/postgresql/pglogicalstream/stream_message.go
@@ -41,6 +41,11 @@ const (
 	// replication slot until every snapshot message has been acknowledged
 	// downstream; it is never forwarded downstream.
 	SnapshotCompleteOpType OpType = "snapshot_complete"
+	// IncrementalSnapshotCheckpointOpType is an internal sentinel carrying
+	// only an incremental snapshot checkpoint (IncrementalSnapshotState) when
+	// state advanced without emitting rows. Must never be forwarded
+	// downstream as a real change event.
+	IncrementalSnapshotCheckpointOpType OpType = "incremental_snapshot_checkpoint"
 )
 
 // StreamMessage represents a single change from the database
@@ -56,4 +61,6 @@ type StreamMessage struct {
 	ColumnSchema any       `json:"-"`
 	CommitTime   time.Time `json:"-"`
 	BeforeData   any       `json:"-"`
+
+	IncrementalSnapshotState []byte `json:"-"`
 }


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #4791.** That PR adds the shared, database-agnostic `internal/replication/incrementalsnapshot` package; this one wires PostgreSQL to it. Review #4791 first, and merge it first - this PR's diff is against that branch, so it shows only the 21 PostgreSQL files.

This change adds support for incremental snapshotting in the PostgreSQL connector, including a more general purpose package that other connectors can use to support such a feature.

### How it Works

I'm going to document how the implementation works (which in this case is more specific to PostgreSQL due to some of its powerful primitives), but from a high level it works by recording the database's transaction visibility state (a snapshot window open state), reads a chunk of (snapshot) rows bounded by primary key, then records transaction visibility state again (snapshot window closed). Those two readings bracket the read: any transaction that could have modified those rows has an id between them. The chunk is held in a buffer while replication continues, and each streamed change evicts its own row from that buffer, meaning the live, current value always wins. Once a commit arrives with an id past both readings, every racing transaction has been seen, and whatever survives in the buffer is released.

Below is a diagram that hopefully makes things a little clearer, however in this case we don't need to use a signal table in Postgres:

<img width="1009" height="528" alt="image" src="https://github.com/user-attachments/assets/34f6682e-0824-4b87-b8a2-c98c770bf2e9" />

### What Does This Give Us?

A few things:

- Without needing to perform a blocking snapshot, we can continue to stream changes whilst also performing a snapshot
- We can easily snapshot/re-snapshot existing or not tables without having to re-snapshot everything.

---

### Proof of Work

Incremental snapshot (with no concurrent streaming):

<img width="1510" height="911" alt="image" src="https://github.com/user-attachments/assets/db709bf2-bea6-4830-9c0e-81162c32fde0" />

<img width="1452" height="829" alt="image" src="https://github.com/user-attachments/assets/5b9abaaf-98df-4618-8e93-34f4d74127a5" />

---

Incremental snapshot (whilst streaming):

<img width="1507" height="912" alt="image" src="https://github.com/user-attachments/assets/d7df12ea-af90-4090-bf9e-418d0b6e4b1e" />

You'll see above, a batch of 5000 had a collision with an update, so we don't see that read. Below log output shows the collisions:

<img width="1499" height="908" alt="image" src="https://github.com/user-attachments/assets/4996fadf-1e8b-4d87-a47c-c1e05d22ae8f" />


