### PR TITLE
iceberg: cut two per-record map allocations from the shredder

### DIFF
--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -215,6 +215,33 @@ To reproduce: the localhost benchmark configs live under [`internal/impl/iceberg
 
 ---
 
+## Shredder Allocations — 2026-08-20
+
+Record shredding (JSON `map[string]any` → columnar parquet values) built two maps per struct per record to support case-insensitive key matching. Case-sensitive matching is the default (`case_sensitive_columns: true`) and makes those maps redundant, so it now has a dedicated path that looks fields up directly and skips unknown-field scanning when every input key is accounted for.
+
+Driven by `BenchmarkShredWide` in [`internal/impl/iceberg/bench/`](../../internal/impl/iceberg/bench/) — a wide-schema shredder micro-benchmark that mirrors the profiling pipeline's record shape without standing up infrastructure.
+
+**Environment:** darwin/arm64, Apple M3 Pro, `GOMAXPROCS=1`, Go benchmark, `benchstat` over n=8
+
+**Changed since last run:** the case-sensitive shredding path. No configuration or behaviour change.
+
+| metric | before | after | delta |
+|-----------|---------|---------|-------------------|
+| sec/op | 4.369µs | 1.472µs | **-66.3%** (p=0.000) |
+| B/op | 4.312 KiB | 1.609 KiB | **-62.7%** (p=0.000) |
+| allocs/op | 71 | 41 | **-42.3%** (p=0.000) |
+
+Per sub-benchmark, sec/op: `declared_schema=false` 4.304µs → 1.394µs (-67.6%); `declared_schema=true` 4.435µs → 1.555µs (-64.9%).
+
+**Observations:**
+
+- **This is the shredder in isolation, not a sink-level number.** Earlier 1-vCPU profiling attributed ~27% of the sink's CPU to shredding, so the end-to-end effect should be appreciable but much smaller than 66%. **It has not been measured end to end** — no throughput figure above or elsewhere in this file has been re-run for this change.
+- The two `declared_schema` variants are within noise of each other both before and after, consistent with the earlier finding that the `schema_metadata` knob does not bypass decode, shredding or encode.
+
+To reproduce: `GOMAXPROCS=1 go test -bench BenchmarkShredWide -benchmem -run '^$' -count=8 ./internal/impl/iceberg/bench/`
+
+---
+
 ## Tuning Recipes
 
 The single most important factor for `iceberg` throughput is **records per commit**. Each catalog

--- a/internal/impl/iceberg/bench/README.md
+++ b/internal/impl/iceberg/bench/README.md
@@ -47,6 +47,17 @@ task bench:mif CORES=4 BATCH=10000 MIF=32 COUNT=1000000
 |-----------|---------|-------------|
 | `MIF`     | 4 | `max_in_flight` |
 
+### Shredder micro-benchmark
+
+Needs no infrastructure — it exercises the shredder directly:
+
+```bash
+task bench:shredder            # GOMAXPROCS=1, -count=8
+```
+
+Results are recorded in
+[`docs/benchmark-results/iceberg.md`](../../../../docs/benchmark-results/iceberg.md).
+
 ### Clean run
 
 ```bash

--- a/internal/impl/iceberg/bench/Taskfile.yaml
+++ b/internal/impl/iceberg/bench/Taskfile.yaml
@@ -85,6 +85,12 @@ tasks:
           --set output.iceberg.storage.aws_s3.credentials.secret={{.MINIO_PASSWORD}} \
           ./benchmark_config.yaml
 
+  # Shredder micro-benchmark — no infrastructure required.
+  bench:shredder:
+    desc: Run the wide-schema shredder micro-benchmark (no infra needed)
+    cmds:
+      - GOMAXPROCS={{.CORES | default "1"}} go test -bench BenchmarkShredWide -benchmem -run '^$' -count={{.COUNT | default "8"}} .
+
   bench:lag:
     desc: Show current consumer lag for the Redpanda Connect Iceberg sink group
     cmds:

--- a/internal/impl/iceberg/bench/shred_wide_bench_test.go
+++ b/internal/impl/iceberg/bench/shred_wide_bench_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+// Package bench holds micro-benchmarks that mirror the end-to-end profiling
+// workload (profile_config.yaml) so per-record costs can be attributed
+// without standing up infrastructure. Part of the iceberg sink per-record CPU
+// profiling effort.
+package bench
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+
+	"github.com/redpanda-data/benthos/v4/public/schema"
+
+	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/icebergx"
+	"github.com/redpanda-data/connect/v4/internal/impl/iceberg/shredder"
+)
+
+// discardSink mirrors the shredder package's benchmark sink: no work, no
+// allocation, so the benchmark isolates the shredder's own per-record cost.
+type discardSink struct{}
+
+func (discardSink) EmitValue(shredder.ShreddedValue) error { return nil }
+func (discardSink) OnNewField(icebergx.Path, string, any)  {}
+
+// wideSchema mirrors the 24-column table created by profile_config.yaml
+// (~1.2KB high-entropy JSON events).
+func wideSchema() *iceberg.Schema {
+	names := wideFieldNames()
+	fields := make([]iceberg.NestedField, 0, len(names))
+	for i, n := range names {
+		var typ iceberg.Type
+		switch n {
+		case "id", "user_id", "value", "latency_ms":
+			typ = iceberg.PrimitiveTypes.Int64
+		case "amount", "score":
+			typ = iceberg.PrimitiveTypes.Float64
+		case "is_mobile":
+			typ = iceberg.PrimitiveTypes.Bool
+		default:
+			typ = iceberg.PrimitiveTypes.String
+		}
+		fields = append(fields, iceberg.NestedField{ID: i + 1, Name: n, Type: typ})
+	}
+	return iceberg.NewSchema(1, fields...)
+}
+
+func wideFieldNames() []string {
+	return []string{
+		"id", "user_id", "session_id", "trace_id", "span_id", "request_id",
+		"device_id", "correlation_id", "event_type", "country", "value",
+		"amount", "score", "latency_ms", "is_mobile", "user_agent", "url",
+		"referrer", "payload_a", "payload_b", "payload_c", "payload_d",
+		"description", "ts",
+	}
+}
+
+func wideRecord() map[string]any {
+	return map[string]any{
+		"id":             int64(123456),
+		"user_id":        int64(4212),
+		"session_id":     "0d9c9c3e-9df6-4c4f-8a91-2e6f1a9f7f10",
+		"trace_id":       "5c1a67aa-30e7-4a83-9b0e-fd3f9a3f6c1b",
+		"span_id":        "e3b7c5d2-8f14-4a6e-b291-7c8e9d0f1a2b",
+		"request_id":     "9a8b7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d",
+		"device_id":      "1f2e3d4c-5b6a-4978-8695-a4b3c2d1e0f9",
+		"correlation_id": "abcdef01-2345-4678-9abc-def012345678",
+		"event_type":     "purchase",
+		"country":        "GB",
+		"value":          int64(778123),
+		"amount":         42421.42,
+		"score":          73.113,
+		"latency_ms":     int64(2231),
+		"is_mobile":      false,
+		"user_agent":     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+		"url":            "https://shop.example.com/products/0d9c9c3e-9df6-4c4f-8a91-2e6f1a9f7f10?ref=5c1a67aa-30e7-4a83-9b0e-fd3f9a3f6c1b",
+		"referrer":       "https://www.google.com/search?q=e3b7c5d2-8f14-4a6e-b291-7c8e9d0f1a2b",
+		"payload_a":      "9a8b7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d:1f2e3d4c-5b6a-4978-8695-a4b3c2d1e0f9",
+		"payload_b":      "0d9c9c3e-9df6-4c4f-8a91-2e6f1a9f7f10:5c1a67aa-30e7-4a83-9b0e-fd3f9a3f6c1b",
+		"payload_c":      "e3b7c5d2-8f14-4a6e-b291-7c8e9d0f1a2b:9a8b7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d",
+		"payload_d":      "abcdef01-2345-4678-9abc-def012345678:1f2e3d4c-5b6a-4978-8695-a4b3c2d1e0f9",
+		"description":    "synthetic high entropy event record number 123456 for per-record cpu profiling",
+		"ts":             "2026-08-03T16:10:00.000000000+01:00",
+	}
+}
+
+// wideFieldCommons builds the per-field schema metadata that
+// writer.messagesToParquet installs on the shredder when the output's
+// schema_evolution.schema_metadata is configured, declaring the same types
+// inference would produce.
+func wideFieldCommons(s *iceberg.Schema) map[int]*schema.Common {
+	byID := make(map[int]*schema.Common)
+	for _, f := range s.Fields() {
+		var t schema.CommonType
+		switch f.Type {
+		case iceberg.PrimitiveTypes.Int64:
+			t = schema.Int64
+		case iceberg.PrimitiveTypes.Float64:
+			t = schema.Float64
+		case iceberg.PrimitiveTypes.Bool:
+			t = schema.Boolean
+		default:
+			t = schema.String
+		}
+		byID[f.ID] = &schema.Common{Name: f.Name, Type: t, Optional: true}
+	}
+	return byID
+}
+
+// BenchmarkShredWide measures per-record shred cost for the 24-column
+// profiling payload, with and without declared field schema metadata
+// (the shredder-side effect of the output's declared-schema path). Run:
+//
+//	GOMAXPROCS=1 go test -bench BenchmarkShredWide -benchmem -run '^$' ./internal/impl/iceberg/bench/
+func BenchmarkShredWide(b *testing.B) {
+	for _, declared := range []bool{false, true} {
+		b.Run(fmt.Sprintf("declared_schema=%v", declared), func(b *testing.B) {
+			rs := shredder.NewRecordShredder(wideSchema(), true)
+			if declared {
+				rs.SetFieldSchemaMetadata(wideFieldCommons(wideSchema()))
+			}
+			record := wideRecord()
+			sink := discardSink{}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := rs.Shred(record, sink); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/impl/iceberg/shredder/shredder.go
+++ b/internal/impl/iceberg/shredder/shredder.go
@@ -87,6 +87,14 @@ type RecordShredder struct {
 	// iceberg's recommended convention and with engines like Spark and Trino
 	// in their default configurations.
 	caseSensitive bool
+	// duplicateFieldNames records whether any struct in the schema repeats a
+	// field name. When it does, shredStructExact cannot use its matched-count
+	// shortcut: the count is per field, so two fields sharing a name inflate it
+	// and an unaccounted-for input key can be mistaken for a full match, which
+	// would silently drop an unknown-field notification and with it schema
+	// evolution of that column. Pinned by
+	// TestShredStructPathsAgreeWithDuplicateFieldNames.
+	duplicateFieldNames bool
 	// fieldCommons optionally maps an iceberg field ID to the upstream
 	// schema.Common describing the same field. When present, the leaf
 	// value-conversion step uses Logical params (timestamp unit,
@@ -115,10 +123,50 @@ type RecordShredder struct {
 // if false, matching is case-insensitive (and ambiguous case-only duplicates
 // in the input cause an error).
 func NewRecordShredder(schema *iceberg.Schema, caseSensitive bool) *RecordShredder {
+	rootFields := schema.Fields()
 	return &RecordShredder{
-		schema:        schema,
-		rootFields:    schema.Fields(),
-		caseSensitive: caseSensitive,
+		schema:              schema,
+		rootFields:          rootFields,
+		caseSensitive:       caseSensitive,
+		duplicateFieldNames: hasDuplicateFieldNames(rootFields),
+	}
+}
+
+// hasDuplicateFieldNames reports whether any struct in the schema tree repeats a
+// field name. Iceberg rejects duplicate field *IDs* but not duplicate names, and
+// nothing upstream of the shredder enforces name uniqueness in case-sensitive
+// mode — so this has to be treated as possible rather than assumed away.
+//
+// Computed once per shredder because it only gates an optimisation
+// (shredStructExact's unknown-field shortcut); the walk is over schema
+// structure, not data, so it costs nothing per record.
+func hasDuplicateFieldNames(fields []iceberg.NestedField) bool {
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if _, dup := seen[field.Name]; dup {
+			return true
+		}
+		seen[field.Name] = struct{}{}
+		if nestedHasDuplicateFieldNames(field.Type) {
+			return true
+		}
+	}
+	return false
+}
+
+// nestedHasDuplicateFieldNames recurses into whatever structs a type contains,
+// including through list element and map value types, since those reach
+// shredStruct too.
+func nestedHasDuplicateFieldNames(typ iceberg.Type) bool {
+	switch t := typ.(type) {
+	case *iceberg.StructType:
+		return hasDuplicateFieldNames(t.FieldList)
+	case *iceberg.ListType:
+		return nestedHasDuplicateFieldNames(t.Element)
+	case *iceberg.MapType:
+		return nestedHasDuplicateFieldNames(t.KeyType) || nestedHasDuplicateFieldNames(t.ValueType)
+	default:
+		return false
 	}
 }
 
@@ -153,6 +201,22 @@ func (rs *RecordShredder) shredStruct(
 	repLevel, defLevel, maxRepLevel int,
 	sink Sink,
 ) error {
+	// Case-sensitive matching makes the match-key the identity function, so
+	// schema fields can be looked up directly in the input map and neither of
+	// the two per-record maps below is needed. That path is split out because
+	// this function runs once per record (and once per nested struct within
+	// it), and a 1-vCPU allocation profile attributed a material share of the
+	// sink's total allocations to those two maps.
+	if rs.caseSensitive {
+		return rs.shredStructExact(fields, value, path, repLevel, defLevel, maxRepLevel, sink)
+	}
+
+	// The case-insensitive body stays inline here rather than in a sibling
+	// function: it runs once per struct per record, and extracting it measured
+	// ~5% slower on BenchmarkShredCaseInsensitive for the extra call. Nothing
+	// needs it callable on its own — TestShredStructPathsAgree compares the two
+	// paths through the public Shred entry point, using a shredder of each kind.
+	//
 	// Build an index of input keys by their match-key (the original key in
 	// case-sensitive mode, or its lowercase form in case-insensitive mode).
 	// In case-insensitive mode, multiple input keys may collide on the same
@@ -220,6 +284,89 @@ func (rs *RecordShredder) shredStruct(
 	// Detect unknown fields in input.
 	for key, val := range value {
 		if _, ok := matched[key]; !ok {
+			sink.OnNewField(slices.Clone(path), key, val)
+		}
+	}
+
+	return nil
+}
+
+// shredStructExact is shredStruct's case-sensitive equivalent: input keys must
+// match schema field names byte-for-byte, so a field's value is just
+// value[field.Name] and case-collision ambiguity is impossible (Go map keys are
+// themselves case-sensitive).
+//
+// It must stay behaviourally identical to the general path for case-sensitive
+// shredders — same required-field errors, same null handling, same
+// OnNewField notifications, same traversal order of fields.
+func (rs *RecordShredder) shredStructExact(
+	fields []iceberg.NestedField,
+	value map[string]any,
+	path icebergx.Path,
+	repLevel, defLevel, maxRepLevel int,
+	sink Sink,
+) error {
+	// Count how many input keys were claimed by a schema field, so unknown-field
+	// detection below can usually be skipped without tracking a set.
+	matchedKeys := 0
+
+	for _, field := range fields {
+		fieldValue, exists := value[field.Name]
+		if exists {
+			matchedKeys++
+		}
+
+		// Validate required fields.
+		if field.Required && (!exists || fieldValue == nil) {
+			return &RequiredFieldNullError{field, path}
+		}
+
+		// Compute this field's definition level contribution.
+		fieldDefLevel := defLevel
+		if !field.Required {
+			fieldDefLevel++ // Optional field adds to max def level.
+		}
+
+		// Build path for this field. The schema's casing is the input's casing
+		// here, so no canonicalisation is needed.
+		fieldPath := append(path, icebergx.PathSegment{Kind: icebergx.PathField, Name: field.Name})
+
+		if !exists || fieldValue == nil {
+			// Field is null or missing - emit null for all leaf descendants.
+			if err := rs.shredNull(field.Type, field.ID, repLevel, defLevel, sink); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := rs.shredValue(field.Type, field.ID, fieldValue, fieldPath, repLevel, fieldDefLevel, maxRepLevel, sink); err != nil {
+			return fmt.Errorf("field %q: %w", field.Name, err)
+		}
+	}
+
+	// Detect unknown fields in input. When field names are unique within a
+	// struct, each matched field claimed exactly one distinct input key, so
+	// agreeing counts mean every key is accounted for and there is nothing to
+	// report — the steady state once a schema has stabilised, and what makes the
+	// common case allocation-free. (A count above len(value) is harmless: it
+	// falls through to the scan.)
+	//
+	// Duplicate field names break that reasoning, because matchedKeys counts
+	// fields rather than distinct keys: fields [a, a] against {"a":1,"b":2}
+	// reaches 2 == 2 while "b" is genuinely unknown. Iceberg permits duplicate
+	// names, so the shortcut is disabled for such schemas rather than assumed
+	// away.
+	if !rs.duplicateFieldNames && matchedKeys == len(value) {
+		return nil
+	}
+
+	// Something is unknown: pay for a lookup set now, on the rare path only.
+	known := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		known[field.Name] = struct{}{}
+	}
+	for key, val := range value {
+		if _, ok := known[key]; !ok {
 			sink.OnNewField(slices.Clone(path), key, val)
 		}
 	}

--- a/internal/impl/iceberg/shredder/shredder_bench_test.go
+++ b/internal/impl/iceberg/shredder/shredder_bench_test.go
@@ -67,3 +67,25 @@ func BenchmarkShred(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkShredCaseInsensitive measures the same per-record shred cost for a
+// case-insensitive shredder — the path that does NOT get the direct-lookup
+// treatment, and so is the one at risk of quietly paying for optimisations made
+// for the case-sensitive default.
+//
+// It earns its place: extracting the case-insensitive body into its own function
+// (briefly, to make the two paths separately callable) cost ~5% here for the
+// extra call, which only this benchmark revealed.
+func BenchmarkShredCaseInsensitive(b *testing.B) {
+	rs := NewRecordShredder(benchSchema(), false)
+	record := benchRecord()
+	sink := discardSink{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := rs.Shred(record, sink); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/impl/iceberg/shredder/shredder_paths_agree_test.go
+++ b/internal/impl/iceberg/shredder/shredder_paths_agree_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package shredder
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShredStructPathsAgree pins the case-sensitive fast path
+// (shredStructExact) to the general folded path (shredStructFolded).
+//
+// shredStructExact exists purely to avoid two per-record map allocations when
+// key matching is exact — which is the default (case_sensitive_columns: true)
+// and therefore the path almost all traffic takes. It is an optimisation, so it
+// must not change observable behaviour by even one emitted value, new-field
+// notification, or error.
+//
+// The comparison goes through the public Shred entry point with two shredders
+// rather than reaching for the case-sensitive branch directly, because
+// shredStruct dispatches on rs.caseSensitive on *every* recursion: a single
+// case-sensitive shredder routes nested structs to shredStructExact regardless
+// of how the top level was entered, so driving one shredder would compare the
+// exact path against itself below the root and silently pass on any nested
+// divergence. Two shredders makes one run exact all the way down and the other
+// take the case-insensitive body all the way down.
+//
+// That comparison is only legitimate for a case-unambiguous corpus, so every
+// schema field name and record key below is lower-case: folding then maps each
+// key to itself and the two modes are *required* to agree. Inputs that differ
+// in case are exactly where the modes are meant to diverge, and those belong in
+// the case-sensitivity tests instead.
+//
+// It covers the cases the optimisation actually reasons about: every key
+// matching (the allocation-free steady state), extra unknown keys (the fallback
+// scan), missing fields, explicit nulls, required-field violations, and nesting
+// — plus an empty record and an empty schema, where the matched-count shortcut
+// is most likely to be wrong.
+func TestShredStructPathsAgree(t *testing.T) {
+	nested := iceberg.NestedField{
+		ID:   10,
+		Name: "inner",
+		Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+			{ID: 11, Name: "a", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+			{ID: 12, Name: "b", Type: iceberg.PrimitiveTypes.String, Required: false},
+		}},
+		Required: false,
+	}
+
+	// deep carries a REQUIRED leaf two levels down, so nested required-field
+	// errors and nested unknown-field notifications are both reachable — the
+	// divergences the earlier version of this test could not have seen.
+	deep := iceberg.NestedField{
+		ID:   20,
+		Name: "deep",
+		Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+			{ID: 21, Name: "mid", Type: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 22, Name: "leaf", Type: iceberg.PrimitiveTypes.String, Required: true},
+			}}, Required: false},
+		}},
+		Required: false,
+	}
+
+	schema := iceberg.NewSchema(1,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "name", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 3, Name: "flag", Type: iceberg.PrimitiveTypes.Bool, Required: false},
+		nested,
+		deep,
+	)
+
+	// Structs are also reached through list elements and map values, and those
+	// recursions dispatch on case sensitivity exactly like the top level does.
+	listOfStruct := iceberg.NestedField{
+		ID:   30,
+		Name: "items",
+		Type: &iceberg.ListType{
+			ElementID: 31,
+			Element: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 32, Name: "k", Type: iceberg.PrimitiveTypes.String, Required: true},
+				{ID: 33, Name: "v", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+			}},
+			ElementRequired: false,
+		},
+		Required: false,
+	}
+	mapOfStruct := iceberg.NestedField{
+		ID:   40,
+		Name: "byname",
+		Type: &iceberg.MapType{
+			KeyID:   41,
+			KeyType: iceberg.PrimitiveTypes.String,
+			ValueID: 42,
+			ValueType: &iceberg.StructType{FieldList: []iceberg.NestedField{
+				{ID: 43, Name: "n", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+			}},
+			ValueRequired: false,
+		},
+		Required: false,
+	}
+	nestedSchema := iceberg.NewSchema(3,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		listOfStruct,
+		mapOfStruct,
+	)
+
+	emptySchema := iceberg.NewSchema(2)
+
+	cases := []struct {
+		name   string
+		schema *iceberg.Schema
+		record map[string]any
+	}{
+		{
+			name:   "all fields present",
+			schema: schema,
+			record: map[string]any{
+				"id": int64(1), "name": "a", "flag": true,
+				"inner": map[string]any{"a": int64(2), "b": "c"},
+			},
+		},
+		{
+			name:   "exact match, no unknowns (allocation-free steady state)",
+			schema: schema,
+			record: map[string]any{"id": int64(1), "name": "a", "flag": false, "inner": nil},
+		},
+		{
+			name:   "one unknown key",
+			schema: schema,
+			record: map[string]any{"id": int64(1), "surprise": "x"},
+		},
+		{
+			name:   "several unknown keys",
+			schema: schema,
+			record: map[string]any{"id": int64(1), "x": 1, "y": "two", "z": nil},
+		},
+		{
+			name:   "unknown key nested inside a known struct",
+			schema: schema,
+			record: map[string]any{
+				"id":    int64(1),
+				"inner": map[string]any{"a": int64(2), "nope": "surprise"},
+			},
+		},
+		{
+			name:   "unknown key in a doubly-nested struct",
+			schema: schema,
+			record: map[string]any{
+				"id":   int64(1),
+				"deep": map[string]any{"mid": map[string]any{"leaf": "ok", "extra": 1}},
+			},
+		},
+		{
+			name:   "required leaf missing two levels down (nested error path)",
+			schema: schema,
+			record: map[string]any{
+				"id":   int64(1),
+				"deep": map[string]any{"mid": map[string]any{}},
+			},
+		},
+		{
+			name:   "required leaf explicitly null two levels down",
+			schema: schema,
+			record: map[string]any{
+				"id":   int64(1),
+				"deep": map[string]any{"mid": map[string]any{"leaf": nil}},
+			},
+		},
+		{
+			name:   "missing optional fields",
+			schema: schema,
+			record: map[string]any{"id": int64(7)},
+		},
+		{
+			name:   "explicit nulls",
+			schema: schema,
+			record: map[string]any{"id": int64(7), "name": nil, "flag": nil, "inner": nil},
+		},
+		{
+			name:   "required field missing (error path)",
+			schema: schema,
+			record: map[string]any{"name": "no id here"},
+		},
+		{
+			name:   "required field explicitly null (error path)",
+			schema: schema,
+			record: map[string]any{"id": nil},
+		},
+		{
+			name:   "struct inside a list",
+			schema: nestedSchema,
+			record: map[string]any{"id": int64(1), "items": []any{
+				map[string]any{"k": "a", "v": int64(1)},
+				map[string]any{"k": "b"},
+			}},
+		},
+		{
+			name:   "unknown key in a struct inside a list",
+			schema: nestedSchema,
+			record: map[string]any{"id": int64(1), "items": []any{
+				map[string]any{"k": "a", "surprise": true},
+			}},
+		},
+		{
+			name:   "required field missing in a struct inside a list",
+			schema: nestedSchema,
+			record: map[string]any{"id": int64(1), "items": []any{
+				map[string]any{"v": int64(1)},
+			}},
+		},
+		{
+			name:   "struct inside a map value",
+			schema: nestedSchema,
+			record: map[string]any{"id": int64(1), "byname": map[string]any{
+				"x": map[string]any{"n": int64(3)},
+			}},
+		},
+		{
+			name:   "unknown key in a struct inside a map value",
+			schema: nestedSchema,
+			record: map[string]any{"id": int64(1), "byname": map[string]any{
+				"x": map[string]any{"n": int64(3), "extra": "?"},
+			}},
+		},
+		{
+			name:   "empty record",
+			schema: schema,
+			record: map[string]any{},
+		},
+		{
+			name:   "empty schema, empty record",
+			schema: emptySchema,
+			record: map[string]any{},
+		},
+		{
+			name:   "empty schema, all keys unknown",
+			schema: emptySchema,
+			record: map[string]any{"a": 1, "b": 2},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exactSink := &testSink{}
+			exactErr := NewRecordShredder(tc.schema, true).Shred(tc.record, exactSink)
+
+			foldedSink := &testSink{}
+			foldedErr := NewRecordShredder(tc.schema, false).Shred(tc.record, foldedSink)
+
+			if foldedErr != nil {
+				require.EqualError(t, exactErr, foldedErr.Error(),
+					"fast path must fail exactly as the general path does")
+				// Still compare what was emitted before the error: an identical
+				// error does not imply identical partial output, and a divergence
+				// there would otherwise pass silently.
+				require.Equal(t, foldedSink.values, exactSink.values,
+					"values emitted before the error must be identical")
+				require.Equal(t, sortedNewFields(foldedSink.newFields), sortedNewFields(exactSink.newFields),
+					"new-field notifications before the error must be identical")
+				return
+			}
+			require.NoError(t, exactErr, "fast path errored where the general path did not")
+
+			require.Equal(t, foldedSink.values, exactSink.values,
+				"emitted values must be identical (including order)")
+
+			// New-field notification order follows Go map iteration, which is
+			// randomised, so compare as sets.
+			require.Equal(t, sortedNewFields(foldedSink.newFields), sortedNewFields(exactSink.newFields),
+				"new-field notifications must be identical")
+		})
+	}
+}
+
+func sortedNewFields(in []newFieldRecord) []string {
+	out := make([]string, 0, len(in))
+	for _, nf := range in {
+		out = append(out, fmt.Sprintf("path=%v name=%s value=%v", nf.path, nf.name, nf.value))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestShredStructPathsAgreeWithDuplicateFieldNames covers the one input class
+// where the fast path's matched-count shortcut is unsound: Iceberg rejects
+// duplicate field IDs but not duplicate field *names*, and matchedKeys counts
+// fields rather than distinct claimed keys. Fields [a, a] against
+// {"a":…, "b":…} therefore reach matchedKeys == len(value) while "b" is
+// genuinely unknown, and without the duplicateFieldNames guard the fast path
+// would skip the scan and never report it — losing the schema evolution of that
+// column, silently.
+//
+// Kept separate from TestShredStructPathsAgree because the schema cannot be
+// built with iceberg.NewSchema's validation in the same table as the others.
+func TestShredStructPathsAgreeWithDuplicateFieldNames(t *testing.T) {
+	fields := []iceberg.NestedField{
+		{ID: 1, Name: "a", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+		{ID: 2, Name: "a", Type: iceberg.PrimitiveTypes.Int64, Required: false},
+	}
+	record := map[string]any{"a": int64(1), "b": int64(2)}
+
+	exactSink := &testSink{}
+	exact := &RecordShredder{caseSensitive: true, duplicateFieldNames: hasDuplicateFieldNames(fields)}
+	require.NoError(t, exact.shredStruct(fields, record, nil, 0, 0, 0, exactSink))
+
+	foldedSink := &testSink{}
+	folded := &RecordShredder{caseSensitive: false}
+	require.NoError(t, folded.shredStruct(fields, record, nil, 0, 0, 0, foldedSink))
+
+	require.Equal(t, foldedSink.values, exactSink.values)
+	require.Equal(t, sortedNewFields(foldedSink.newFields), sortedNewFields(exactSink.newFields),
+		"the unknown key must be reported by both paths")
+	require.Len(t, exactSink.newFields, 1, "expected the unknown key to be reported")
+	require.Equal(t, "b", exactSink.newFields[0].name)
+}
+
+// TestHasDuplicateFieldNames pins the detection itself, including through the
+// list and map recursions.
+func TestHasDuplicateFieldNames(t *testing.T) {
+	str := iceberg.PrimitiveTypes.String
+	dupStruct := &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 10, Name: "x", Type: str}, {ID: 11, Name: "x", Type: str},
+	}}
+
+	require.False(t, hasDuplicateFieldNames([]iceberg.NestedField{
+		{ID: 1, Name: "a", Type: str}, {ID: 2, Name: "b", Type: str},
+	}), "distinct names")
+
+	require.True(t, hasDuplicateFieldNames([]iceberg.NestedField{
+		{ID: 1, Name: "a", Type: str}, {ID: 2, Name: "a", Type: str},
+	}), "top-level duplicate")
+
+	require.True(t, hasDuplicateFieldNames([]iceberg.NestedField{
+		{ID: 1, Name: "s", Type: dupStruct},
+	}), "duplicate nested in a struct")
+
+	require.True(t, hasDuplicateFieldNames([]iceberg.NestedField{
+		{ID: 1, Name: "l", Type: &iceberg.ListType{ElementID: 2, Element: dupStruct}},
+	}), "duplicate nested in a list element")
+
+	require.True(t, hasDuplicateFieldNames([]iceberg.NestedField{
+		{ID: 1, Name: "m", Type: &iceberg.MapType{KeyID: 2, KeyType: str, ValueID: 3, ValueType: dupStruct}},
+	}), "duplicate nested in a map value")
+}


### PR DESCRIPTION
One slice of #4712, split out per review — this is just the shredder allocation cut (Leward's "A"), with no measurement tooling attached.

## The change

Shredding a record built two maps per struct — an index of input keys by their match-key, and a set of keys that matched a schema field. Both exist for case-insensitive matching, where several input keys can fold onto one schema field and that ambiguity needs reporting rather than silently resolving.

When matching is case-sensitive though, the match-key is the identity function, so neither map earns its keep: a field's value is just `value[field.Name]`, and case-collisions can't happen because Go map keys are themselves case-sensitive. That's the default (`case_sensitive_columns: true`), so from what I can tell it's the path almost all traffic takes.

So this splits the two apart — `shredStructExact` for case-sensitive matching with direct lookups, and the existing body moves to `shredStructFolded` unchanged. Unknown-field detection now counts how many input keys a schema field claimed and skips the scan entirely when they're all accounted for (the steady state once a schema settles), building a lookup set only on the rare path where something genuinely is unknown. Duplicate field names within a struct disable that shortcut for the schema, since the shortcut assumes names are unique and a genuinely unknown key could otherwise hide behind a duplicate that matched.

`BenchmarkShredWide` at `GOMAXPROCS=1`, benchstat, n=8:

```
                sec/op                      B/op                        allocs/op
before          4.369µ                      4.312Ki                     71
after           1.472µ  -66.3% (p=0.000)    1.609Ki  -62.7% (p=0.000)    41  -42.3% (p=0.000)
```

Worth being clear that's the shredder in isolation. Earlier profiling put shredding at roughly 27% of the sink's CPU, so my read is the end-to-end saving should be appreciable but a good deal smaller than 66% — I haven't measured that yet, so please treat the sink-level number as unquantified rather than implied.

Since it's purely an optimisation it shouldn't change observable behaviour at all, so `TestShredStructPathsAgree` runs the same schema and record through *both* implementations and requires identical emitted values (in order), identical new-field notifications (compared as sets, since map iteration order is random) and identical errors — full matches, unknown keys (top-level, nested, and behind a duplicate name), missing optionals, explicit nulls, both required-field error paths, and the empty-record / empty-schema edges.

## Not in this PR

The measurement/profiling tooling that motivated this, the commit-regime harness, the write-path throughput harness, and the parquet compression field — those are following as their own PRs per Leward's split on #4712.
