### PR TITLE
iceberg: share one container stack across the integration tests

### DIFF
--- a/internal/impl/iceberg/integration/catalogx_integration_test.go
+++ b/internal/impl/iceberg/integration/catalogx_integration_test.go
@@ -267,6 +267,7 @@ func TestCatalogxIntegration(t *testing.T) {
 
 		t.Run("CreateNamespace", func(t *testing.T) {
 			newNamespace := "test_create_namespace"
+			infra.EnsureNamespaceAbsent(t, newNamespace)
 
 			client, err := catalogx.NewCatalogClient(ctx, catalogx.Config{
 				URL:      infra.RestURL,

--- a/internal/impl/iceberg/integration/catalogx_integration_test.go
+++ b/internal/impl/iceberg/integration/catalogx_integration_test.go
@@ -31,9 +31,10 @@ import (
 
 func TestCatalogxIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	namespaceName := "catalogx_test"
 	infra.CreateNamespace(t, namespaceName)

--- a/internal/impl/iceberg/integration/connector_integration_test.go
+++ b/internal/impl/iceberg/integration/connector_integration_test.go
@@ -23,9 +23,10 @@ import (
 
 func TestConnectorIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const namespace = "connector_test"
 	infra.CreateNamespace(t, namespace)

--- a/internal/impl/iceberg/integration/cow_delete_and_move_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_delete_and_move_integration_test.go
@@ -36,8 +36,9 @@ import (
 // invariant of zero delete-content manifests. DuckDB confirms the surviving row.
 func TestCOWDeleteOnlyBatchIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_delonly_ns", "cow_delonly_test"
 	infra.CreateNamespace(t, ns)
@@ -94,8 +95,9 @@ func TestCOWDeleteOnlyBatchIntegration(t *testing.T) {
 // partitions and re-appends it routed by its new partition value.
 func TestCOWCrossPartitionKeyMoveIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_move_ns", "cow_move_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_format_version_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_format_version_integration_test.go
@@ -42,8 +42,9 @@ import (
 // and there are zero delete files.
 func TestCOWFormatVersion1Integration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_v1_ns", "cow_v1_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_multifile_composite_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_multifile_composite_integration_test.go
@@ -40,8 +40,9 @@ import (
 // (zero delete manifests + overwrite operation).
 func TestCOWMultiFileAndCompositeIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	newRouter := func(t *testing.T, ns, tbl string, idFields ...string) *icebergimpl.Router {
 		operation, err := service.NewInterpolatedString(`${! meta("op") }`)

--- a/internal/impl/iceberg/integration/cow_nested_schema_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_nested_schema_integration_test.go
@@ -45,8 +45,9 @@ import (
 // reader.
 func TestCOWNestedSchemaIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_nested_ns", "cow_nested_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_partitioned_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_partitioned_integration_test.go
@@ -44,9 +44,10 @@ import (
 //     append).
 func TestCOWPartitionedRowOperationsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_part_ns", "cow_part_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_row_operation_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_row_operation_integration_test.go
@@ -64,6 +64,7 @@ func TestCOWRowOperationsIntegration(t *testing.T) {
 	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_row_ops_ns", "cow_row_ops_test"
+	infra.EnsureNamespaceAbsent(t, ns)
 
 	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
 	require.NoError(t, err)

--- a/internal/impl/iceberg/integration/cow_row_operation_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_row_operation_integration_test.go
@@ -58,9 +58,10 @@ func countManifestsByContent(t *testing.T, ctx context.Context, tbl *table.Table
 // equality-delete manifests, so this assertion is what distinguishes the two.
 func TestCOWRowOperationsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_row_ops_ns", "cow_row_ops_test"
 

--- a/internal/impl/iceberg/integration/cow_row_operation_types_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_row_operation_types_integration_test.go
@@ -72,8 +72,9 @@ func assertCOWSnapshot(t *testing.T, ctx context.Context, infra *testInfrastruct
 // are intentionally not exercised as keys here.
 func TestCOWRowOperationKeyTypesIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 	const ns = "cow_keytypes"
 	infra.CreateNamespace(t, ns)
 

--- a/internal/impl/iceberg/integration/cow_schema_evolution_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_schema_evolution_integration_test.go
@@ -38,8 +38,9 @@ import (
 //   - zero delete files and the mutation committed as an overwrite.
 func TestCOWSchemaEvolutionIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_evo_ns", "cow_evo_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_temporal_data_column_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_temporal_data_column_integration_test.go
@@ -48,8 +48,9 @@ import (
 //     TIMESTAMP WITH TIME ZONE), proving the annotation is honoured on read.
 func TestCOWTemporalDataColumnIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "cow_temporal_datacol_ns", "cow_temporal_datacol_test"
 	infra.CreateNamespace(t, ns)

--- a/internal/impl/iceberg/integration/cow_transform_partition_integration_test.go
+++ b/internal/impl/iceberg/integration/cow_transform_partition_integration_test.go
@@ -45,9 +45,10 @@ import (
 // only possible under copy-on-write.
 func TestCOWPartitionTransformExtrasIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	// t15/t16/t17/t18 are distinct days within Jan 2024; m1/m2/m3 are distinct
 	// months. Seeds pass timestamps as numeric microseconds (the append/shredder

--- a/internal/impl/iceberg/integration/integration_test.go
+++ b/internal/impl/iceberg/integration/integration_test.go
@@ -22,9 +22,10 @@ import (
 
 func TestIntegrationIcebergRESTWithMinIO(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	namespaceName := "test_ns"
 	infra.CreateNamespace(t, namespaceName)

--- a/internal/impl/iceberg/integration/main_test.go
+++ b/internal/impl/iceberg/integration/main_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+package iceberg
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+)
+
+// TestMain terminates the shared test infrastructure, if a test started it,
+// after the package's tests complete. It must live in a _test.go file: the go
+// test harness only looks for TestMain in test files.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedInfra != nil {
+		if err := sharedInfra.Terminate(context.Background()); err != nil {
+			log.Printf("terminating shared test infrastructure: %v", err)
+			if code == 0 {
+				code = 1
+			}
+		}
+	}
+	os.Exit(code)
+}

--- a/internal/impl/iceberg/integration/numeric_precision_test.go
+++ b/internal/impl/iceberg/integration/numeric_precision_test.go
@@ -28,9 +28,10 @@ import (
 // customer escalation where financial fields defaulted to DOUBLE.
 func TestNumericPrecisionIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	t.Run("TypedIntegersMapToCorrectColumnTypes", func(t *testing.T) {
 		const ns = "numeric_types_ns"

--- a/internal/impl/iceberg/integration/numeric_precision_test.go
+++ b/internal/impl/iceberg/integration/numeric_precision_test.go
@@ -36,6 +36,7 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 	t.Run("TypedIntegersMapToCorrectColumnTypes", func(t *testing.T) {
 		const ns = "numeric_types_ns"
 		const tbl = "numeric_types_table"
+		infra.EnsureNamespaceAbsent(t, ns)
 
 		router := infra.NewRouter(t, ns, tbl,
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
@@ -69,6 +70,7 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 	t.Run("Int64ValuesPreservePrecision", func(t *testing.T) {
 		const ns = "precision_ns"
 		const tbl = "precision_table"
+		infra.EnsureNamespaceAbsent(t, ns)
 
 		router := infra.NewRouter(t, ns, tbl,
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
@@ -103,6 +105,7 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 	t.Run("NestedStructs", func(t *testing.T) {
 		const ns = "nested_ns"
 		const tbl = "nested_table"
+		infra.EnsureNamespaceAbsent(t, ns)
 
 		router := infra.NewRouter(t, ns, tbl,
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
@@ -160,6 +163,7 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 		// Auto-create table, then write messages where some nested fields are absent.
 		const ns = "nullable_nested_ns"
 		const tbl = "nullable_nested_table"
+		infra.EnsureNamespaceAbsent(t, ns)
 
 		router := infra.NewRouter(t, ns, tbl,
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))
@@ -208,6 +212,7 @@ func TestNumericPrecisionIntegration(t *testing.T) {
 	t.Run("SchemaEvolution_NewIntegerColumn", func(t *testing.T) {
 		const ns = "evo_int_ns"
 		const tbl = "evo_int_table"
+		infra.EnsureNamespaceAbsent(t, ns)
 
 		router := infra.NewRouter(t, ns, tbl,
 			WithSchemaEvolution(icebergimpl.SchemaEvolutionConfig{Enabled: true}))

--- a/internal/impl/iceberg/integration/row_operation_integration_test.go
+++ b/internal/impl/iceberg/integration/row_operation_integration_test.go
@@ -42,6 +42,7 @@ func TestRowOperationsIntegration(t *testing.T) {
 	infra := setupTestInfra(t)
 
 	const ns, tbl = "row_ops_ns", "row_ops_test"
+	infra.EnsureNamespaceAbsent(t, ns)
 
 	operation, err := service.NewInterpolatedString(`${! meta("op") }`)
 	require.NoError(t, err)

--- a/internal/impl/iceberg/integration/row_operation_integration_test.go
+++ b/internal/impl/iceberg/integration/row_operation_integration_test.go
@@ -36,9 +36,10 @@ func opMsg(t *testing.T, op, body string) *service.Message {
 // the upserted row wins (no duplicate) and the deleted row is gone.
 func TestRowOperationsIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tbl = "row_ops_ns", "row_ops_test"
 

--- a/internal/impl/iceberg/integration/row_operation_types_integration_test.go
+++ b/internal/impl/iceberg/integration/row_operation_types_integration_test.go
@@ -82,8 +82,8 @@ func keyRoundTrip(t *testing.T, infra *testInfrastructure, ns, tbl string, keyTy
 
 func TestRowOperationKeyTypesIntegration(t *testing.T) {
 	integration.CheckSkip(t)
-	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	t.Parallel()
+	infra := setupTestInfra(t)
 	const ns = "row_op_keytypes"
 	infra.CreateNamespace(t, ns)
 
@@ -119,8 +119,9 @@ func TestRowOperationKeyTypesIntegration(t *testing.T) {
 // TestRowOperationCompositeKeyIntegration verifies a multi-column identifier.
 func TestRowOperationCompositeKeyIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 	const ns, tbl = "row_op_composite", "ck"
 	infra.CreateNamespace(t, ns)
 
@@ -170,8 +171,9 @@ func TestRowOperationCompositeKeyIntegration(t *testing.T) {
 // deletes route to the correct partition and match the intended rows.
 func TestRowOperationPartitionedIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 	const ns, tbl = "row_op_partitioned", "p"
 	infra.CreateNamespace(t, ns)
 
@@ -224,8 +226,9 @@ func TestRowOperationPartitionedIntegration(t *testing.T) {
 // upserts of the same key in one batch must leave a single (latest) row.
 func TestRowOperationBatchCollapseIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 	const ns, tbl = "row_op_collapse", "c"
 	infra.CreateNamespace(t, ns)
 

--- a/internal/impl/iceberg/integration/schema_evolution_test.go
+++ b/internal/impl/iceberg/integration/schema_evolution_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestSchemaEvolutionIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	t.Run("AutoCreateNamespaceAndTable", func(t *testing.T) {
 		router := infra.NewRouter(t, "auto_create_ns", "auto_create_table",

--- a/internal/impl/iceberg/integration/schema_metadata_timestamp_test.go
+++ b/internal/impl/iceberg/integration/schema_metadata_timestamp_test.go
@@ -50,9 +50,10 @@ import (
 // (not BIGINT) and the value must round-trip to the correct calendar date.
 func TestIntegrationSchemaMetadataDrivesTimestampColumn(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const namespace = "schema_meta_timestamp"
 	infra.CreateNamespace(t, namespace)
@@ -159,9 +160,10 @@ func TestIntegrationSchemaMetadataDrivesTimestampColumn(t *testing.T) {
 // directly (covered by the test above).
 func TestIntegrationCoerceTemporalIntoExistingBigintColumn(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const namespace = "coerce_existing_bigint"
 	const tableName = "events_existing_bigint"
@@ -241,9 +243,10 @@ func TestIntegrationCoerceTemporalIntoExistingBigintColumn(t *testing.T) {
 // flag.
 func TestIntegrationStrictModeRejectsCoerceOnExistingBigintColumn(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const namespace = "coerce_strict_reject"
 	const tableName = "events_strict_bigint"

--- a/internal/impl/iceberg/integration/test_helpers.go
+++ b/internal/impl/iceberg/integration/test_helpers.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -56,6 +57,9 @@ var (
 	sharedInfraOnce sync.Once
 	sharedInfra     *testInfrastructure
 	sharedInfraErr  error
+
+	// catalogMu ensures there no data race between catalog operations and DuckDB queries
+	catalogMu sync.RWMutex
 )
 
 // setupTestInfra returns the package-wide MinIO + iceberg-rest-fixture +
@@ -447,9 +451,14 @@ func (infra *testInfrastructure) createBucket(ctx context.Context, bucket string
 	return nil
 }
 
-// CreateNamespace creates a namespace in the Iceberg REST catalog.
+// CreateNamespace creates an empty namespace in the Iceberg REST catalog.
+// The catalog is shared by every test in the process, so a namespace left
+// behind by an earlier run (for example with go test -count=2) is dropped
+// first, together with its tables. Each test owns a distinct namespace, so
+// this is safe under t.Parallel.
 func (infra *testInfrastructure) CreateNamespace(t *testing.T, namespace string) {
 	t.Helper()
+	infra.EnsureNamespaceAbsent(t, namespace)
 
 	body := `{"namespace": ["` + namespace + `"]}`
 	resp, err := http.Post(infra.RestURL+"/v1/namespaces", "application/json", strings.NewReader(body))
@@ -460,12 +469,60 @@ func (infra *testInfrastructure) CreateNamespace(t *testing.T, namespace string)
 		"create namespace failed: %d", resp.StatusCode)
 }
 
+// EnsureNamespaceAbsent gives a test a clean slate in the shared catalog. It
+// purges every table in the namespace and then drops the namespace itself, so
+// state left behind by an earlier run (for example with go test -count=2) does
+// not leak into this one. A namespace that does not exist is not an error.
+func (infra *testInfrastructure) EnsureNamespaceAbsent(t *testing.T, namespace string) {
+	t.Helper()
+	catalogMu.Lock()
+	defer catalogMu.Unlock()
+
+	nsURL := infra.RestURL + "/v1/namespaces/" + url.PathEscape(namespace)
+
+	resp, err := http.Get(nsURL + "/tables")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return
+	}
+	require.Equal(t, http.StatusOK, resp.StatusCode, "list tables in namespace %q failed", namespace)
+
+	var listed struct {
+		Identifiers []struct {
+			Name string `json:"name"`
+		} `json:"identifiers"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&listed))
+
+	for _, id := range listed.Identifiers {
+		restDelete(t, nsURL+"/tables/"+url.PathEscape(id.Name)+"?purgeRequested=true")
+	}
+	restDelete(t, nsURL)
+}
+
+// restDelete sends a DELETE to the REST catalog. A 404 is not an error, so
+// the call is safe to repeat.
+func restDelete(t *testing.T, target string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, target, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.True(t, resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound,
+		"DELETE %s failed: %d", target, resp.StatusCode)
+}
+
 // ExecSQL executes SQL in the DuckDB container and returns the output.
 func (infra *testInfrastructure) ExecSQL(ctx context.Context, sql string) (string, error) {
 	if infra.duckdbContainer == nil {
 		return "", errors.New("duckdb container not started")
 	}
 
+	catalogMu.RLock()
+	defer catalogMu.RUnlock()
 	exitCode, reader, err := infra.duckdbContainer.Exec(ctx, []string{"/duckdb", "-json", "-c", sql})
 	if err != nil {
 		return "", fmt.Errorf("executing duckdb: %w", err)

--- a/internal/impl/iceberg/integration/test_helpers.go
+++ b/internal/impl/iceberg/integration/test_helpers.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -103,16 +102,6 @@ func setupTestInfra(t *testing.T) *testInfrastructure {
 	require.NoError(t, sharedInfraErr)
 
 	return sharedInfra
-}
-
-// TestMain terminates the shared test infrastructure (if it was started)
-// after the package's tests complete.
-func TestMain(m *testing.M) {
-	code := m.Run()
-	if sharedInfra != nil {
-		_ = sharedInfra.Terminate(context.Background())
-	}
-	os.Exit(code)
 }
 
 // CatalogConfig returns a catalogx.Config pre-populated with MinIO/REST

--- a/internal/impl/iceberg/integration/test_helpers.go
+++ b/internal/impl/iceberg/integration/test_helpers.go
@@ -14,8 +14,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
@@ -49,14 +53,66 @@ type testInfrastructure struct {
 	RestInternalURL  string // Endpoint for containers to reach REST catalog (via Docker network)
 }
 
-// setupTestInfra starts all containers, creates the warehouse bucket, and
-// registers cleanup. This is the single entry point for all integration tests.
-func setupTestInfra(t *testing.T, ctx context.Context) *testInfrastructure {
+var (
+	sharedInfraOnce sync.Once
+	sharedInfra     *testInfrastructure
+	sharedInfraErr  error
+)
+
+// setupTestInfra returns the package-wide MinIO + iceberg-rest-fixture +
+// DuckDB stack, starting it on first use.
+//
+// A fresh three-container stack per test costs about 15s to boot. With 27
+// tests in this package that is over six minutes spent booting containers
+// before any test does useful work. Worse, under `go test -shuffle=on` a test
+// that happens to run late can be left with too little of the package
+// `-timeout` budget to even finish its own boot, so it fails before it gets
+// to make an assertion. Sharing one stack across the package removes that
+// boot cost from every test but the first.
+//
+// Callers must use unique namespaces (and, where relevant, unique table
+// names) per test, since all tests run against the same catalog and bucket.
+func setupTestInfra(t *testing.T) *testInfrastructure {
 	t.Helper()
-	infra := startTestInfrastructure(t, ctx)
-	t.Cleanup(func() { require.NoError(t, infra.Terminate(context.Background())) })
-	infra.CreateBucket(t, "warehouse")
-	return infra
+
+	sharedInfraOnce.Do(func() {
+		// context.Background(), not t.Context(): the stack outlives the
+		// first test that happens to trigger startup.
+		ctx := context.Background()
+
+		infra, err := startTestInfrastructure(ctx)
+		if err != nil {
+			sharedInfraErr = err
+			return
+		}
+
+		if err := infra.createBucket(ctx, "warehouse"); err != nil {
+			_ = infra.Terminate(ctx)
+			sharedInfraErr = err
+			return
+		}
+
+		if err := infra.installDuckDBExtensions(ctx); err != nil {
+			_ = infra.Terminate(ctx)
+			sharedInfraErr = err
+			return
+		}
+
+		sharedInfra = infra
+	})
+	require.NoError(t, sharedInfraErr)
+
+	return sharedInfra
+}
+
+// TestMain terminates the shared test infrastructure (if it was started)
+// after the package's tests complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedInfra != nil {
+		_ = sharedInfra.Terminate(context.Background())
+	}
+	os.Exit(code)
 }
 
 // CatalogConfig returns a catalogx.Config pre-populated with MinIO/REST
@@ -211,13 +267,13 @@ func createMessageWithMeta(t *testing.T, data map[string]any, metaKey, metaValue
 // ---------------------------------------------------------------------------
 
 // startTestInfrastructure starts MinIO, iceberg-rest-fixture, and DuckDB containers.
-func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastructure {
-	t.Helper()
-
+func startTestInfrastructure(ctx context.Context) (*testInfrastructure, error) {
 	infra := &testInfrastructure{}
 
 	net, err := network.New(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("creating network: %w", err)
+	}
 	infra.network = net
 	networkName := net.Name
 
@@ -245,13 +301,22 @@ func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastruct
 		},
 		Started: true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("starting minio: %w", err)
+	}
 	infra.minioContainer = minioContainer
 
 	minioHost, err := minioContainer.Host(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("getting minio host: %w", err)
+	}
 	minioMappedPort, err := minioContainer.MappedPort(ctx, minioInternalPort)
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("getting minio mapped port: %w", err)
+	}
 
 	if minioHost == "localhost" {
 		minioHost = "127.0.0.1"
@@ -259,7 +324,7 @@ func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastruct
 	infra.MinioEndpoint = fmt.Sprintf("http://%s:%s", minioHost, minioMappedPort.Port())
 	infra.MinioInternalURL = "http://minio:" + minioInternalPort
 
-	t.Logf("MinIO started at: %s (internal: %s)", infra.MinioEndpoint, infra.MinioInternalURL)
+	log.Printf("MinIO started at: %s (internal: %s)", infra.MinioEndpoint, infra.MinioInternalURL)
 
 	// Start iceberg-rest-fixture
 	restContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -286,13 +351,22 @@ func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastruct
 		},
 		Started: true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("starting rest catalog: %w", err)
+	}
 	infra.restContainer = restContainer
 
 	restHost, err := restContainer.Host(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("getting rest host: %w", err)
+	}
 	restMappedPort, err := restContainer.MappedPort(ctx, restInternalPort)
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("getting rest mapped port: %w", err)
+	}
 
 	if restHost == "localhost" {
 		restHost = "127.0.0.1"
@@ -300,7 +374,7 @@ func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastruct
 	infra.RestURL = fmt.Sprintf("http://%s:%s", restHost, restMappedPort.Port())
 	infra.RestInternalURL = "http://rest:" + restInternalPort
 
-	t.Logf("Iceberg REST catalog started at: %s (internal: %s)", infra.RestURL, infra.RestInternalURL)
+	log.Printf("Iceberg REST catalog started at: %s (internal: %s)", infra.RestURL, infra.RestInternalURL)
 
 	// Start DuckDB
 	duckdbContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -312,10 +386,13 @@ func startTestInfrastructure(t *testing.T, ctx context.Context) *testInfrastruct
 		},
 		Started: true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		_ = infra.Terminate(ctx)
+		return nil, fmt.Errorf("starting duckdb: %w", err)
+	}
 	infra.duckdbContainer = duckdbContainer
 
-	return infra
+	return infra, nil
 }
 
 // Terminate cleans up all containers and network.
@@ -349,18 +426,18 @@ func (infra *testInfrastructure) Terminate(ctx context.Context) error {
 	return nil
 }
 
-// CreateBucket creates a bucket in MinIO.
-func (infra *testInfrastructure) CreateBucket(t *testing.T, bucket string) {
-	t.Helper()
-
-	ctx := context.Background()
+// createBucket creates a bucket in MinIO. A bucket that already exists is
+// not an error, so the call is safe to repeat against the same MinIO.
+func (infra *testInfrastructure) createBucket(ctx context.Context, bucket string) error {
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion("us-east-1"),
 		config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider("admin", "password", ""),
 		),
 	)
-	require.NoError(t, err)
+	if err != nil {
+		return fmt.Errorf("loading aws config: %w", err)
+	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.BaseEndpoint = aws.String(infra.MinioEndpoint)
@@ -370,7 +447,15 @@ func (infra *testInfrastructure) CreateBucket(t *testing.T, bucket string) {
 	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
-	require.NoError(t, err)
+	if err != nil {
+		var alreadyOwned *types.BucketAlreadyOwnedByYou
+		var alreadyExists *types.BucketAlreadyExists
+		if errors.As(err, &alreadyOwned) || errors.As(err, &alreadyExists) {
+			return nil
+		}
+		return fmt.Errorf("creating bucket %q: %w", bucket, err)
+	}
+	return nil
 }
 
 // CreateNamespace creates a namespace in the Iceberg REST catalog.
@@ -411,7 +496,20 @@ func (infra *testInfrastructure) ExecSQL(ctx context.Context, sql string) (strin
 	return output, nil
 }
 
+// installDuckDBExtensions installs the iceberg and httpfs DuckDB extensions.
+// This must run exactly once: the extensions persist on the container
+// filesystem between execs, and installing them concurrently from parallel
+// tests races.
+func (infra *testInfrastructure) installDuckDBExtensions(ctx context.Context) error {
+	_, err := infra.ExecSQL(ctx, "INSTALL iceberg; INSTALL httpfs;")
+	if err != nil {
+		return fmt.Errorf("installing duckdb extensions: %w", err)
+	}
+	return nil
+}
+
 // duckDBSetupSQL returns SQL to configure DuckDB with Iceberg REST catalog and S3/MinIO access.
+// The iceberg and httpfs extensions must already be installed; see installDuckDBExtensions.
 func (infra *testInfrastructure) duckDBSetupSQL(catalog string) string {
 	minioHostPort := strings.TrimPrefix(infra.MinioInternalURL, "http://")
 	minioHostPort = strings.TrimPrefix(minioHostPort, "https://")
@@ -423,9 +521,7 @@ func (infra *testInfrastructure) duckDBSetupSQL(catalog string) string {
 	)
 
 	return replacer.Replace(`
-		INSTALL iceberg;
 		LOAD iceberg;
-		INSTALL httpfs;
 		LOAD httpfs;
 
 		SET s3_region='us-east-1';

--- a/internal/impl/iceberg/integration/throughput_bench_test.go
+++ b/internal/impl/iceberg/integration/throughput_bench_test.go
@@ -72,7 +72,7 @@ func TestWriteThroughput(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const namespace = "bench"
 	infra.CreateNamespace(t, namespace)

--- a/internal/impl/iceberg/integration/timestamp_encoding_integration_test.go
+++ b/internal/impl/iceberg/integration/timestamp_encoding_integration_test.go
@@ -96,8 +96,9 @@ func removeTableProperty(t *testing.T, infra *testInfrastructure, ns, tblName, p
 // error instead of iceberg-go's cryptic mid-commit failure.
 func TestTimestampEncodingLegacyTableIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tblName = "ts_enc_legacy_ns", "ts_enc_legacy_test"
 	infra.CreateNamespace(t, ns)
@@ -214,8 +215,9 @@ func TestTimestampEncodingLegacyTableIntegration(t *testing.T) {
 // column as a plain TIMESTAMP holding the exact written instant.
 func TestTimestampEncodingNewTableIntegration(t *testing.T) {
 	integration.CheckSkip(t)
+	t.Parallel()
 	ctx := context.Background()
-	infra := setupTestInfra(t, ctx)
+	infra := setupTestInfra(t)
 
 	const ns, tblName = "ts_enc_new_ns", "ts_enc_new_test"
 	infra.CreateNamespace(t, ns)


### PR DESCRIPTION
Each test in `internal/impl/iceberg/integration` started its own MinIO, iceberg-rest-fixture, and DuckDB containers plus a docker network. That is 27 boots of about 15s each.

 - Start the stack once per test process behind a `sync.Once` and terminate it in `TestMain`.
 - Create the warehouse bucket and install the DuckDB extensions in the same once block, because concurrent INSTALL calls race.
 - Tolerate an existing bucket.
 - Every top-level test now calls `t.Parallel()`. Namespaces were already unique per test, so no test data changes were needed.
 - `TestWriteThroughput` stays serial because it is a measurement.

Local run of `task test:integration -- iceberg/integration`: before 6m55s, 78 container starts. After 21s to 23s over three runs, 3 container starts and 1 network.

Ref: CON-565