### PR TITLE
iceberg: measure write-path throughput without the pipeline suite

### DIFF
--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -277,6 +277,63 @@ To reproduce: `go test -v -run TestCommitRegimeSweep -iceberg.commit-regime -tim
 
 ---
 
+## Write-path Throughput — Shredder Change, End to End
+
+The sink write path driven directly against containerised MinIO + Iceberg REST, by the flag-gated `TestWriteThroughput` in [`internal/impl/iceberg/integration/`](../../internal/impl/iceberg/integration/). Measures JSON decode, shredding, parquet encode, upload and catalog commit. Compression held at `uncompressed` so only the shredder differs.
+
+**Environment:** darwin/arm64, Apple M3 Pro; MinIO + `apache/iceberg-rest-fixture` in containers on the same machine; batches of 5,000 records; n=1 per point
+
+**Changed since last run:** the case-sensitive shredding path ([#4784](https://github.com/redpanda-data/connect/pull/4784)), measured against the same code with that change reverted.
+
+| schema | cores | records | before (rec/s) | after (rec/s) |
+|---|---:|---:|---:|---:|
+| 5 columns | 1 | 200,000 | 123,599 | 120,185 |
+| 5 columns | 4 | 200,000 | 133,732 | 133,621 |
+| 50 columns | 1 | 100,000 | 38,132 / 36,182 | 37,314 / 36,508 |
+
+**Observations:**
+
+- **No measurable end-to-end gain, at either schema width or core count.** The isolated shredder benchmark for this change is a 66% reduction (see [#4784](https://github.com/redpanda-data/connect/pull/4784)'s benchmark results), and none of it shows up here. The 50-column runs were repeated twice per side precisely because the difference is inside run-to-run variance.
+- **The most likely reading is that this harness is not shredder-bound.** Even at 50 columns, per-record time here is dominated by parquet encode, upload and commit, and the earlier profile that motivated the change (46% JSON decode, 27% shredding) came from a full pipeline run under the actual binary, not from this seam.
+- **Treat `GOMAXPROCS=1` here as "one core for the writer", not as a 1-vCPU deployment.** MinIO and the catalog run in containers with their own cores on the same machine, and there is no benthos input or pipeline in the loop, so the CPU mix differs from a constrained container running the whole thing.
+- Consequence for the shredder change: the isolated win is solid and measured, and its end-to-end value on these workloads is **not demonstrated**. It reduces per-record allocations and CPU in a component that profiling says accounts for about a quarter of sink CPU; whether that is visible at the sink depends on what else the workload is spending time on, and on these two record shapes it is not.
+
+To reproduce: `TESTCONTAINERS_RYUK_DISABLED=true go test ./internal/impl/iceberg/integration/ -run TestWriteThroughput -timeout 25m -iceberg.throughput -iceberg.throughput.records=200000 -iceberg.throughput.codec=uncompressed` (add `-iceberg.throughput.columns=45` for the wide schema).
+
+---
+
+## Write-path Throughput — Compression Codecs
+
+Same harness, varying the table's `write.parquet.compression-codec` property. 100,000 records per point, n=1. The harness reads the codec back out of a written file's footer and fails the run if it is not the one requested, so each row is a measurement of the codec named.
+
+**Environment:** as above
+
+**Changed since last run:** first measurement of the `parquet.compression` field's codecs ([#4785](https://github.com/redpanda-data/connect/pull/4785)).
+
+Record shape matters more than anything else here, so both are given. "regular" is ~90 B with sequential ids and an `info` string sharing a 21-character prefix; "high-entropy" fills `info` with 1,100 freshly random characters per record.
+
+| payload | codec | rec/s (4 cores) | rec/s (1 core) | bytes/record |
+|---|---|---:|---:|---:|
+| regular | uncompressed | 120,693 | 116,524 | 57.2 |
+| regular | snappy | 128,934 | 114,261 | 14.7 |
+| regular | zstd | 129,081 | 119,433 | 3.9 |
+| high-entropy | uncompressed | 46,396 | 42,994 | 1,151.4 |
+| high-entropy | snappy | 46,089 | — | 1,130.8 |
+| high-entropy | zstd | 45,152 | 43,209 | 1,124.4 |
+
+**Observations:**
+
+- **Compression showed no throughput cost worth reporting, including at one core.** Every codec is within a few percent of uncompressed on both payloads and both core counts, in both directions — zstd was nominally the *fastest* row twice. Any earlier expectation that compression would visibly cost throughput at low core counts is not supported by these numbers.
+- **The size effect is entirely about the data.** On the compressible shape zstd is **14.7x smaller** than uncompressed (57.2 → 3.9 bytes/record) and snappy 3.9x. On genuinely random content both save about 2%, because there is nothing to compress. Parquet's dictionary and byte-array encodings run before any codec, so a repetitive column is already compact and the codec adds little; the gain lives in high-entropy columns *that are not random*, which neither of these shapes represents.
+- **Local object storage understates the case for compression.** Uploads here are to a container on the same machine, so the bytes saved buy less time than they would against a remote endpoint. The direction of the trade-off would not reverse.
+- Caveat on all of the above: n=1 per point, one machine, no repetition — read these as order-of-magnitude and direction, not as precise figures.
+
+**Note on defaults, worth knowing before reading the table:** a table created through the Iceberg Go library — which includes tables this output creates itself — comes back carrying `write.parquet.compression-codec: zstd` in its properties, materialised at creation. Since an unset `parquet.compression` defers to the table property, such tables get **zstd**, not the uncompressed default that applies only to a table whose property is absent. The uncompressed rows above required setting the property explicitly.
+
+To reproduce: as above, with `-iceberg.throughput.codec=zstd|snappy|uncompressed` and `-iceberg.throughput.payload=regular|high-entropy`.
+
+---
+
 ## Tuning Recipes
 
 The single most important factor for `iceberg` throughput is **records per commit**. Each catalog

--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -298,7 +298,7 @@ The sink write path driven directly against containerised MinIO + Iceberg REST, 
 - **Treat `GOMAXPROCS=1` here as "one core for the writer", not as a 1-vCPU deployment.** MinIO and the catalog run in containers with their own cores on the same machine, and there is no benthos input or pipeline in the loop, so the CPU mix differs from a constrained container running the whole thing.
 - Consequence for the shredder change: the isolated win is solid and measured, and its end-to-end value on these workloads is **not demonstrated**. It reduces per-record allocations and CPU in a component that profiling says accounts for about a quarter of sink CPU; whether that is visible at the sink depends on what else the workload is spending time on, and on these two record shapes it is not.
 
-To reproduce: `TESTCONTAINERS_RYUK_DISABLED=true go test ./internal/impl/iceberg/integration/ -run TestWriteThroughput -timeout 25m -iceberg.throughput -iceberg.throughput.records=200000 -iceberg.throughput.codec=uncompressed` (add `-iceberg.throughput.columns=45` for the wide schema).
+To reproduce the 5-column rows: `TESTCONTAINERS_RYUK_DISABLED=true go test ./internal/impl/iceberg/integration/ -run TestWriteThroughput -timeout 25m -iceberg.throughput -iceberg.throughput.records=200000 -iceberg.throughput.codec=uncompressed`. For the 50-column row, drop the record count to match the table: add `-iceberg.throughput.columns=45 -iceberg.throughput.records=100000`.
 
 ---
 
@@ -330,7 +330,7 @@ Record shape matters more than anything else here, so both are given. "regular" 
 
 **Note on defaults, worth knowing before reading the table:** a table created through the Iceberg Go library — which includes tables this output creates itself — comes back carrying `write.parquet.compression-codec: zstd` in its properties, materialised at creation. Since an unset `parquet.compression` defers to the table property, such tables get **zstd**, not the uncompressed default that applies only to a table whose property is absent. The uncompressed rows above required setting the property explicitly.
 
-To reproduce: as above, with `-iceberg.throughput.codec=zstd|snappy|uncompressed` and `-iceberg.throughput.payload=regular|high-entropy`.
+To reproduce: `TESTCONTAINERS_RYUK_DISABLED=true go test ./internal/impl/iceberg/integration/ -run TestWriteThroughput -timeout 25m -iceberg.throughput -iceberg.throughput.records=100000 -iceberg.throughput.codec=zstd|snappy|uncompressed -iceberg.throughput.payload=regular|high-entropy`.
 
 ---
 

--- a/internal/impl/iceberg/integration/throughput_bench_test.go
+++ b/internal/impl/iceberg/integration/throughput_bench_test.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	iceio "github.com/apache/iceberg-go/io"
+	"github.com/apache/iceberg-go/table"
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/redpanda-data/benthos/v4/public/service/integration"
+)
+
+// Sink write-path throughput against the containerised MinIO + Iceberg REST
+// catalog, driving the Router directly.
+//
+// Why not the pipeline benchmark under bench/: that runs the assembled
+// `iceberg` output, which is an enterprise component and so needs a valid
+// licence to initialise. This measures the same write path one layer down —
+// JSON decode, shredding, parquet encode, upload, catalog commit — by driving
+// the Router the way the integration tests already do, which needs no licence.
+//
+// What it therefore does NOT include, and what the numbers should not be read
+// as covering: benthos input, pipeline and batching overhead, and object
+// storage that behaves like a real cloud endpoint rather than a local
+// container. It is a comparative instrument — before/after a change, or codec
+// against codec — not an absolute throughput figure for a deployment.
+var (
+	throughputRun = flag.Bool("iceberg.throughput", false,
+		"run the write-path throughput measurement (needs Docker; takes minutes)")
+	throughputRecords = flag.Int("iceberg.throughput.records", 200000,
+		"records to write per run")
+	throughputBatch = flag.Int("iceberg.throughput.batch", 5000,
+		"records per Route call")
+	throughputCodec = flag.String("iceberg.throughput.codec", "",
+		"value for the table's write.parquet.compression-codec property; empty leaves it unset, in which case the codec is whatever the table resolves to — note the Iceberg library materialises zstd at table creation, so unset does NOT mean uncompressed here")
+	throughputLabel = flag.String("iceberg.throughput.label", "run",
+		"label to print alongside the result, for telling A/B runs apart")
+	throughputColumns = flag.Int("iceberg.throughput.columns", 0,
+		"extra string columns beyond the base five; the shredder's per-record cost scales with schema width, so this is the axis its optimisation targets")
+	throughputPayload = flag.String("iceberg.throughput.payload", "regular",
+		"record shape: 'regular' (~90B, sequential ids and a shared string prefix) or 'high-entropy' (~1.2kB of random text)")
+)
+
+// TestWriteThroughput writes a fixed number of records and reports the rate and
+// the bytes they occupy, so a change to the write path can be measured
+// before/after and so the cost of a compression codec can be quantified.
+func TestWriteThroughput(t *testing.T) {
+	integration.CheckSkip(t)
+	if !*throughputRun {
+		t.Skip("set -iceberg.throughput to run the write-path throughput measurement")
+	}
+
+	ctx := t.Context()
+	infra := setupTestInfra(t, ctx)
+
+	const namespace = "bench"
+	infra.CreateNamespace(t, namespace)
+
+	tableName := fmt.Sprintf("tput_%d", time.Now().UnixNano())
+
+	// Pre-create the table so the measured window contains no CREATE TABLE, and
+	// so the compression codec can be set through the property the resolver
+	// actually reads. Schema mirrors the localhost bench config's record shape.
+	fields := []iceberg.NestedField{
+		{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+		{ID: 2, Name: "user_id", Type: iceberg.PrimitiveTypes.Int64},
+		{ID: 3, Name: "event_type", Type: iceberg.PrimitiveTypes.String},
+		{ID: 4, Name: "value", Type: iceberg.PrimitiveTypes.Int64},
+		{ID: 5, Name: "info", Type: iceberg.PrimitiveTypes.String},
+	}
+	for i := range *throughputColumns {
+		fields = append(fields, iceberg.NestedField{
+			ID: 100 + i, Name: fmt.Sprintf("col_%d", i), Type: iceberg.PrimitiveTypes.String,
+		})
+	}
+	sc := iceberg.NewSchema(0, fields...)
+
+	client := infra.NewCatalogClient(t, namespace)
+	var opts []catalog.CreateTableOpt
+	if *throughputCodec != "" {
+		opts = append(opts, catalog.WithProperties(iceberg.Properties{
+			"write.parquet.compression-codec": *throughputCodec,
+		}))
+	}
+	_, err := client.CreateTable(ctx, tableName, sc, opts...)
+	require.NoError(t, err)
+
+	// Capture what the table actually carries: whether a property was set here
+	// or materialised by the catalog decides which codec the writer resolves to,
+	// and the assertion below has to expect the same thing.
+	created, err := client.LoadTable(ctx, tableName)
+	require.NoError(t, err)
+	tableProps := created.Properties()
+	t.Logf("TABLEPROPS %v", tableProps)
+
+	router := infra.NewRouter(t, namespace, tableName)
+
+	// Build every batch up front so record generation is not inside the timed
+	// window — the point of measurement is the sink, not the generator.
+	batches := buildThroughputBatches(t, *throughputRecords, *throughputBatch, *throughputPayload, *throughputColumns)
+
+	start := time.Now()
+	for _, batch := range batches {
+		require.NoError(t, router.Route(ctx, batch))
+	}
+	elapsed := time.Since(start)
+
+	// Bytes come from the snapshot summary rather than being counted locally, so
+	// the figure is what the table actually holds.
+	tbl, err := client.LoadTable(ctx, tableName)
+	require.NoError(t, err)
+	var committedRecords int64
+	summary := map[string]string{}
+	if snap := tbl.CurrentSnapshot(); snap != nil && snap.Summary != nil {
+		summary = snap.Summary.Properties
+		committedRecords, _ = strconv.ParseInt(summary["total-records"], 10, 64)
+	}
+
+	// Size is summed from the manifests rather than taken from the snapshot
+	// summary's total-files-size, which this catalog does not populate with the
+	// data-file total — it reported 82kB for a table whose string column alone
+	// reads back as 528kB, so it cannot be used for a bytes-per-record figure.
+	totalBytes, dataFiles, writtenCodec := sumDataFileBytes(t, ctx, tbl)
+
+	// Assert the codec that was actually written, rather than assuming the
+	// property took effect. Without this a run that silently ignored the
+	// property would produce a plausible-looking size comparison.
+	wantCodec := expectedCodec(*throughputCodec, tableProps)
+	require.Equal(t, wantCodec, writtenCodec,
+		"data files were written with %s; expected %s from codec flag %q and table property %q",
+		writtenCodec, wantCodec, *throughputCodec, tableProps[parquetCompressionProperty])
+
+	// Refuse to report a rate for a run that did not actually land the data. A
+	// throughput number from a partial or failed write looks entirely plausible
+	// and is worthless, so this is asserted rather than trusted.
+	require.EqualValues(t, *throughputRecords, committedRecords,
+		"table holds %d records, expected %d — the measured rate would be meaningless (summary: %v)",
+		committedRecords, *throughputRecords, summary)
+	require.Positive(t, totalBytes, "table reports no file bytes (summary: %v)", summary)
+
+	// Read the data back and confirm the columns carry real content. Row counts
+	// alone would not catch a column silently arriving empty, which would make
+	// any bytes-per-record figure nonsense.
+	type contentRow struct {
+		N        int64 `json:"n"`
+		InfoLen  int64 `json:"info_len"`
+		Distinct int64 `json:"distinct_info"`
+	}
+	content := querySQL[contentRow](t, ctx, infra, fmt.Sprintf(
+		`SELECT count(*) AS n, sum(length(info)) AS info_len, count(DISTINCT info) AS distinct_info FROM iceberg_cat."%s"."%s";`,
+		namespace, tableName))
+	require.Len(t, content, 1)
+	require.EqualValues(t, *throughputRecords, content[0].N, "read-back row count")
+	require.Positive(t, content[0].InfoLen, "the info column read back empty")
+	t.Logf("READBACK rows=%d info_bytes=%d distinct_info=%d",
+		content[0].N, content[0].InfoLen, content[0].Distinct)
+
+	records := int64(*throughputRecords)
+	rate := float64(records) / elapsed.Seconds()
+	perRecord := 0.0
+	if records > 0 {
+		perRecord = float64(totalBytes) / float64(records)
+	}
+
+	t.Logf("RESULT label=%s payload=%s cols=%d codec=%q written=%s records=%d batch=%d files=%d elapsed=%s rec/s=%.0f bytes=%d bytes/rec=%.1f",
+		*throughputLabel, *throughputPayload, 5+*throughputColumns, *throughputCodec, writtenCodec, records, *throughputBatch, dataFiles,
+		elapsed.Round(time.Millisecond), rate, totalBytes, perRecord)
+}
+
+// parquetCompressionProperty is Iceberg's table property for the codec data
+// files are written with.
+const parquetCompressionProperty = "write.parquet.compression-codec"
+
+// expectedCodec restates the output's own resolution rule, so the assertion
+// checks behaviour against the documented contract rather than against a fixed
+// value: an explicit setting wins, otherwise the table's property applies,
+// otherwise uncompressed. Codecs the output declines to write, and values it
+// does not recognise, both fall back to uncompressed.
+//
+// Deliberately a restatement rather than a call into the resolver — that lives
+// in an unexported function in another package, and asserting an implementation
+// against itself would prove nothing.
+func expectedCodec(configured string, props iceberg.Properties) string {
+	name := strings.ToLower(strings.TrimSpace(configured))
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(props[parquetCompressionProperty]))
+	}
+	switch name {
+	case "snappy", "gzip", "zstd":
+		return strings.ToUpper(name)
+	default:
+		// uncompressed, none, absent, declined (lz4/lz4_raw/brotli/lzo) or junk.
+		return "UNCOMPRESSED"
+	}
+}
+
+// sumDataFileBytes totals the on-disk size of every data file the table's
+// current snapshot references, and returns that with the file count.
+func sumDataFileBytes(t *testing.T, ctx context.Context, tbl *table.Table) (bytes, files int64, codec string) {
+	t.Helper()
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap, "table has no snapshot")
+
+	fs, err := tbl.FS(ctx)
+	require.NoError(t, err)
+
+	manifests, err := snap.Manifests(fs)
+	require.NoError(t, err)
+
+	for _, m := range manifests {
+		for e, err := range m.Entries(fs, true) {
+			require.NoError(t, err)
+			df := e.DataFile()
+			if df.ContentType() != iceberg.EntryContentData {
+				continue
+			}
+			bytes += df.FileSizeBytes()
+			files++
+
+			// Every data file should carry the same codec; read one and check
+			// the rest agree, so a partially-applied setting cannot hide.
+			fileCodec := parquetCodecOf(t, fs, df.FilePath())
+			if codec == "" {
+				codec = fileCodec
+			}
+			require.Equal(t, codec, fileCodec,
+				"data files disagree on codec: %s vs %s", codec, fileCodec)
+		}
+	}
+	return bytes, files, codec
+}
+
+// parquetCodecOf reports the compression codec recorded in a parquet file's
+// footer, read from object storage.
+func parquetCodecOf(t *testing.T, fs iceio.IO, path string) string {
+	t.Helper()
+	f, err := fs.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+
+	pf, err := parquet.OpenFile(bytesReaderAt(data), int64(len(data)))
+	require.NoError(t, err)
+
+	for _, rg := range pf.Metadata().RowGroups {
+		for _, col := range rg.Columns {
+			return col.MetaData.Codec.String()
+		}
+	}
+	t.Fatalf("parquet file %s has no column chunks", path)
+	return ""
+}
+
+// bytesReaderAt adapts a byte slice to the io.ReaderAt parquet needs.
+func bytesReaderAt(b []byte) *bytes.Reader { return bytes.NewReader(b) }
+
+// buildThroughputBatches produces batches of JSON records in one of two shapes.
+//
+// The shape matters a great deal for anything size-related, which is why it is
+// selectable rather than fixed. "regular" mirrors the localhost bench config's
+// generator: sequential ids and an `info` string sharing a 21-character prefix.
+// Parquet's byte-array encoding compresses that prefix away before any codec
+// runs, so the same 20k records occupy ~4 bytes each with no compression at all
+// — measuring a codec against it would show almost no win and imply, wrongly,
+// that compression does not pay. "high-entropy" fills `info` with random text
+// instead, which is the regime where a codec earns its cost.
+func buildThroughputBatches(t *testing.T, total, perBatch int, payload string, extraColumns int) []service.MessageBatch {
+	t.Helper()
+	require.Contains(t, []string{"regular", "high-entropy"}, payload,
+		"unknown payload shape %q", payload)
+
+	eventTypes := []string{"click", "view", "purchase", "scroll", "hover"}
+	const alnum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	// Deterministic, but freshly generated per record rather than sliced from a
+	// shared pool. Slicing a 64kB pool 100k times produces values that overlap
+	// heavily, and parquet's encoders exploit that redundancy across records —
+	// the result looked like 4:1 compression on supposedly random data, which
+	// would have made any codec comparison meaningless.
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // benchmark entropy, not crypto
+	const highEntropyLen = 1100
+
+	var batches []service.MessageBatch
+	for start := 0; start < total; start += perBatch {
+		n := min(perBatch, total-start)
+		batch := make(service.MessageBatch, n)
+		for i := range n {
+			id := start + i
+			info := fmt.Sprintf("event info for record %d", id)
+			if payload == "high-entropy" {
+				buf := make([]byte, highEntropyLen)
+				for j := range buf {
+					buf[j] = alnum[rng.Intn(len(alnum))]
+				}
+				info = string(buf)
+			}
+			var extra strings.Builder
+			for c := range extraColumns {
+				fmt.Fprintf(&extra, `,"col_%d":"v%d_%d"`, c, c, id%97)
+			}
+			batch[i] = service.NewMessage(fmt.Appendf(nil,
+				`{"id":%d,"user_id":%d,"event_type":%q,"value":%d,"info":%q%s}`,
+				id, id%10000+1, eventTypes[id%5], id%1000, info, extra.String()))
+		}
+		batches = append(batches, batch)
+	}
+	return batches
+}

--- a/internal/impl/iceberg/integration/throughput_bench_test.go
+++ b/internal/impl/iceberg/integration/throughput_bench_test.go
@@ -282,11 +282,11 @@ func bytesReaderAt(b []byte) *bytes.Reader { return bytes.NewReader(b) }
 // The shape matters a great deal for anything size-related, which is why it is
 // selectable rather than fixed. "regular" mirrors the localhost bench config's
 // generator: sequential ids and an `info` string sharing a 21-character prefix.
-// Parquet's byte-array encoding compresses that prefix away before any codec
-// runs, so the same 20k records occupy ~4 bytes each with no compression at all
-// — measuring a codec against it would show almost no win and imply, wrongly,
-// that compression does not pay. "high-entropy" fills `info` with random text
-// instead, which is the regime where a codec earns its cost.
+// That repetition is exactly what a codec exploits, so this is the shape that
+// shows a codec's size win (measured at ~15x smaller with zstd). "high-entropy"
+// fills `info` with random text instead — genuinely incompressible content, so
+// it bounds the size win at a few percent and isolates a codec's CPU cost from
+// its size benefit, since there is barely any size benefit left to confound it.
 func buildThroughputBatches(t *testing.T, total, perBatch int, payload string, extraColumns int) []service.MessageBatch {
 	t.Helper()
 	require.Contains(t, []string{"regular", "high-entropy"}, payload,


### PR DESCRIPTION
Leward's "C" from the #4712 split — stacked on #4785 (the `parquet.compression` field), since this harness measures those codecs and reads them back out of the written files. Please merge #4785 first, or review this as the diff on top of it.

## Why a separate harness

The localhost pipeline benchmark runs the assembled `iceberg` output, which is an enterprise component needing a valid licence to initialise — and the licence available in dev has expired, so that suite can't produce before/after numbers here. The write path itself doesn't need one though: `license.CheckRunningEnterprise` is called by the output constructor, not by the `Router`, so driving the `Router` directly against containerised MinIO + Iceberg REST — as the integration tests already do — measures JSON decode, shredding, parquet encode, upload and catalog commit with no licence involved. That's what `TestWriteThroughput` does.

The harness refuses to report a rate it can't vouch for: it asserts the table holds exactly the records written, reads the data back to confirm the columns are populated, and reads the codec out of a written file's footer rather than trusting what was requested. Each of those caught a real bug during development (a run reporting a rate while exiting on a licence error, a bytes-per-record figure that under-reported actual bytes, a supposedly-uncompressed run that was in fact zstd from the table property default).

## What it found

- **Compression has no throughput cost worth planning around** — every codec landed within a few percent of uncompressed, at one core and four.
- **The shredder change (#4784) shows no measurable end-to-end gain** on these shapes, against a 66% reduction in the isolated micro-benchmark — most likely because this harness isn't shredder-bound; per-record time here is dominated by encode, upload and commit. Recorded as-is rather than explained away.

Full numbers and caveats are in `docs/benchmark-results/iceberg.md`.

## Not in this PR

The shredder change and compression field themselves (already up as #4784/#4785), the commit-regime harness, profiling configs, and Databricks e2e bench — following separately.
