### PR TITLE
redis_script: fix the dead LUA scripts link in the summary

### DIFF
--- a/docs/modules/components/pages/processors/redis_script.adoc
+++ b/docs/modules/components/pages/processors/redis_script.adoc
@@ -23,7 +23,7 @@
 component_type_dropdown::[]
 
 
-Performs actions against Redis using https://redis.io/docs/manual/programmability/eval-intro/[LUA scripts^].
+Performs actions against Redis using https://redis.io/docs/latest/develop/programmability/eval-intro/[LUA scripts^].
 
 Introduced in version 4.11.0.
 

--- a/internal/impl/redis/script_processor.go
+++ b/internal/impl/redis/script_processor.go
@@ -29,7 +29,7 @@ func redisScriptProcConfig() *service.ConfigSpec {
 	spec := service.NewConfigSpec().
 		Stable().
 		Version("4.11.0").
-		Summary(`Performs actions against Redis using https://redis.io/docs/manual/programmability/eval-intro/[LUA scripts^].`).
+		Summary(`Performs actions against Redis using https://redis.io/docs/latest/develop/programmability/eval-intro/[LUA scripts^].`).
 		Description(`Actions are performed for each message and the message contents are replaced with the result.
 
 In order to merge the result into the original message compose this processor within a ` + "xref:components:processors/branch.adoc[`branch` processor]" + `.`).


### PR DESCRIPTION
## Problem

`redisScriptProcConfig`'s summary links to `https://redis.io/docs/manual/programmability/eval-intro/`, which returns HTTP 404. Redis moved the page under `docs/latest/develop`.

The summary is published verbatim as the first line of the `redis_script` reference page, so the dead link ships in the docs. It was picked up by the weekly Redpanda docs link check.

## Fix

Point at the current page: `https://redis.io/docs/latest/develop/programmability/eval-intro/` (HTTP 200).

No behavior change: the string is documentation metadata only.