### PR TITLE
redis: fix failing ci test

### DIFF
--- a/internal/impl/redis/cache_integration_test.go
+++ b/internal/impl/redis/cache_integration_test.go
@@ -202,6 +202,7 @@ func TestIntegrationRedisFailoverCache(t *testing.T) {
 			hc.ExtraHosts = []string{"host.docker.internal:host-gateway"}
 		}),
 		testcontainers.WithEnv(map[string]string{
+			"ALLOW_EMPTY_PASSWORD":         "yes",
 			"REDIS_SENTINEL_ANNOUNCE_IP":   "127.0.0.1",
 			"REDIS_SENTINEL_ANNOUNCE_PORT": strconv.Itoa(sentinelPort),
 			"REDIS_SENTINEL_QUORUM":        "1",


### PR DESCRIPTION
Small fix for a failing `redis` test that only fails in CI (for Linux only):

### Proof of Work

https://github.com/redpanda-data/connect/actions/runs/34467080549

<img width="988" height="637" alt="image" src="https://github.com/user-attachments/assets/4178d7ae-148d-4ad3-8225-9ed9395bbdec" />
