### PR TITLE
replication: add incremental snapshot coordinator package

### DIFF
--- a/internal/replication/incrementalsnapshot/coordinator.go
+++ b/internal/replication/incrementalsnapshot/coordinator.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/coordinator.go
+++ b/internal/replication/incrementalsnapshot/coordinator.go
@@ -58,6 +58,15 @@ type Coordinator[P any, W Watermark[P]] struct {
 	committedCurrent    *TableID
 	committedMaxPK      PrimaryKey
 	committedLastSentPK PrimaryKey
+
+	// knownTables is every table this run covers, the finished ones
+	// included. Start fixes it and State reports it, so a later run can tell
+	// a newly configured table from one already backfilled.
+	knownTables []TableID
+	// addedOnResume and removedOnResume record what reconcileTables changed,
+	// for the caller to report.
+	addedOnResume   []TableID
+	removedOnResume []TableID
 }
 
 // NewCoordinator builds a Coordinator. A non-nil resume makes Start continue
@@ -99,12 +108,14 @@ func (c *Coordinator[P, W]) Start(ctx context.Context) error {
 
 	if resume == nil {
 		c.remaining = slices.Clone(c.cfg.Tables)
+		c.knownTables = slices.Clone(c.cfg.Tables)
 	} else {
 		c.done = resume.Done
 		c.current = resume.CurrentTable
 		c.lastSentPK = resume.LastSentPK
 		c.maxPK = resume.MaxPK
 		c.remaining = resume.RemainingTables
+		c.reconcileTables(resume)
 
 		if c.done {
 			return nil
@@ -123,6 +134,83 @@ func (c *Coordinator[P, W]) Start(ctx context.Context) error {
 	// State never captures an unflushed chunk, so resuming always means
 	// planning the next one. Watermarks are always re-derived.
 	return c.planNextChunk(ctx)
+}
+
+// reconcileTables makes a resumed checkpoint match the configured tables.
+//
+// A table the checkpoint does not know is new to the config, so it joins the
+// back of the queue and gets backfilled. A finished run reopens for it,
+// because the checkpoint would otherwise report complete for ever and the
+// table would never be read.
+//
+// A table the checkpoint knows but the config no longer lists is dropped. If
+// it is the one being read, the read stops where it is and the next plan
+// moves on, which leaves that table part-delivered downstream. The caller
+// reports this.
+//
+// A version 1 checkpoint carries no Tables. Its finished tables cannot be
+// recovered, so every configured table counts as known: this run adds
+// nothing, and the version 2 checkpoint it writes makes later additions
+// visible. Removals still apply, since they need only the queue.
+func (c *Coordinator[P, W]) reconcileTables(resume *State) {
+	c.knownTables = resume.Tables
+	if c.knownTables == nil {
+		c.knownTables = slices.Clone(c.cfg.Tables)
+	}
+	if c.current != nil && !slices.Contains(c.knownTables, *c.current) {
+		c.knownTables = append(c.knownTables, *c.current)
+	}
+	for _, table := range c.remaining {
+		if !slices.Contains(c.knownTables, table) {
+			c.knownTables = append(c.knownTables, table)
+		}
+	}
+
+	for _, table := range c.cfg.Tables {
+		if slices.Contains(c.knownTables, table) {
+			continue
+		}
+		c.addedOnResume = append(c.addedOnResume, table)
+		c.knownTables = append(c.knownTables, table)
+		c.remaining = append(c.remaining, table)
+	}
+	if len(c.addedOnResume) > 0 {
+		c.done = false
+		c.doneEmitted = false
+	}
+
+	configured := func(table TableID) bool { return slices.Contains(c.cfg.Tables, table) }
+
+	for _, table := range c.knownTables {
+		if !configured(table) {
+			c.removedOnResume = append(c.removedOnResume, table)
+		}
+	}
+	if len(c.removedOnResume) == 0 {
+		return
+	}
+
+	c.knownTables = slices.DeleteFunc(c.knownTables, func(table TableID) bool { return !configured(table) })
+	c.remaining = slices.DeleteFunc(c.remaining, func(table TableID) bool { return !configured(table) })
+	if c.current != nil && !configured(*c.current) {
+		// Abandon the part-read table. Clearing the bounds too makes the
+		// next plan take the following table from the front of the queue.
+		c.current = nil
+		c.lastSentPK = nil
+		c.maxPK = nil
+	}
+}
+
+// AddedOnResume lists the configured tables the checkpoint did not know,
+// which this run backfills. Valid after Start.
+func (c *Coordinator[P, W]) AddedOnResume() []TableID {
+	return c.addedOnResume
+}
+
+// RemovedOnResume lists the tables the checkpoint covered that the config no
+// longer lists, which this run dropped. Valid after Start.
+func (c *Coordinator[P, W]) RemovedOnResume() []TableID {
+	return c.removedOnResume
 }
 
 // commitLiveState snapshots the live fields into the committed ones. Call
@@ -305,7 +393,10 @@ func (c *Coordinator[P, W]) readUndisturbed() bool {
 // finish the snapshot, and that buffers nothing.
 func (c *Coordinator[P, W]) State() *State {
 	if c.done {
-		return &State{Version: CurrentStateVersion, Done: true}
+		// Tables still ships: without it a later run cannot tell a newly
+		// configured table from one this run already finished.
+		s := &State{Version: CurrentStateVersion, Done: true, Tables: c.knownTables}
+		return s.Clone()
 	}
 	s := &State{
 		Version:         CurrentStateVersion,
@@ -313,6 +404,7 @@ func (c *Coordinator[P, W]) State() *State {
 		LastSentPK:      c.committedLastSentPK,
 		MaxPK:           c.committedMaxPK,
 		RemainingTables: c.committedRemaining,
+		Tables:          c.knownTables,
 	}
 	return s.Clone()
 }

--- a/internal/replication/incrementalsnapshot/coordinator.go
+++ b/internal/replication/incrementalsnapshot/coordinator.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"context"
+	"fmt"
+	"slices"
+)
+
+// Coordinator backfills a set of tables in key-ordered, key-bounded chunks
+// while a replication stream runs, dropping each buffered row the stream has
+// already delivered.
+//
+// It holds only the algorithm: which table and key range to read next, when a
+// chunk is safe to emit, and what the caller may checkpoint. Side effects come
+// from Deps, window comparisons from Watermark.
+//
+// Not safe for concurrent use: call OnStreamedRow and OnCommit from a single
+// goroutine, in stream order. OnCommit's chunk read blocks on I/O by design.
+type Coordinator[P any, W Watermark[P]] struct {
+	cfg CoordinatorConfig[P, W]
+
+	// resume holds the state given to NewCoordinator; nil once Start has
+	// consumed it.
+	resume *State
+
+	remaining []TableID
+	current   *TableID
+	// currentExhausted marks current's last chunk as fetched, so the next
+	// plan advances tables. current stays set until then, keeping the
+	// buffered final chunk dedupable. Deliberately not in State: a resume
+	// re-issues one empty query for the table and moves on.
+	currentExhausted bool
+	pkCols           map[string][]string
+	maxPK            PrimaryKey
+	lastSentPK       PrimaryKey
+	low              W
+	high             W
+	windowOpened     bool
+	done             bool
+	// doneEmitted records that the terminal Done checkpoint has been handed
+	// to emit. Until it is persisted a resume re-resolves every table's key
+	// bounds and re-issues an empty chunk query, and never reports complete.
+	doneEmitted bool
+	window      *WindowBuffer
+
+	// committed mirrors remaining/current/maxPK/lastSentPK but only advances
+	// after a flush. State reports these, so a crash before a flush re-reads
+	// the chunk on resume rather than skipping it.
+	committedRemaining  []TableID
+	committedCurrent    *TableID
+	committedMaxPK      PrimaryKey
+	committedLastSentPK PrimaryKey
+}
+
+// NewCoordinator builds a Coordinator. A non-nil resume makes Start continue
+// from that state; otherwise it starts fresh from cfg.Tables.
+func NewCoordinator[P any, W Watermark[P]](cfg CoordinatorConfig[P, W], resume *State) (*Coordinator[P, W], error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if cfg.MaxDrainChunks == 0 {
+		cfg.MaxDrainChunks = DefaultMaxDrainChunks
+	}
+
+	return &Coordinator[P, W]{
+		cfg:    cfg,
+		resume: resume.Clone(),
+		pkCols: make(map[string][]string),
+		window: NewWindowBuffer(),
+	}, nil
+}
+
+// EmitFunc receives one chunk's rows as the coordinator releases them. It is
+// called after the committed state has advanced past those rows, so State may
+// be read from inside it to get their checkpoint.
+//
+// It is also the drain's backpressure: the next chunk is only released once
+// EmitFunc returns, so a slow consumer costs one buffered chunk. An error
+// aborts the operation.
+type EmitFunc func(rows []Row) error
+
+// Start must be called once before any other method.
+//
+// It never emits: it buffers the first chunk and returns, leaving OnCommit to
+// release everything. Callers may therefore start the coordinator before
+// their downstream is consuming. A resume that finds nothing left completes
+// here, and the first OnCommit then releases the terminal checkpoint.
+func (c *Coordinator[P, W]) Start(ctx context.Context) error {
+	resume := c.resume
+	c.resume = nil
+
+	if resume == nil {
+		c.remaining = slices.Clone(c.cfg.Tables)
+	} else {
+		c.done = resume.Done
+		c.current = resume.CurrentTable
+		c.lastSentPK = resume.LastSentPK
+		c.maxPK = resume.MaxPK
+		c.remaining = resume.RemainingTables
+
+		if c.done {
+			return nil
+		}
+	}
+
+	// Baseline: nothing fetched yet. planNextChunk advances past it.
+	c.commitLiveState()
+
+	// Once only, so the stream has a known position for the first watermark.
+	// See Deps.ForceFreshTransaction for why not per watermark.
+	if err := c.cfg.Deps.ForceFreshTransaction(ctx); err != nil {
+		return fmt.Errorf("forcing fresh transaction: %w", err)
+	}
+
+	// State never captures an unflushed chunk, so resuming always means
+	// planning the next one. Watermarks are always re-derived.
+	return c.planNextChunk(ctx)
+}
+
+// commitLiveState snapshots the live fields into the committed ones. Call
+// only once everything fetched so far has been flushed.
+func (c *Coordinator[P, W]) commitLiveState() {
+	c.committedRemaining = slices.Clone(c.remaining)
+	c.committedCurrent = c.current
+	c.committedMaxPK = c.maxPK
+	c.committedLastSentPK = c.lastSentPK
+}
+
+// Done reports whether every configured table is fully snapshotted.
+func (c *Coordinator[P, W]) Done() bool {
+	return c.done
+}
+
+// OnStreamedRow must be cheap and do no I/O. It removes pk from the buffer
+// only while that table is being snapshotted; otherwise it is a no-op.
+//
+// Known limitation: a row can be delivered twice when an insert reuses a key
+// below MaxPK and streams in before the covering chunk is read. Monotonic
+// keys (serial, UUIDv7) cannot hit this. Consumers should treat rows as
+// idempotent upserts by key, as standard CDC practice.
+func (c *Coordinator[P, W]) OnStreamedRow(table TableID, pk PrimaryKey) (removed bool) {
+	if c.done || c.current == nil || table != *c.current {
+		return false
+	}
+	return c.window.Remove(table, pk)
+}
+
+// OnCommit is called once per completed transaction, in stream order.
+//
+// Pass only a position the database actually reported. Filter unknown ones
+// first: a zero value standing in for a missing BEGIN can open or close the
+// window spuriously.
+func (c *Coordinator[P, W]) OnCommit(ctx context.Context, pos P, emit EmitFunc) (changed bool, err error) {
+	if c.done {
+		// Start sets done on a resume that finds nothing left, and it has no
+		// emit to hand the terminal checkpoint to. Flush it on the first
+		// commit instead.
+		if c.doneEmitted {
+			return false, nil
+		}
+		if err := c.emitTerminalState(emit); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	if !c.windowOpened && c.low.OpensAt(pos) {
+		c.windowOpened = true
+	}
+
+	// Both watermarks must be clear of pos: they bracket the chunk read, so
+	// the later of the two is the real bound.
+	if !c.windowOpened || !c.low.ClosesAt(pos) || !c.high.ClosesAt(pos) {
+		return false, nil
+	}
+
+	if err := c.releaseWindow(emit); err != nil {
+		return false, err
+	}
+	return true, c.planAndDrain(ctx, emit)
+}
+
+// releaseWindow hands the buffered chunk to emit, advancing the committed
+// state first so State reports the right checkpoint from inside emit.
+func (c *Coordinator[P, W]) releaseWindow(emit EmitFunc) error {
+	rows := c.window.Flush()
+	c.windowOpened = false
+	c.commitLiveState()
+	return emit(rows)
+}
+
+// planAndDrain buffers the next chunk, then keeps releasing and replanning
+// while each chunk came from an undisturbed read.
+//
+// An equal, quiesced watermark pair proves nothing could have modified the
+// chunk during the read, so no streamed row can supersede it and there is
+// nothing to wait for. Holding it would mean waiting for a commit that, on a
+// quiet table, only arrives with the next heartbeat -- which is what
+// otherwise caps the backfill at one chunk per heartbeat.
+//
+// Capped at cfg.MaxDrainChunks per call: emitting runs on the caller's
+// replication loop, which usually also owes standby keepalives, so an
+// unbounded drain risks the server dropping the connection. Progress resumes
+// on the next commit.
+func (c *Coordinator[P, W]) planAndDrain(ctx context.Context, emit EmitFunc) error {
+	for range c.cfg.MaxDrainChunks {
+		if err := c.planNextChunk(ctx); err != nil {
+			return err
+		}
+		if c.done {
+			return c.emitTerminalState(emit)
+		}
+		if !c.readUndisturbed() {
+			return nil
+		}
+		if err := c.releaseWindow(emit); err != nil {
+			return err
+		}
+	}
+	if err := c.planNextChunk(ctx); err != nil {
+		return err
+	}
+	if c.done {
+		return c.emitTerminalState(emit)
+	}
+	return nil
+}
+
+// emitTerminalState releases the Done checkpoint, once. The window is empty by
+// then -- only a zero-row read completes the snapshot -- so this emits state
+// alone.
+func (c *Coordinator[P, W]) emitTerminalState(emit EmitFunc) error {
+	if c.doneEmitted {
+		return nil
+	}
+	c.doneEmitted = true
+	return c.releaseWindow(emit)
+}
+
+// readUndisturbed reports whether the buffered chunk's watermarks prove a
+// still database: nothing in flight at either end, and nothing assigned
+// between them.
+func (c *Coordinator[P, W]) readUndisturbed() bool {
+	return c.low == c.high && c.low.Quiesced()
+}
+
+// State returns the resumable state; safe to call any time after Start. It
+// reports the committed fields, except when done -- only a zero-row read can
+// finish the snapshot, and that buffers nothing.
+func (c *Coordinator[P, W]) State() *State {
+	if c.done {
+		return &State{Version: CurrentStateVersion, Done: true}
+	}
+	s := &State{
+		Version:         CurrentStateVersion,
+		CurrentTable:    c.committedCurrent,
+		LastSentPK:      c.committedLastSentPK,
+		MaxPK:           c.committedMaxPK,
+		RemainingTables: c.committedRemaining,
+	}
+	return s.Clone()
+}
+
+// planNextChunk buffers the current table's next chunk, advancing tables
+// until one has rows or none remain.
+func (c *Coordinator[P, W]) planNextChunk(ctx context.Context) error {
+	for {
+		if c.current == nil || c.currentExhausted {
+			if len(c.remaining) == 0 {
+				c.current = nil
+				c.currentExhausted = false
+				c.done = true
+				return nil
+			}
+
+			next := c.remaining[0]
+			c.remaining = c.remaining[1:]
+			c.current = &next
+			c.currentExhausted = false
+			c.lastSentPK = nil
+			c.maxPK = nil
+		}
+
+		table := *c.current
+
+		pkCols, err := c.resolvePKCols(ctx, table)
+		if err != nil {
+			return err
+		}
+
+		if err := c.resolveMaxPK(ctx, table, pkCols); err != nil {
+			return err
+		}
+
+		if c.maxPK == nil {
+			// Empty table: treat like an exhausted one rather than
+			// failing the whole coordinator.
+			c.current = nil
+			continue
+		}
+
+		low, err := c.resolveWatermark(ctx)
+		if err != nil {
+			return err
+		}
+
+		rows, err := c.cfg.Deps.FetchChunk(ctx, table, pkCols, c.lastSentPK, c.maxPK, c.cfg.ChunkSize)
+		if err != nil {
+			return fmt.Errorf("fetching chunk for table %s: %w", table, err)
+		}
+
+		high, err := c.resolveWatermark(ctx)
+		if err != nil {
+			return err
+		}
+
+		c.low = low
+		c.high = high
+
+		if len(rows) == 0 {
+			// Exhausted; keep looping until a table has rows or none
+			// remain.
+			c.current = nil
+			continue
+		}
+
+		for _, row := range rows {
+			c.window.Add(row)
+		}
+		c.lastSentPK = rows[len(rows)-1].PK
+
+		if len(rows) < c.cfg.ChunkSize {
+			// Final, partial chunk. Mark the table exhausted so the next
+			// plan skips a wasted empty query, but leave c.current set:
+			// these rows are still buffered, and OnStreamedRow can only
+			// dedup them while current names their table. Clearing it
+			// would let a concurrent update stream past undeduped and be
+			// overwritten by this stale chunk on flush.
+			c.currentExhausted = true
+		}
+
+		return nil
+	}
+}
+
+func (c *Coordinator[P, W]) resolvePKCols(ctx context.Context, table TableID) ([]string, error) {
+	key := table.String()
+	if cols, exists := c.pkCols[key]; exists {
+		return cols, nil
+	}
+
+	cols, err := c.cfg.Deps.ResolvePrimaryKey(ctx, table)
+	if err != nil {
+		return nil, fmt.Errorf("resolving primary key columns for table %s: %w", table, err)
+	}
+	c.pkCols[key] = cols
+	return cols, nil
+}
+
+// resolveMaxPK resolves and caches the table's max key, leaving c.maxPK nil
+// for an empty table -- which planNextChunk treats as nothing to backfill.
+func (c *Coordinator[P, W]) resolveMaxPK(ctx context.Context, table TableID, pkCols []string) error {
+	if c.maxPK != nil {
+		return nil
+	}
+
+	maxPK, err := c.cfg.Deps.ResolveMaxKey(ctx, table, pkCols)
+	if err != nil {
+		return fmt.Errorf("resolving max key for table %s: %w", table, err)
+	}
+	c.maxPK = maxPK
+	return nil
+}
+
+// resolveWatermark reads a watermark. It deliberately forces no transaction
+// first: each read is its own statement and already sees a current snapshot,
+// and assigning an id here would make every chunk's pair differ, which
+// readUndisturbed relies on not happening.
+func (c *Coordinator[P, W]) resolveWatermark(ctx context.Context) (W, error) {
+	var zero W
+	wm, err := c.cfg.Deps.ResolveWatermark(ctx)
+	if err != nil {
+		return zero, fmt.Errorf("resolving watermark: %w", err)
+	}
+	return wm, nil
+}

--- a/internal/replication/incrementalsnapshot/coordinator.go
+++ b/internal/replication/incrementalsnapshot/coordinator.go
@@ -190,11 +190,54 @@ func (c *Coordinator[P, W]) OnCommit(ctx context.Context, pos P, emit EmitFunc) 
 
 // releaseWindow hands the buffered chunk to emit, advancing the committed
 // state first so State reports the right checkpoint from inside emit.
+//
+// emit is what delivers the rows, so an error from it means nothing was
+// sent. The advance is then undone and the rows go back in the buffer:
+// State must never report a chunk as checkpointed that no consumer
+// received, or a resume from that State would fetch past those rows and
+// drop them.
 func (c *Coordinator[P, W]) releaseWindow(emit EmitFunc) error {
 	rows := c.window.Flush()
+	undo := c.snapshotCommitted()
+	wasOpened := c.windowOpened
+
 	c.windowOpened = false
 	c.commitLiveState()
-	return emit(rows)
+
+	if err := emit(rows); err != nil {
+		c.restoreCommitted(undo)
+		c.windowOpened = wasOpened
+		for _, row := range rows {
+			c.window.Add(row)
+		}
+		return err
+	}
+	return nil
+}
+
+// committedState is the checkpoint half of the coordinator, saved so a
+// failed emit can be undone.
+type committedState struct {
+	remaining  []TableID
+	current    *TableID
+	maxPK      PrimaryKey
+	lastSentPK PrimaryKey
+}
+
+func (c *Coordinator[P, W]) snapshotCommitted() committedState {
+	return committedState{
+		remaining:  c.committedRemaining,
+		current:    c.committedCurrent,
+		maxPK:      c.committedMaxPK,
+		lastSentPK: c.committedLastSentPK,
+	}
+}
+
+func (c *Coordinator[P, W]) restoreCommitted(s committedState) {
+	c.committedRemaining = s.remaining
+	c.committedCurrent = s.current
+	c.committedMaxPK = s.maxPK
+	c.committedLastSentPK = s.lastSentPK
 }
 
 // planAndDrain buffers the next chunk, then keeps releasing and replanning
@@ -242,7 +285,12 @@ func (c *Coordinator[P, W]) emitTerminalState(emit EmitFunc) error {
 		return nil
 	}
 	c.doneEmitted = true
-	return c.releaseWindow(emit)
+	if err := c.releaseWindow(emit); err != nil {
+		// Nothing was delivered, so the terminal checkpoint is still owed.
+		c.doneEmitted = false
+		return err
+	}
+	return nil
 }
 
 // readUndisturbed reports whether the buffered chunk's watermarks prove a

--- a/internal/replication/incrementalsnapshot/coordinator_test.go
+++ b/internal/replication/incrementalsnapshot/coordinator_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/coordinator_test.go
+++ b/internal/replication/incrementalsnapshot/coordinator_test.go
@@ -976,6 +976,71 @@ func TestCoordinatorDrainPropagatesEmitError(t *testing.T) {
 	})
 	require.ErrorIs(t, err, wantErr)
 	assert.Equal(t, 2, calls, "the drain must stop at the failing emit")
+
+	// Only the first chunk reached the consumer, so the checkpoint must
+	// cover that chunk and no more. The second chunk stays buffered for a
+	// retry or a resume to deliver.
+	state := coord.State()
+	assert.Equal(t, PrimaryKey{2}, state.LastSentPK)
+	assert.Equal(t, 2, coord.window.Len(), "the undelivered chunk must go back in the buffer")
+}
+
+// TestCoordinatorEmitFailureLeavesCheckpointUnmoved: emit is what delivers
+// the rows, so State must not report a chunk as sent when emit rejected it.
+// Otherwise a resume fetches past those rows and drops them silently.
+func TestCoordinatorEmitFailureLeavesCheckpointUnmoved(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+	const chunkSize = 2
+	rows := []Row{
+		rowFor(table, 1), rowFor(table, 2),
+		rowFor(table, 3), rowFor(table, 4),
+	}
+
+	newDeps := func() *refetchMockDeps {
+		return &refetchMockDeps{
+			rows:       rows,
+			maxPK:      PrimaryKey{4},
+			chunkSize:  chunkSize,
+			watermarks: []testWatermark{{Xmin: 100, Xmax: 100}},
+		}
+	}
+
+	cfg := testConfig{Tables: []TableID{table}, ChunkSize: chunkSize, Deps: newDeps()}
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	sentinel := errors.New("downstream gone")
+	changed, err := coord.OnCommit(t.Context(), 101, func([]Row) error { return sentinel })
+	require.ErrorIs(t, err, sentinel)
+	assert.False(t, changed, "nothing was delivered, so nothing changed")
+
+	// Nothing was sent, so the checkpoint must still be at the start and
+	// the rows must still be buffered.
+	state := coord.State()
+	require.False(t, state.Done)
+	assert.Nil(t, state.LastSentPK)
+	assert.Equal(t, chunkSize, coord.window.Len())
+
+	// A coordinator resumed from that checkpoint must deliver the whole
+	// table, first chunk included.
+	resumed, err := NewCoordinator(testConfig{
+		Tables:    []TableID{table},
+		ChunkSize: chunkSize,
+		Deps:      newDeps(),
+	}, state)
+	require.NoError(t, err)
+	require.NoError(t, resumed.Start(t.Context()))
+
+	var got []int
+	_, err = resumed.OnCommit(t.Context(), 201, func(chunk []Row) error {
+		for _, row := range chunk {
+			got = append(got, row.PK[0].(int))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3, 4}, got)
 }
 
 func TestCoordinatorForcesFreshTransactionOnceOnly(t *testing.T) {

--- a/internal/replication/incrementalsnapshot/coordinator_test.go
+++ b/internal/replication/incrementalsnapshot/coordinator_test.go
@@ -578,6 +578,188 @@ func TestCoordinatorMidDrainFailureResumesWithoutLoss(t *testing.T) {
 	}
 }
 
+// TestCoordinatorReconcilesConfiguredTablesOnResume covers what Start makes
+// of a checkpoint whose table set no longer matches the config.
+func TestCoordinatorReconcilesConfiguredTablesOnResume(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	tableB := TableID{Schema: "public", Table: "b"}
+	tableC := TableID{Schema: "public", Table: "c"}
+
+	newCoordinator := func(t *testing.T, configured []TableID, resume *State) *Coordinator[uint64, testWatermark] {
+		t.Helper()
+		tables := map[string]*mockTable{}
+		for _, table := range append([]TableID{tableA, tableB, tableC}, configured...) {
+			tables[table.String()] = &mockTable{
+				pkCols: []string{"id"},
+				rows:   []Row{rowFor(table, 1)},
+				maxPK:  PrimaryKey{1},
+			}
+		}
+		mock := newScriptedMockDeps(tables, 1)
+		mock.pushWatermark(testWatermark{Xmin: 1, Xmax: 1})
+
+		coord, err := NewCoordinator(testConfig{
+			Tables:    configured,
+			ChunkSize: 1,
+			Deps:      mock,
+		}, resume)
+		require.NoError(t, err)
+		require.NoError(t, coord.Start(t.Context()))
+		return coord
+	}
+
+	t.Run("fresh start records the configured set", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA, tableB}, nil)
+		assert.Equal(t, []TableID{tableA, tableB}, coord.State().Tables)
+		assert.Empty(t, coord.AddedOnResume())
+		assert.Empty(t, coord.RemovedOnResume())
+	})
+
+	t.Run("added table is queued for backfill", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA, tableB}, &State{
+			Version:      CurrentStateVersion,
+			CurrentTable: &tableA,
+			LastSentPK:   PrimaryKey{int64(5)},
+			MaxPK:        PrimaryKey{int64(9)},
+			Tables:       []TableID{tableA},
+		})
+
+		assert.Equal(t, []TableID{tableB}, coord.AddedOnResume())
+		assert.Equal(t, []TableID{tableA, tableB}, coord.State().Tables)
+		assert.Equal(t, []TableID{tableB}, coord.State().RemainingTables,
+			"the added table joins the back of the queue")
+	})
+
+	t.Run("added table reopens a finished snapshot", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA, tableB}, &State{
+			Version: CurrentStateVersion,
+			Done:    true,
+			Tables:  []TableID{tableA},
+		})
+
+		assert.False(t, coord.Done(), "a finished checkpoint must reopen, or the new table is never read")
+		assert.Equal(t, []TableID{tableB}, coord.AddedOnResume())
+	})
+
+	t.Run("finished snapshot stays finished when nothing was added", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA}, &State{
+			Version: CurrentStateVersion,
+			Done:    true,
+			Tables:  []TableID{tableA},
+		})
+
+		assert.True(t, coord.Done())
+		assert.Empty(t, coord.AddedOnResume())
+		assert.Equal(t, []TableID{tableA}, coord.State().Tables,
+			"the terminal checkpoint must keep the table set, or a later addition looks known")
+	})
+
+	t.Run("already finished table is not backfilled again", func(t *testing.T) {
+		// tableA is in Tables but neither current nor remaining, so this run
+		// finished it. Listing it in the config must not re-read it.
+		coord := newCoordinator(t, []TableID{tableA, tableB}, &State{
+			Version:      CurrentStateVersion,
+			CurrentTable: &tableB,
+			LastSentPK:   PrimaryKey{int64(3)},
+			MaxPK:        PrimaryKey{int64(7)},
+			Tables:       []TableID{tableA, tableB},
+		})
+
+		assert.Empty(t, coord.AddedOnResume())
+		assert.Empty(t, coord.State().RemainingTables)
+	})
+
+	t.Run("queued table dropped when no longer configured", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA}, &State{
+			Version:         CurrentStateVersion,
+			CurrentTable:    &tableA,
+			LastSentPK:      PrimaryKey{int64(1)},
+			MaxPK:           PrimaryKey{int64(9)},
+			RemainingTables: []TableID{tableC},
+			Tables:          []TableID{tableA, tableC},
+		})
+
+		assert.Equal(t, []TableID{tableC}, coord.RemovedOnResume())
+		assert.Empty(t, coord.State().RemainingTables)
+		assert.Equal(t, []TableID{tableA}, coord.State().Tables)
+	})
+
+	t.Run("current table dropped when no longer configured", func(t *testing.T) {
+		// tableC is mid-backfill. Dropping it abandons the read where it
+		// stopped, and the next plan takes tableA from the queue.
+		coord := newCoordinator(t, []TableID{tableA}, &State{
+			Version:         CurrentStateVersion,
+			CurrentTable:    &tableC,
+			LastSentPK:      PrimaryKey{int64(4)},
+			MaxPK:           PrimaryKey{int64(9)},
+			RemainingTables: []TableID{tableA},
+			Tables:          []TableID{tableC, tableA},
+		})
+
+		assert.Equal(t, []TableID{tableC}, coord.RemovedOnResume())
+
+		// State reports the committed fields, so the chunk Start just
+		// buffered is not in it yet. The checkpoint must therefore leave
+		// tableA queued, so a crash before the first flush re-plans it.
+		state := coord.State()
+		assert.Nil(t, state.CurrentTable)
+		assert.Equal(t, []TableID{tableA}, state.RemainingTables)
+		assert.Equal(t, []TableID{tableA}, state.Tables)
+		assert.Nil(t, state.LastSentPK, "the abandoned table's key bound must not carry over")
+		assert.Nil(t, state.MaxPK)
+	})
+
+	t.Run("removing every table completes the snapshot", func(t *testing.T) {
+		coord := newCoordinator(t, []TableID{tableA}, &State{
+			Version:         CurrentStateVersion,
+			CurrentTable:    &tableB,
+			LastSentPK:      PrimaryKey{int64(1)},
+			MaxPK:           PrimaryKey{int64(9)},
+			RemainingTables: []TableID{tableC},
+			Tables:          []TableID{tableB, tableC},
+		})
+
+		assert.ElementsMatch(t, []TableID{tableB, tableC}, coord.RemovedOnResume())
+		// tableA is configured but unknown, so it is added and backfilled.
+		assert.Equal(t, []TableID{tableA}, coord.AddedOnResume())
+		assert.Equal(t, []TableID{tableA}, coord.State().Tables)
+	})
+
+	t.Run("removal applies to a version 1 checkpoint", func(t *testing.T) {
+		// A version 1 checkpoint adds nothing, but a removal needs only the
+		// queue, so it still applies.
+		coord := newCoordinator(t, []TableID{tableA}, &State{
+			Version:         1,
+			CurrentTable:    &tableA,
+			LastSentPK:      PrimaryKey{int64(2)},
+			MaxPK:           PrimaryKey{int64(9)},
+			RemainingTables: []TableID{tableC},
+		})
+
+		assert.Equal(t, []TableID{tableC}, coord.RemovedOnResume())
+		assert.Empty(t, coord.State().RemainingTables)
+		assert.Equal(t, []TableID{tableA}, coord.State().Tables)
+	})
+
+	t.Run("version 1 checkpoint adds nothing", func(t *testing.T) {
+		// A version 1 checkpoint has no Tables, so its finished tables are
+		// unknown. Adding on that basis would re-read them, so this run adds
+		// nothing and only records the set for next time.
+		coord := newCoordinator(t, []TableID{tableA, tableB}, &State{
+			Version:      1,
+			CurrentTable: &tableA,
+			LastSentPK:   PrimaryKey{int64(4)},
+			MaxPK:        PrimaryKey{int64(8)},
+		})
+
+		assert.Empty(t, coord.AddedOnResume())
+		assert.Empty(t, coord.State().RemainingTables)
+		assert.Equal(t, []TableID{tableA, tableB}, coord.State().Tables)
+		assert.Equal(t, CurrentStateVersion, coord.State().Version,
+			"the checkpoint it writes must be the current version")
+	})
+}
+
 func TestCoordinatorConfigValidation(t *testing.T) {
 	validDeps := newScriptedMockDeps(map[string]*mockTable{}, 1)
 

--- a/internal/replication/incrementalsnapshot/coordinator_test.go
+++ b/internal/replication/incrementalsnapshot/coordinator_test.go
@@ -428,6 +428,156 @@ func TestCoordinatorResumeRefetchesUnflushedChunk(t *testing.T) {
 	assert.Equal(t, PrimaryKey{4}, emitted[1].PK)
 }
 
+// TestCoordinatorWrapsDepsErrors: a Deps failure must reach the caller
+// saying what the coordinator was doing, and must stay unwrapped-to so
+// callers can match on it. Start reaches all five methods, in this order.
+func TestCoordinatorWrapsDepsErrors(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+
+	for _, tc := range []struct {
+		method string
+		want   string
+	}{
+		{"ForceFreshTransaction", "forcing fresh transaction"},
+		{"ResolvePrimaryKey", "resolving primary key columns for table public.a"},
+		{"ResolveMaxKey", "resolving max key for table public.a"},
+		{"ResolveWatermark", "resolving watermark"},
+		{"FetchChunk", "fetching chunk for table public.a"},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			sentinel := errors.New("deps unavailable")
+
+			mock := newScriptedMockDeps(map[string]*mockTable{
+				table.String(): {
+					pkCols: []string{"id"},
+					rows:   []Row{rowFor(table, 1)},
+					maxPK:  PrimaryKey{1},
+				},
+			}, 1)
+			mock.pushWatermark(testWatermark{Xmin: 1, Xmax: 1})
+			mock.failOn(tc.method, sentinel)
+
+			coord, err := NewCoordinator(testConfig{
+				Tables:    []TableID{table},
+				ChunkSize: 1,
+				Deps:      mock,
+			}, nil)
+			require.NoError(t, err)
+
+			err = coord.Start(t.Context())
+			require.ErrorIs(t, err, sentinel)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// TestCoordinatorMidDrainFailureResumesWithoutLoss: a Deps failure partway
+// through a drain leaves the coordinator part-advanced. releaseWindow has
+// already committed and emitted every chunk before the failing one, so the
+// checkpoint has moved. State must therefore report a position a fresh
+// coordinator continues from, losing and repeating no row.
+//
+// The two cases fail a different Deps method partway through the drain,
+// after earlier chunks have already been committed and emitted.
+func TestCoordinatorMidDrainFailureResumesWithoutLoss(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+	const chunkSize = 2
+	rows := []Row{
+		rowFor(table, 1), rowFor(table, 2),
+		rowFor(table, 3), rowFor(table, 4),
+		rowFor(table, 5), rowFor(table, 6),
+	}
+
+	// refetchMockDeps honours the lower bound, so the resumed coordinator
+	// reads from the checkpoint rather than from a cursor the double keeps.
+	newDeps := func() *refetchMockDeps {
+		return &refetchMockDeps{
+			rows:      rows,
+			maxPK:     PrimaryKey{6},
+			chunkSize: chunkSize,
+			// One quiesced pair, repeated: every read looks undisturbed, so
+			// the coordinator drains instead of stopping after one chunk.
+			watermarks: []testWatermark{{Xmin: 100, Xmax: 100}},
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		fail func(*refetchMockDeps, error)
+		want string
+	}{
+		{
+			name: "fetch fails",
+			// Start fetches chunk 1 and the drain fetches chunk 2, so the
+			// third call is the one that fails, buffering nothing.
+			fail: func(d *refetchMockDeps, err error) { d.failAfter("FetchChunk", 2, err) },
+			want: "fetching chunk for table public.a",
+		},
+		{
+			name: "watermark fails",
+			// Two watermarks per chunk, so the sixth call is chunk 3's high
+			// watermark. planNextChunk reads it before buffering the rows,
+			// so this covers the watermark path mid-drain rather than at
+			// Start.
+			fail: func(d *refetchMockDeps, err error) { d.failAfter("ResolveWatermark", 5, err) },
+			want: "resolving watermark",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sentinel := errors.New("deps unavailable")
+			deps := newDeps()
+			tc.fail(deps, sentinel)
+
+			coord, err := NewCoordinator(testConfig{
+				Tables:    []TableID{table},
+				ChunkSize: chunkSize,
+				Deps:      deps,
+			}, nil)
+			require.NoError(t, err)
+			require.NoError(t, coord.Start(t.Context()))
+
+			var before [][]Row
+			changed, err := coord.OnCommit(t.Context(), 101, collect(&before))
+			require.ErrorIs(t, err, sentinel)
+			require.ErrorContains(t, err, tc.want)
+			assert.True(t, changed, "the chunks released before the failure did advance the state")
+			require.Len(t, before, 2, "chunks 1 and 2 were released before the failure")
+
+			// The checkpoint must cover exactly what was emitted -- never a
+			// chunk that was only fetched.
+			state := coord.State()
+			require.False(t, state.Done)
+			require.NotNil(t, state.CurrentTable)
+			assert.Equal(t, table, *state.CurrentTable)
+			assert.Equal(t, PrimaryKey{4}, state.LastSentPK)
+
+			resumed, err := NewCoordinator(testConfig{
+				Tables:    []TableID{table},
+				ChunkSize: chunkSize,
+				Deps:      newDeps(),
+			}, state)
+			require.NoError(t, err)
+			require.NoError(t, resumed.Start(t.Context()))
+
+			var after [][]Row
+			_, err = resumed.OnCommit(t.Context(), 201, collect(&after))
+			require.NoError(t, err)
+			assert.True(t, resumed.Done())
+
+			// The whole table must come out exactly once across the two runs.
+			var got []int
+			for _, chunks := range [][][]Row{before, after} {
+				for _, chunk := range chunks {
+					for _, row := range chunk {
+						got = append(got, row.PK[0].(int))
+					}
+				}
+			}
+			assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, got)
+		})
+	}
+}
+
 func TestCoordinatorConfigValidation(t *testing.T) {
 	validDeps := newScriptedMockDeps(map[string]*mockTable{}, 1)
 
@@ -448,6 +598,45 @@ func TestCoordinatorConfigValidation(t *testing.T) {
 	})
 }
 
+// depsFaults injects failures into a Deps test double, so the coordinator's
+// error paths can be exercised without a database. A method fails once it has
+// been called more than its allowance, which lets a test fail it on the first
+// call or partway through a drain.
+type depsFaults struct {
+	errs  map[string]error
+	after map[string]int
+	calls map[string]int
+}
+
+// failOn makes method fail on its first call.
+func (f *depsFaults) failOn(method string, err error) {
+	f.failAfter(method, 0, err)
+}
+
+// failAfter makes method fail once it has served after calls.
+func (f *depsFaults) failAfter(method string, after int, err error) {
+	if f.errs == nil {
+		f.errs = map[string]error{}
+		f.after = map[string]int{}
+	}
+	f.errs[method] = err
+	f.after[method] = after
+}
+
+// check counts a call to method and returns the injected error once that
+// method is past its allowance.
+func (f *depsFaults) check(method string) error {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[method]++
+	err, injected := f.errs[method]
+	if !injected || f.calls[method] <= f.after[method] {
+		return nil
+	}
+	return err
+}
+
 // mockTable is a fixture of fake rows used to script FetchChunk/ResolveMaxKey
 // without a real database.
 type mockTable struct {
@@ -460,6 +649,8 @@ type mockTable struct {
 // from an in-memory fixture and scripted watermarks, tracking a per-table
 // cursor instead of parsing SQL/args.
 type scriptedMockDeps struct {
+	depsFaults
+
 	tables    map[string]*mockTable
 	cursor    map[string]int
 	chunkSize int
@@ -482,14 +673,23 @@ func (m *scriptedMockDeps) pushWatermark(wm testWatermark) {
 }
 
 func (m *scriptedMockDeps) ResolvePrimaryKey(_ context.Context, table TableID) ([]string, error) {
+	if err := m.check("ResolvePrimaryKey"); err != nil {
+		return nil, err
+	}
 	return m.tables[table.String()].pkCols, nil
 }
 
 func (m *scriptedMockDeps) ResolveMaxKey(_ context.Context, table TableID, _ []string) (PrimaryKey, error) {
+	if err := m.check("ResolveMaxKey"); err != nil {
+		return nil, err
+	}
 	return m.tables[table.String()].maxPK, nil
 }
 
 func (m *scriptedMockDeps) ResolveWatermark(context.Context) (testWatermark, error) {
+	if err := m.check("ResolveWatermark"); err != nil {
+		return testWatermark{}, err
+	}
 	idx := m.watermarkCalls
 	if idx >= len(m.watermarks) {
 		idx = len(m.watermarks) - 1
@@ -499,11 +699,17 @@ func (m *scriptedMockDeps) ResolveWatermark(context.Context) (testWatermark, err
 }
 
 func (m *scriptedMockDeps) ForceFreshTransaction(context.Context) error {
+	if err := m.check("ForceFreshTransaction"); err != nil {
+		return err
+	}
 	m.forceFreshCalls++
 	return nil
 }
 
 func (m *scriptedMockDeps) FetchChunk(_ context.Context, table TableID, _ []string, _, _ PrimaryKey, _ int) ([]Row, error) {
+	if err := m.check("FetchChunk"); err != nil {
+		return nil, err
+	}
 	key := table.String()
 	mt := m.tables[key]
 	start := m.cursor[key]
@@ -530,6 +736,8 @@ func rowFor(table TableID, pk int) Row {
 // the same lower bound is idempotent -- proving a resumed Coordinator
 // refetches rather than skips a chunk. Assumes single-column int keys.
 type refetchMockDeps struct {
+	depsFaults
+
 	rows      []Row
 	maxPK     PrimaryKey
 	chunkSize int
@@ -539,25 +747,37 @@ type refetchMockDeps struct {
 	fetchLog       []string
 }
 
-func (*refetchMockDeps) ResolvePrimaryKey(context.Context, TableID) ([]string, error) {
+func (d *refetchMockDeps) ResolvePrimaryKey(context.Context, TableID) ([]string, error) {
+	if err := d.check("ResolvePrimaryKey"); err != nil {
+		return nil, err
+	}
 	return []string{"id"}, nil
 }
 
 func (d *refetchMockDeps) ResolveMaxKey(context.Context, TableID, []string) (PrimaryKey, error) {
+	if err := d.check("ResolveMaxKey"); err != nil {
+		return nil, err
+	}
 	return d.maxPK, nil
 }
 
-func (*refetchMockDeps) ForceFreshTransaction(context.Context) error {
-	return nil
+func (d *refetchMockDeps) ForceFreshTransaction(context.Context) error {
+	return d.check("ForceFreshTransaction")
 }
 
 func (d *refetchMockDeps) ResolveWatermark(context.Context) (testWatermark, error) {
+	if err := d.check("ResolveWatermark"); err != nil {
+		return testWatermark{}, err
+	}
 	idx := min(d.watermarkCalls, len(d.watermarks)-1)
 	d.watermarkCalls++
 	return d.watermarks[idx], nil
 }
 
 func (d *refetchMockDeps) FetchChunk(_ context.Context, _ TableID, _ []string, lower, _ PrimaryKey, _ int) ([]Row, error) {
+	if err := d.check("FetchChunk"); err != nil {
+		return nil, err
+	}
 	d.fetchLog = append(d.fetchLog, fmt.Sprint(lower))
 	return sortedRowsAfter(d.rows, lower, d.chunkSize), nil
 }

--- a/internal/replication/incrementalsnapshot/coordinator_test.go
+++ b/internal/replication/incrementalsnapshot/coordinator_test.go
@@ -1,0 +1,815 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testWatermark is a minimal Watermark[uint64] for exercising the
+// coordinator: an xmin/xmax pair over integer transaction ids, mirroring the
+// shape real databases report without depending on any of them.
+type testWatermark struct {
+	Xmin uint64
+	Xmax uint64
+}
+
+func (w testWatermark) OpensAt(pos uint64) bool  { return pos >= w.Xmin }
+func (w testWatermark) ClosesAt(pos uint64) bool { return pos > w.Xmax }
+func (w testWatermark) Quiesced() bool           { return w.Xmin == w.Xmax }
+
+// testConfig saves repeating the coordinator's type arguments at every
+// construction site.
+type testConfig = CoordinatorConfig[uint64, testWatermark]
+
+// collect keeps the rows that one call releases. It lets the older tests
+// use the EmitFunc parameter.
+func collect(rows *[][]Row) EmitFunc {
+	return func(r []Row) error {
+		*rows = append(*rows, r)
+		return nil
+	}
+}
+
+// onCommit calls OnCommit and joins the released chunks. The tests that are
+// older than the drain then still read one chunk for each commit.
+func onCommit[W Watermark[uint64]](t *testing.T, c *Coordinator[uint64, W], pos uint64) (emitted []Row, changed bool, err error) {
+	t.Helper()
+	var chunks [][]Row
+	changed, err = c.OnCommit(t.Context(), pos, collect(&chunks))
+	for _, chunk := range chunks {
+		emitted = append(emitted, chunk...)
+	}
+	return emitted, changed, err
+}
+
+func TestCoordinatorFullScenario(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	tableB := TableID{Schema: "public", Table: "b"}
+
+	const chunkSize = 3
+
+	// A: one full chunk, then an empty follow-up (zero-row advance path).
+	rowsA := []Row{rowFor(tableA, 1), rowFor(tableA, 2), rowFor(tableA, 3)}
+	// B: a short chunk (short-chunk advance path).
+	rowsB := []Row{rowFor(tableB, 10), rowFor(tableB, 11)}
+
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		tableA.String(): {pkCols: []string{"id"}, rows: rowsA, maxPK: PrimaryKey{3}},
+		tableB.String(): {pkCols: []string{"id"}, rows: rowsB, maxPK: PrimaryKey{11}},
+	}, chunkSize)
+
+	// low/high pairs: A chunk1, A chunk2 (empty, triggers advance), B chunk1.
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100}) // low, A chunk 1
+	mock.pushWatermark(testWatermark{Xmin: 105, Xmax: 105}) // high, A chunk 1
+	mock.pushWatermark(testWatermark{Xmin: 110, Xmax: 110}) // low, A chunk 2 (empty)
+	mock.pushWatermark(testWatermark{Xmin: 112, Xmax: 112}) // high, A chunk 2 (empty)
+	mock.pushWatermark(testWatermark{Xmin: 120, Xmax: 120}) // low, B chunk 1
+	mock.pushWatermark(testWatermark{Xmin: 125, Xmax: 125}) // high, B chunk 1
+
+	cfg := testConfig{
+		Tables:    []TableID{tableA, tableB},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	require.False(t, coord.Done())
+	require.NotNil(t, coord.current)
+	assert.Equal(t, tableA, *coord.current)
+	assert.Equal(t, PrimaryKey{3}, coord.lastSentPK)
+	assert.Equal(t, 3, coord.window.Len())
+
+	// Streamed row PK=2 arrives while still buffered.
+	removed := coord.OnStreamedRow(tableA, PrimaryKey{2})
+	assert.True(t, removed)
+
+	// Different table: must not touch the window.
+	removedOther := coord.OnStreamedRow(tableB, PrimaryKey{999})
+	assert.False(t, removedOther)
+
+	// txid below low.Xmin: window must not open yet.
+	emitted, changed, err := onCommit(t, coord, 50)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, emitted)
+
+	// A position that is smaller than low.Xmin does nothing, at any value.
+	// The coordinator has no special test for a zero position and asks the
+	// watermark. The caller removes unknown positions. Refer to OnCommit.
+	emitted, changed, err = onCommit(t, coord, 0)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, emitted)
+
+	// txid==low.Xmin: opens, but doesn't close (threshold=105).
+	emitted, changed, err = onCommit(t, coord, 100)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, emitted)
+
+	// txid at the threshold exactly: still not closed (<=).
+	emitted, changed, err = onCommit(t, coord, 105)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, emitted)
+
+	// txid > threshold: closes, flushes, advances to B via A's empty follow-up.
+	emitted, changed, err = onCommit(t, coord, 106)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	require.Len(t, emitted, 2)
+	assert.Equal(t, PrimaryKey{1}, emitted[0].PK)
+	assert.Equal(t, PrimaryKey{3}, emitted[1].PK)
+
+	// The chunk of table B was not full, so table B is complete. current
+	// stays at table B until the next plan, and OnStreamedRow can therefore
+	// still remove the buffered rows.
+	assert.True(t, coord.currentExhausted)
+	require.NotNil(t, coord.current)
+	assert.Equal(t, tableB, *coord.current)
+	assert.Equal(t, PrimaryKey{11}, coord.lastSentPK)
+	assert.Equal(t, 2, coord.window.Len())
+
+	// B's open/close cycle (low=120, high=125).
+	_, changed, err = onCommit(t, coord, 119)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	_, changed, err = onCommit(t, coord, 120)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	emitted, changed, err = onCommit(t, coord, 126)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	require.Len(t, emitted, 2)
+	assert.Equal(t, PrimaryKey{10}, emitted[0].PK)
+	assert.Equal(t, PrimaryKey{11}, emitted[1].PK)
+
+	// B's short chunk skipped the zero-row round-trip straight to done.
+	assert.True(t, coord.Done())
+}
+
+func TestCoordinatorZeroRowAdvanceBetweenTables(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	tableB := TableID{Schema: "public", Table: "b"}
+
+	const chunkSize = 2
+
+	rowsA := []Row{rowFor(tableA, 1), rowFor(tableA, 2)}
+	rowsB := []Row{rowFor(tableB, 5), rowFor(tableB, 6)}
+
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		tableA.String(): {pkCols: []string{"id"}, rows: rowsA, maxPK: PrimaryKey{2}},
+		tableB.String(): {pkCols: []string{"id"}, rows: rowsB, maxPK: PrimaryKey{6}},
+	}, chunkSize)
+
+	// A's chunk isn't short, so a real zero-row fetch precedes advancing to
+	// B: 4 pairs (A full, A empty, B full, B empty->done).
+	mock.pushWatermark(testWatermark{Xmin: 10, Xmax: 10})
+	mock.pushWatermark(testWatermark{Xmin: 11, Xmax: 11})
+	mock.pushWatermark(testWatermark{Xmin: 12, Xmax: 12})
+	mock.pushWatermark(testWatermark{Xmin: 13, Xmax: 13})
+	mock.pushWatermark(testWatermark{Xmin: 14, Xmax: 14})
+	mock.pushWatermark(testWatermark{Xmin: 15, Xmax: 15})
+	mock.pushWatermark(testWatermark{Xmin: 16, Xmax: 16})
+	mock.pushWatermark(testWatermark{Xmin: 17, Xmax: 17})
+
+	cfg := testConfig{
+		Tables:    []TableID{tableA, tableB},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	require.NotNil(t, coord.current)
+	assert.Equal(t, tableA, *coord.current)
+	assert.Equal(t, 2, coord.window.Len())
+
+	// Closes A's window; triggers A's zero-row fetch, advancing to B.
+	_, changed, err := onCommit(t, coord, 10)
+	require.NoError(t, err)
+	assert.False(t, changed) // window opened, not yet closed
+
+	emitted, changed, err := onCommit(t, coord, 12)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Len(t, emitted, 2)
+
+	require.NotNil(t, coord.current)
+	assert.Equal(t, tableB, *coord.current)
+	assert.Equal(t, 2, coord.window.Len())
+
+	// Closes B's window; B's zero-row follow-up exhausts the queue.
+	_, changed, err = onCommit(t, coord, 14)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	emitted, changed, err = onCommit(t, coord, 16)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Len(t, emitted, 2)
+
+	assert.True(t, coord.Done())
+}
+
+func TestCoordinatorOnCommitNoopsWhenDone(t *testing.T) {
+	cfg := testConfig{
+		Tables:    nil,
+		ChunkSize: 10,
+		Deps:      newScriptedMockDeps(map[string]*mockTable{}, 10),
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+	require.True(t, coord.Done())
+
+	emitted, changed, err := onCommit(t, coord, 100)
+	require.NoError(t, err)
+	assert.True(t, changed, "the Done checkpoint must reach the caller")
+	assert.Empty(t, emitted, "it carries state only, no rows")
+
+	emitted, changed, err = onCommit(t, coord, 101)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, emitted)
+
+	assert.False(t, coord.OnStreamedRow(TableID{Schema: "public", Table: "a"}, PrimaryKey{1}))
+}
+
+// TestCoordinatorSkipsEmptyTable: a table with no rows (ResolveMaxKey
+// returns a nil PrimaryKey with a nil error) must be skipped as
+// already-backfilled rather than failing the coordinator outright.
+func TestCoordinatorSkipsEmptyTable(t *testing.T) {
+	tableEmpty := TableID{Schema: "public", Table: "empty"}
+	tableB := TableID{Schema: "public", Table: "b"}
+
+	const chunkSize = 2
+	rowsB := []Row{rowFor(tableB, 1), rowFor(tableB, 2)}
+
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		tableEmpty.String(): {pkCols: []string{"id"}, rows: nil, maxPK: nil},
+		tableB.String():     {pkCols: []string{"id"}, rows: rowsB, maxPK: PrimaryKey{2}},
+	}, chunkSize)
+	mock.pushWatermark(testWatermark{Xmin: 1, Xmax: 1})
+	mock.pushWatermark(testWatermark{Xmin: 2, Xmax: 2})
+
+	cfg := testConfig{
+		Tables:    []TableID{tableEmpty, tableB},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	// The empty table must be skipped entirely, straight on to table B,
+	// without erroring or wasting a watermark/fetch round trip on it.
+	require.False(t, coord.Done())
+	require.NotNil(t, coord.current)
+	assert.Equal(t, tableB, *coord.current)
+	assert.Equal(t, 2, coord.window.Len())
+
+	emitted, changed, err := onCommit(t, coord, 3)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Len(t, emitted, 2)
+	assert.True(t, coord.Done())
+}
+
+// TestCoordinatorAllTablesEmpty: every configured table having no rows must
+// mark the coordinator done immediately, not fail the whole incremental
+// snapshot (and therefore the replication stream it runs alongside).
+func TestCoordinatorAllTablesEmpty(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	tableB := TableID{Schema: "public", Table: "b"}
+
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		tableA.String(): {pkCols: []string{"id"}, rows: nil, maxPK: nil},
+		tableB.String(): {pkCols: []string{"id"}, rows: nil, maxPK: nil},
+	}, 10)
+
+	cfg := testConfig{
+		Tables:    []TableID{tableA, tableB},
+		ChunkSize: 10,
+		Deps:      mock,
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+	assert.True(t, coord.Done())
+}
+
+func TestCoordinatorResumeAlwaysDerivesFreshWatermark(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	tableB := TableID{Schema: "public", Table: "b"}
+
+	const chunkSize = 2
+
+	rowsA := []Row{rowFor(tableA, 1), rowFor(tableA, 2)}
+	rowsB := []Row{rowFor(tableB, 5)}
+
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		tableA.String(): {pkCols: []string{"id"}, rows: rowsA, maxPK: PrimaryKey{2}},
+		tableB.String(): {pkCols: []string{"id"}, rows: rowsB, maxPK: PrimaryKey{5}},
+	}, chunkSize)
+	mock.pushWatermark(testWatermark{Xmin: 1, Xmax: 1})
+	mock.pushWatermark(testWatermark{Xmin: 2, Xmax: 2})
+
+	cfg := testConfig{
+		Tables:    []TableID{tableA, tableB},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	callsBeforeResume := mock.watermarkCalls
+	require.Positive(t, callsBeforeResume)
+
+	// Pre-flush checkpoint must report the baseline, not tableA's unflushed
+	// first chunk.
+	state := coord.State()
+	require.False(t, state.Done)
+	assert.Nil(t, state.CurrentTable)
+	assert.Equal(t, []TableID{tableA, tableB}, state.RemainingTables)
+
+	// New watermarks for the "restart".
+	mock.pushWatermark(testWatermark{Xmin: 3, Xmax: 3})
+	mock.pushWatermark(testWatermark{Xmin: 4, Xmax: 4})
+
+	resumed, err := NewCoordinator(cfg, state)
+	require.NoError(t, err)
+	require.NoError(t, resumed.Start(t.Context()))
+
+	// Call count must increase: watermarks are never persisted, only re-derived.
+	assert.Greater(t, mock.watermarkCalls, callsBeforeResume)
+	assert.Positive(t, mock.forceFreshCalls)
+}
+
+// TestCoordinatorResumeRefetchesUnflushedChunk: State() must only advance
+// once flushed, or a resumed coordinator skips unflushed rows.
+func TestCoordinatorResumeRefetchesUnflushedChunk(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "a"}
+	const chunkSize = 2
+	rowsA := []Row{rowFor(tableA, 1), rowFor(tableA, 2), rowFor(tableA, 3), rowFor(tableA, 4)}
+
+	deps := &refetchMockDeps{
+		rows:      rowsA,
+		maxPK:     PrimaryKey{4},
+		chunkSize: chunkSize,
+		watermarks: []testWatermark{
+			{Xmin: 1, Xmax: 1}, {Xmin: 2, Xmax: 2}, // chunk 1 ([1,2]): low, high
+			{Xmin: 3, Xmax: 3}, {Xmin: 4, Xmax: 4}, // chunk 2 ([3,4]): low, high
+		},
+	}
+
+	cfg := testConfig{Tables: []TableID{tableA}, ChunkSize: chunkSize, Deps: deps}
+
+	coord, err := NewCoordinator(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context())) // fetches chunk 1 ([1,2])
+
+	_, changed, err := onCommit(t, coord, 1) // opens, doesn't close (1 <= closeThreshold 2)
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	emitted, changed, err := onCommit(t, coord, 3) // closes: flushes chunk 1, fetches chunk 2
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, emitted, 2)
+	assert.Equal(t, PrimaryKey{1}, emitted[0].PK)
+	assert.Equal(t, PrimaryKey{2}, emitted[1].PK)
+
+	// Chunk 2 fetched but not flushed; checkpoint must reflect only chunk 1.
+	state := coord.State()
+	require.False(t, state.Done)
+	require.NotNil(t, state.CurrentTable)
+	assert.Equal(t, tableA, *state.CurrentTable)
+	assert.Equal(t, PrimaryKey{2}, state.LastSentPK)
+	require.Len(t, deps.fetchLog, 2, "sanity: exactly one FetchChunk call for chunk 1's fetch so far")
+
+	resumed, err := NewCoordinator(cfg, state)
+	require.NoError(t, err)
+	require.NoError(t, resumed.Start(t.Context())) // must refetch chunk 2, not skip it
+
+	require.Len(t, deps.fetchLog, 3)
+	assert.Equal(t, deps.fetchLog[1], deps.fetchLog[2], "resumed coordinator must request the same lower bound as the original chunk 2 fetch")
+
+	emitted, changed, err = onCommit(t, resumed, 5) // opens and closes in one call (5 > closeThreshold 4)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, emitted, 2, "chunk 2's rows must still be emitted exactly once, on the resumed coordinator")
+	assert.Equal(t, PrimaryKey{3}, emitted[0].PK)
+	assert.Equal(t, PrimaryKey{4}, emitted[1].PK)
+}
+
+func TestCoordinatorConfigValidation(t *testing.T) {
+	validDeps := newScriptedMockDeps(map[string]*mockTable{}, 1)
+
+	t.Run("zero chunk size", func(t *testing.T) {
+		_, err := NewCoordinator(testConfig{ChunkSize: 0, Deps: validDeps}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("negative chunk size", func(t *testing.T) {
+		_, err := NewCoordinator(testConfig{ChunkSize: -1, Deps: validDeps}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("nil deps", func(t *testing.T) {
+		_, err := NewCoordinator(testConfig{ChunkSize: 1, Deps: nil}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Deps")
+	})
+}
+
+// mockTable is a fixture of fake rows used to script FetchChunk/ResolveMaxKey
+// without a real database.
+type mockTable struct {
+	pkCols []string
+	rows   []Row // full ordered set of rows in the table, PK-ascending
+	maxPK  PrimaryKey
+}
+
+// scriptedMockDeps implements Deps, serving chunk data
+// from an in-memory fixture and scripted watermarks, tracking a per-table
+// cursor instead of parsing SQL/args.
+type scriptedMockDeps struct {
+	tables    map[string]*mockTable
+	cursor    map[string]int
+	chunkSize int
+
+	watermarks      []testWatermark
+	watermarkCalls  int
+	forceFreshCalls int
+}
+
+func newScriptedMockDeps(tables map[string]*mockTable, chunkSize int) *scriptedMockDeps {
+	return &scriptedMockDeps{
+		tables:    tables,
+		cursor:    make(map[string]int),
+		chunkSize: chunkSize,
+	}
+}
+
+func (m *scriptedMockDeps) pushWatermark(wm testWatermark) {
+	m.watermarks = append(m.watermarks, wm)
+}
+
+func (m *scriptedMockDeps) ResolvePrimaryKey(_ context.Context, table TableID) ([]string, error) {
+	return m.tables[table.String()].pkCols, nil
+}
+
+func (m *scriptedMockDeps) ResolveMaxKey(_ context.Context, table TableID, _ []string) (PrimaryKey, error) {
+	return m.tables[table.String()].maxPK, nil
+}
+
+func (m *scriptedMockDeps) ResolveWatermark(context.Context) (testWatermark, error) {
+	idx := m.watermarkCalls
+	if idx >= len(m.watermarks) {
+		idx = len(m.watermarks) - 1
+	}
+	m.watermarkCalls++
+	return m.watermarks[idx], nil
+}
+
+func (m *scriptedMockDeps) ForceFreshTransaction(context.Context) error {
+	m.forceFreshCalls++
+	return nil
+}
+
+func (m *scriptedMockDeps) FetchChunk(_ context.Context, table TableID, _ []string, _, _ PrimaryKey, _ int) ([]Row, error) {
+	key := table.String()
+	mt := m.tables[key]
+	start := m.cursor[key]
+	if start >= len(mt.rows) {
+		return nil, nil
+	}
+	end := min(start+m.chunkSize, len(mt.rows))
+	chunk := mt.rows[start:end]
+	m.cursor[key] = end
+	return chunk, nil
+}
+
+func rowFor(table TableID, pk int) Row {
+	return Row{
+		Table: table,
+		PK:    PrimaryKey{pk},
+		Data:  map[string]any{"id": pk},
+	}
+}
+
+// refetchMockDeps is a purpose-built Deps used only by
+// TestCoordinatorResumeRefetchesUnflushedChunk: it logs every FetchChunk
+// call's lower bound and serves a static, PK-sorted row set, so re-querying
+// the same lower bound is idempotent -- proving a resumed Coordinator
+// refetches rather than skips a chunk. Assumes single-column int keys.
+type refetchMockDeps struct {
+	rows      []Row
+	maxPK     PrimaryKey
+	chunkSize int
+
+	watermarks     []testWatermark
+	watermarkCalls int
+	fetchLog       []string
+}
+
+func (*refetchMockDeps) ResolvePrimaryKey(context.Context, TableID) ([]string, error) {
+	return []string{"id"}, nil
+}
+
+func (d *refetchMockDeps) ResolveMaxKey(context.Context, TableID, []string) (PrimaryKey, error) {
+	return d.maxPK, nil
+}
+
+func (*refetchMockDeps) ForceFreshTransaction(context.Context) error {
+	return nil
+}
+
+func (d *refetchMockDeps) ResolveWatermark(context.Context) (testWatermark, error) {
+	idx := min(d.watermarkCalls, len(d.watermarks)-1)
+	d.watermarkCalls++
+	return d.watermarks[idx], nil
+}
+
+func (d *refetchMockDeps) FetchChunk(_ context.Context, _ TableID, _ []string, lower, _ PrimaryKey, _ int) ([]Row, error) {
+	d.fetchLog = append(d.fetchLog, fmt.Sprint(lower))
+	return sortedRowsAfter(d.rows, lower, d.chunkSize), nil
+}
+
+// sortedRowsAfter is a pure "WHERE pk > lower LIMIT limit" query over a
+// static, PK-sorted row set. Assumes single-column int primary keys.
+func sortedRowsAfter(rows []Row, lower PrimaryKey, limit int) []Row {
+	start := 0
+	if lower != nil {
+		start = len(rows)
+		for i, r := range rows {
+			if r.PK[0].(int) > lower[0].(int) {
+				start = i
+				break
+			}
+		}
+	}
+	if start >= len(rows) {
+		return nil
+	}
+	return rows[start:min(start+limit, len(rows))]
+}
+
+// TestCoordinatorDedupsBufferedFinalChunk tests the last chunk of a table.
+// That chunk is not full, but its rows are in the buffer like all other
+// rows. Therefore a change that streams in before the window closes must
+// remove its row from the buffer.
+//
+// This test is a regression test. The coordinator set current to nil as soon
+// as it buffered a chunk that was not full. OnStreamedRow then did nothing,
+// and the stream emitted the old snapshot row after the new change.
+func TestCoordinatorDedupsBufferedFinalChunk(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+
+	// chunkSize 4 against 2 rows: the table's only chunk is a short one.
+	const chunkSize = 4
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		table.String(): {
+			pkCols: []string{"id"},
+			rows:   []Row{rowFor(table, 1), rowFor(table, 2)},
+			maxPK:  PrimaryKey{2},
+		},
+	}, chunkSize)
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100}) // low
+	mock.pushWatermark(testWatermark{Xmin: 105, Xmax: 105}) // high
+
+	coord, err := NewCoordinator(testConfig{
+		Tables:    []TableID{table},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	require.Equal(t, 2, coord.window.Len())
+
+	// An update of row 1 commits while the chunk is still in the buffer.
+	// The pipeline has already sent that update. The update must remove the
+	// old row from the buffer. The old row must not replace the update at
+	// the flush.
+	require.True(t, coord.OnStreamedRow(table, PrimaryKey{1}))
+	assert.Equal(t, 1, coord.window.Len())
+
+	// A row of another table must not change the buffer.
+	other := TableID{Schema: "public", Table: "other"}
+	assert.False(t, coord.OnStreamedRow(other, PrimaryKey{1}))
+
+	// The window closes. The coordinator emits the other row only. No table
+	// remains, so the snapshot is complete.
+	emitted, changed, err := onCommit(t, coord, 106)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Len(t, emitted, 1)
+	assert.Equal(t, PrimaryKey{2}, emitted[0].PK)
+	assert.True(t, coord.Done())
+}
+
+// newDrainCoordinator makes a coordinator for one table of six rows in three
+// equal chunks. Each watermark is the same and is quiesced. The test
+// database is therefore completely quiet.
+func newDrainCoordinator(t *testing.T, maxDrain int) (*Coordinator[uint64, testWatermark], TableID) {
+	t.Helper()
+	table := TableID{Schema: "public", Table: "a"}
+
+	const chunkSize = 2
+	rows := []Row{
+		rowFor(table, 1), rowFor(table, 2),
+		rowFor(table, 3), rowFor(table, 4),
+		rowFor(table, 5), rowFor(table, 6),
+	}
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		table.String(): {pkCols: []string{"id"}, rows: rows, maxPK: PrimaryKey{6}},
+	}, chunkSize)
+	// One watermark is enough. The test double repeats its last watermark,
+	// so each chunk gets the same quiesced pair.
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100})
+
+	coord, err := NewCoordinator(testConfig{
+		Tables:         []TableID{table},
+		ChunkSize:      chunkSize,
+		Deps:           mock,
+		MaxDrainChunks: maxDrain,
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+	return coord, table
+}
+
+func TestCoordinatorDrainsQuietDatabaseInOneCommit(t *testing.T) {
+	// A chunk that the coordinator reads while no transaction is in flight
+	// needs no row removal. If the coordinator keeps that chunk, it must
+	// wait for the next commit. On a quiet table that commit comes only with
+	// the next heartbeat. Therefore all three chunks must come out on this
+	// one commit.
+	coord, _ := newDrainCoordinator(t, DefaultMaxDrainChunks)
+
+	var chunks [][]Row
+	changed, err := coord.OnCommit(t.Context(), 101, collect(&chunks))
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.Len(t, chunks, 4, "every chunk should drain on one commit")
+	assert.Equal(t, PrimaryKey{1}, chunks[0][0].PK)
+	assert.Equal(t, PrimaryKey{3}, chunks[1][0].PK)
+	assert.Equal(t, PrimaryKey{5}, chunks[2][0].PK)
+	assert.Empty(t, chunks[3])
+	assert.True(t, coord.Done())
+}
+
+func TestCoordinatorDrainRespectsMaxDrainChunks(t *testing.T) {
+	// The coordinator emits on the replication loop of the caller.
+	// Therefore the drain must return control and must not read the full
+	// table.
+	coord, _ := newDrainCoordinator(t, 1)
+
+	var chunks [][]Row
+	changed, err := coord.OnCommit(t.Context(), 101, collect(&chunks))
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	// The chunk of the window, and one more chunk from the drain.
+	require.Len(t, chunks, 2)
+	assert.False(t, coord.Done(), "a chunk stays buffered for the next commit")
+}
+
+func TestCoordinatorDrainStopsOnConcurrentActivity(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+
+	const chunkSize = 2
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		table.String(): {
+			pkCols: []string{"id"},
+			rows:   []Row{rowFor(table, 1), rowFor(table, 2), rowFor(table, 3), rowFor(table, 4)},
+			maxPK:  PrimaryKey{4},
+		},
+	}, chunkSize)
+	// Chunk 1 gets two equal watermarks. Chunk 2 gets two different
+	// watermarks, because a transaction started during that read. A later
+	// row can replace a row of chunk 2, so the coordinator must keep it.
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100}) // low, chunk 1
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100}) // high, chunk 1
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100}) // low, chunk 2
+	mock.pushWatermark(testWatermark{Xmin: 102, Xmax: 102}) // high, chunk 2
+
+	coord, err := NewCoordinator(testConfig{
+		Tables:    []TableID{table},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+
+	var chunks [][]Row
+	changed, err := coord.OnCommit(t.Context(), 101, collect(&chunks))
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.Len(t, chunks, 1, "the disturbed chunk must stay buffered for dedup")
+	assert.Equal(t, PrimaryKey{1}, chunks[0][0].PK)
+	assert.Equal(t, 2, coord.window.Len())
+}
+
+func TestCoordinatorDrainPropagatesEmitError(t *testing.T) {
+	// At the call site, emit sends to a channel. Its error is therefore how
+	// a stopped stream ends a drain.
+	coord, _ := newDrainCoordinator(t, DefaultMaxDrainChunks)
+
+	wantErr := errors.New("downstream gone")
+	calls := 0
+	_, err := coord.OnCommit(t.Context(), 101, func([]Row) error {
+		calls++
+		if calls == 2 {
+			return wantErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 2, calls, "the drain must stop at the failing emit")
+}
+
+func TestCoordinatorForcesFreshTransactionOnceOnly(t *testing.T) {
+	// A call for each watermark uses two transaction ids for each chunk. It
+	// also makes the two watermarks of each read different, and this stops
+	// the drain.
+	coord, _ := newDrainCoordinator(t, DefaultMaxDrainChunks)
+
+	_, err := coord.OnCommit(t.Context(), 101, func([]Row) error { return nil })
+	require.NoError(t, err)
+
+	deps := coord.cfg.Deps.(*scriptedMockDeps)
+	assert.Equal(t, 1, deps.forceFreshCalls, "only Start should force a transaction id")
+}
+
+func TestCoordinatorEmitsTerminalStateAfterResume(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+
+	const chunkSize = 2
+	mock := newScriptedMockDeps(map[string]*mockTable{
+		table.String(): {pkCols: []string{"id"}, rows: nil, maxPK: PrimaryKey{2}},
+	}, chunkSize)
+	mock.pushWatermark(testWatermark{Xmin: 100, Xmax: 100})
+
+	// A checkpoint written just before the backfill finished: the table is
+	// current, its keys are exhausted, but done is still false.
+	resume := &State{
+		Version:      CurrentStateVersion,
+		CurrentTable: &table,
+		LastSentPK:   PrimaryKey{2},
+		MaxPK:        PrimaryKey{2},
+	}
+
+	coord, err := NewCoordinator(testConfig{
+		Tables:    []TableID{table},
+		ChunkSize: chunkSize,
+		Deps:      mock,
+	}, resume)
+	require.NoError(t, err)
+	require.NoError(t, coord.Start(t.Context()))
+	require.True(t, coord.Done(), "the empty chunk read should complete the snapshot")
+
+	var chunks [][]Row
+	changed, err := coord.OnCommit(t.Context(), 101, collect(&chunks))
+	require.NoError(t, err)
+	require.True(t, changed, "the caller must see the completion so it can checkpoint and report it")
+	require.Len(t, chunks, 1)
+	assert.Empty(t, chunks[0], "the terminal checkpoint carries no rows")
+	assert.True(t, coord.State().Done, "the persisted state must now be done")
+
+	// Nothing further: the checkpoint is written once.
+	chunks = nil
+	changed, err = coord.OnCommit(t.Context(), 102, collect(&chunks))
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Empty(t, chunks)
+}

--- a/internal/replication/incrementalsnapshot/deps.go
+++ b/internal/replication/incrementalsnapshot/deps.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/deps.go
+++ b/internal/replication/incrementalsnapshot/deps.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Deps supplies every side-effecting operation the coordinator needs, so the
+// coordinator itself carries no database driver.
+//
+// The coordinator picks the next table and key range; the implementation
+// builds its own query for it. This package builds no SQL, because keyset
+// pagination is not portable -- Postgres and MySQL compare row constructors,
+// Oracle cannot.
+//
+// W must satisfy Watermark[P]. Methods are called from a single goroutine
+// and may block on I/O.
+type Deps[W any] interface {
+	// ResolvePrimaryKey returns the table's unquoted key columns. The
+	// coordinator caches the result per table.
+	ResolvePrimaryKey(ctx context.Context, table TableID) (columns []string, err error)
+
+	// ResolveMaxKey returns the table's current largest key, which bounds the
+	// backfill: rows inserted after that are left to the stream. A nil key
+	// with a nil error means the table is empty, which is not an error.
+	ResolveMaxKey(ctx context.Context, table TableID, pkColumnsUnquoted []string) (PrimaryKey, error)
+
+	// ResolveWatermark reads a fresh watermark.
+	ResolveWatermark(ctx context.Context) (W, error)
+
+	// ForceFreshTransaction assigns the connection a real transaction id, so
+	// the stream has a known position for the first watermark.
+	//
+	// Start calls it once. Calling it per watermark would make every chunk's
+	// two watermarks differ, which disables the drain entirely.
+	ForceFreshTransaction(ctx context.Context) error
+
+	// FetchChunk returns up to limit rows in key order, covering the keys
+	// after lower up to and including upper. A nil lower means the table's
+	// first chunk; upper is never nil. Returning fewer than limit rows tells
+	// the coordinator the table is exhausted.
+	FetchChunk(ctx context.Context, table TableID, pkColumnsUnquoted []string, lower, upper PrimaryKey, limit int) ([]Row, error)
+}
+
+// CoordinatorConfig configures a Coordinator. P is the database's position
+// type and W its watermark type; see Watermark.
+type CoordinatorConfig[P any, W Watermark[P]] struct {
+	Tables    []TableID
+	ChunkSize int
+	Deps      Deps[W]
+	// MaxDrainChunks caps how many chunks one OnCommit may release, which it
+	// only does while the database is quiet enough to need no deduplication.
+	// Emitting runs on the caller's replication loop, so this bounds how long
+	// that loop is held -- leaving it free for standby keepalives and such.
+	//
+	// Zero selects DefaultMaxDrainChunks; a negative value disables draining.
+	MaxDrainChunks int
+}
+
+// DefaultMaxDrainChunks applies when CoordinatorConfig.MaxDrainChunks is
+// zero.
+const DefaultMaxDrainChunks = 32
+
+// Validate checks the config is usable, so a mistake surfaces here rather
+// than deep inside the algorithm.
+func (c CoordinatorConfig[P, W]) Validate() error {
+	if c.ChunkSize <= 0 {
+		return fmt.Errorf("chunk size must be > 0, got %d", c.ChunkSize)
+	}
+	if c.Deps == nil {
+		return errors.New("incrementalsnapshot: Deps must not be nil")
+	}
+	return nil
+}

--- a/internal/replication/incrementalsnapshot/state.go
+++ b/internal/replication/incrementalsnapshot/state.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/state.go
+++ b/internal/replication/incrementalsnapshot/state.go
@@ -16,7 +16,12 @@ import (
 )
 
 // CurrentStateVersion contains the version of the state.
-const CurrentStateVersion = 1
+const CurrentStateVersion = 2
+
+// minSupportedStateVersion is the oldest layout a checkpoint may use. A
+// version 1 checkpoint carries no Tables, which Start treats as an unknown
+// table set. Refer to reconcileTables.
+const minSupportedStateVersion = 1
 
 // ErrUnsupportedStateVersion reports a checkpoint written by a build using a
 // different State layout.
@@ -32,6 +37,10 @@ type State struct {
 	LastSentPK      PrimaryKey `json:"last_sent_pk,omitempty"`
 	MaxPK           PrimaryKey `json:"max_pk,omitempty"`
 	RemainingTables []TableID  `json:"remaining_tables,omitempty"`
+	// Tables is every table this run covers, the finished ones included. It
+	// is what makes a table added to the config afterwards recognisable as
+	// new. Version 1 checkpoints omit it.
+	Tables []TableID `json:"tables,omitempty"`
 }
 
 // UnmarshalJSON decodes a checkpoint, keeping integer keys exact.
@@ -61,8 +70,8 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	narrowPrimaryKey(s.LastSentPK)
 	narrowPrimaryKey(s.MaxPK)
 
-	if s.Version != CurrentStateVersion {
-		return fmt.Errorf("%w: got %d, want %d", ErrUnsupportedStateVersion, s.Version, CurrentStateVersion)
+	if s.Version < minSupportedStateVersion || s.Version > CurrentStateVersion {
+		return fmt.Errorf("%w: got %d, want %d..%d", ErrUnsupportedStateVersion, s.Version, minSupportedStateVersion, CurrentStateVersion)
 	}
 	return nil
 }
@@ -113,6 +122,9 @@ func (s *State) Clone() *State {
 	}
 	if s.RemainingTables != nil {
 		clone.RemainingTables = append([]TableID{}, s.RemainingTables...)
+	}
+	if s.Tables != nil {
+		clone.Tables = append([]TableID{}, s.Tables...)
 	}
 
 	return clone

--- a/internal/replication/incrementalsnapshot/state.go
+++ b/internal/replication/incrementalsnapshot/state.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// CurrentStateVersion contains the version of the state.
+const CurrentStateVersion = 1
+
+// ErrUnsupportedStateVersion reports a checkpoint written by a build using a
+// different State layout.
+var ErrUnsupportedStateVersion = errors.New("unsupported incremental snapshot state version")
+
+// State is a coordinator's resumable state, stored as a checkpoint. It holds
+// no watermark: a persisted one could be arbitrarily stale, so watermarks are
+// always re-derived on resume.
+type State struct {
+	Version         int        `json:"version"`
+	Done            bool       `json:"done"`
+	CurrentTable    *TableID   `json:"current_table,omitempty"`
+	LastSentPK      PrimaryKey `json:"last_sent_pk,omitempty"`
+	MaxPK           PrimaryKey `json:"max_pk,omitempty"`
+	RemainingTables []TableID  `json:"remaining_tables,omitempty"`
+}
+
+// UnmarshalJSON decodes a checkpoint, keeping integer keys exact.
+//
+// PrimaryKey is []any, so the stock decoder makes a float64 of every JSON
+// number and rounds anything above 2^53 -- ordinary for a bigint key.
+// Encoding is exact, so the damage only shows on resume: a MaxPK that rounds
+// down excludes rows from `pk <= max` for good, while a rounded LastSentPK
+// re-delivers them.
+//
+// UseNumber plus a conversion back to int64 fixes integer keys. A key too
+// large for int64, such as a wide NUMERIC, stays a lossy float64; that would
+// need a typed encoding.
+func (s *State) UnmarshalJSON(data []byte) error {
+	// Shadow type without this method, to avoid recursing.
+	type stateJSON State
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var raw stateJSON
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+
+	*s = State(raw)
+	narrowPrimaryKey(s.LastSentPK)
+	narrowPrimaryKey(s.MaxPK)
+
+	if s.Version != CurrentStateVersion {
+		return fmt.Errorf("%w: got %d, want %d", ErrUnsupportedStateVersion, s.Version, CurrentStateVersion)
+	}
+	return nil
+}
+
+// narrowPrimaryKey converts each json.Number back to the type the encoder
+// wrote, in place.
+func narrowPrimaryKey(pk PrimaryKey) {
+	for i, v := range pk {
+		num, ok := v.(json.Number)
+		if !ok {
+			continue
+		}
+		if intVal, err := num.Int64(); err == nil {
+			pk[i] = intVal
+			continue
+		}
+		if floatVal, err := num.Float64(); err == nil {
+			pk[i] = floatVal
+			continue
+		}
+		// Fits no number type. Keep the digits so a bad checkpoint fails
+		// loudly at query time rather than shifting the bound silently.
+		pk[i] = num.String()
+	}
+}
+
+// Clone returns a deep-enough copy: new slices and pointers, with PrimaryKey
+// elements copied by value since they are JSON scalars.
+func (s *State) Clone() *State {
+	if s == nil {
+		return nil
+	}
+
+	clone := &State{
+		Version: s.Version,
+		Done:    s.Done,
+	}
+
+	if s.CurrentTable != nil {
+		table := *s.CurrentTable
+		clone.CurrentTable = &table
+	}
+	if s.LastSentPK != nil {
+		clone.LastSentPK = append(PrimaryKey{}, s.LastSentPK...)
+	}
+	if s.MaxPK != nil {
+		clone.MaxPK = append(PrimaryKey{}, s.MaxPK...)
+	}
+	if s.RemainingTables != nil {
+		clone.RemainingTables = append([]TableID{}, s.RemainingTables...)
+	}
+
+	return clone
+}

--- a/internal/replication/incrementalsnapshot/state_test.go
+++ b/internal/replication/incrementalsnapshot/state_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/state_test.go
+++ b/internal/replication/incrementalsnapshot/state_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateRoundTripsBigintPrimaryKeysExactly(t *testing.T) {
+	const (
+		snowflake = int64(1234567890123456789)
+		justOver  = int64(1)<<53 + 1
+	)
+
+	state := &State{
+		Version:      CurrentStateVersion,
+		CurrentTable: &TableID{Schema: "public", Table: "events"},
+		LastSentPK:   PrimaryKey{snowflake},
+		MaxPK:        PrimaryKey{justOver},
+	}
+
+	encoded, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	var got State
+	require.NoError(t, json.Unmarshal(encoded, &got))
+
+	assert.Equal(t, snowflake, got.LastSentPK[0])
+	assert.Equal(t, justOver, got.MaxPK[0])
+}
+
+func TestStateUnmarshalPrimaryKeyElementTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want any
+	}{
+		{
+			// This case is the usual one. pgx makes an int64 or an int32
+			// from a Postgres integer. Both must return as an integer and
+			// not as a float.
+			name: "small integer stays integral",
+			raw:  `42`,
+			want: int64(42),
+		},
+		{
+			name: "negative integer",
+			raw:  `-42`,
+			want: int64(-42),
+		},
+		{
+			name: "max int64",
+			raw:  `9223372036854775807`,
+			want: int64(9223372036854775807),
+		},
+		{
+			// A composite key can hold text or a UUID. This defect never
+			// changed such a value, and the value must not change now.
+			name: "string passes through",
+			raw:  `"a7b3e6e4-0000-4000-8000-000000000000"`,
+			want: "a7b3e6e4-0000-4000-8000-000000000000",
+		},
+		{
+			name: "fractional falls back to float64",
+			raw:  `1.5`,
+			want: 1.5,
+		},
+		{
+			// Go has no exact integer type for a value above int64.
+			// Therefore this value is not exact. This test shows that the
+			// result is intentional.
+			name: "beyond int64 falls back to float64",
+			raw:  `18446744073709551615`,
+			want: float64(18446744073709551615),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got State
+			require.NoError(t, json.Unmarshal([]byte(`{"version":1,"max_pk":[`+test.raw+`]}`), &got))
+			require.Len(t, got.MaxPK, 1)
+			assert.Equal(t, test.want, got.MaxPK[0])
+		})
+	}
+}
+
+func TestStateUnmarshalCompositeAndAbsentKeys(t *testing.T) {
+	var got State
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"version":1,"done":false,"last_sent_pk":[1234567890123456789,"tenant-a"],"remaining_tables":[{"Schema":"public","Table":"orders"}]}`,
+	), &got))
+
+	assert.Equal(t, PrimaryKey{int64(1234567890123456789), "tenant-a"}, got.LastSentPK)
+	assert.Nil(t, got.MaxPK, "an absent key must stay nil, not become an empty slice")
+	assert.Equal(t, []TableID{{Schema: "public", Table: "orders"}}, got.RemainingTables)
+}
+
+func TestStateUnmarshalRejectsMalformedJSON(t *testing.T) {
+	var got State
+	require.Error(t, json.Unmarshal([]byte(`{"version":`), &got))
+}
+
+func TestStateUnmarshalDoneCheckpoint(t *testing.T) {
+	// State returns this value after the snapshot of each table is
+	// complete.
+	var got State
+	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"done":true}`), &got))
+
+	assert.True(t, got.Done)
+	assert.Equal(t, CurrentStateVersion, got.Version)
+	assert.Nil(t, got.CurrentTable)
+}
+
+func TestStateUnmarshalRejectsForeignVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"newer version", `{"version":2,"last_sent_pk":[42]}`},
+		{"older version", `{"version":0,"last_sent_pk":[42]}`},
+		{"version absent", `{"last_sent_pk":[42]}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got State
+			err := json.Unmarshal([]byte(test.raw), &got)
+			require.ErrorIs(t, err, ErrUnsupportedStateVersion)
+		})
+	}
+}
+
+func TestStateUnmarshalAcceptsCurrentVersion(t *testing.T) {
+	var got State
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, `{"version":%d,"done":true}`, CurrentStateVersion), &got))
+	assert.True(t, got.Done)
+}

--- a/internal/replication/incrementalsnapshot/state_test.go
+++ b/internal/replication/incrementalsnapshot/state_test.go
@@ -116,11 +116,24 @@ func TestStateUnmarshalDoneCheckpoint(t *testing.T) {
 	// State returns this value after the snapshot of each table is
 	// complete.
 	var got State
-	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"done":true}`), &got))
+	require.NoError(t, json.Unmarshal(fmt.Appendf(nil, `{"version":%d,"done":true}`, CurrentStateVersion), &got))
 
 	assert.True(t, got.Done)
 	assert.Equal(t, CurrentStateVersion, got.Version)
 	assert.Nil(t, got.CurrentTable)
+}
+
+// TestStateUnmarshalAcceptsVersion1: a checkpoint written before Tables
+// existed must still load, or an upgrade would restart every backfill. It
+// carries no table set, which Start makes safe by counting every configured
+// table as known.
+func TestStateUnmarshalAcceptsVersion1(t *testing.T) {
+	var got State
+	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"last_sent_pk":[42],"remaining_tables":[{"schema":"public","table":"b"}]}`), &got))
+
+	assert.Equal(t, 1, got.Version)
+	assert.Equal(t, PrimaryKey{int64(42)}, got.LastSentPK)
+	assert.Nil(t, got.Tables)
 }
 
 func TestStateUnmarshalRejectsForeignVersion(t *testing.T) {
@@ -128,7 +141,7 @@ func TestStateUnmarshalRejectsForeignVersion(t *testing.T) {
 		name string
 		raw  string
 	}{
-		{"newer version", `{"version":2,"last_sent_pk":[42]}`},
+		{"newer version", `{"version":3,"last_sent_pk":[42]}`},
 		{"older version", `{"version":0,"last_sent_pk":[42]}`},
 		{"version absent", `{"last_sent_pk":[42]}`},
 	}

--- a/internal/replication/incrementalsnapshot/types.go
+++ b/internal/replication/incrementalsnapshot/types.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 // Package incrementalsnapshot backfills database tables in key-ordered,
 // key-bounded chunks while a replication stream runs, dropping each buffered

--- a/internal/replication/incrementalsnapshot/types.go
+++ b/internal/replication/incrementalsnapshot/types.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+// Package incrementalsnapshot backfills database tables in key-ordered,
+// key-bounded chunks while a replication stream runs, dropping each buffered
+// row the stream has already delivered.
+//
+// Coordinator holds the algorithm. Everything database-specific is injected:
+// side effects through Deps, window comparisons through Watermark. The
+// package therefore needs no database driver.
+//
+// A component for one database supplies a Deps and a Watermark, and usually
+// aliases Coordinator to its own position and watermark types to keep the
+// type arguments out of its call sites.
+package incrementalsnapshot
+
+import "fmt"
+
+// TableID identifies a table by schema and name.
+type TableID struct {
+	Schema string
+	Table  string
+}
+
+// String returns the TableID as "schema.table".
+func (t TableID) String() string {
+	return fmt.Sprintf("%s.%s", t.Schema, t.Table)
+}
+
+// PrimaryKey is one key value, with an element per key column in column
+// order. A composite key has more than one element.
+type PrimaryKey []any
+
+// Row is one row the snapshot read, with the metadata the caller needs to
+// turn it into a change event.
+type Row struct {
+	Table TableID
+	PK    PrimaryKey
+	Data  map[string]any
+	// ColumnSchema is opaque here. Callers may attach whatever schema
+	// metadata they need to decode Data later.
+	ColumnSchema any
+}

--- a/internal/replication/incrementalsnapshot/watermark.go
+++ b/internal/replication/incrementalsnapshot/watermark.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/watermark.go
+++ b/internal/replication/incrementalsnapshot/watermark.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+// Watermark shows which transactions were in flight at one instant. The
+// coordinator reads one either side of a chunk read and compares the pair
+// with each streamed commit to decide when the chunk can be emitted.
+//
+// P is the database's position type: whatever identifies and orders a
+// committed transaction, such as a Postgres xid, a MySQL GTID or an Oracle
+// SCN.
+//
+// Every method runs once per streamed commit, so each must be fast, must not
+// change state, and must not panic on the zero value. Implementations must be
+// comparable, because the coordinator compares a chunk's two watermarks for
+// equality.
+type Watermark[P any] interface {
+	comparable
+
+	// OpensAt reports whether pos started at or after this watermark, meaning
+	// everything the watermark could not see has had time to stream.
+	OpensAt(pos P) bool
+
+	// ClosesAt reports whether pos follows every transaction in flight at
+	// this watermark. Both watermarks must agree before a chunk is emitted.
+	ClosesAt(pos P) bool
+
+	// Quiesced reports whether nothing at all was in flight. An equal,
+	// quiesced pair proves no transaction could have touched the chunk during
+	// the read, which is what lets Coordinator drain it immediately.
+	Quiesced() bool
+}

--- a/internal/replication/incrementalsnapshot/window.go
+++ b/internal/replication/incrementalsnapshot/window.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"fmt"
+	"strings"
+)
+
+// windowKey identifies a buffered row by table and key, joining their text
+// forms with a separator that will not occur in the scalar key values this
+// package targets.
+type windowKey string
+
+const windowKeySeparator = "\x1f"
+
+func newWindowKey(table TableID, pk PrimaryKey) windowKey {
+	var b strings.Builder
+	b.WriteString(table.String())
+	for _, v := range pk {
+		b.WriteString(windowKeySeparator)
+		fmt.Fprintf(&b, "%v", v)
+	}
+	return windowKey(b.String())
+}
+
+// WindowBuffer is an ordered, deduplicated buffer of Rows keyed by (table,
+// key). Remove is O(1) and preserves the order of the remaining rows; Flush
+// returns them in insertion order.
+type WindowBuffer struct {
+	rows    []Row
+	indexOf map[windowKey]int
+	// deleted marks the slots Remove has vacated, and live counts the rest.
+	//
+	// Remove runs on the caller's replication loop for every streamed row on
+	// a snapshotted table, so it must not re-index indexOf or shift rows: a
+	// chunk drained row by row would then cost O(len(rows)^2), enough at a
+	// large chunk size to stall that loop past the server's timeout. Marking
+	// the slot instead leaves the compaction to Flush, which runs once.
+	deleted []bool
+	live    int
+}
+
+// NewWindowBuffer returns an empty WindowBuffer.
+func NewWindowBuffer() *WindowBuffer {
+	return &WindowBuffer{
+		indexOf: make(map[windowKey]int),
+	}
+}
+
+// Add puts a row at the end of the buffer. If the buffer already holds that
+// key, the new row replaces it and keeps the later position.
+func (w *WindowBuffer) Add(row Row) {
+	key := newWindowKey(row.Table, row.PK)
+	if idx, exists := w.indexOf[key]; exists {
+		w.deleted[idx] = true
+		w.live--
+	}
+	w.indexOf[key] = len(w.rows)
+	w.rows = append(w.rows, row)
+	w.deleted = append(w.deleted, false)
+	w.live++
+}
+
+// Remove excises the row for table and pk, reporting whether it was there.
+func (w *WindowBuffer) Remove(table TableID, pk PrimaryKey) bool {
+	key := newWindowKey(table, pk)
+	idx, exists := w.indexOf[key]
+	if !exists {
+		return false
+	}
+
+	delete(w.indexOf, key)
+	w.deleted[idx] = true
+	w.live--
+	return true
+}
+
+// Flush returns the buffered rows in insertion order and empties the buffer.
+func (w *WindowBuffer) Flush() []Row {
+	rows := w.rows
+	if w.live < len(rows) {
+		compacted := make([]Row, 0, w.live)
+		for i, row := range rows {
+			if !w.deleted[i] {
+				compacted = append(compacted, row)
+			}
+		}
+		rows = compacted
+	}
+
+	w.rows = nil
+	w.deleted = nil
+	w.live = 0
+	w.indexOf = make(map[windowKey]int)
+	return rows
+}
+
+// Len returns the number of rows in the buffer, excluding removed ones.
+func (w *WindowBuffer) Len() int {
+	return w.live
+}

--- a/internal/replication/incrementalsnapshot/window.go
+++ b/internal/replication/incrementalsnapshot/window.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/window_test.go
+++ b/internal/replication/incrementalsnapshot/window_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+// https://github.com/redpanda-data/connect/blob/main/licenses/rcl.md
 
 package incrementalsnapshot
 

--- a/internal/replication/incrementalsnapshot/window_test.go
+++ b/internal/replication/incrementalsnapshot/window_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/connect/v4/blob/main/licenses/rcl.md
+
+package incrementalsnapshot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowBufferInsertionOrderPreserved(t *testing.T) {
+	table := TableID{Schema: "public", Table: "orders"}
+	w := NewWindowBuffer()
+
+	rows := []Row{
+		{Table: table, PK: PrimaryKey{1}, Data: map[string]any{"v": "a"}},
+		{Table: table, PK: PrimaryKey{2}, Data: map[string]any{"v": "b"}},
+		{Table: table, PK: PrimaryKey{3}, Data: map[string]any{"v": "c"}},
+	}
+	for _, r := range rows {
+		w.Add(r)
+	}
+
+	require.Equal(t, len(rows), w.Len())
+	assert.Equal(t, rows, w.Flush())
+}
+
+func TestWindowBufferRemoveAbsentIsNoop(t *testing.T) {
+	table := TableID{Schema: "public", Table: "orders"}
+	w := NewWindowBuffer()
+	w.Add(Row{Table: table, PK: PrimaryKey{1}})
+
+	removed := w.Remove(table, PrimaryKey{999})
+	assert.False(t, removed)
+	assert.Equal(t, 1, w.Len())
+}
+
+func TestWindowBufferFlushClearsBuffer(t *testing.T) {
+	table := TableID{Schema: "public", Table: "orders"}
+	w := NewWindowBuffer()
+	w.Add(Row{Table: table, PK: PrimaryKey{1}})
+
+	first := w.Flush()
+	assert.Len(t, first, 1)
+
+	second := w.Flush()
+	assert.Empty(t, second)
+	assert.Equal(t, 0, w.Len())
+}
+
+func TestWindowBufferCompositePrimaryKeys(t *testing.T) {
+	table := TableID{Schema: "public", Table: "orders"}
+	w := NewWindowBuffer()
+
+	rowA := Row{Table: table, PK: PrimaryKey{1, "a"}, Data: map[string]any{"v": "row-a"}}
+	rowB := Row{Table: table, PK: PrimaryKey{1, "b"}, Data: map[string]any{"v": "row-b"}}
+	w.Add(rowA)
+	w.Add(rowB)
+
+	removed := w.Remove(table, PrimaryKey{1, "a"})
+	assert.True(t, removed)
+	assert.Equal(t, 1, w.Len())
+
+	remaining := w.Flush()
+	require.Len(t, remaining, 1)
+	assert.Equal(t, rowB, remaining[0])
+}
+
+func TestWindowBufferRemoveMiddlePreservesOrderOfRest(t *testing.T) {
+	table := TableID{Schema: "public", Table: "orders"}
+	w := NewWindowBuffer()
+
+	rowA := Row{Table: table, PK: PrimaryKey{1}}
+	rowB := Row{Table: table, PK: PrimaryKey{2}}
+	rowC := Row{Table: table, PK: PrimaryKey{3}}
+	w.Add(rowA)
+	w.Add(rowB)
+	w.Add(rowC)
+
+	require.True(t, w.Remove(table, PrimaryKey{2}))
+
+	assert.Equal(t, []Row{rowA, rowC}, w.Flush())
+}
+
+func TestWindowBufferDifferentTablesSamePKAreDistinct(t *testing.T) {
+	tableA := TableID{Schema: "public", Table: "orders"}
+	tableB := TableID{Schema: "public", Table: "customers"}
+	w := NewWindowBuffer()
+
+	rowA := Row{Table: tableA, PK: PrimaryKey{1}}
+	rowB := Row{Table: tableB, PK: PrimaryKey{1}}
+	w.Add(rowA)
+	w.Add(rowB)
+
+	require.True(t, w.Remove(tableA, PrimaryKey{1}))
+	remaining := w.Flush()
+	require.Len(t, remaining, 1)
+	assert.Equal(t, rowB, remaining[0])
+}
+
+func TestWindowBufferRemoveKeepsOrder(t *testing.T) {
+	// Removal marks a slot rather than shifting the slice, so Flush has to
+	// compact while preserving insertion order.
+	table := TableID{Schema: "public", Table: "a"}
+	w := NewWindowBuffer()
+	for pk := 1; pk <= 6; pk++ {
+		w.Add(Row{Table: table, PK: PrimaryKey{pk}})
+	}
+
+	// Take one from each end and two from the middle.
+	for _, pk := range []int{1, 3, 4, 6} {
+		require.True(t, w.Remove(table, PrimaryKey{pk}))
+	}
+	assert.Equal(t, 2, w.Len())
+
+	flushed := w.Flush()
+	require.Len(t, flushed, 2)
+	assert.Equal(t, PrimaryKey{2}, flushed[0].PK)
+	assert.Equal(t, PrimaryKey{5}, flushed[1].PK)
+	assert.Zero(t, w.Len(), "Flush must empty the buffer")
+}
+
+func TestWindowBufferRemoveEveryRow(t *testing.T) {
+	table := TableID{Schema: "public", Table: "a"}
+	w := NewWindowBuffer()
+	for pk := 1; pk <= 3; pk++ {
+		w.Add(Row{Table: table, PK: PrimaryKey{pk}})
+	}
+	for pk := 1; pk <= 3; pk++ {
+		require.True(t, w.Remove(table, PrimaryKey{pk}))
+	}
+
+	assert.Zero(t, w.Len())
+	assert.Empty(t, w.Flush())
+}
+
+func TestWindowBufferAddReplacesExistingKey(t *testing.T) {
+	// A repeated key must not leave the earlier row behind to be emitted as
+	// well, since the buffer holds one row per key.
+	table := TableID{Schema: "public", Table: "a"}
+	w := NewWindowBuffer()
+	w.Add(Row{Table: table, PK: PrimaryKey{1}, Data: map[string]any{"v": "first"}})
+	w.Add(Row{Table: table, PK: PrimaryKey{2}})
+	w.Add(Row{Table: table, PK: PrimaryKey{1}, Data: map[string]any{"v": "second"}})
+
+	assert.Equal(t, 2, w.Len())
+	flushed := w.Flush()
+	require.Len(t, flushed, 2)
+	assert.Equal(t, PrimaryKey{2}, flushed[0].PK)
+	assert.Equal(t, PrimaryKey{1}, flushed[1].PK)
+	assert.Equal(t, "second", flushed[1].Data["v"])
+}
+
+func TestWindowBufferAddAfterRemoveSameKey(t *testing.T) {
+	// The stream can evict a key that a later chunk then re-reads.
+	table := TableID{Schema: "public", Table: "a"}
+	w := NewWindowBuffer()
+	w.Add(Row{Table: table, PK: PrimaryKey{1}})
+	require.True(t, w.Remove(table, PrimaryKey{1}))
+	w.Add(Row{Table: table, PK: PrimaryKey{1}})
+
+	assert.Equal(t, 1, w.Len())
+	require.True(t, w.Remove(table, PrimaryKey{1}), "the re-added row must be removable")
+	assert.Zero(t, w.Len())
+}
+
+// BenchmarkWindowBufferDrainChunk drains a full chunk one row at a time,
+// which is what a table under sustained write load does during its backfill.
+// Removal must not depend on the chunk size.
+func BenchmarkWindowBufferDrainChunk(b *testing.B) {
+	table := TableID{Schema: "public", Table: "a"}
+	for _, size := range []int{1024, 16384, 100000} {
+		b.Run(fmt.Sprintf("chunk=%d", size), func(b *testing.B) {
+			for b.Loop() {
+				w := NewWindowBuffer()
+				for pk := range size {
+					w.Add(Row{Table: table, PK: PrimaryKey{pk}})
+				}
+				for pk := range size {
+					w.Remove(table, PrimaryKey{pk})
+				}
+				w.Flush()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `internal/replication/incrementalsnapshot`, a database-agnostic implementation of watermark-based incremental (chunked) snapshotting.

This is the first of two stacked PRs; it contains only the shared package, with no connector wired to it yet. The PostgreSQL implementation that uses it is stacked on top in #4781.

### How it works

The `Coordinator` drives the DBLog algorithm. For each chunk it:

1. reads a **low watermark** - the database's transaction visibility state,
2. reads a chunk of rows bounded by primary key into a buffer,
3. reads a **high watermark**.

Those two readings bracket the read, so any transaction that could have modified the chunk has an id between them. While the window is open, each streamed change evicts its own row from the buffer, so the live value always wins. Once a commit arrives past both readings every racing transaction has been seen, and whatever survives in the buffer is released as a set of read events.

### What is in the package

| File | Contents |
|---|---|
| `coordinator.go` | The algorithm: chunk planning, window open/close, the drain loop, resume |
| `window.go` | The dedup buffer. `Remove` is O(1) via tombstones, because it runs on the caller's replication loop for every streamed row |
| `watermark.go` | The `Watermark[P]` interface a connector implements: `OpensAt`, `ClosesAt`, `Quiesced` |
| `deps.go` | The side-effecting operations a connector supplies, plus `CoordinatorConfig` |
| `state.go` | The versioned, JSON-serialised checkpoint |
| `types.go` | `TableID`, `PrimaryKey`, `Row` |

### Why it is generic

`Coordinator[P any, W Watermark[P]]` is parameterised over the position type a connector reads from its replication stream and the watermark type that brackets a read. A connector supplies its own bounds and queries and reuses the algorithm; Postgres pins these to `uint32` (the xid `pgoutput` reports on `BEGIN`) and its own `Watermark`.

The package has no driver dependency - stdlib and testify only - so the next CDC connector to want incremental snapshotting implements the two interfaces rather than the algorithm.
