### PR TITLE
iceberg: add a commit-regime harness for latency-bound throughput

### DIFF
--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -273,7 +273,7 @@ How commit coalescing responds to catalog commit latency and the number of concu
 - **At `max_in_flight: 1` records per commit is pinned to a single submission**, giving `records-per-submission / commit-latency` — 591 rec/sec at 500ms, matching the "throughput trap" regime described under Tuning Recipes. This is structural: the sole submitter is blocked inside the commit it is waiting on, so no second submission can exist to batch with. A commit-side linger cannot improve this case, and would add latency to it.
 - Submissions per commit settles near `max_in_flight / 2` rather than `max_in_flight`, which suggests the batcher samples its queue before the just-released submitters have all re-queued. Whether closing that gap is worth anything is untested.
 
-To reproduce: `go test -run TestCommitRegimeSweep -iceberg.commit-regime -timeout 20m ./internal/impl/iceberg/` (add `-iceberg.commit-regime-realistic` for 320ms/5s/10s latencies).
+To reproduce: `go test -v -run TestCommitRegimeSweep -iceberg.commit-regime -timeout 20m ./internal/impl/iceberg/` (add `-iceberg.commit-regime-realistic` for 320ms/5s/10s latencies). The `-v` is required — the sweep never asserts, so it always passes, and `go test` suppresses `t.Log` output (which is how the table is printed) for passing tests without it.
 
 ---
 

--- a/docs/benchmark-results/iceberg.md
+++ b/docs/benchmark-results/iceberg.md
@@ -242,6 +242,41 @@ To reproduce: `GOMAXPROCS=1 go test -bench BenchmarkShredWide -benchmem -run '^$
 
 ---
 
+## Commit Regime — Commit Latency vs `max_in_flight` (synthetic)
+
+How commit coalescing responds to catalog commit latency and the number of concurrent in-flight submissions, measured by the flag-gated `TestCommitRegimeSweep` in [`internal/impl/iceberg/commit_regime_bench_test.go`](../../internal/impl/iceberg/commit_regime_bench_test.go).
+
+**Environment:** darwin/arm64, Apple M3 Pro; in-memory catalog with a fixed injected per-commit delay; 6s window per point; 300 records per submission
+
+**Changed since last run:** first run of this harness. No production change — the committer and its batcher are as on `main`. These numbers describe batcher coalescing behaviour, so re-run them if the commit batching path changes.
+
+**Caveat — read the numbers as ratios, not throughput.** Nothing here writes parquet or touches object storage, and the injected delay is not a real catalog, so the absolute rec/sec are not sink throughput figures and are not comparable with the localhost or live-catalog sections above. What the harness measures is how many submissions a commit carries, and at what latency.
+
+| commit latency | `max_in_flight` | rec/sec | records/commit | submissions/commit |
+|---------------:|----------------:|--------:|---------------:|-------------------:|
+| 50ms | 1 | 5,238 | 300 | 1.00 |
+| 50ms | 4 | 10,437 | 600 | 2.00 |
+| 50ms | 16 | 41,790 | 2,400 | 8.00 |
+| 50ms | 64 | 166,306 | 9,600 | 32.00 |
+| 200ms | 1 | 1,449 | 300 | 1.00 |
+| 200ms | 4 | 2,896 | 600 | 2.00 |
+| 200ms | 16 | 11,563 | 2,400 | 8.00 |
+| 200ms | 64 | 46,230 | 9,600 | 32.00 |
+| 500ms | 1 | 591 | 300 | 1.00 |
+| 500ms | 4 | 1,187 | 600 | 2.00 |
+| 500ms | 16 | 4,416 | 2,238 | 7.46 |
+| 500ms | 64 | 20,354 | 10,338 | 34.46 |
+
+**Observations:**
+
+- **The commit batcher already coalesces concurrent submissions.** Submissions that arrive while a commit is in flight are merged into the next one, so records per commit scales with `max_in_flight` without any time-based batching involved.
+- **At `max_in_flight: 1` records per commit is pinned to a single submission**, giving `records-per-submission / commit-latency` — 591 rec/sec at 500ms, matching the "throughput trap" regime described under Tuning Recipes. This is structural: the sole submitter is blocked inside the commit it is waiting on, so no second submission can exist to batch with. A commit-side linger cannot improve this case, and would add latency to it.
+- Submissions per commit settles near `max_in_flight / 2` rather than `max_in_flight`, which suggests the batcher samples its queue before the just-released submitters have all re-queued. Whether closing that gap is worth anything is untested.
+
+To reproduce: `go test -run TestCommitRegimeSweep -iceberg.commit-regime -timeout 20m ./internal/impl/iceberg/` (add `-iceberg.commit-regime-realistic` for 320ms/5s/10s latencies).
+
+---
+
 ## Tuning Recipes
 
 The single most important factor for `iceberg` throughput is **records per commit**. Each catalog

--- a/internal/impl/iceberg/commit_regime_bench_test.go
+++ b/internal/impl/iceberg/commit_regime_bench_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/table"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// This harness isolates the COMMIT REGIME: how sink throughput responds to
+// catalog commit latency, the number of concurrent in-flight submissions
+// (max_in_flight), and the records carried per submission. It exists because
+// the sink's headline throughput problem is latency-bound rather than
+// CPU-bound, and the fix under evaluation (a commit linger) is a property of
+// the commit batcher alone.
+//
+// It deliberately does NOT write parquet or touch object storage: files are
+// synthesised metadata-only, so nothing here is confounded by encode or upload
+// cost. Per-record CPU is measured separately by the bench/ package.
+//
+// Why a local latency injection is a faithful stand-in for a live catalog:
+// measurement against a live Unity Catalog found commit latency near-flat
+// across a 667x range of batch sizes (~5.2s at 300 records/commit rising only
+// to ~9.7s at 200,000). Commit latency therefore behaves as a near-constant
+// independent of batch size, which is exactly what a fixed injected delay
+// models — with the advantage that the delay can be swept across regimes
+// (a fast catalog at ~320ms, a slow engine-backed one at 5-10s) instead of
+// being pinned to whatever one hosted service happens to do.
+
+var (
+	regimeSweep = flag.Bool("iceberg.commit-regime", false,
+		"run the commit-regime sweep (takes minutes of wall time; prints a table)")
+	regimeRealistic = flag.Bool("iceberg.commit-regime-realistic", false,
+		"sweep at real engine-backed catalog latencies (5s/10s) instead of scaled-down ones")
+)
+
+// latentCatalog wraps memCatalog with a fixed per-commit delay and counts
+// commits, standing in for a catalog whose commit path costs real wall time
+// (credential vending, metadata write, engine-side validation).
+//
+// The committer serialises all commits under commitMu, so CommitTable is never
+// called concurrently; the counter is atomic only so readers can sample it
+// while the sweep runs.
+type latentCatalog struct {
+	*memCatalog
+	delay   time.Duration
+	commits atomic.Int64
+}
+
+func (c *latentCatalog) CommitTable(ctx context.Context, ident table.Identifier, reqs []table.Requirement, updates []table.Update) (table.Metadata, string, error) {
+	if c.delay > 0 {
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	}
+	meta, loc, err := c.memCatalog.CommitTable(ctx, ident, reqs, updates)
+	if err == nil {
+		// Counted after the fact so this is commits, not attempts: a retry would
+		// otherwise inflate the count and deflate the reported records/commit.
+		c.commits.Add(1)
+	}
+	return meta, loc, err
+}
+
+// regimeParams describes one point in the sweep.
+type regimeParams struct {
+	commitLatency    time.Duration // injected per-commit catalog cost
+	inFlight         int           // concurrent submitters, i.e. max_in_flight
+	recordsPerSubmit int           // records carried by each submission
+	window           time.Duration // measurement window
+}
+
+// regimeResult is what one point measured.
+type regimeResult struct {
+	params           regimeParams
+	records          int64
+	submissions      int64
+	commits          int64
+	elapsed          time.Duration
+	recordsPerSecond float64
+	recordsPerCommit float64
+	submitsPerCommit float64
+}
+
+func (r regimeResult) String() string {
+	return fmt.Sprintf("latency=%-6v in_flight=%-3d rec/submit=%-7d | rec/s=%-10.0f rec/commit=%-10.0f submits/commit=%-5.2f commits=%d",
+		r.params.commitLatency, r.params.inFlight, r.params.recordsPerSubmit,
+		r.recordsPerSecond, r.recordsPerCommit, r.submitsPerCommit, r.commits)
+}
+
+// runRegime drives `inFlight` concurrent submitters against a committer whose
+// catalog costs `commitLatency` per commit, for `window` of wall time, and
+// reports what got through. Each submitter models one in-flight WriteBatch:
+// build files, submit, block until the commit that carries them returns.
+func runRegime(tb testing.TB, p regimeParams) regimeResult {
+	tb.Helper()
+	ctx := tb.Context()
+
+	tbl, mem := newTestTable(tb)
+	cat := &latentCatalog{memCatalog: mem, delay: p.commitLatency}
+
+	c, err := NewCommitter(tbl, cat, CommitConfig{
+		ManifestMergeEnabled: false,
+		MaxRetries:           1,
+	}, func(context.Context) (*table.Table, error) { return cat.snapshot(), nil },
+		service.MockResources().Logger())
+	require.NoError(tb, err)
+	defer c.Close()
+
+	var records, submissions atomic.Int64
+	deadline := time.Now().Add(p.window)
+	schemaID := c.currentSchemaID()
+
+	// Submitters cannot assert: require's FailNow is only valid on the test
+	// goroutine. Each records its first error for the test goroutine to check.
+	errs := make([]error, p.inFlight)
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for i := range p.inFlight {
+		wg.Go(func() {
+			// The deadline is checked before submitting, so elapsed includes the
+			// tail of each submitter's last in-flight commit and can overshoot
+			// the window by up to one commit latency. Records from that tail are
+			// counted too, so the derived rate stays representative.
+			for time.Now().Before(deadline) {
+				df, err := recordCountDataFile(tbl.Spec(),
+					fmt.Sprintf("%s/data/%s.parquet", tbl.Location(), uuid.New()),
+					int64(p.recordsPerSubmit))
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				if err := c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{df}, SchemaID: schemaID}); err != nil {
+					errs[i] = err
+					return
+				}
+				submissions.Add(1)
+				records.Add(int64(p.recordsPerSubmit))
+			}
+		})
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// Assert before deriving any rate from a possibly half-completed run.
+	require.NoError(tb, errors.Join(errs...), "submitter(s) failed")
+
+	commits := cat.commits.Load()
+	res := regimeResult{
+		params:      p,
+		records:     records.Load(),
+		submissions: submissions.Load(),
+		commits:     commits,
+		elapsed:     elapsed,
+	}
+	res.recordsPerSecond = float64(res.records) / elapsed.Seconds()
+	if commits > 0 {
+		res.recordsPerCommit = float64(res.records) / float64(commits)
+		res.submitsPerCommit = float64(res.submissions) / float64(commits)
+	}
+	return res
+}
+
+// recordCountDataFile is synthDataFile with a caller-chosen record count, so a
+// submission can represent a realistic batch rather than a single row.
+//
+// It returns an error rather than asserting, because the submitters that call it
+// run on their own goroutines: require's FailNow is only valid on the goroutine
+// running the test, so a failure here has to be carried back and asserted after
+// the submitters have been waited on.
+func recordCountDataFile(spec iceberg.PartitionSpec, path string, records int64) (iceberg.DataFile, error) {
+	b, err := iceberg.NewDataFileBuilder(
+		spec,
+		iceberg.EntryContentData,
+		path,
+		iceberg.ParquetFile,
+		nil, nil, nil,
+		records, records*64,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return b.Build(), nil
+}
+
+// TestCommitRegimeSweep characterises throughput across the commit regime.
+// Flag-gated: it spends real wall time on purpose.
+//
+// The question it answers: does the existing batcher already coalesce
+// concurrent submissions during a slow commit (in which case max_in_flight is
+// the lever and a linger adds nothing), or does each commit carry only one
+// submission (in which case a time-based linger is the fix)?
+func TestCommitRegimeSweep(t *testing.T) {
+	if !*regimeSweep {
+		t.Skip("set -iceberg.commit-regime to run the commit-regime sweep")
+	}
+
+	latencies := []time.Duration{50 * time.Millisecond, 200 * time.Millisecond, 500 * time.Millisecond}
+	window := 6 * time.Second
+	if *regimeRealistic {
+		latencies = []time.Duration{320 * time.Millisecond, 5 * time.Second, 10 * time.Second}
+		window = 60 * time.Second
+	}
+
+	var results []regimeResult
+	for _, latency := range latencies {
+		for _, inFlight := range []int{1, 4, 16, 64} {
+			res := runRegime(t, regimeParams{
+				commitLatency:    latency,
+				inFlight:         inFlight,
+				recordsPerSubmit: 300, // the observed "throughput trap" batch size
+				window:           window,
+			})
+			results = append(results, res)
+		}
+	}
+
+	t.Log("=== commit regime sweep (records/submit = 300) ===")
+	for _, r := range results {
+		t.Log(r.String())
+	}
+}
+
+// TestCommitCoalescesConcurrentSubmissions pins the mechanism the sweep
+// explores, cheaply enough to run in CI: when several submissions are in
+// flight while a slow commit is running, they must be merged into ONE
+// subsequent commit rather than committed one at a time.
+//
+// This is the property any linger implementation must preserve — and the
+// reason a linger cannot help at max_in_flight=1, where there is never a
+// second submission to coalesce with.
+func TestCommitCoalescesConcurrentSubmissions(t *testing.T) {
+	const (
+		inFlight = 8
+		latency  = 300 * time.Millisecond
+	)
+	ctx := t.Context()
+
+	tbl, mem := newTestTable(t)
+	cat := &latentCatalog{memCatalog: mem, delay: latency}
+
+	c, err := NewCommitter(tbl, cat, CommitConfig{
+		ManifestMergeEnabled: false,
+		MaxRetries:           1,
+	}, func(context.Context) (*table.Table, error) { return cat.snapshot(), nil },
+		service.MockResources().Logger())
+	require.NoError(t, err)
+	defer c.Close()
+
+	schemaID := c.currentSchemaID()
+
+	// Build the data files up front, on the test goroutine, so the submitters
+	// below only have to commit — and so nothing in them needs to assert.
+	files := make([]iceberg.DataFile, inFlight)
+	for i := range files {
+		df, err := recordCountDataFile(tbl.Spec(),
+			fmt.Sprintf("%s/data/coalesce-%d-%s.parquet", tbl.Location(), i, uuid.New()), 300)
+		require.NoError(t, err)
+		files[i] = df
+	}
+
+	// Occupy the committer so the rest of the submissions queue behind it.
+	errs := make([]error, inFlight)
+	var wg sync.WaitGroup
+	for i := range inFlight {
+		wg.Go(func() {
+			errs[i] = c.Commit(ctx, CommitInput{Files: []iceberg.DataFile{files[i]}, SchemaID: schemaID})
+		})
+	}
+	wg.Wait()
+	require.NoError(t, errors.Join(errs...), "submitter(s) failed")
+
+	commits := cat.commits.Load()
+	require.Positive(t, commits, "expected at least one commit")
+	// Tight on purpose: `< inFlight` would pass at 7-of-8, which is essentially
+	// no coalescing. The mechanism under test merges a queued cohort into one
+	// commit, so allow only a small margin for the cohort being split across two
+	// commits by scheduling.
+	require.LessOrEqual(t, commits, int64(2),
+		"expected %d concurrent submissions to coalesce into at most 2 commits, got %d",
+		inFlight, commits)
+	t.Logf("%d concurrent submissions coalesced into %d commits (%.2f submissions/commit)",
+		inFlight, commits, float64(inFlight)/float64(commits))
+}


### PR DESCRIPTION
Leward's "E" from the #4712 split — the commit-regime harness on its own, no production change attached.

## Why

The sink's headline throughput problem is latency-bound rather than CPU-bound: against a slow catalog, throughput is roughly records-per-commit divided by commit latency. This harness isolates that regime so it can be reasoned about without needing a hosted catalog to hand.

`latentCatalog` wraps the existing in-memory test catalog with a configurable per-commit delay and a commit counter, and the sweep drives N concurrent submitters against it, reporting records/sec, records/commit and submissions/commit across commit latency, `max_in_flight` and records-per-submission. Nothing writes parquet or touches object storage, so the numbers aren't confounded by encode or upload cost.

A fixed injected delay looked like a reasonable stand-in for a real catalog: measurement against a live engine-backed catalog found commit latency near-flat across a 667x range of batch sizes, so latency behaves as roughly constant with respect to batch size — and unlike a hosted service, this lets us sweep it across regimes.

The sweep itself is flag-gated since it spends real wall time, but `TestCommitCoalescesConcurrentSubmissions` pins the coalescing mechanism cheaply enough to run in CI, and passes under `-race`.

## What it found

- The commit batcher already coalesces concurrent submissions maximally — nothing to gain from a time-based commit linger there.
- At `max_in_flight: 1`, records-per-commit is pinned to a single submission by construction (the sole submitter is blocked inside the commit it's waiting on), so a linger can't help that case either — it could only add latency.

Full sweep numbers are in `docs/benchmark-results/iceberg.md`, with the caveat that these are ratios for comparing coalescing behaviour, not sink throughput figures.

## Not in this PR

The shredder change, compression field, write-path throughput harness, profiling configs, and Databricks e2e bench — those are their own PRs off #4712.
